### PR TITLE
Add and remove map annotations only when necessary

### DIFF
--- a/Examples/LocationManager/Common/AppCore.swift
+++ b/Examples/LocationManager/Common/AppCore.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import ComposableCoreLocation
 import MapKit
 
-public struct PointOfInterest: Equatable {
+public struct PointOfInterest: Equatable, Hashable {
   public let coordinate: CLLocationCoordinate2D
   public let subtitle: String?
   public let title: String?
@@ -224,5 +224,12 @@ extension PointOfInterest {
       && lhs.coordinate.longitude == rhs.coordinate.longitude
       && lhs.subtitle == rhs.subtitle
       && lhs.title == rhs.title
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(coordinate.latitude)
+    hasher.combine(coordinate.longitude)
+    hasher.combine(title)
+    hasher.combine(subtitle)
   }
 }

--- a/Examples/LocationManager/Common/MapView.swift
+++ b/Examples/LocationManager/Common/MapView.swift
@@ -55,10 +55,16 @@ public struct MapView: ViewRepresentable {
       mapView.setRegion(region.asMKCoordinateRegion, animated: true)
     }
 
-    mapView.removeAnnotations(mapView.annotations)
-    mapView.addAnnotations(
-      self.pointsOfInterest.map(PointOfInterestAnnotation.init(pointOfInterest:))
-    )
+    let currentlyDisplayedPOIs = mapView.annotations.compactMap { $0 as? PointOfInterestAnnotation }.map(\.pointOfInterest)
+    
+    let addedPOIs = Set(pointsOfInterest).subtracting(currentlyDisplayedPOIs)
+    let removedPOIs = Set(currentlyDisplayedPOIs).subtracting(pointsOfInterest)
+
+    let addedAnnotations = addedPOIs.map(PointOfInterestAnnotation.init(pointOfInterest:))
+    let removedAnnotations = mapView.annotations.compactMap { $0 as? PointOfInterestAnnotation }.filter { removedPOIs.contains($0.pointOfInterest) }
+
+    mapView.removeAnnotations(removedAnnotations)
+    mapView.addAnnotations(addedAnnotations)
   }
 }
 

--- a/Examples/LocationManager/Common/MapView.swift
+++ b/Examples/LocationManager/Common/MapView.swift
@@ -55,7 +55,7 @@ public struct MapView: ViewRepresentable {
       mapView.setRegion(region.asMKCoordinateRegion, animated: true)
     }
 
-    let currentlyDisplayedPOIs = mapView.annotations.compactMap { $0 as? PointOfInterestAnnotation }.map(\.pointOfInterest)
+    let currentlyDisplayedPOIs = mapView.annotations.compactMap { $0 as? PointOfInterestAnnotation }.map { $0.pointOfInterest }
     
     let addedPOIs = Set(pointsOfInterest).subtracting(currentlyDisplayedPOIs)
     let removedPOIs = Set(currentlyDisplayedPOIs).subtracting(pointsOfInterest)


### PR DESCRIPTION
Currently `MapView` removes and then re-adds all annotations regardless of if it's currently displayed or not. This causes an unpleasant flashing after each region change. 
This PR diffs the new point of interests with the existing ones to decide which annotations should be removed / added.