### PR TITLE
Allow references to missing items of IdentifiedArray.

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/IdentifiedArray.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/IdentifiedArray.swift
@@ -110,7 +110,7 @@ where ID: Hashable {
             """
           )
         }
-        if newValue == nil {
+        if newValue == nil, self.dictionary[id] != nil {
           fatalError(
             """
             Can't update element with identifier \(id) with nil.

--- a/Tests/ComposableArchitectureTests/IdentifiedArrayTests.swift
+++ b/Tests/ComposableArchitectureTests/IdentifiedArrayTests.swift
@@ -195,4 +195,10 @@ final class IdentifiedArrayTests: XCTestCase {
       ], array)
 
   }
+
+    func testReferenceToMissing() {
+        var array = IdentifiedArray<Int, Int>([1], id: \.self)
+        func takesReference(_ item: inout Int?) { }
+        takesReference(&array[id: 3])
+    }
 }


### PR DESCRIPTION
I started some discussion of this on the [Swift Forums](https://forums.swift.org/t/allow-sending-actions-to-deleted-identifiedarray-items/36999/4).

After digging into the crash, and the implementation of `forEach`, I think it's just a bug in IdentifiedArray.

This pull request fixes the issue for DEBUG builds by allowing a newValue of `nil` if there is no key for id present in the dictionary.