### PR TITLE
Fix crash on TCA Test support

### DIFF
--- a/Sources/ComposableArchitectureTestSupport/TestStore.swift
+++ b/Sources/ComposableArchitectureTestSupport/TestStore.swift
@@ -166,8 +166,8 @@ extension TestStore where LocalState: Equatable {
 
     var cancellables: [AnyCancellable] = []
 
-    func runReducer(state: inout State, action: Action) {
-      let effect = self.reducer.callAsFunction(&state, action, self.environment)
+    func runReducer(action: Action) {
+      let effect = self.reducer.callAsFunction(&self.state, action, self.environment)
       var isComplete = false
       var cancellable: AnyCancellable?
       cancellable = effect.sink(
@@ -201,7 +201,7 @@ extension TestStore where LocalState: Equatable {
             file: step.file, line: step.line
           )
         }
-        runReducer(state: &self.state, action: self.fromLocalAction(action))
+        runReducer(action: self.fromLocalAction(action))
         update(&expectedState)
 
       case let .receive(expectedAction, update):
@@ -229,7 +229,7 @@ extension TestStore where LocalState: Equatable {
             line: step.line
           )
         }
-        runReducer(state: &self.state, action: receivedAction)
+        runReducer(action: receivedAction)
         update(&expectedState)
 
       case let .environment(work):


### PR DESCRIPTION
**Crash**
I'm getting a crash because of "Simultaneous accesses to state", apparently this is the culprit:
```swift
public func assert() {
  func runReducer(state: inout State, action: Action) {
      let effect = self.reducer.callAsFunction(&state, action, self.environment)
  ...
  }
 ...
 runReducer(state: &self.state, action: receivedAction)
 ...
}
```

I did this change in the assert function. by avoiding passing the state to the inner function the crash not longer happens. 
```swift
    func runReducer(action: Action) {
        let effect = self.reducer.callAsFunction(&self.state, action, self.environment)
...
}

runReducer(action: self.fromLocalAction(action))
```

Here is the console log
```
Simultaneous accesses to 0x600003bbd780, but modification requires exclusive access.
Previous access (a modification) started at ComposableArchitectureTestSupport`TestStore<>.assert(_:file:line:) + 4049 (0x108adde81).
Current access (a read) started at:
0    libswiftCore.dylib                 0x00007fff51b80590 swift_beginAccess + 568
1    ComposableArchitectureTestSupport  0x0000000108ae0410 runReducer #1 <A, B, C, D, E>(state:action:) in TestStore<>.assert(_:file:line:) + 375
2    ComposableArchitectureTestSupport  0x0000000108adceb0 TestStore<>.assert(_:file:line:) + 4096
```

**To Reproduce**
```swift
import ComposableArchitectureTestSupport
import ComposableArchitecture
import XCTest

class ComposableArchitectureTests: XCTestCase {
    struct State: Equatable {}
    enum Action: Equatable { case didTap }
    struct Environment {}

    let reducer = Reducer<State, Action, Environment> {
        _, _, _ in

        return .none
    }

    func testComposableArchitecture() {
        let store = TestStore(
            initialState: State(),
            reducer: reducer,
            environment: Environment()
        )

        store.assert(
            .send(.didTap)
        )
    }
}
```

**Environment**
 - OS: iOS
 - Version: 13.0

