### PR TITLE
removed unused parameter definition

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/ViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ViewStore.swift
@@ -171,8 +171,6 @@ public final class ViewStore<State, Action>: ObservableObject {
   ///     )
   ///
   /// - Parameters:
-  ///   - get: A function to get the state for the binding from the view
-  ///     store's full state.
   ///   - localStateToViewAction: A function that transforms the binding's value
   ///     into an action that can be sent to the store.
   /// - Returns: A binding.


### PR DESCRIPTION
This removes the 'get' parameter definition for the following function:
```
public func binding(
    send localStateToViewAction: @escaping (State) -> Action
  ) -> Binding<State> {
    self.binding(get: { $0 }, send: localStateToViewAction)
  }
```