### PR TITLE
Remove unnecessary combine in the example

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -167,12 +167,10 @@ struct EpisodesEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-let episodesReducer = Reducer<EpisodesState, EpisodesAction, EpisodesEnvironment>.combine(
-  episodeReducer.forEach(
-    state: \EpisodesState.episodes,
-    action: /EpisodesAction.episode(index:action:),
-    environment: { EpisodeEnvironment(favorite: $0.favorite, mainQueue: $0.mainQueue) }
-  )
+let episodesReducer: Reducer<EpisodesState, EpisodesAction, EpisodesEnvironment> = episodeReducer.forEach(
+  state: \EpisodesState.episodes,
+  action: /EpisodesAction.episode(index:action:),
+  environment: { EpisodeEnvironment(favorite: $0.favorite, mainQueue: $0.mainQueue) }
 )
 
 struct EpisodesView: View {


### PR DESCRIPTION
As discussed https://github.com/pointfreeco/swift-composable-architecture/pull/85#issuecomment-627583778 the example doesn't need to use `Reducer.combine` because it only has 1 reducer.

Note that the type declaration can't be removed because the compiler can't infer the type of the global environment. 