### PR TITLE
Make Reducer.debug API more like Publisher.print

### DIFF
--- a/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
@@ -14,12 +14,12 @@ extension Reducer {
   ///     function and a background queue.
   /// - Returns: A reducer that prints debug messages for all received actions.
   public func debug(
-    prefix: String = "",
+    _ prefix: String = "",
     environment toDebugEnvironment: @escaping (Environment) -> DebugEnvironment = { _ in
       DebugEnvironment()
     }
   ) -> Reducer {
-    self.debug(prefix: prefix, state: { $0 }, action: .self, environment: toDebugEnvironment)
+    self.debug(prefix, state: { $0 }, action: .self, environment: toDebugEnvironment)
   }
 
   /// Prints debug messages describing all received actions.
@@ -39,7 +39,7 @@ extension Reducer {
       DebugEnvironment()
     }
   ) -> Reducer {
-    self.debug(prefix: prefix, state: { _ in () }, action: .self, environment: toDebugEnvironment)
+    self.debug(prefix, state: { _ in () }, action: .self, environment: toDebugEnvironment)
   }
 
   /// Prints debug messages describing all received local actions and local state mutations.
@@ -56,7 +56,7 @@ extension Reducer {
   ///     function and a background queue.
   /// - Returns: A reducer that prints debug messages for all received actions.
   public func debug<LocalState, LocalAction>(
-    prefix: String = "",
+    _ prefix: String = "",
     state toLocalState: @escaping (State) -> LocalState,
     action toLocalAction: CasePath<Action, LocalAction>,
     environment toDebugEnvironment: @escaping (Environment) -> DebugEnvironment = { _ in

--- a/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
@@ -34,7 +34,7 @@ extension Reducer {
   ///     function and a background queue.
   /// - Returns: A reducer that prints debug messages for all received actions.
   public func debugActions(
-    prefix: String = "",
+    _ prefix: String = "",
     environment toDebugEnvironment: @escaping (Environment) -> DebugEnvironment = { _ in
       DebugEnvironment()
     }

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -1,5 +1,48 @@
 import Combine
 
+// NB: Deprecated after 0.1.4:
+
+extension Reducer {
+  @available(*, deprecated, renamed: "debug(_:environment:)")
+  public func debug(
+    prefix: String,
+    environment toDebugEnvironment: @escaping (Environment) -> DebugEnvironment = { _ in
+      DebugEnvironment()
+    }
+  ) -> Reducer {
+    self.debug(prefix, state: { $0 }, action: .self, environment: toDebugEnvironment)
+  }
+
+  @available(*, deprecated, renamed: "debugActions(_:environment:)")
+  public func debugActions(
+    prefix: String,
+    environment toDebugEnvironment: @escaping (Environment) -> DebugEnvironment = { _ in
+      DebugEnvironment()
+    }
+  ) -> Reducer {
+    self.debug(prefix, state: { _ in () }, action: .self, environment: toDebugEnvironment)
+  }
+
+  @available(*, deprecated, renamed: "debug(_:state:action:environment:)")
+  public func debug<LocalState, LocalAction>(
+    prefix: String,
+    state toLocalState: @escaping (State) -> LocalState,
+    action toLocalAction: CasePath<Action, LocalAction>,
+    environment toDebugEnvironment: @escaping (Environment) -> DebugEnvironment = { _ in
+      DebugEnvironment()
+    }
+  ) -> Reducer {
+    self.debug(prefix, state: toLocalState, action: toLocalAction, environment: toDebugEnvironment)
+  }
+}
+
+extension WithViewStore {
+  @available(*, deprecated, renamed: "debug(_:)")
+  public func debug(prefix: String) -> Self {
+    self.debug(prefix)
+  }
+}
+
 // NB: Deprecated after 0.1.3:
 
 extension Effect {

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -56,7 +56,7 @@ public struct WithViewStore<State, Action, Content>: View where Content: View {
   ///
   /// - Parameter prefix: A string with which to prefix all debug messages.
   /// - Returns: A structure that prints debug messages for all computations.
-  public func debug(prefix: String = "") -> Self {
+  public func debug(_ prefix: String = "") -> Self {
     var view = self
     view.prefix = prefix
     return view

--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -107,7 +107,7 @@ final class ReducerTests: XCTestCase {
       state.count += 1
       return .none
     }
-    .debug(prefix: "[prefix]") { _ in
+    .debug("[prefix]") { _ in
       DebugEnvironment(
         printer: {
           logs.append($0)


### PR DESCRIPTION
- [x] Deprecate old API