### PR TITLE
Add toast on failures case study

### DIFF
--- a/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
+++ b/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		36DBEC47247BFFFD00AF9C80 /* 04-HigherOrderReducers-FailureToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36DBEC46247BFFFD00AF9C80 /* 04-HigherOrderReducers-FailureToast.swift */; };
 		CA0C51FB245389CC00A04EAB /* 04-HigherOrderReducers-ResuableOfflineDownloadsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C51FA245389CC00A04EAB /* 04-HigherOrderReducers-ResuableOfflineDownloadsTests.swift */; };
 		CA25E5D224463AD700DA666A /* 01-GettingStarted-Bindings-Basics.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA25E5D124463AD700DA666A /* 01-GettingStarted-Bindings-Basics.swift */; };
 		CA27C0B7245780CE00CB1E59 /* 03-Effects-SystemEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA27C0B6245780CE00CB1E59 /* 03-Effects-SystemEnvironment.swift */; };
@@ -122,6 +123,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		36DBEC46247BFFFD00AF9C80 /* 04-HigherOrderReducers-FailureToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-FailureToast.swift"; sourceTree = "<group>"; };
 		CA0C51FA245389CC00A04EAB /* 04-HigherOrderReducers-ResuableOfflineDownloadsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-ResuableOfflineDownloadsTests.swift"; sourceTree = "<group>"; };
 		CA25E5D124463AD700DA666A /* 01-GettingStarted-Bindings-Basics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-GettingStarted-Bindings-Basics.swift"; sourceTree = "<group>"; };
 		CA27C0B6245780CE00CB1E59 /* 03-Effects-SystemEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "03-Effects-SystemEnvironment.swift"; sourceTree = "<group>"; };
@@ -323,6 +325,7 @@
 				DCE63B70245CC0B90080A23D /* 04-HigherOrderReducers-Recursion.swift */,
 				DCC68EE22447C8540037F998 /* 04-HigherOrderReducers-ReusableFavoriting.swift */,
 				DC2E370C24573ACB00B94699 /* 04-HigherOrderReducers-StrictReducers.swift */,
+				36DBEC46247BFFFD00AF9C80 /* 04-HigherOrderReducers-FailureToast.swift */,
 				DC89C41824460F95006900B9 /* SceneDelegate.swift */,
 				DC89C41C24460F96006900B9 /* Assets.xcassets */,
 				CA6AC25F2451131C00C71CB3 /* 04-HigherOrderReducers-ResuableOfflineDownloads */,
@@ -572,6 +575,7 @@
 				CAA9ADC624465C810003A984 /* 02-Effects-Cancellation.swift in Sources */,
 				DC2E370D24573ACB00B94699 /* 04-HigherOrderReducers-StrictReducers.swift in Sources */,
 				DC9EB4172450CBD2005F413B /* UIViewRepresented.swift in Sources */,
