### PR TITLE
Animations case study dark mode

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -2,19 +2,19 @@ import ComposableArchitecture
 import SwiftUI
 
 private let readMe = """
-  This screen demonstrates how changes to application state can drive animations. Because the \
-  `Store` processes actions sent to it synchronously you can typically perform animations \
-  in the Composable Architecture just as you would in regular SwiftUI.
+This screen demonstrates how changes to application state can drive animations. Because the \
+`Store` processes actions sent to it synchronously you can typically perform animations \
+in the Composable Architecture just as you would in regular SwiftUI.
 
-  To animate the changes made to state when an action is sent to the store you only need to wrap \
-  instances of `viewStore.send` in a `withAnimations` block. For example, when sending an action \
-  to the store when a button is tapped.
+To animate the changes made to state when an action is sent to the store you only need to wrap \
+instances of `viewStore.send` in a `withAnimations` block. For example, when sending an action \
+to the store when a button is tapped.
 
-  To animate changes made to state through a binding, use the `.animation` method on `Binding`.
+To animate changes made to state through a binding, use the `.animation` method on `Binding`.
 
-  Try it out by tapping or dragging anywhere on the screen to move the dot, and by flipping the \
-  toggle at the bottom of the screen.
-  """
+Try it out by tapping or dragging anywhere on the screen to move the dot, and by flipping the \
+toggle at the bottom of the screen.
+"""
 
 struct AnimationsState: Equatable {
   var circleCenter = CGPoint.zero
@@ -43,6 +43,7 @@ let animationsReducer = Reducer<AnimationsState, AnimationsAction, AnimationsEnv
 }
 
 struct AnimationsView: View {
+  @Environment(\.colorScheme) var colorScheme
   let store: Store<AnimationsState, AnimationsAction>
 
   var body: some View {
@@ -61,9 +62,10 @@ struct AnimationsView: View {
               .offset(
                 x: viewStore.circleCenter.x - proxy.size.width / 2,
                 y: viewStore.circleCenter.y - proxy.size.height / 2
-              )
+            )
           }
           .frame(maxWidth: .infinity, maxHeight: .infinity)
+          .background(self.colorScheme == .dark ? Color.black : Color.white)
           .simultaneousGesture(
             DragGesture(minimumDistance: 0).onChanged { gesture in
               withAnimation(.interactiveSpring(response: 0.25, dampingFraction: 0.1)) {
@@ -74,11 +76,11 @@ struct AnimationsView: View {
           Toggle(
             "Big mode",
             isOn:
-              viewStore
+            viewStore
               .binding(get: \.isCircleScaled, send: AnimationsAction.circleScaleToggleChanged)
               .animation(.interactiveSpring(response: 0.25, dampingFraction: 0.1))
           )
-          .padding()
+            .padding()
         }
       }
     }
@@ -87,12 +89,28 @@ struct AnimationsView: View {
 
 struct AnimationsView_Previews: PreviewProvider {
   static var previews: some View {
-    AnimationsView(
-      store: Store(
-        initialState: AnimationsState(circleCenter: CGPoint(x: 50, y: 50)),
-        reducer: animationsReducer,
-        environment: AnimationsEnvironment()
-      )
-    )
+    Group {
+
+      NavigationView {
+        AnimationsView(
+          store: Store(
+            initialState: AnimationsState(circleCenter: CGPoint(x: 50, y: 50)),
+            reducer: animationsReducer,
+            environment: AnimationsEnvironment()
+          )
+        )
+      }
+
+      NavigationView {
+        AnimationsView(
+          store: Store(
+            initialState: AnimationsState(circleCenter: CGPoint(x: 50, y: 50)),
+            reducer: animationsReducer,
+            environment: AnimationsEnvironment()
+          )
+        )
+      }
+      .environment(\.colorScheme, .dark)
+    }
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -90,7 +90,6 @@ struct AnimationsView: View {
 struct AnimationsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-
       NavigationView {
         AnimationsView(
           store: Store(

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -2,19 +2,19 @@ import ComposableArchitecture
 import SwiftUI
 
 private let readMe = """
-This screen demonstrates how changes to application state can drive animations. Because the \
-`Store` processes actions sent to it synchronously you can typically perform animations \
-in the Composable Architecture just as you would in regular SwiftUI.
+  This screen demonstrates how changes to application state can drive animations. Because the \
+  `Store` processes actions sent to it synchronously you can typically perform animations \
+  in the Composable Architecture just as you would in regular SwiftUI.
 
-To animate the changes made to state when an action is sent to the store you only need to wrap \
-instances of `viewStore.send` in a `withAnimations` block. For example, when sending an action \
-to the store when a button is tapped.
+  To animate the changes made to state when an action is sent to the store you only need to wrap \
+  instances of `viewStore.send` in a `withAnimations` block. For example, when sending an action \
+  to the store when a button is tapped.
 
-To animate changes made to state through a binding, use the `.animation` method on `Binding`.
+  To animate changes made to state through a binding, use the `.animation` method on `Binding`.
 
-Try it out by tapping or dragging anywhere on the screen to move the dot, and by flipping the \
-toggle at the bottom of the screen.
-"""
+  Try it out by tapping or dragging anywhere on the screen to move the dot, and by flipping the \
+  toggle at the bottom of the screen.
+  """
 
 struct AnimationsState: Equatable {
   var circleCenter = CGPoint.zero
@@ -62,7 +62,7 @@ struct AnimationsView: View {
               .offset(
                 x: viewStore.circleCenter.x - proxy.size.width / 2,
                 y: viewStore.circleCenter.y - proxy.size.height / 2
-            )
+              )
           }
           .frame(maxWidth: .infinity, maxHeight: .infinity)
           .background(self.colorScheme == .dark ? Color.black : Color.white)
@@ -76,11 +76,11 @@ struct AnimationsView: View {
           Toggle(
             "Big mode",
             isOn:
-            viewStore
+              viewStore
               .binding(get: \.isCircleScaled, send: AnimationsAction.circleScaleToggleChanged)
               .animation(.interactiveSpring(response: 0.25, dampingFraction: 0.1))
           )
-            .padding()
+          .padding()
         }
       }
     }


### PR DESCRIPTION
Bring back background color so that touches are recognized on full screen, not just text.