### PR TITLE
Run swift-format on master post-merge

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,6 +2,7 @@ name: Format
 
 on:
   pull_request:
+    branch: 'master'
     paths:
       - '**.swift'
 
@@ -11,8 +12,6 @@ jobs:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
       - name: Install
         run: brew install swift-format
       - name: Format
@@ -20,6 +19,6 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v4.1.6
         with:
           commit_message: Run swift-format
-          branch: ${{ github.head_ref }}
+          branch: 'master'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Looks like actions can't run on forks: https://github.com/stefanzweifel/git-auto-commit-action/issues/25#issuecomment-570800796

So instead of formatting PRs we can instead let master auto-format itself when need be.