+				36DBEC47247BFFFD00AF9C80 /* 04-HigherOrderReducers-FailureToast.swift in Sources */,
 				DC89C41924460F95006900B9 /* SceneDelegate.swift in Sources */,
 				CA6AC2652451135C00C71CB3 /* CircularProgressView.swift in Sources */,
 				CA6AC2642451135C00C71CB3 /* ReusableComponents-Download.swift in Sources */,

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -309,7 +309,6 @@ struct RootView: View {
                 initialState: AppState(),
                 reducer: combinedFailureToastReducer,
                 environment: AppEnvironment(
-                  mainQueue: DispatchQueue.main.eraseToAnyScheduler(),
                   loadData: {
                     Fail(error: AppError.api)
                       .delay(for: 1, scheduler: DispatchQueue.main)

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -304,10 +304,10 @@ struct RootView: View {
 
           NavigationLink(
             "Toast on all failures",
-            destination: DataView(
+            destination: AppView(
               store: Store(
                 initialState: AppState(),
-                reducer: Reducer<AppState, AppAction, AppEnvironment>.errorHandling(appReducer),
+                reducer: combinedFailureToastReducer,
                 environment: AppEnvironment(
                   mainQueue: DispatchQueue.main.eraseToAnyScheduler(),
                   loadData: {

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -301,6 +301,24 @@ struct RootView: View {
               )
             )
           )
+
+          NavigationLink(
+            "Toast on all failures",
+            destination: DataView(
+              store: Store(
+                initialState: AppState(),
+                reducer: Reducer<AppState, AppAction, AppEnvironment>.errorHandling(appReducer),
+                environment: AppEnvironment(
+                  mainQueue: DispatchQueue.main.eraseToAnyScheduler(),
+                  loadData: {
+                    Fail(error: AppError.api)
+                      .delay(for: 1, scheduler: DispatchQueue.main)
+                      .eraseToEffect()
+                  }
+                )
+              )
+            )
+          )
         }
       }
       .navigationBarTitle("Case Studies")

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-FailureToast.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-FailureToast.swift
@@ -45,11 +45,7 @@ enum ToastAction {
   case hide
 }
 
-struct ToastEnvironment {
-  var mainQueue: AnySchedulerOf<DispatchQueue>
-}
-
-let toastReducer = Reducer<ToastState, ToastAction, ToastEnvironment> { state, action, environment in
+let toastReducer = Reducer<ToastState, ToastAction, Void> { state, action, _ in
   switch action {
   case .show(let text):
     state.status = .showing(text)
@@ -112,7 +108,6 @@ enum AppAction {
 }
 
 struct AppEnvironment {
-  var mainQueue: AnySchedulerOf<DispatchQueue>
   var loadData: () -> Effect<[String], Error>
 }
 
@@ -159,7 +154,7 @@ let combinedFailureToastReducer = Reducer<AppState, AppAction, AppEnvironment>.c
   toastReducer.pullback(
     state: \AppState.toastState,
     action: /AppAction.toastAction,
-    environment: { _ in ToastEnvironment(mainQueue: DispatchQueue.main.eraseToAnyScheduler()) }
+    environment: { _ in () }
   )
 )
 
@@ -170,7 +165,6 @@ struct ToastView_Previews: PreviewProvider {
         initialState: AppState(),
         reducer: combinedFailureToastReducer,
         environment: AppEnvironment(
-          mainQueue: DispatchQueue.main.eraseToAnyScheduler(),
           loadData: {
             Fail(error: AppError.api)
               .delay(for: 1, scheduler: DispatchQueue.main)

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-FailureToast.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-FailureToast.swift
@@ -1,0 +1,145 @@
+import Combine
+import ComposableArchitecture
+import SwiftUI
+
+private let readMe = """
+  This screen demonstrates how the `Reducer` struct can be extended to enhance reducers with extra \
+  functionality.
+
+  In it we introduce an `errorHandling` reducer that consumes the failable `appReducer`. \
+  It handles the errors by way of a toast, and returns the usual non-failing reducer.
+
+  This form of reducer is useful if you want to centralize and handle failures in the same way. \
+  Without this, each routine executed in the `appReducer` would need to handle it's own failure.
+
+  Tapping the "Load Data" button will fail after one second and show a toast.
+  """
+
+enum AppError: Error, LocalizedError {
+  case api
+
+  var errorDescription: String? { "Whoops! There was a server error." }
+}
+
+struct AppState: Equatable {
+  var toastStatus: ToastStatus = .hiding
+  var data: [String] = []
+}
+
+enum ToastStatus: Equatable {
+  case showing(String)
+  case hiding
+
+  var isShowing: Bool {
+      switch self {
+      case .showing: return true
+      case .hiding: return false
+      }
+  }
+
+  var text: String {
+      switch self {
+      case .showing(let text): return text
+      case .hiding: return ""
+      }
+  }
+}
+
+enum AppAction {
+  case showToast(String)
+  case hideToast
+  case loadData
+  case didLoadData([String])
+}
+
+struct AppEnvironment {
+  var mainQueue: AnySchedulerOf<DispatchQueue>
+  var loadData: () -> Effect<[String], Error>
+}
+
+let appReducer: (inout AppState, AppAction, AppEnvironment) -> Effect<AppAction, Error> = { state, action, environment in
+  switch action {
+  case .showToast(let text):
+    state.toastStatus = .showing(text)
+    return .none
+
+  case .hideToast:
+    state.toastStatus = .hiding
+    return .none
+
+  case .loadData:
+    return environment.loadData().map(AppAction.didLoadData)
+
+  case .didLoadData(let data):
+    state.data = data
+    return .none
+  }
+}
+
+extension Reducer {
+  static func errorHandling(
+    _ reducer: @escaping (inout AppState, AppAction, AppEnvironment) -> Effect<AppAction, Error>
+  ) -> Reducer<AppState, AppAction, AppEnvironment> {
+    Reducer<AppState, AppAction, AppEnvironment> { state, action, environment in
+      reducer(&state, action, environment)
+        .catch { Just(.showToast($0.localizedDescription)) }
+        .eraseToEffect()
+    }
+  }
+}
+
+struct ToastView: View {
+  let store: Store<AppState, AppAction>
+
+  var body: some View {
+    WithViewStore(self.store) { viewStore in
+      if viewStore.toastStatus.isShowing {
+        Text(viewStore.toastStatus.text)
+          .padding()
+          .foregroundColor(.white)
+          .background(Color.gray.opacity(0.8))
+          .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) { viewStore.send(.hideToast) }
+          }
+      }
+    }
+  }
+}
+
+struct DataView: View {
+  let store: Store<AppState, AppAction>
+
+  var body: some View {
+    WithViewStore(self.store) { viewStore in
+      ZStack(alignment: .bottom) {
+        Form {
+          Section(header: Text(template: readMe, .caption)) {
+            Button("Load Data") { viewStore.send(.loadData) }
+            ForEach(viewStore.state.data, id: \.self) { Text($0) }
+          }
+        }
+        ToastView(store: self.store)
+      }
+      .navigationBarTitle("Failure Toast")
+    }
+  }
+}
+
+struct ToastView_Previews: PreviewProvider {
+  static var previews: some View {
+    DataView(
+      store: Store(
+        initialState: AppState(),
+        reducer: Reducer<AppState, AppAction, AppEnvironment>.errorHandling(appReducer),
+        environment: AppEnvironment(
+          mainQueue: DispatchQueue.main.eraseToAnyScheduler(),
+          loadData: {
+            Fail(error: AppError.api)
+              .delay(for: 1, scheduler: DispatchQueue.main)
+              .eraseToEffect()
+          }
+        )
+      )
+    )
+  }
+}


### PR DESCRIPTION
Demonstrates how a higher order reducer can be used to show a toast on all failures.

We're looking for this kind of functionality in our app and came up with this based on the other case studies. Looking for feedback and if suitable, hopefully helpful for others. 🙏 

![Toasts](https://user-images.githubusercontent.com/2365037/83684818-ab4f8380-a5b5-11ea-9636-9a481e61080d.gif)