### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ let appReducer = Reducer<AppState, AppAction, AppEnvironment> { state, action, e
   case .numberFactButtonTapped:
     return environment.numberFact(state.count)
       .receive(on: environment.mainQueue)
-      .map(AppAction.numberFactResponse)
       .catchToEffect()
+      .map(AppAction.numberFactResponse)
 
   case let .numberFactResponse(.success(fact)):
     state.numberFactAlert = fact


### PR DESCRIPTION
Change order of methods.`catchToEffect` should be called before mapping on the `Result`.