### PR TITLE
Implement sort() and sort(by:) for IdentifiedArray.

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/IdentifiedArray.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/IdentifiedArray.swift
@@ -184,6 +184,12 @@ where ID: Hashable {
   public mutating func move(fromOffsets source: IndexSet, toOffset destination: Int) {
     self.ids.move(fromOffsets: source, toOffset: destination)
   }
+
+  public mutating func sort(by areInIncreasingOrder: (Element, Element) throws -> Bool) rethrows {
+    try self.ids.sort {
+      try areInIncreasingOrder(self.dictionary[$0]!, self.dictionary[$1]!)
+    }
+  }
 }
 
 extension IdentifiedArray: CustomDebugStringConvertible {
@@ -219,6 +225,12 @@ extension IdentifiedArray: Encodable where Element: Encodable {
 extension IdentifiedArray: Equatable where Element: Equatable {}
 
 extension IdentifiedArray: Hashable where Element: Hashable {}
+
+extension IdentifiedArray where Element: Comparable {
+  public mutating func sort() {
+    sort(by: <)
+  }
+}
 
 extension IdentifiedArray: ExpressibleByArrayLiteral where Element: Identifiable, ID == Element.ID {
   public init(arrayLiteral elements: Element...) {

--- a/Tests/ComposableArchitectureTests/IdentifiedArrayTests.swift
+++ b/Tests/ComposableArchitectureTests/IdentifiedArrayTests.swift
@@ -149,4 +149,50 @@ final class IdentifiedArrayTests: XCTestCase {
       ]
     )
   }
+
+  struct ComparableValue: Comparable, Identifiable {
+    let id: Int
+    let value: Int
+
+    static func < (lhs: ComparableValue, rhs: ComparableValue) -> Bool {
+      return lhs.value < rhs.value
+    }
+  }
+
+  func testSortBy() {
+    var array: IdentifiedArray = [
+      ComparableValue(id: 1, value: 100),
+      ComparableValue(id: 2, value: 50),
+      ComparableValue(id: 3, value: 75),
+    ]
+
+    array.sort { $0.value < $1.value }
+
+    XCTAssertEqual([2, 3, 1], array.ids)
+    XCTAssertEqual(
+      [
+        ComparableValue(id: 2, value: 50),
+        ComparableValue(id: 3, value: 75),
+        ComparableValue(id: 1, value: 100),
+      ], array)
+  }
+
+  func testSort() {
+    var array: IdentifiedArray = [
+      ComparableValue(id: 1, value: 100),
+      ComparableValue(id: 2, value: 50),
+      ComparableValue(id: 3, value: 75),
+    ]
+
+    array.sort()
+
+    XCTAssertEqual([2, 3, 1], array.ids)
+    XCTAssertEqual(
+      [
+        ComparableValue(id: 2, value: 50),
+        ComparableValue(id: 3, value: 75),
+        ComparableValue(id: 1, value: 100),
+      ], array)
+
+  }
 }


### PR DESCRIPTION
I'd love to figure out why `sort` didn't work without these methods, but it seemed like the elements were sorted correctly, but the ids were not.