### PR TITLE
Identified Array Updates

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/IdentifiedArray.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/IdentifiedArray.swift
@@ -92,15 +92,19 @@ where ID: Hashable {
     }
   }
 
+  /// Direct access to an element by its identifier.
+  ///
+  /// - Parameter id: The identifier of element to access. Must be a valid identifier for an element
+  ///   of the array and will _not_ insert elements that are not already in the array, or remove
+  ///   elements when passed `nil`. Use `insert(_:at:)` and `remove(id:)` to insert and remove
+  ///   elements.
+  /// - Returns: The element.
   public subscript(id id: ID) -> Element? {
     get {
       self.dictionary[id]
     }
-    set {
-      self.dictionary[id] = newValue
-      if newValue == nil {
-        self.ids.removeAll(where: { $0 == id })
-      }
+    _modify {
+      yield &self.dictionary[id]
     }
   }
 
@@ -118,14 +122,22 @@ where ID: Hashable {
     }
   }
 
+  /// Removes and returns the element with the specified identifier.
+  ///
+  /// - Parameter id: The identifier of the element to remove.
+  /// - Returns: The removed element.
+  @discardableResult
+  public mutating func remove(id: ID) -> Element {
+    let element = self.dictionary[id]
+    assert(element != nil, "Unexpectedly found nil while removing an identified element.")
+    self.dictionary[id] = nil
+    self.ids.removeAll(where: { $0 == id })
+    return element!
+  }
+
   @discardableResult
   public mutating func remove(at position: Int) -> Element {
-    let id = self.ids.remove(at: position)
-    let element = self.dictionary[id]!
-    if !self.ids.contains(id) {
-      self.dictionary[id] = nil
-    }
-    return element
+    self.remove(id: self.ids.remove(at: position))
   }
 
   public mutating func removeAll(where shouldBeRemoved: (Element) throws -> Bool) rethrows {

--- a/Tests/ComposableArchitectureTests/IdentifiedArrayTests.swift
+++ b/Tests/ComposableArchitectureTests/IdentifiedArrayTests.swift
@@ -12,8 +12,17 @@ final class IdentifiedArrayTests: XCTestCase {
     var array: IdentifiedArray = [User(id: 1, name: "Blob")]
 
     XCTAssertEqual(array[id: 1], .some(User(id: 1, name: "Blob")))
+  }
 
-    array[id: 1] = nil
+  func testRemoveId() {
+    struct User: Equatable, Identifiable {
+      let id: Int
+      var name: String
+    }
+
+    var array: IdentifiedArray = [User(id: 1, name: "Blob")]
+
+    XCTAssertEqual(array.remove(id: 1), User(id: 1, name: "Blob"))
     XCTAssertEqual(array, [])
   }
 


### PR DESCRIPTION
  * Identifier-based subscript should get direct `modify` access, with caveats.
  * Add `remove(id:)` method.

Addressing discussion from #76.