### PR TITLE
Fix ordering of simultaneous work in test scheduler.

### DIFF
--- a/Sources/ComposableArchitecture/Scheduling/TestScheduler.swift
+++ b/Sources/ComposableArchitecture/Scheduling/TestScheduler.swift
@@ -21,9 +21,7 @@ where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeInte
   ///
   /// - Parameter stride: A stride.
   public func advance(by stride: SchedulerTimeType.Stride = .zero) {
-    self.scheduled.sort {
-      $0.date < $1.date || $0.id < $1.id
-    }
+    self.scheduled.sort { $0.date < $1.date || $0.id < $1.id }
 
     guard
       let nextDate = self.scheduled.first?.date,

--- a/Sources/ComposableArchitecture/Scheduling/TestScheduler.swift
+++ b/Sources/ComposableArchitecture/Scheduling/TestScheduler.swift
@@ -49,11 +49,6 @@ where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeInte
     }
   }
 
-  func nextId() -> Int {
-    self.lastId += 1
-    return self.lastId
-  }
-
   public func schedule(
     after date: SchedulerTimeType,
     interval: SchedulerTimeType.Stride,
@@ -89,6 +84,11 @@ where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeInte
 
   public func schedule(options _: SchedulerOptions?, _ action: @escaping () -> Void) {
     self.scheduled.append((self.nextId(), self.now, action))
+  }
+
+  private func nextId() -> Int {
+    self.lastId += 1
+    return self.lastId
   }
 }
 

--- a/Sources/ComposableArchitecture/Scheduling/TestScheduler.swift
+++ b/Sources/ComposableArchitecture/Scheduling/TestScheduler.swift
@@ -5,10 +5,10 @@ import Foundation
 public final class TestScheduler<SchedulerTimeType, SchedulerOptions>: Scheduler
 where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeIntervalConvertible {
 
-  private var lastId = 0
+  private var lastId: UInt = 0
   public let minimumTolerance: SchedulerTimeType.Stride = .zero
   public private(set) var now: SchedulerTimeType
-  private var scheduled: [(id: Int, date: SchedulerTimeType, action: () -> Void)] = []
+  private var scheduled: [(id: UInt, date: SchedulerTimeType, action: () -> Void)] = []
 
   /// Creates a test scheduler with the given date.
   ///
@@ -86,7 +86,7 @@ where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeInte
     self.scheduled.append((self.nextId(), self.now, action))
   }
 
