### PR TITLE
Make throttling public

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Throttling.swift
+++ b/Sources/ComposableArchitecture/Effects/Throttling.swift
@@ -13,7 +13,7 @@ extension Effect {
   ///     `false`, the publisher emits the first element received during the interval.
   /// - Returns: An effect that emits either the most-recent or first element received during the
   ///   specified interval.
-  func throttle<S>(
+  public func throttle<S>(
     id: AnyHashable,
     for interval: S.SchedulerTimeType.Stride,
     scheduler: S,


### PR DESCRIPTION
Throttling can be as useful as debouncing, there's no reason to keep one public and the other internal.


![](https://i.imgflip.com/41jfqm.jpg)
