### PR TITLE
Remove debug gracefully for Release configurations

### DIFF
--- a/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
@@ -88,7 +88,7 @@ extension Reducer {
         )
       }
     #else
-      return .empty
+      return self
     #endif
   }
 }


### PR DESCRIPTION
When the app is compiled in Release configuration with `.debug()` function still attached to a reducer, `return .none` short-circuts the reducer instead of just removing debug feature.

Just released an app to TestFlight, that doesn't work there but works on-device in Debug configuration : )