### PR TITLE
Another fix for order test scheduler intervals.

### DIFF
--- a/Sources/ComposableArchitecture/Scheduling/TestScheduler.swift
+++ b/Sources/ComposableArchitecture/Scheduling/TestScheduler.swift
@@ -21,7 +21,7 @@ where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeInte
   ///
   /// - Parameter stride: A stride.
   public func advance(by stride: SchedulerTimeType.Stride = .zero) {
-    self.scheduled.sort { $0.date < $1.date || $0.id < $1.id }
+    self.scheduled.sort { $0.date < $1.date || ($0.date == $1.date && $0.id < $1.id) }
 
     guard
       let nextDate = self.scheduled.first?.date,

--- a/Tests/ComposableArchitectureTests/SchedulerTests.swift
+++ b/Tests/ComposableArchitectureTests/SchedulerTests.swift
@@ -114,4 +114,22 @@ final class SchedulerTests: XCTestCase {
       """
     )
   }
+
+  func testTwoIntervalOrdering() {
+    let testScheduler = DispatchQueue.testScheduler
+
+    var values: [Int] = []
+
+    testScheduler.schedule(after: testScheduler.now, interval: 2) { values.append(1) }
+      .store(in: &self.cancellables)
+
+    testScheduler.schedule(after: testScheduler.now, interval: 1) { values.append(42) }
+      .store(in: &self.cancellables)
+
+    XCTAssertEqual(values, [])
+    testScheduler.advance()
+    XCTAssertEqual(values, [1, 42])
+    testScheduler.advance(by: 2)
+    XCTAssertEqual(values, [1, 42, 42, 1, 42])
+  }
 }


### PR DESCRIPTION
Another small test scheduler bug, this time due to the sorting not properly sorting first by date and then by id.