### PR TITLE
Clarify assertion failure for incorrect send usage

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -149,7 +149,7 @@ public final class Store<State, Action> {
         
         * The store has been sent actions from multiple threads. The `send` method is not thread \
         safe, and should only ever be used from a single thread (typically the main thread). 
-        Instead call `send` from multiple threads you should use effects to process expensive \
+        Instead of calling `send` from multiple threads you should use effects to process expensive \
         computations on background threads so that it can be fed back into the store.
         """
       )

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -147,8 +147,8 @@ public final class Store<State, Action> {
         frames corresponding to one of your reducers. That code should be refactored to not invoke \
         the effect directly.
         
-        * The store has been sent actions from multiple threads. The `send` method is not thread \
-        safe, and should only ever be used from a single thread (typically the main thread). 
+        * The store has been sent actions from multiple threads. The `send` method is not \
+        thread-safe, and should only ever be used from a single thread (typically the main thread). 
         Instead of calling `send` from multiple threads you should use effects to process expensive \
         computations on background threads so that it can be fed back into the store.
         """

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -139,10 +139,18 @@ public final class Store<State, Action> {
     if self.isSending {
       assertionFailure(
         """
-        The store was sent an action recursively. This can occur when you run an effect directly \
+        The store was sent an action while it was already processing another action. This can \
+        happen for a few reasons:
+        
+        * The store was sent an action recursively. This can occur when you run an effect directly \
         in the reducer, rather than returning it from the reducer. Check the stack (⌘7) to find \
         frames corresponding to one of your reducers. That code should be refactored to not invoke \
         the effect directly.
+        
+        * The store has been sent actions from multiple threads. The `send` method is not thread \
+        safe, and should only ever be used from a single thread (typically the main thread). 
+        Instead call `send` from multiple threads you should use effects to process expensive \
+        computations on background threads so that it can be fed back into the store.
         """
       )
     }

--- a/Sources/ComposableArchitecture/SwiftUI/ViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ViewStore.swift
@@ -78,6 +78,10 @@ public final class ViewStore<State, Action>: ObservableObject {
   /// Sends an action to the store.
   ///
   /// `ViewStore` is not thread safe and you should only send actions to it from the main thread.
+  /// If you are wanting to send actions on background threads due to the fact that the reducer
+  /// is performing computationally expensive work, then a better way to handle this is to wrap
+  /// that work in an `Effect` that is performed on a background thread so that the result can
+  /// be fed back into the store.
   ///
   /// - Parameter action: An action.
   public func send(_ action: Action) {


### PR DESCRIPTION
[This](https://forums.swift.org/t/why-isnt-send-method-atomic/36984) question on the forum made me realize that we need to better clarify this assertion failure. This is one idea, open to others though.