### PR TITLE
Added Reducer.combine instance method

### DIFF
--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -75,6 +75,15 @@ public struct Reducer<State, Action, Environment> {
     }
   }
 
+  /// Combines a reducer with another given reducer by running each one on the state, and
+  /// concatenating both of their effects.
+  ///
+  /// - Parameter reducers: Another reducer.
+  /// - Returns: A single reducer.
+  public func combine(_ other: Reducer) -> Reducer {
+    Reducer.combine(self, other)
+  }
+
   /// Transforms a reducer that works on local state, action and environment into one that works on
   /// global state, action and environment. It accomplishes this by providing 3 transformations to
   /// the method:

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -78,9 +78,9 @@ public struct Reducer<State, Action, Environment> {
   /// Combines a reducer with another given reducer by running each one on the state, and
   /// concatenating both of their effects.
   ///
-  /// - Parameter reducers: Another reducer.
+  /// - Parameter other: Another reducer.
   /// - Returns: A single reducer.
-  public func combine(_ other: Reducer) -> Reducer {
+  public func combined(with other: Reducer) -> Reducer {
     Reducer.combine(self, other)
   }
 

--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -87,7 +87,7 @@ final class ReducerTests: XCTestCase {
       return Effect.fireAndForget { mainEffectExecuted = true }
         .eraseToEffect()
     }
-    .combine(childReducer)
+    .combined(with: childReducer)
 
     let store = TestStore(
       initialState: 0,

--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -69,6 +69,42 @@ final class ReducerTests: XCTestCase {
     )
   }
 
+  func testCombine() {
+    enum Action: Equatable {
+      case increment
+    }
+    
+    var childEffectExecuted = false
+    let childReducer = Reducer<Int, Action, Void> { state, _, _ in
+      state += 1
+      return Effect.fireAndForget { childEffectExecuted = true }
+        .eraseToEffect()
+    }
+
+    var mainEffectExecuted = false
+    let mainReducer = Reducer<Int, Action, Void> { state, _, _ in
+      state += 1
+      return Effect.fireAndForget { mainEffectExecuted = true }
+        .eraseToEffect()
+    }
+    .combine(childReducer)
+
+    let store = TestStore(
+      initialState: 0,
+      reducer: mainReducer,
+      environment: ()
+    )
+
+    store.assert(
+      .send(.increment) {
+        $0 = 2
+      }
+    )
+    
+    XCTAssertTrue(childEffectExecuted)
+    XCTAssertTrue(mainEffectExecuted)
+  }
+
   func testPrint() {
     struct Unit: Equatable {}
     struct State: Equatable { var count = 0 }


### PR DESCRIPTION
As requested here there is this little method. Is a Reducer.combine as an instance method so you can chain a reducer with another. Quite useful when you want to chain a "main" reducer with a "child" reducer. The static Reducer.combine feels more adequate when all reducers have the same "importance". 

I've added a method that accepts a single other reducer as that's what my [original tweet](https://twitter.com/alexito4/status/1260279123907416064) was about but feel free to ping me if you prefer another API. I wouldn't add an overload with varargs because at that point you may want to use the static one.
I've also toyed around with a label ->  `mainReducer.combine(with: childReducer)`, not sure what you prefer. 
I've tried to follow your wording on the docs, but feel free to suggest edits. 
I've also added a simple test kinda following the other combine one but simpler, I'm not sure if you want some other type of coverage. 


FYI, running `make format` errors in my machine
```
▶ make format
swift format --in-place --recursive .
error: unable to invoke subcommand: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-format (No such file or directory)
make: *** [format] Error 2
```
so I formatted the files manually, not sure if they are totally correct 😅