### PR TITLE
Gracefully handle recursive state debug output

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Debug.swift
+++ b/Sources/ComposableArchitecture/Internal/Debug.swift
@@ -1,104 +1,121 @@
 import Foundation
 
 func debugOutput(_ value: Any, indent: Int = 0) -> String {
-  let mirror = Mirror(reflecting: value)
-  switch (value, mirror.displayStyle) {
-  case let (value as CustomDebugOutputConvertible, _):
-    return value.debugOutput.indent(by: indent)
-  case (_, .collection?):
-    return """
-      [
-      \(mirror.children.map { "\(debugOutput($0.value, indent: 2)),\n" }.joined())]
-      """
-      .indent(by: indent)
-  case (_, .dictionary?):
-    let pairs = mirror.children.map { label, value -> String in
-      let pair = value as! (key: AnyHashable, value: Any)
-      return "\("\(debugOutput(pair.key.base)): \(debugOutput(pair.value)),".indent(by: 2))\n"
-    }
-    return """
-      [
-      \(pairs.sorted().joined())]
-      """
-      .indent(by: indent)
-  case (_, .set?):
-    return """
-      Set([
-      \(mirror.children.map { "\(debugOutput($0.value, indent: 2)),\n" }.sorted().joined())])
-      """
-      .indent(by: indent)
-  case (_, .optional?):
-    return mirror.children.isEmpty
-      ? "nil".indent(by: indent)
-      : debugOutput(mirror.children.first!.value, indent: indent)
-  case (_, .enum?) where !mirror.children.isEmpty:
-    let child = mirror.children.first!
-    let childMirror = Mirror(reflecting: child.value)
-    let elements =
-      childMirror.displayStyle != .tuple
-      ? debugOutput(child.value, indent: 2)
-      : childMirror.children.map { child -> String in
-        let label = child.label!
-        return "\(label.hasPrefix(".") ? "" : "\(label): ")\(debugOutput(child.value))"
+  var visitedItems: Set<ObjectIdentifier> = []
+
+  func debugOutputHelp(_ value: Any, indent: Int = 0) -> String {
+    let mirror = Mirror(reflecting: value)
+    switch (value, mirror.displayStyle) {
+    case let (value as CustomDebugOutputConvertible, _):
+      return value.debugOutput.indent(by: indent)
+    case (_, .collection?):
+      return """
+        [
+        \(mirror.children.map { "\(debugOutput($0.value, indent: 2)),\n" }.joined())]
+        """
+        .indent(by: indent)
+    case (_, .dictionary?):
+      let pairs = mirror.children.map { label, value -> String in
+        let pair = value as! (key: AnyHashable, value: Any)
+        return "\("\(debugOutputHelp(pair.key.base)): \(debugOutputHelp(pair.value)),".indent(by: 2))\n"
       }
-      .joined(separator: ",\n")
-      .indent(by: 2)
-    return """
-      \(mirror.subjectType).\(child.label!)(
-      \(elements)
-      )
-      """
-      .indent(by: indent)
-  case (_, .enum?):
-    return """
-      \(mirror.subjectType).\(value)
-      """
-      .indent(by: indent)
-  case (_, .struct?) where !mirror.children.isEmpty, (_, .class?) where !mirror.children.isEmpty:
-    let elements = mirror.children
-      .map { "\($0.label.map { "\($0): " } ?? "")\(debugOutput($0.value))".indent(by: 2) }
-      .joined(separator: ",\n")
-    return """
-      \(mirror.subjectType)(
-      \(elements)
-      )
-      """
-      .indent(by: indent)
-  case let (value as CustomStringConvertible, .class?):
-    return value.description
-      .replacingOccurrences(of: #"^<([^:]+): 0x[^>]+>$"#, with: "$1()", options: .regularExpression)
-      .indent(by: indent)
-  case let (value as CustomDebugStringConvertible, _):
-    return value.debugDescription
-      .replacingOccurrences(of: #"^<([^:]+): 0x[^>]+>$"#, with: "$1()", options: .regularExpression)
-      .indent(by: indent)
-  case let (value as CustomStringConvertible, _):
-    return value.description
-      .indent(by: indent)
-  case (_, .struct?), (_, .class?):
-    return "\(mirror.subjectType)()"
-      .indent(by: indent)
-  case (_, .tuple?) where mirror.children.isEmpty:
-    return "()"
-      .indent(by: indent)
-  case (_, .tuple?):
-    let elements = mirror.children.map { child -> String in
-      let label = child.label!
-      return "\(label.hasPrefix(".") ? "" : "\(label): ")\(debugOutput(child.value))".indent(by: 2)
+      return """
+        [
+        \(pairs.sorted().joined())]
+        """
+        .indent(by: indent)
+    case (_, .set?):
+      return """
+        Set([
+        \(mirror.children.map { "\(debugOutputHelp($0.value, indent: 2)),\n" }.sorted().joined())])
+        """
+        .indent(by: indent)
+    case (_, .optional?):
+      return mirror.children.isEmpty
+        ? "nil".indent(by: indent)
+        : debugOutputHelp(mirror.children.first!.value, indent: indent)
+    case (_, .enum?) where !mirror.children.isEmpty:
+      let child = mirror.children.first!
+      let childMirror = Mirror(reflecting: child.value)
+      let elements =
+        childMirror.displayStyle != .tuple
+        ? debugOutputHelp(child.value, indent: 2)
+        : childMirror.children.map { child -> String in
+          let label = child.label!
+          return "\(label.hasPrefix(".") ? "" : "\(label): ")\(debugOutputHelp(child.value))"
+        }
+        .joined(separator: ",\n")
+        .indent(by: 2)
+      return """
+        \(mirror.subjectType).\(child.label!)(
+        \(elements)
+        )
+        """
+        .indent(by: indent)
+    case (_, .enum?):
+      return """
+        \(mirror.subjectType).\(value)
+        """
+        .indent(by: indent)
+    case (_, .struct?) where !mirror.children.isEmpty:
+      let elements = mirror.children
+        .map { "\($0.label.map { "\($0): " } ?? "")\(debugOutputHelp($0.value))".indent(by: 2) }
+        .joined(separator: ",\n")
+      return """
+        \(mirror.subjectType)(
+        \(elements)
+        )
+        """
+        .indent(by: indent)
+    case let (value as AnyObject, .class?) where !mirror.children.isEmpty && !visitedItems.contains(ObjectIdentifier(value)):
+      visitedItems.insert(ObjectIdentifier(value))
+      let elements = mirror.children
+        .map { "\($0.label.map { "\($0): " } ?? "")\(debugOutputHelp($0.value))".indent(by: 2) }
+        .joined(separator: ",\n")
+      return """
+        \(mirror.subjectType)(
+        \(elements)
+        )
+        """
+        .indent(by: indent)
+    case let (value as CustomStringConvertible, .class?):
+      return value.description
+        .replacingOccurrences(of: #"^<([^:]+): 0x[^>]+>$"#, with: "$1()", options: .regularExpression)
+        .indent(by: indent)
+    case let (value as CustomDebugStringConvertible, _):
+      return value.debugDescription
+        .replacingOccurrences(of: #"^<([^:]+): 0x[^>]+>$"#, with: "$1()", options: .regularExpression)
+        .indent(by: indent)
+    case let (value as CustomStringConvertible, _):
+      return value.description
+        .indent(by: indent)
+    case (_, .struct?), (_, .class?):
+      return "\(mirror.subjectType)()"
+        .indent(by: indent)
+    case (_, .tuple?) where mirror.children.isEmpty:
+      return "()"
+        .indent(by: indent)
+    case (_, .tuple?):
+      let elements = mirror.children.map { child -> String in
+        let label = child.label!
+        return "\(label.hasPrefix(".") ? "" : "\(label): ")\(debugOutputHelp(child.value))".indent(by: 2)
+      }
+      return """
+        (
+        \(elements.joined(separator: ",\n"))
+        )
+        """
+        .indent(by: indent)
+    case (_, nil):
+      return "\(value)"
+        .indent(by: indent)
+    @unknown default:
+      return "\(value)"
+        .indent(by: indent)
     }
-    return """
-      (
-      \(elements.joined(separator: ",\n"))
-      )
-      """
-      .indent(by: indent)
-  case (_, nil):
-    return "\(value)"
-      .indent(by: indent)
-  @unknown default:
-    return "\(value)"
-      .indent(by: indent)
   }
+
+  return debugOutputHelp(value, indent: indent)
 }
 
 func debugDiff<T>(_ before: T, _ after: T, printer: (T) -> String = { debugOutput($0) }) -> String?

--- a/Sources/ComposableArchitecture/Internal/Debug.swift
+++ b/Sources/ComposableArchitecture/Internal/Debug.swift
@@ -14,26 +14,31 @@ func debugOutput(_ value: Any, indent: Int = 0) -> String {
         \(mirror.children.map { "\(debugOutput($0.value, indent: 2)),\n" }.joined())]
         """
         .indent(by: indent)
+
     case (_, .dictionary?):
       let pairs = mirror.children.map { label, value -> String in
         let pair = value as! (key: AnyHashable, value: Any)
-        return "\("\(debugOutputHelp(pair.key.base)): \(debugOutputHelp(pair.value)),".indent(by: 2))\n"
+        return
+          "\("\(debugOutputHelp(pair.key.base)): \(debugOutputHelp(pair.value)),".indent(by: 2))\n"
       }
       return """
         [
         \(pairs.sorted().joined())]
         """
         .indent(by: indent)
+
     case (_, .set?):
       return """
         Set([
         \(mirror.children.map { "\(debugOutputHelp($0.value, indent: 2)),\n" }.sorted().joined())])
         """
         .indent(by: indent)
+
     case (_, .optional?):
       return mirror.children.isEmpty
         ? "nil".indent(by: indent)
         : debugOutputHelp(mirror.children.first!.value, indent: indent)
+
     case (_, .enum?) where !mirror.children.isEmpty:
       let child = mirror.children.first!
       let childMirror = Mirror(reflecting: child.value)
@@ -52,11 +57,13 @@ func debugOutput(_ value: Any, indent: Int = 0) -> String {
         )
         """
         .indent(by: indent)
+
     case (_, .enum?):
       return """
         \(mirror.subjectType).\(value)
         """
         .indent(by: indent)
+
     case (_, .struct?) where !mirror.children.isEmpty:
       let elements = mirror.children
         .map { "\($0.label.map { "\($0): " } ?? "")\(debugOutputHelp($0.value))".indent(by: 2) }
@@ -67,7 +74,9 @@ func debugOutput(_ value: Any, indent: Int = 0) -> String {
         )
         """
         .indent(by: indent)
-    case let (value as AnyObject, .class?) where !mirror.children.isEmpty && !visitedItems.contains(ObjectIdentifier(value)):
+
+    case let (value as AnyObject, .class?)
+    where !mirror.children.isEmpty && !visitedItems.contains(ObjectIdentifier(value)):
       visitedItems.insert(ObjectIdentifier(value))
       let elements = mirror.children
         .map { "\($0.label.map { "\($0): " } ?? "")\(debugOutputHelp($0.value))".indent(by: 2) }
@@ -78,27 +87,42 @@ func debugOutput(_ value: Any, indent: Int = 0) -> String {
         )
         """
         .indent(by: indent)
+
+    case let (value as AnyObject, .class?)
+    where !mirror.children.isEmpty && visitedItems.contains(ObjectIdentifier(value)):
+      return "\(mirror.subjectType)(↩︎)"
+
     case let (value as CustomStringConvertible, .class?):
       return value.description
-        .replacingOccurrences(of: #"^<([^:]+): 0x[^>]+>$"#, with: "$1()", options: .regularExpression)
+        .replacingOccurrences(
+          of: #"^<([^:]+): 0x[^>]+>$"#, with: "$1()", options: .regularExpression
+        )
         .indent(by: indent)
+
     case let (value as CustomDebugStringConvertible, _):
       return value.debugDescription
-        .replacingOccurrences(of: #"^<([^:]+): 0x[^>]+>$"#, with: "$1()", options: .regularExpression)
+        .replacingOccurrences(
+          of: #"^<([^:]+): 0x[^>]+>$"#, with: "$1()", options: .regularExpression
+        )
         .indent(by: indent)
+
     case let (value as CustomStringConvertible, _):
       return value.description
         .indent(by: indent)
+
     case (_, .struct?), (_, .class?):
       return "\(mirror.subjectType)()"
         .indent(by: indent)
+
     case (_, .tuple?) where mirror.children.isEmpty:
       return "()"
         .indent(by: indent)
+
     case (_, .tuple?):
       let elements = mirror.children.map { child -> String in
         let label = child.label!
-        return "\(label.hasPrefix(".") ? "" : "\(label): ")\(debugOutputHelp(child.value))".indent(by: 2)
+        return "\(label.hasPrefix(".") ? "" : "\(label): ")\(debugOutputHelp(child.value))"
+          .indent(by: 2)
       }
       return """
         (
@@ -106,9 +130,11 @@ func debugOutput(_ value: Any, indent: Int = 0) -> String {
         )
         """
         .indent(by: indent)
+
     case (_, nil):
       return "\(value)"
         .indent(by: indent)
+
     @unknown default:
       return "\(value)"
         .indent(by: indent)

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -373,6 +373,22 @@ final class DebugTests: XCTestCase {
     )
   }
 
+  func testRecursiveOutput() {
+    class Foo {
+      var foo: Foo?
+    }
+    let foo = Foo()
+    foo.foo = foo
+    XCTAssertEqual(
+      debugOutput(foo),
+      """
+      Foo(
+        foo: Foo()
+      )
+      """
+    )
+  }
+
   func testEffectOutput() {
     //    XCTAssertEqual(
     //      Effect<Int, Never>(value: 42)

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -383,7 +383,7 @@ final class DebugTests: XCTestCase {
       debugOutput(foo),
       """
       Foo(
-        foo: Foo()
+        foo: Foo(↩︎)
       )
       """
     )


### PR DESCRIPTION
While state is generally a value type that cannot recursively reference itself, state still could contain the occasional reference type, which could contain a recursive reference to itself, so let's do what `dump` does and keep track of recursive items.