### PR TITLE
Remove paths from format action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,8 +3,6 @@ name: Format
 on:
   pull_request:
     branch: 'master'
-    paths:
-      - '**.swift'
 
 jobs:
   swift_format:


### PR DESCRIPTION
Seems more reliable to always run. Otherwise the build can "fail" weirdly on merges of README-only changes.