-  private func nextId() -> Int {
+  private func nextId() -> UInt {
     self.lastId += 1
     return self.lastId
   }

--- a/Sources/ComposableArchitecture/Scheduling/TestScheduler.swift
+++ b/Sources/ComposableArchitecture/Scheduling/TestScheduler.swift
@@ -5,9 +5,10 @@ import Foundation
 public final class TestScheduler<SchedulerTimeType, SchedulerOptions>: Scheduler
 where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeIntervalConvertible {
 
+  private var lastId = 0
   public let minimumTolerance: SchedulerTimeType.Stride = .zero
   public private(set) var now: SchedulerTimeType
-  private var scheduled: [(id: UUID, date: SchedulerTimeType, action: () -> Void)] = []
+  private var scheduled: [(id: Int, date: SchedulerTimeType, action: () -> Void)] = []
 
   /// Creates a test scheduler with the given date.
   ///
@@ -20,11 +21,9 @@ where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeInte
   ///
   /// - Parameter stride: A stride.
   public func advance(by stride: SchedulerTimeType.Stride = .zero) {
-    self.scheduled = self.scheduled
-      // NB: Stabilizes sort via offset.
-      .enumerated()
-      .sorted(by: { $0.element.date < $1.element.date || $0.offset < $1.offset })
-      .map { $0.element }
+    self.scheduled.sort {
+      $0.date < $1.date || $0.id < $1.id
+    }
 
     guard
       let nextDate = self.scheduled.first?.date,
@@ -52,6 +51,11 @@ where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeInte
     }
   }
 
+  func nextId() -> Int {
+    self.lastId += 1
+    return self.lastId
+  }
+
   public func schedule(
     after date: SchedulerTimeType,
     interval: SchedulerTimeType.Stride,
@@ -59,17 +63,17 @@ where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeInte
     options _: SchedulerOptions?,
     _ action: @escaping () -> Void
   ) -> Cancellable {
+    let id = self.nextId()
 
-    let id = UUID()
-
-    func scheduleAction(_ date: SchedulerTimeType) -> () -> Void {
+    func scheduleAction(for date: SchedulerTimeType) -> () -> Void {
       return { [weak self] in
         action()
-        self?.scheduled.append((id, date, scheduleAction(date.advanced(by: interval))))
+        let nextDate = date.advanced(by: interval)
+        self?.scheduled.append((id, nextDate, scheduleAction(for: nextDate)))
       }
     }
 
-    self.scheduled.append((id, date, scheduleAction(date.advanced(by: interval))))
+    self.scheduled.append((id, date, scheduleAction(for: date)))
 
     return AnyCancellable { [weak self] in
       self?.scheduled.removeAll(where: { $0.id == id })
@@ -82,11 +86,11 @@ where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeInte
     options _: SchedulerOptions?,
     _ action: @escaping () -> Void
   ) {
-    self.scheduled.append((UUID(), date, action))
+    self.scheduled.append((self.nextId(), date, action))
   }
 
   public func schedule(options _: SchedulerOptions?, _ action: @escaping () -> Void) {
-    self.scheduled.append((UUID(), self.now, action))
+    self.scheduled.append((self.nextId(), self.now, action))
   }
 }
 

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -3,6 +3,8 @@ import ComposableArchitecture
 import XCTest
 
 final class ComposableArchitectureTests: XCTestCase {
+  var cancellables: Set<AnyCancellable> = []
+
   func testScheduling() {
     enum CounterAction: Equatable {
       case incrAndSquareLater
@@ -58,6 +60,24 @@ final class ComposableArchitectureTests: XCTestCase {
       .receive(.incrNow) { $0 = 626 },
       .receive(.squareNow) { $0 = 391876 }
     )
+  }
+
+  func testSimultaneousWorkOrdering() {
+    let testScheduler = TestScheduler<DispatchQueue.SchedulerTimeType, DispatchQueue.SchedulerOptions>(
+      now: .init(.init(uptimeNanoseconds: 1))
+    )
+
+    var values: [Int] = []
+    testScheduler.schedule(after: testScheduler.now, interval: 1) { values.append(1) }
+      .store(in: &self.cancellables)
+    testScheduler.schedule(after: testScheduler.now, interval: 2) { values.append(42) }
+      .store(in: &self.cancellables)
+
+    XCTAssertEqual(values, [])
+    testScheduler.advance()
+    XCTAssertEqual(values, [1, 42])
+    testScheduler.advance(by: 2)
+    XCTAssertEqual(values, [1, 42, 1, 1, 42])
   }
 
   func testLongLivingEffects() {

--- a/Tests/ComposableArchitectureTests/TimerTests.swift
+++ b/Tests/ComposableArchitectureTests/TimerTests.swift
@@ -103,8 +103,8 @@ final class TimerTests: XCTestCase {
 
     scheduler.run()
 
-    XCTAssertEqual(count2, 14)
-    XCTAssertEqual(count3, 9)
+    XCTAssertEqual(count2, 15)
+    XCTAssertEqual(count3, 10)
   }
 
   func testTimerCompletion() {


### PR DESCRIPTION
There was a small bug in the test scheduler where if two timers have emissions that later coalesce to happen simultaneously, then it is possible for them to emit in the wrong order. We need to track the order in which the timers were started in order to fix this, and we can do that with a simple auto-incrementing id instead of a UUID.

I haven't run the full demo test suite locally to see if there are any places in our demo tests where we may have been accidentally depending on this logic. Will let CI do that for me...