### PR TITLE
Run swift-format when master is pushed

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,9 +1,7 @@
 name: Format
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
       - master
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,7 +9,6 @@ jobs:
   swift_format:
     name: swift-format
     runs-on: macOS-latest
-    if: github.event.pull_request.merged == 'true'
     steps:
       - uses: actions/checkout@v2
       - name: Install


### PR DESCRIPTION
Hm, https://github.com/pointfreeco/swift-composable-architecture/pull/33 doesn't seem to have worked as advertised. Formatting was skipped for some reason: https://github.com/pointfreeco/swift-composable-architecture/runs/654060950?check_suite_focus=true

Might have to revoke my kudos...