### PR TITLE
Introduce TestStore.scope

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -21,7 +21,7 @@ struct AnimationsEnvironment {}
 
 let animationsReducer = Reducer<AnimationsState, AnimationsAction, AnimationsEnvironment> {
   state, action, environment in
-  
+
   switch action {
   case let .tapped(point):
     state.circleCenter = point

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -45,7 +45,7 @@ let lazySheetReducer = Reducer<
       state.isActivityIndicatorVisible = false
       state.optionalCounter = CounterState()
       return .none
-      
+
     case .optionalCounter:
       return .none
     }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -42,7 +42,7 @@ let eagerSheetReducer = Reducer<
     case .setSheetIsPresentedDelayCompleted:
       state.optionalCounter = CounterState()
       return .none
-      
+
     case .optionalCounter:
       return .none
     }

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -57,7 +57,7 @@ let nestedReducer = Reducer<
   case let .remove(indexSet):
     state.children.remove(atOffsets: indexSet)
     return .none
-    
+
   case let .rename(name):
     state.description = name
     return .none

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -80,7 +80,7 @@ extension Reducer {
         case let .response(.failure(error)):
           state.error = error
           return .none
-          
+
         case let .response(.success(isFavorite)):
           state.isFavorite = isFavorite
           return .none

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-StrictReducers.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-StrictReducers.swift
@@ -51,7 +51,7 @@ let dieRollReducer = Reducer<DieRollState, DieRollAction, DieRollEnvironment>.st
     return { environment in
       Effect(value: .dieRolled(side: environment.rollDie()))
     }
-    
+
   case let .dieRolled(side):
     state.dieSide = side
     return { _ in .none }

--- a/Examples/TicTacToe/Tests/GameSwiftUITests.swift
+++ b/Examples/TicTacToe/Tests/GameSwiftUITests.swift
@@ -11,10 +11,9 @@ class GameSwiftUITests: XCTestCase {
       xPlayerName: "Blob Sr."
     ),
     reducer: gameReducer,
-    environment: GameEnvironment(),
-    state: \.view,
-    action: { $0 }
+    environment: GameEnvironment()
   )
+  .scope(state: \.view, action: { $0 })
 
   func testFlow_Winner_Quit() {
     self.store.assert(

--- a/Examples/TicTacToe/Tests/LoginSwiftUITests.swift
+++ b/Examples/TicTacToe/Tests/LoginSwiftUITests.swift
@@ -22,10 +22,9 @@ class LoginSwiftUITests: XCTestCase {
           }
         ),
         mainQueue: .init(self.scheduler)
-      ),
-      state: \.view,
-      action: LoginAction.view
+      )
     )
+    .scope(state: \.view, action: LoginAction.view)
 
     store.assert(
       .send(.emailChanged("blob@pointfree.co")) {
@@ -61,10 +60,9 @@ class LoginSwiftUITests: XCTestCase {
           }
         ),
         mainQueue: .init(self.scheduler)
-      ),
-      state: \.view,
-      action: LoginAction.view
+      )
     )
+    .scope(state: \.view, action: LoginAction.view)
 
     store.assert(
       .send(.emailChanged("2fa@pointfree.co")) {
@@ -102,10 +100,9 @@ class LoginSwiftUITests: XCTestCase {
           login: { _ in Effect(error: .invalidUserPassword) }
         ),
         mainQueue: .init(self.scheduler)
-      ),
-      state: \.view,
-      action: LoginAction.view
+      )
     )
+    .scope(state: \.view, action: LoginAction.view)
 
     store.assert(
       .send(.emailChanged("blob")) {

--- a/Examples/TicTacToe/Tests/NewGameSwiftUITests.swift
+++ b/Examples/TicTacToe/Tests/NewGameSwiftUITests.swift
@@ -8,10 +8,9 @@ class NewGameSwiftUITests: XCTestCase {
   let store = TestStore(
     initialState: NewGameState(),
     reducer: newGameReducer,
-    environment: NewGameEnvironment(),
-    state: \.view,
-    action: NewGameAction.view
+    environment: NewGameEnvironment()
   )
+  .scope(state: \.view, action: NewGameAction.view)
 
   func testNewGame() {
     self.store.assert(

--- a/Examples/TicTacToe/Tests/TwoFactorSwiftUITests.swift
+++ b/Examples/TicTacToe/Tests/TwoFactorSwiftUITests.swift
@@ -22,10 +22,9 @@ class TwoFactorSwiftUITests: XCTestCase {
           }
         ),
         mainQueue: AnyScheduler(self.scheduler)
-      ),
-      state: \.view,
-      action: TwoFactorAction.view
+      )
     )
+    .scope(state: \.view, action: TwoFactorAction.view)
 
     store.assert(
       .environment {
@@ -73,10 +72,9 @@ class TwoFactorSwiftUITests: XCTestCase {
           }
         ),
         mainQueue: AnyScheduler(self.scheduler)
-      ),
-      state: \.view,
-      action: TwoFactorAction.view
+      )
     )
