### PR TITLE
Correctly show (no state changes) in diff.

### DIFF
--- a/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
@@ -75,7 +75,7 @@ extension Reducer {
             debugEnvironment.queue.async {
               let actionOutput = debugOutput(localAction).indent(by: 2)
               let stateOutput =
-                debugDiff(previousState, nextState).map { "\($0)\n" } ?? "  (No state changes)"
+                debugDiff(previousState, nextState).map { "\($0)\n" } ?? "  (No state changes)\n"
               debugEnvironment.printer(
                 """
                 \(prefix.isEmpty ? "" : "\(prefix): ")received action:

--- a/Sources/ComposableArchitecture/Internal/Diff.swift
+++ b/Sources/ComposableArchitecture/Internal/Diff.swift
@@ -71,7 +71,7 @@ func diff(_ first: String, _ second: String) -> String? {
     first.split(separator: "\n", omittingEmptySubsequences: false)[...],
     second.split(separator: "\n", omittingEmptySubsequences: false)[...]
   )
-  guard !differences.isEmpty else { return nil }
+  if differences.count == 1, case .both = differences[0].which { return nil }
   var string = differences.reduce(into: "") { string, diff in
     diff.elements.forEach { line in
       string += "\(diff.which.prefix) \(line)\n"


### PR DESCRIPTION
We found this while working off a feature branch, so just wanting to get it into master.