### PR TITLE
Fix Xcode previews crash

### DIFF
--- a/Examples/TicTacToe/Sources/Core/GameCore.swift
+++ b/Examples/TicTacToe/Sources/Core/GameCore.swift
@@ -87,14 +87,15 @@ extension Array where Element == [Player?] {
 
   func hasWin(_ player: Player) -> Bool {
     let winConditions = [
-      [0,1,2], [3,4,5], [6,7,8],
-      [0,3,6], [1,4,7], [2,5,8],
-      [0,4,8], [6,4,2]
+      [0, 1, 2], [3, 4, 5], [6, 7, 8],
+      [0, 3, 6], [1, 4, 7], [2, 5, 8],
+      [0, 4, 8], [6, 4, 2],
     ]
 
     for condition in winConditions {
-      let matchCount = condition
-        .map { self[$0%3][$0/3] }
+      let matchCount =
+        condition
+        .map { self[$0 % 3][$0 / 3] }
         .filter { $0 == player }
         .count
 

--- a/Sources/ComposableArchitecture/SwiftUI/IdentifiedArray.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/IdentifiedArray.swift
@@ -96,9 +96,9 @@ where ID: Hashable {
     get {
       self.dictionary[id]
     }
-    _modify {
-      yield &self.dictionary[id]
-      if self.dictionary[id] == nil {
+    set {
+      self.dictionary[id] = newValue
+      if newValue == nil {
         self.ids.removeAll(where: { $0 == id })
       }
     }


### PR DESCRIPTION
#25 inadvertently broke Xcode previews, which would crash during compilation due to a `_modify` block on `IdentifiedArray` that yielded _and_ accessed the value that it just yielded.

We can explore different avenues for optimizing `IdentifiedArray` in the future.