### PR TITLE
Update docs for Effect.timer

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Timer.swift
+++ b/Sources/ComposableArchitecture/Effects/Timer.swift
@@ -14,7 +14,6 @@ extension Effect {
   ///     case .startTimer:
   ///       return Effect.timer(id: TimerId(), every: 1, on: environment.scheduler)
   ///         .map { .timerUpdated($0) }
-  ///         .cancellable(id: TimerId())
   ///     case let .timerUpdated(date):
   ///       state.date = date
   ///       return .none


### PR DESCRIPTION
@dannyhertz tipped us off to this. This documentation is a little out of date because cancellation is now automatically baked into all effect timers.