+    .scope(state: \.view, action: TwoFactorAction.view)
 
     store.assert(
       .send(.codeChanged("1234")) {

--- a/Sources/ComposableArchitectureTestSupport/TestStore.swift
+++ b/Sources/ComposableArchitectureTestSupport/TestStore.swift
@@ -111,9 +111,7 @@ import XCTest
 ///         $0.results = ["Composable Architecture"]
 ///       }
 ///     )
-public final class TestStore<
-  State, LocalState: Equatable, Action: Equatable, LocalAction, Environment
-> {
+public final class TestStore<State, LocalState, Action: Equatable, LocalAction, Environment> {
   private var environment: Environment
   private let fromLocalAction: (LocalAction) -> Action
   private let reducer: Reducer<State, Action, Environment>
@@ -157,7 +155,7 @@ extension TestStore where State == LocalState, Action == LocalAction {
   }
 }
 
-extension TestStore {
+extension TestStore where LocalState: Equatable {
   /// Asserts against a script of actions.
   public func assert(
     _ steps: Step...,
@@ -298,7 +296,9 @@ extension TestStore {
       )
     }
   }
+}
 
+extension TestStore {
   /// Scopes a reducer to assert against more local state and actions.
   ///
   ///   - toLocalState: A function that transforms the reducer's state into more local state. This

--- a/Sources/ComposableArchitectureTestSupport/TestStore.swift
+++ b/Sources/ComposableArchitectureTestSupport/TestStore.swift
@@ -120,20 +120,7 @@ public final class TestStore<
   private var state: State
   private let toLocalState: (State) -> LocalState
 
-  /// Initializes a test store from an initial state, a reducer, an initial environment, and
-  /// functions that scope the reducer's state and actions for its assertions.
-  ///
-  /// - Parameters:
-  ///   - initialState: The state to start the test from.
-  ///   - reducer: A reducer.
-  ///   - environment: The environment to start the test from.
-  ///   - toLocalState: A function that transforms the reducer's state into more local state. This
-  ///     state will be asserted against as it is mutated by the reducer.  Useful for testing view
-  ///     store state transformations.
-  ///   - fromLocalAction: A function that wraps a more local action in the reducer's action. Local
-  ///     actions can be "sent" to the store, while any reducer action may be received. Useful for
-  ///     testing view store action transformations.
-  public init(
+  private init(
     initialState: State,
     reducer: Reducer<State, Action, Environment>,
     environment: Environment,
@@ -146,7 +133,31 @@ public final class TestStore<
     self.toLocalState = toLocalState
     self.fromLocalAction = fromLocalAction
   }
+}
 
+extension TestStore where State == LocalState, Action == LocalAction {
+  /// Initializes a test store from an initial state, a reducer, and an initial environment.
+  ///
+  /// - Parameters:
+  ///   - initialState: The state to start the test from.
+  ///   - reducer: A reducer.
+  ///   - environment: The environment to start the test from.
+  public convenience init(
+    initialState: State,
+    reducer: Reducer<State, Action, Environment>,
+    environment: Environment
+  ) {
+    self.init(
+      initialState: initialState,
+      reducer: reducer,
+      environment: environment,
+      state: { $0 },
+      action: { $0 }
+    )
+  }
+}
+
+extension TestStore {
   /// Asserts against a script of actions.
   public func assert(
     _ steps: Step...,
@@ -288,6 +299,27 @@ public final class TestStore<
     }
   }
 
+  /// Scopes a reducer to assert against more local state and actions.
+  ///
+  ///   - toLocalState: A function that transforms the reducer's state into more local state. This
+  ///     state will be asserted against as it is mutated by the reducer. Useful for testing view
+  ///     store state transformations.
+  ///   - fromLocalAction: A function that wraps a more local action in the reducer's action. Local
+  ///     actions can be "sent" to the store, while any reducer action may be received. Useful for
+  ///     testing view store action transformations.
+  public func scope<S, A>(
+    state toLocalState: @escaping (LocalState) -> S,
+    action fromLocalAction: @escaping (A) -> LocalAction
+  ) -> TestStore<State, S, Action, A, Environment> {
+    .init(
+      initialState: self.state,
+      reducer: self.reducer,
+      environment: self.environment,
+      state: { toLocalState(self.toLocalState($0)) },
+      action: { self.fromLocalAction(fromLocalAction($0)) }
+    )
+  }
+
   /// A single step of a `TestStore` assertion.
   public struct Step {
     fileprivate let type: StepType
@@ -368,27 +400,5 @@ public final class TestStore<
       case receive(Action, (inout LocalState) -> Void)
       case environment((inout Environment) -> Void)
     }
-  }
-}
-
-extension TestStore where State == LocalState, Action == LocalAction {
-  /// Initializes a test store from an initial state, a reducer, an initial environment.
-  ///
-  /// - Parameters:
-  ///   - initialState: The state to start the test from.
-  ///   - reducer: A reducer.
-  ///   - environment: The environment to start the test from.
-  public convenience init(
-    initialState: State,
-    reducer: Reducer<State, Action, Environment>,
-    environment: Environment
-  ) {
-    self.init(
-      initialState: initialState,
-      reducer: reducer,
-      environment: environment,
-      state: { $0 },
-      action: { $0 }
-    )
   }
 }


### PR DESCRIPTION
This modifies the `TestStore` interface to be a little more inline with `Store`. Rather than expose a 5-argument initializer to `TestStore`'s auto-complete, we can instead disclose this transformation as a `scope` method. Should hopefully simplify things for folks that don't need to `scope` by only exposing a single initializer!