### PR TITLE
Change link to Loop / ReactiveFeedback project

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ The Composable Architecture was built on a foundation of ideas started by other 
 There are also many architecture libraries in the Swift and iOS community. Each one of these has their own set of priorities and trade-offs that differ from the Composable Architecture.
 
 * [RIBs](https://github.com/uber/RIBs)
-* [Loop](https://github.com/ReactiveCocoa/Loop) (previously know as ReactiveFeedback)
+* [Loop](https://github.com/ReactiveCocoa/Loop)
 * [ReSwift](https://github.com/ReSwift/ReSwift)
 * [Workflow](https://github.com/square/workflow)
 * [ReactorKit](https://github.com/ReactorKit/ReactorKit)

--- a/README.md
+++ b/README.md
@@ -375,12 +375,12 @@ The Composable Architecture was built on a foundation of ideas started by other 
 There are also many architecture libraries in the Swift and iOS community. Each one of these has their own set of priorities and trade-offs that differ from the Composable Architecture.
 
 * [RIBs](https://github.com/uber/RIBs)
+* [Loop](https://github.com/ReactiveCocoa/Loop) (previously know as ReactiveFeedback)
 * [ReSwift](https://github.com/ReSwift/ReSwift)
 * [Workflow](https://github.com/square/workflow)
 * [ReactorKit](https://github.com/ReactorKit/ReactorKit)
 * [RxFeedback](https://github.com/NoTests/RxFeedback.swift)
 * [Mobius.swift](https://github.com/spotify/mobius.swift)
-* [Loop](https://github.com/ReactiveCocoa/Loop) (previously know as ReactiveFeedback)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ There are also many architecture libraries in the Swift and iOS community. Each 
 * [ReactorKit](https://github.com/ReactorKit/ReactorKit)
 * [RxFeedback](https://github.com/NoTests/RxFeedback.swift)
 * [Mobius.swift](https://github.com/spotify/mobius.swift)
-* [ReactiveFeedback](https://github.com/babylonhealth/ReactiveFeedback)
+* [Loop](https://github.com/ReactiveCocoa/Loop) (previously know as ReactiveFeedback)
 
 ## License
 


### PR DESCRIPTION
The original creators and maintainers of ReactiveFeedback have created a fork in the [ReactiveCocoa](https://github.com/ReactiveCocoa) organisation, called Loop, and are no longer maintaining the ReactiveFeedback repo. Loop should now be considered the canonical version of this project.

cc: @sergdort and @andersio