### PR TITLE
Rename certain Effect APIs

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadClient.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadClient.swift
@@ -24,7 +24,7 @@ extension DownloadClient {
       }
     },
     download: { id, url in
-      Effect.async { subscriber in
+      .run { subscriber in
         let task = URLSession.shared.dataTask(with: url) { data, _, error in
           switch (data, error) {
           case let (.some(data), _):
@@ -54,7 +54,8 @@ extension DownloadClient {
           dependencies[id] = nil
         }
       }
-    })
+    }
+  )
 }
 
 private struct Dependencies {

--- a/Examples/MotionManager/MotionManager/MotionClient/Live.swift
+++ b/Examples/MotionManager/MotionManager/MotionClient/Live.swift
@@ -5,7 +5,7 @@ import CoreMotion
 extension MotionClient {
   static let live = MotionClient(
     create: { id in
-      Effect.async { subscriber in
+      .run { subscriber in
         let manager = MotionManager(
           manager: CMMotionManager(),
           handler: { motion, error in

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Live.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Live.swift
@@ -17,7 +17,7 @@ extension SpeechClient {
       }
     },
     recognitionTask: { id, request in
-      Effect.async { subscriber in
+      Effect.run { subscriber in
         let cancellable = AnyCancellable {
           dependencies[id]?.cancel()
           dependencies[id] = nil

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -167,13 +167,6 @@ public struct Effect<Output, Failure: Error>: Publisher {
     AnyPublisher.create(work).eraseToEffect()
   }
 
-  @available(*, deprecated, renamed: "run")
-  public static func async(
-    _ work: @escaping (Effect.Subscriber<Output, Failure>) -> Cancellable
-  ) -> Self {
-    self.run(work)
-  }
-
   /// Concatenates a variadic list of effects together into a single effect, which runs the effects
   /// one after the other.
   ///
@@ -266,11 +259,6 @@ extension Effect where Failure == Swift.Error {
   /// - Returns: An effect.
   public static func catching(_ work: @escaping () throws -> Output) -> Self {
     .future { $0(Result { try work() }) }
-  }
-
-  @available(*, deprecated, renamed: "catching")
-  public static func sync(_ work: @escaping () throws -> Output) -> Self {
-    self.catching(work)
   }
 }
 

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -1,3 +1,5 @@
+import Combine
+
 // NB: Deprecated after 0.1.3:
 
 extension Effect {
@@ -7,7 +9,9 @@ extension Effect {
   ) -> Self {
     self.run(work)
   }
+}
 
+extension Effect where Failure == Swift.Error {
   @available(*, deprecated, renamed: "catching")
   public static func sync(_ work: @escaping () throws -> Output) -> Self {
     self.catching(work)

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -1,0 +1,15 @@
+// NB: Deprecated after 0.1.3:
+
+extension Effect {
+  @available(*, deprecated, renamed: "run")
+  public static func async(
+    _ work: @escaping (Effect.Subscriber<Output, Failure>) -> Cancellable
+  ) -> Self {
+    self.run(work)
+  }
+
+  @available(*, deprecated, renamed: "catching")
+  public static func sync(_ work: @escaping () throws -> Output) -> Self {
+    self.catching(work)
+  }
+}

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -93,7 +93,7 @@ final class EffectTests: XCTestCase {
   }
 
   func testEffectSubscriberInitializer() {
-    let effect = Effect<Int, Never>.async { subscriber in
+    let effect = Effect<Int, Never>.run { subscriber in
       subscriber.send(1)
       subscriber.send(2)
       self.scheduler.schedule(after: self.scheduler.now.advanced(by: .seconds(1))) {
@@ -130,7 +130,7 @@ final class EffectTests: XCTestCase {
   func testEffectSubscriberInitializer_WithCancellation() {
     struct CancelId: Hashable {}
 
-    let effect = Effect<Int, Never>.async { subscriber in
+    let effect = Effect<Int, Never>.run { subscriber in
       subscriber.send(1)
       self.scheduler.schedule(after: self.scheduler.now.advanced(by: .seconds(1))) {
         subscriber.send(2)


### PR DESCRIPTION
The `async` and `sync` APIs don't quite feel right when we also have `future` and `result`.