### PR TITLE
Add strict initialization to Reducer

### DIFF
--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -27,6 +27,16 @@ final class ReducerTests: XCTestCase {
     XCTAssertEqual(state, 1)
   }
 
+  func testStrictReducer() {
+    let reducer = Reducer<Int, Void, Void>.strict { state, _ in state += 1
+      return { _ in .none }
+    }
+
+    var state = 0
+    _ = reducer.callAsFunction(&state, ())
+    XCTAssertEqual(state, 1)
+  }
+
   func testCombine_EffectsAreMerged() {
     typealias Scheduler = AnySchedulerOf<DispatchQueue>
     enum Action: Equatable {


### PR DESCRIPTION
Add a `Reducer.strict` static func for initializing a reducer by providing a function that does not take an environment as input: only state and action. Instead, it returns a function that is given the environment. The motivation is that this makes it impossible to access the environment and invoke effects directly within the reducer, which shouldn't be done.

Inspired by [exercise 2](https://www.pointfree.co/episodes/ep98-ergonomic-state-management-part-1#exercises) from your *Ergonomic State Management: Part 1* episode.