### PR TITLE
Add assertion to Reducer.optional

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -26,6 +26,11 @@ struct OptionalBasicsEnvironment {}
 let optionalBasicsReducer = Reducer<
   OptionalBasicsState, OptionalBasicsAction, OptionalBasicsEnvironment
 >.combine(
+  counterReducer.optional.pullback(
+    state: \.optionalCounter,
+    action: /OptionalBasicsAction.optionalCounter,
+    environment: { _ in CounterEnvironment() }
+  ),
   Reducer { state, action, environment in
     switch action {
     case .toggleCounterButtonTapped:
@@ -37,12 +42,7 @@ let optionalBasicsReducer = Reducer<
     case .optionalCounter:
       return .none
     }
-  },
-  counterReducer.optional.pullback(
-    state: \.optionalCounter,
-    action: /OptionalBasicsAction.optionalCounter,
-    environment: { _ in CounterEnvironment() }
-  )
+  }
 )
 
 struct OptionalBasicsView: View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -23,27 +23,29 @@ enum OptionalBasicsAction: Equatable {
 
 struct OptionalBasicsEnvironment {}
 
-let optionalBasicsReducer = Reducer<
-  OptionalBasicsState, OptionalBasicsAction, OptionalBasicsEnvironment
->.combine(
-  counterReducer.optional.pullback(
+let optionalBasicsReducer = counterReducer
+  .optional
+  .pullback(
     state: \.optionalCounter,
     action: /OptionalBasicsAction.optionalCounter,
     environment: { _ in CounterEnvironment() }
-  ),
-  Reducer { state, action, environment in
-    switch action {
-    case .toggleCounterButtonTapped:
-      state.optionalCounter =
-        state.optionalCounter == nil
-        ? CounterState()
-        : nil
-      return .none
-    case .optionalCounter:
-      return .none
+  )
+  .combined(
+    with: Reducer<
+      OptionalBasicsState, OptionalBasicsAction, OptionalBasicsEnvironment
+    > { state, action, environment in
+      switch action {
+      case .toggleCounterButtonTapped:
+        state.optionalCounter =
+          state.optionalCounter == nil
+          ? CounterState()
+          : nil
+        return .none
+      case .optionalCounter:
+        return .none
+      }
     }
-  }
-)
+  )
 
 struct OptionalBasicsView: View {
   let store: Store<OptionalBasicsState, OptionalBasicsAction>

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
@@ -123,7 +123,7 @@ let sharedStateProfileReducer = Reducer<
   }
 }
 
-let sharedStateReducer: Reducer<SharedState, SharedStateAction, Void> = .combine(
+let sharedStateReducer = Reducer<SharedState, SharedStateAction, Void>.combine(
   sharedStateCounterReducer.pullback(
     state: \SharedState.counter,
     action: /SharedStateAction.counter,

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -29,6 +29,11 @@ struct LazyNavigationEnvironment {
 let lazyNavigationReducer = Reducer<
   LazyNavigationState, LazyNavigationAction, LazyNavigationEnvironment
 >.combine(
+  counterReducer.optional.pullback(
+    state: \.optionalCounter,
+    action: /LazyNavigationAction.optionalCounter,
+    environment: { _ in CounterEnvironment() }
+  ),
   Reducer { state, action, environment in
     switch action {
     case .setNavigation(isActive: true):
@@ -49,12 +54,7 @@ let lazyNavigationReducer = Reducer<
     case .optionalCounter:
       return .none
     }
-  },
-  counterReducer.optional.pullback(
-    state: \.optionalCounter,
-    action: /LazyNavigationAction.optionalCounter,
-    environment: { _ in CounterEnvironment() }
-  )
+  }
 )
 
 struct LazyNavigationView: View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -26,36 +26,38 @@ struct LazyNavigationEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-let lazyNavigationReducer = Reducer<
-  LazyNavigationState, LazyNavigationAction, LazyNavigationEnvironment
->.combine(
-  counterReducer.optional.pullback(
+let lazyNavigationReducer = counterReducer
+  .optional
+  .pullback(
     state: \.optionalCounter,
     action: /LazyNavigationAction.optionalCounter,
     environment: { _ in CounterEnvironment() }
-  ),
-  Reducer { state, action, environment in
-    switch action {
-    case .setNavigation(isActive: true):
-      state.isActivityIndicatorVisible = true
-      return Effect(value: .setNavigationIsActiveDelayCompleted)
-        .delay(for: 1, scheduler: environment.mainQueue)
-        .eraseToEffect()
+  )
+  .combined(
+    with: Reducer<
+      LazyNavigationState, LazyNavigationAction, LazyNavigationEnvironment
+    > { state, action, environment in
+      switch action {
+      case .setNavigation(isActive: true):
+        state.isActivityIndicatorVisible = true
+        return Effect(value: .setNavigationIsActiveDelayCompleted)
+          .delay(for: 1, scheduler: environment.mainQueue)
+          .eraseToEffect()
 
-    case .setNavigation(isActive: false):
-      state.optionalCounter = nil
-      return .none
+      case .setNavigation(isActive: false):
+        state.optionalCounter = nil
+        return .none
 
-    case .setNavigationIsActiveDelayCompleted:
-      state.isActivityIndicatorVisible = false
-      state.optionalCounter = CounterState()
-      return .none
+      case .setNavigationIsActiveDelayCompleted:
+        state.isActivityIndicatorVisible = false
+        state.optionalCounter = CounterState()
+        return .none
 
-    case .optionalCounter:
-      return .none
+      case .optionalCounter:
+        return .none
+      }
     }
-  }
-)
+  )
 
 struct LazyNavigationView: View {
   let store: Store<LazyNavigationState, LazyNavigationAction>

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -28,6 +28,11 @@ struct EagerNavigationEnvironment {
 let eagerNavigationReducer = Reducer<
   EagerNavigationState, EagerNavigationAction, EagerNavigationEnvironment
 >.combine(
+  counterReducer.optional.pullback(
+    state: \.optionalCounter,
+    action: /EagerNavigationAction.optionalCounter,
+    environment: { _ in CounterEnvironment() }
+  ),
   Reducer { state, action, environment in
     switch action {
     case .setNavigation(isActive: true):
@@ -48,12 +53,7 @@ let eagerNavigationReducer = Reducer<
     case .optionalCounter:
       return .none
     }
-  },
-  counterReducer.optional.pullback(
-    state: \.optionalCounter,
-    action: /EagerNavigationAction.optionalCounter,
-    environment: { _ in CounterEnvironment() }
-  )
+  }
 )
 
 struct EagerNavigationView: View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -25,36 +25,38 @@ struct EagerNavigationEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-let eagerNavigationReducer = Reducer<
-  EagerNavigationState, EagerNavigationAction, EagerNavigationEnvironment
->.combine(
-  counterReducer.optional.pullback(
+let eagerNavigationReducer = counterReducer
+  .optional
+  .pullback(
     state: \.optionalCounter,
     action: /EagerNavigationAction.optionalCounter,
     environment: { _ in CounterEnvironment() }
-  ),
-  Reducer { state, action, environment in
-    switch action {
-    case .setNavigation(isActive: true):
-      state.isNavigationActive = true
-      return Effect(value: .setNavigationIsActiveDelayCompleted)
-        .delay(for: 1, scheduler: environment.mainQueue)
-        .eraseToEffect()
+  )
+  .combined(
+    with: Reducer<
+      EagerNavigationState, EagerNavigationAction, EagerNavigationEnvironment
+    > { state, action, environment in
+      switch action {
+      case .setNavigation(isActive: true):
+        state.isNavigationActive = true
+        return Effect(value: .setNavigationIsActiveDelayCompleted)
+          .delay(for: 1, scheduler: environment.mainQueue)
+          .eraseToEffect()
 
-    case .setNavigation(isActive: false):
-      state.isNavigationActive = false
-      state.optionalCounter = nil
-      return .none
+      case .setNavigation(isActive: false):
+        state.isNavigationActive = false
+        state.optionalCounter = nil
+        return .none
 
-    case .setNavigationIsActiveDelayCompleted:
-      state.optionalCounter = CounterState()
-      return .none
+      case .setNavigationIsActiveDelayCompleted:
+        state.optionalCounter = CounterState()
+        return .none
 
-    case .optionalCounter:
-      return .none
+      case .optionalCounter:
+        return .none
+      }
     }
-  }
-)
+  )
 
 struct EagerNavigationView: View {
   let store: Store<EagerNavigationState, EagerNavigationAction>

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -29,6 +29,11 @@ struct LazySheetEnvironment {
 let lazySheetReducer = Reducer<
   LazySheetState, LazySheetAction, LazySheetEnvironment
 >.combine(
+  counterReducer.optional.pullback(
+    state: \.optionalCounter,
+    action: /LazySheetAction.optionalCounter,
+    environment: { _ in CounterEnvironment() }
+  ),
   Reducer { state, action, environment in
     switch action {
     case .setSheet(isPresented: true):
@@ -49,12 +54,7 @@ let lazySheetReducer = Reducer<
     case .optionalCounter:
       return .none
     }
-  },
-  counterReducer.optional.pullback(
-    state: \.optionalCounter,
-    action: /LazySheetAction.optionalCounter,
-    environment: { _ in CounterEnvironment() }
-  )
+  }
 )
 
 struct LazySheetView: View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -26,36 +26,38 @@ struct LazySheetEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-let lazySheetReducer = Reducer<
-  LazySheetState, LazySheetAction, LazySheetEnvironment
->.combine(
-  counterReducer.optional.pullback(
+let lazySheetReducer = counterReducer
+  .optional
+  .pullback(
     state: \.optionalCounter,
     action: /LazySheetAction.optionalCounter,
     environment: { _ in CounterEnvironment() }
-  ),
-  Reducer { state, action, environment in
-    switch action {
-    case .setSheet(isPresented: true):
-      state.isActivityIndicatorVisible = true
-      return Effect(value: .setSheetIsPresentedDelayCompleted)
-        .delay(for: 1, scheduler: environment.mainQueue)
-        .eraseToEffect()
+  )
+  .combined(
+    with: Reducer<
+      LazySheetState, LazySheetAction, LazySheetEnvironment
+    > { state, action, environment in
+      switch action {
+      case .setSheet(isPresented: true):
+        state.isActivityIndicatorVisible = true
+        return Effect(value: .setSheetIsPresentedDelayCompleted)
+          .delay(for: 1, scheduler: environment.mainQueue)
+          .eraseToEffect()
 
-    case .setSheet(isPresented: false):
-      state.optionalCounter = nil
-      return .none
+      case .setSheet(isPresented: false):
+        state.optionalCounter = nil
+        return .none
 
-    case .setSheetIsPresentedDelayCompleted:
-      state.isActivityIndicatorVisible = false
-      state.optionalCounter = CounterState()
-      return .none
+      case .setSheetIsPresentedDelayCompleted:
+        state.isActivityIndicatorVisible = false
+        state.optionalCounter = CounterState()
+        return .none
 
-    case .optionalCounter:
-      return .none
+      case .optionalCounter:
+        return .none
+      }
     }
-  }
-)
+  )
 
 struct LazySheetView: View {
   let store: Store<LazySheetState, LazySheetAction>

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -23,36 +23,38 @@ struct EagerSheetEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-let eagerSheetReducer = Reducer<
-  EagerSheetState, EagerSheetAction, EagerSheetEnvironment
->.combine(
-  counterReducer.optional.pullback(
+let eagerSheetReducer = counterReducer
+  .optional
+  .pullback(
     state: \.optionalCounter,
     action: /EagerSheetAction.optionalCounter,
     environment: { _ in CounterEnvironment() }
-  ),
-  Reducer { state, action, environment in
-    switch action {
-    case .setSheet(isPresented: true):
-      state.isSheetPresented = true
-      return Effect(value: .setSheetIsPresentedDelayCompleted)
-        .delay(for: 1, scheduler: environment.mainQueue)
-        .eraseToEffect()
+  )
+  .combined(
+    with: Reducer<
+      EagerSheetState, EagerSheetAction, EagerSheetEnvironment
+    > { state, action, environment in
+      switch action {
+      case .setSheet(isPresented: true):
+        state.isSheetPresented = true
+        return Effect(value: .setSheetIsPresentedDelayCompleted)
+          .delay(for: 1, scheduler: environment.mainQueue)
+          .eraseToEffect()
 
-    case .setSheet(isPresented: false):
-      state.isSheetPresented = false
-      state.optionalCounter = nil
-      return .none
+      case .setSheet(isPresented: false):
+        state.isSheetPresented = false
+        state.optionalCounter = nil
+        return .none
 
-    case .setSheetIsPresentedDelayCompleted:
-      state.optionalCounter = CounterState()
-      return .none
+      case .setSheetIsPresentedDelayCompleted:
+        state.optionalCounter = CounterState()
+        return .none
 
-    case .optionalCounter:
-      return .none
+      case .optionalCounter:
+        return .none
+      }
     }
-  }
-)
+  )
 
 struct EagerSheetView: View {
   let store: Store<EagerSheetState, EagerSheetAction>

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -26,6 +26,11 @@ struct EagerSheetEnvironment {
 let eagerSheetReducer = Reducer<
   EagerSheetState, EagerSheetAction, EagerSheetEnvironment
 >.combine(
+  counterReducer.optional.pullback(
+    state: \.optionalCounter,
+    action: /EagerSheetAction.optionalCounter,
+    environment: { _ in CounterEnvironment() }
+  ),
   Reducer { state, action, environment in
     switch action {
     case .setSheet(isPresented: true):
@@ -46,12 +51,7 @@ let eagerSheetReducer = Reducer<
     case .optionalCounter:
       return .none
     }
-  },
-  counterReducer.optional.pullback(
-    state: \.optionalCounter,
-    action: /EagerSheetAction.optionalCounter,
-    environment: { _ in CounterEnvironment() }
-  )
+  }
 )
 
 struct EagerSheetView: View {

--- a/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
@@ -18,33 +18,35 @@ struct LazyNavigationEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-let lazyNavigationReducer = Reducer<
-  LazyNavigationState, LazyNavigationAction, LazyNavigationEnvironment
->.combine(
-  counterReducer.optional.pullback(
+let lazyNavigationReducer = counterReducer
+  .optional
+  .pullback(
     state: \.optionalCounter,
     action: /LazyNavigationAction.optionalCounter,
     environment: { _ in CounterEnvironment() }
-  ),
-  Reducer { state, action, environment in
-    switch action {
-    case .setNavigation(isActive: true):
-      state.isActivityIndicatorHidden = false
-      return Effect(value: .setNavigationIsActiveDelayCompleted)
-        .delay(for: 1, scheduler: environment.mainQueue)
-        .eraseToEffect()
-    case .setNavigation(isActive: false):
-      state.optionalCounter = nil
-      return .none
-    case .setNavigationIsActiveDelayCompleted:
-      state.isActivityIndicatorHidden = true
-      state.optionalCounter = CounterState()
-      return .none
-    case .optionalCounter:
-      return .none
+  )
+  .combined(
+    with: Reducer<
+      LazyNavigationState, LazyNavigationAction, LazyNavigationEnvironment
+    > { state, action, environment in
+      switch action {
+      case .setNavigation(isActive: true):
+        state.isActivityIndicatorHidden = false
+        return Effect(value: .setNavigationIsActiveDelayCompleted)
+          .delay(for: 1, scheduler: environment.mainQueue)
+          .eraseToEffect()
+      case .setNavigation(isActive: false):
+        state.optionalCounter = nil
+        return .none
+      case .setNavigationIsActiveDelayCompleted:
+        state.isActivityIndicatorHidden = true
+        state.optionalCounter = CounterState()
+        return .none
+      case .optionalCounter:
+        return .none
+      }
     }
-  }
-)
+  )
 
 class LazyNavigationViewController: UIViewController {
   var cancellables: [AnyCancellable] = []

--- a/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
@@ -21,6 +21,11 @@ struct LazyNavigationEnvironment {
 let lazyNavigationReducer = Reducer<
   LazyNavigationState, LazyNavigationAction, LazyNavigationEnvironment
 >.combine(
+  counterReducer.optional.pullback(
+    state: \.optionalCounter,
+    action: /LazyNavigationAction.optionalCounter,
+    environment: { _ in CounterEnvironment() }
+  ),
   Reducer { state, action, environment in
     switch action {
     case .setNavigation(isActive: true):
@@ -38,12 +43,7 @@ let lazyNavigationReducer = Reducer<
     case .optionalCounter:
       return .none
     }
-  },
-  counterReducer.optional.pullback(
-    state: \.optionalCounter,
-    action: /LazyNavigationAction.optionalCounter,
-    environment: { _ in CounterEnvironment() }
-  )
+  }
 )
 
 class LazyNavigationViewController: UIViewController {

--- a/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
@@ -21,6 +21,11 @@ struct EagerNavigationEnvironment {
 let eagerNavigationReducer = Reducer<
   EagerNavigationState, EagerNavigationAction, EagerNavigationEnvironment
 >.combine(
+  counterReducer.optional.pullback(
+    state: \.optionalCounter,
+    action: /EagerNavigationAction.optionalCounter,
+    environment: { _ in CounterEnvironment() }
+  ),
   Reducer { state, action, environment in
     switch action {
     case .setNavigation(isActive: true):
@@ -38,12 +43,7 @@ let eagerNavigationReducer = Reducer<
     case .optionalCounter:
       return .none
     }
-  },
-  counterReducer.optional.pullback(
-    state: \.optionalCounter,
-    action: /EagerNavigationAction.optionalCounter,
-    environment: { _ in CounterEnvironment() }
-  )
+  }
 )
 
 class EagerNavigationViewController: UIViewController {

--- a/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
@@ -18,33 +18,35 @@ struct EagerNavigationEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-let eagerNavigationReducer = Reducer<
-  EagerNavigationState, EagerNavigationAction, EagerNavigationEnvironment
->.combine(
-  counterReducer.optional.pullback(
+let eagerNavigationReducer = counterReducer
+  .optional
+  .pullback(
     state: \.optionalCounter,
     action: /EagerNavigationAction.optionalCounter,
     environment: { _ in CounterEnvironment() }
-  ),
-  Reducer { state, action, environment in
-    switch action {
-    case .setNavigation(isActive: true):
-      state.isNavigationActive = true
-      return Effect(value: .setNavigationIsActiveDelayCompleted)
-        .delay(for: 1, scheduler: environment.mainQueue)
-        .eraseToEffect()
-    case .setNavigation(isActive: false):
-      state.isNavigationActive = false
-      state.optionalCounter = nil
-      return .none
-    case .setNavigationIsActiveDelayCompleted:
-      state.optionalCounter = CounterState()
-      return .none
-    case .optionalCounter:
-      return .none
+  )
+  .combined(
+    with: Reducer<
+      EagerNavigationState, EagerNavigationAction, EagerNavigationEnvironment
+    > { state, action, environment in
+      switch action {
+      case .setNavigation(isActive: true):
+        state.isNavigationActive = true
+        return Effect(value: .setNavigationIsActiveDelayCompleted)
+          .delay(for: 1, scheduler: environment.mainQueue)
+          .eraseToEffect()
+      case .setNavigation(isActive: false):
+        state.isNavigationActive = false
+        state.optionalCounter = nil
+        return .none
+      case .setNavigationIsActiveDelayCompleted:
+        state.optionalCounter = CounterState()
+        return .none
+      case .optionalCounter:
+        return .none
+      }
     }
-  }
-)
+  )
 
 class EagerNavigationViewController: UIViewController {
   var cancellables: [AnyCancellable] = []

--- a/Examples/TicTacToe/Sources/Core/AppCore.swift
+++ b/Examples/TicTacToe/Sources/Core/AppCore.swift
@@ -29,8 +29,8 @@ public struct AppEnvironment {
   }
 }
 
-public let appReducer: Reducer<AppState, AppAction, AppEnvironment> = Reducer.combine(
-  loginFeatureReducer.optional.pullback(
+public let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
+  loginReducer.optional.pullback(
     state: \.login,
     action: /AppAction.login,
     environment: {
@@ -40,7 +40,7 @@ public let appReducer: Reducer<AppState, AppAction, AppEnvironment> = Reducer.co
       )
     }
   ),
-  newGameFeatureReducer.optional.pullback(
+  newGameReducer.optional.pullback(
     state: \.newGame,
     action: /AppAction.newGame,
     environment: { _ in NewGameEnvironment() }

--- a/Examples/TicTacToe/Sources/Core/AppCore.swift
+++ b/Examples/TicTacToe/Sources/Core/AppCore.swift
@@ -30,6 +30,21 @@ public struct AppEnvironment {
 }
 
 public let appReducer: Reducer<AppState, AppAction, AppEnvironment> = Reducer.combine(
+  loginFeatureReducer.optional.pullback(
+    state: \.login,
+    action: /AppAction.login,
+    environment: {
+      LoginEnvironment(
+        authenticationClient: $0.authenticationClient,
+        mainQueue: $0.mainQueue
+      )
+    }
+  ),
+  newGameFeatureReducer.optional.pullback(
+    state: \.newGame,
+    action: /AppAction.newGame,
+    environment: { _ in NewGameEnvironment() }
+  ),
   Reducer { state, action, _ in
     switch action {
     case let .login(.twoFactor(.twoFactorResponse(.success(response)))),
@@ -49,20 +64,5 @@ public let appReducer: Reducer<AppState, AppAction, AppEnvironment> = Reducer.co
     case .newGame:
       return .none
     }
-  },
-  loginFeatureReducer.optional.pullback(
-    state: \.login,
-    action: /AppAction.login,
-    environment: {
-      LoginEnvironment(
-        authenticationClient: $0.authenticationClient,
-        mainQueue: $0.mainQueue
-      )
-    }
-  ),
-  newGameFeatureReducer.optional.pullback(
-    state: \.newGame,
-    action: /AppAction.newGame,
-    environment: { _ in NewGameEnvironment() }
-  )
+  }
 )

--- a/Examples/TicTacToe/Sources/Core/LoginCore.swift
+++ b/Examples/TicTacToe/Sources/Core/LoginCore.swift
@@ -38,54 +38,9 @@ public struct LoginEnvironment {
   }
 }
 
-public let loginReducer = Reducer<LoginState, LoginAction, LoginEnvironment> {
-  state, action, environment in
-  switch action {
-  case .alertDismissed:
-    state.alertData = nil
-    return .none
-
-  case let .emailChanged(email):
-    state.email = email
-    state.isFormValid = !state.email.isEmpty && !state.password.isEmpty
-    return .none
-
-  case let .loginResponse(.success(response)):
-    state.isLoginRequestInFlight = false
-    if response.twoFactorRequired {
-      state.twoFactor = TwoFactorState(token: response.token)
-    }
-    return .none
-
-  case let .loginResponse(.failure(error)):
-    state.alertData = AlertData(title: error.localizedDescription)
-    state.isLoginRequestInFlight = false
-    return .none
-
-  case let .passwordChanged(password):
-    state.password = password
-    state.isFormValid = !state.email.isEmpty && !state.password.isEmpty
-    return .none
-
-  case .loginButtonTapped:
-    state.isLoginRequestInFlight = true
-    return environment.authenticationClient
-      .login(LoginRequest(email: state.email, password: state.password))
-      .receive(on: environment.mainQueue)
-      .catchToEffect()
-      .map(LoginAction.loginResponse)
-
-  case .twoFactor:
-    return .none
-
-  case .twoFactorDismissed:
-    state.twoFactor = nil
-    return .none
-  }
-}
-
-public let loginFeatureReducer = Reducer.combine(
-  twoFactorReducer.optional.pullback(
+public let loginReducer = twoFactorReducer
+  .optional
+  .pullback(
     state: \.twoFactor,
     action: /LoginAction.twoFactor,
     environment: {
@@ -94,6 +49,51 @@ public let loginFeatureReducer = Reducer.combine(
         mainQueue: $0.mainQueue
       )
     }
-  ),
-  loginReducer
-)
+  )
+  .combined(
+    with: Reducer<LoginState, LoginAction, LoginEnvironment> {
+      state, action, environment in
+      switch action {
+      case .alertDismissed:
+        state.alertData = nil
+        return .none
+
+      case let .emailChanged(email):
+        state.email = email
+        state.isFormValid = !state.email.isEmpty && !state.password.isEmpty
+        return .none
+
+      case let .loginResponse(.success(response)):
+        state.isLoginRequestInFlight = false
+        if response.twoFactorRequired {
+          state.twoFactor = TwoFactorState(token: response.token)
+        }
+        return .none
+
+      case let .loginResponse(.failure(error)):
+        state.alertData = AlertData(title: error.localizedDescription)
+        state.isLoginRequestInFlight = false
+        return .none
+
+      case let .passwordChanged(password):
+        state.password = password
+        state.isFormValid = !state.email.isEmpty && !state.password.isEmpty
+        return .none
+
+      case .loginButtonTapped:
+        state.isLoginRequestInFlight = true
+        return environment.authenticationClient
+          .login(LoginRequest(email: state.email, password: state.password))
+          .receive(on: environment.mainQueue)
+          .catchToEffect()
+          .map(LoginAction.loginResponse)
+
+      case .twoFactor:
+        return .none
+
+      case .twoFactorDismissed:
+        state.twoFactor = nil
+        return .none
+      }
+    }
+  )

--- a/Examples/TicTacToe/Sources/Core/LoginCore.swift
+++ b/Examples/TicTacToe/Sources/Core/LoginCore.swift
@@ -85,7 +85,6 @@ public let loginReducer = Reducer<LoginState, LoginAction, LoginEnvironment> {
 }
 
 public let loginFeatureReducer = Reducer.combine(
-  loginReducer,
   twoFactorReducer.optional.pullback(
     state: \.twoFactor,
     action: /LoginAction.twoFactor,
@@ -95,5 +94,6 @@ public let loginFeatureReducer = Reducer.combine(
         mainQueue: $0.mainQueue
       )
     }
-  )
+  ),
+  loginReducer
 )

--- a/Examples/TicTacToe/Sources/Core/NewGameCore.swift
+++ b/Examples/TicTacToe/Sources/Core/NewGameCore.swift
@@ -58,10 +58,10 @@ public let newGameReducer = Reducer<NewGameState, NewGameAction, NewGameEnvironm
 }
 
 public let newGameFeatureReducer = Reducer.combine(
-  newGameReducer,
   gameReducer.optional.pullback(
     state: \.game,
     action: /NewGameAction.game,
     environment: { _ in GameEnvironment() }
-  )
+  ),
+  newGameReducer
 )

--- a/Examples/TicTacToe/Sources/Core/NewGameCore.swift
+++ b/Examples/TicTacToe/Sources/Core/NewGameCore.swift
@@ -23,45 +23,44 @@ public struct NewGameEnvironment {
   public init() {}
 }
 
-public let newGameReducer = Reducer<NewGameState, NewGameAction, NewGameEnvironment> {
-  state, action, _ in
-  switch action {
-  case .game(.quitButtonTapped):
-    state.game = nil
-    return .none
-
-  case .gameDismissed:
-    state.game = nil
-    return .none
-
-  case .game:
-    return .none
-
-  case .letsPlayButtonTapped:
-    state.game = GameState(
-      oPlayerName: state.oPlayerName,
-      xPlayerName: state.xPlayerName
-    )
-    return .none
-
-  case .logoutButtonTapped:
-    return .none
-
-  case let .oPlayerNameChanged(name):
-    state.oPlayerName = name
-    return .none
-
-  case let .xPlayerNameChanged(name):
-    state.xPlayerName = name
-    return .none
-  }
-}
-
-public let newGameFeatureReducer = Reducer.combine(
-  gameReducer.optional.pullback(
+public let newGameReducer = gameReducer
+  .optional
+  .pullback(
     state: \.game,
     action: /NewGameAction.game,
     environment: { _ in GameEnvironment() }
-  ),
-  newGameReducer
-)
+  )
+  .combined(
+    with: Reducer<NewGameState, NewGameAction, NewGameEnvironment> { state, action, _ in
+      switch action {
+      case .game(.quitButtonTapped):
+        state.game = nil
+        return .none
+
+      case .gameDismissed:
+        state.game = nil
+        return .none
+
+      case .game:
+        return .none
+
+      case .letsPlayButtonTapped:
+        state.game = GameState(
+          oPlayerName: state.oPlayerName,
+          xPlayerName: state.xPlayerName
+        )
+        return .none
+
+      case .logoutButtonTapped:
+        return .none
+
+      case let .oPlayerNameChanged(name):
+        state.oPlayerName = name
+        return .none
+
+      case let .xPlayerNameChanged(name):
+        state.xPlayerName = name
+        return .none
+      }
+    }
+  )

--- a/Examples/TicTacToe/Sources/Views-SwiftUI/LoginSwiftView.swift
+++ b/Examples/TicTacToe/Sources/Views-SwiftUI/LoginSwiftView.swift
@@ -131,7 +131,7 @@ struct LoginView_Previews: PreviewProvider {
       LoginView(
         store: Store(
           initialState: LoginState(),
-          reducer: loginFeatureReducer,
+          reducer: loginReducer,
           environment: LoginEnvironment(
             authenticationClient: AuthenticationClient(
               login: { _ in Effect(value: .init(token: "deadbeef", twoFactorRequired: false)) },

--- a/Examples/TicTacToe/Tests/LoginCoreTests.swift
+++ b/Examples/TicTacToe/Tests/LoginCoreTests.swift
@@ -11,7 +11,7 @@ class LoginCoreTests: XCTestCase {
   func testFlow_Success_TwoFactor_Integration() {
     let store = TestStore(
       initialState: LoginState(),
-      reducer: loginFeatureReducer,
+      reducer: loginReducer,
       environment: LoginEnvironment(
         authenticationClient: .mock(
           login: { _ in

--- a/Examples/TicTacToe/Tests/LoginSwiftUITests.swift
+++ b/Examples/TicTacToe/Tests/LoginSwiftUITests.swift
@@ -13,7 +13,7 @@ class LoginSwiftUITests: XCTestCase {
   func testFlow_Success() {
     let store = TestStore(
       initialState: LoginState(),
-      reducer: loginFeatureReducer,
+      reducer: loginReducer,
       environment: LoginEnvironment(
         authenticationClient: .mock(
           login: { _ in
@@ -51,7 +51,7 @@ class LoginSwiftUITests: XCTestCase {
   func testFlow_Success_TwoFactor() {
     let store = TestStore(
       initialState: LoginState(),
-      reducer: loginFeatureReducer,
+      reducer: loginReducer,
       environment: LoginEnvironment(
         authenticationClient: .mock(
           login: { _ in
@@ -93,7 +93,7 @@ class LoginSwiftUITests: XCTestCase {
   func testFlow_Failure() {
     let store = TestStore(
       initialState: LoginState(),
-      reducer: loginFeatureReducer,
+      reducer: loginReducer,
       environment: LoginEnvironment(
         authenticationClient: .mock(
           login: { _ in Effect(error: .invalidUserPassword) }

--- a/Examples/TicTacToe/Tests/NewGameCoreTests.swift
+++ b/Examples/TicTacToe/Tests/NewGameCoreTests.swift
@@ -6,7 +6,7 @@ import XCTest
 class NewGameCoreTests: XCTestCase {
   let store = TestStore(
     initialState: NewGameState(),
-    reducer: newGameFeatureReducer,
+    reducer: newGameReducer,
     environment: NewGameEnvironment()
   )
 

--- a/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
@@ -86,7 +86,7 @@ extension Publisher where Failure == Never {
   }
 }
 
-private func debugCaseOutput(_ value: Any) -> String {
+func debugCaseOutput(_ value: Any) -> String {
   let mirror = Mirror(reflecting: value)
   switch mirror.displayStyle {
   case .enum:

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -176,12 +176,12 @@ public struct Reducer<State, Action, Environment> {
           set their state to "nil". This ensures that optional reducers can handle their actions \
           while their state is still non-"nil".
 
+          * An active effect emitted this action while state was "nil". Make sure that effects for this \
+          optional reducer are canceled when optional state is set to "nil".
+
           * This action was sent to the store while state was "nil". Make sure that actions for \
           this reducer can only be sent to a view store when state is non-"nil". In SwiftUI \
           applications, use "IfLetStore".
-
-          * An effect returned this action while state was "nil". Make sure that effects for this \
-          optional reducer are canceled when optional state is set to "nil".
           """
         )
         return .none

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -236,14 +236,14 @@ public struct Reducer<State, Action, Environment> {
         that can move or remove elements from their state. This ensures that "forEach" reducers \
         can handle their actions for their state at the intended index.
 
-        * This action was sent to the store while state contained no element at this index. Make \
-        sure that actions for this reducer can only be sent to a view store when state contains an \
-        element at this index. In SwiftUI applications, use `ForEachStore`.
-
-        * An effect returned this action while state contained no element at this index. Make sure \
+        * An active effect emitted this action while state contained no element at this index. Make sure \
         that effects for this "forEach" reducer are canceled whenever elements are moved or \
         removed from state. If your "forEach" reducer returns any long-living effects, you should \
         use the identifier-based "forEach", instead.
+        
+        * This action was sent to the store while state contained no element at this index. Make \
+        sure that actions for this reducer can only be sent to a view store when state contains an \
+        element at this index. In SwiftUI applications, use `ForEachStore`.
         """
       )
       return self.reducer(

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -170,14 +170,14 @@ public struct Reducer<State, Action, Environment> {
           """
           "\(debugCaseOutput(action))" was received by an optional reducer when its state was \
           "nil". This can happen for a few reasons:
+          
+          * The optional reducer was combined with or run from another reducer that set \
+          "\(State.self)" to "nil" before the optional reducer ran. Combine or run optional \
+          reducers before reducers that can set their state to "nil". This ensures that optional \
+          reducers can handle their actions while their state is still non-"nil".
 
-          * The optional reducer was combined with another reducer that set "\(State.self)" to \
-          "nil" when it handled this action. Combine optional reducers before reducers that can \
-          set their state to "nil". This ensures that optional reducers can handle their actions \
-          while their state is still non-"nil".
-
-          * An active effect emitted this action while state was "nil". Make sure that effects for this \
-          optional reducer are canceled when optional state is set to "nil".
+          * An active effect emitted this action while state was "nil". Make sure that effects for \
+          this optional reducer are canceled when optional state is set to "nil".
 
           * This action was sent to the store while state was "nil". Make sure that actions for \
           this reducer can only be sent to a view store when state is non-"nil". In SwiftUI \
@@ -231,10 +231,10 @@ public struct Reducer<State, Action, Environment> {
         "\(debugCaseOutput(localAction))" was received by a "forEach" reducer at index \(index) \
         when state contained no element at this index. This can happen for a few reasons:
 
-        * The "forEach" reducer was combined with another reducer that removed an element from \
-        state when it handled this action. Combine index-based "forEach" reducers before reducers \
-        that can move or remove elements from their state. This ensures that "forEach" reducers \
-        can handle their actions for their state at the intended index.
+        * The "forEach" reducer was combined with or run from another reducer that removed an \
+        element from state when it handled this action. Combine or run index-based "forEach" \
+        reducers before reducers that can move or remove elements from their state. This ensures \
+        that "forEach" reducers can handle their actions for their state at the intended index.
 
         * An active effect emitted this action while state contained no element at this index. Make sure \
         that effects for this "forEach" reducer are canceled whenever elements are moved or \

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -165,7 +165,25 @@ public struct Reducer<State, Action, Environment> {
   ///   state.
   public var optional: Reducer<State?, Action, Environment> {
     .init { state, action, environment in
-      guard state != nil else { return .none }
+      guard state != nil else {
+        assertionFailure(
+          """
+          "\(debugCaseOutput(action))" was received by an optional reducer when its state was \
+          "nil". This can happen for a few reasons:
+
+          * The optional reducer was combined with another reducer that ran and set \
+          "\(State.self)" to "nil" when it handled the same action. Combine the optional reducer \
+          before this reducer to ensure the optional reducer can handle its case.
+
+          * This action was sent to the store while state was "nil". Make sure that actions for \
+          this reducer can only be sent to a view store when state is non-"nil".
+
+          * An effect returned this action while state was "nil". Make sure that effects for this \
+          optional reducer are canceled when optional state is set to "nil".
+          """
+        )
+        return .none
+      }
       return self.reducer(&state!, action, environment)
     }
   }

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -147,15 +147,16 @@ public final class Store<State, Action> {
           The store was sent an action while it was already processing another action. This can \
           happen for a few reasons:
 
-          * The store was sent an action recursively. This can occur when you run an effect directly \
-          in the reducer, rather than returning it from the reducer. Check the stack (⌘7) to find \
-          frames corresponding to one of your reducers. That code should be refactored to not invoke \
-          the effect directly.
+          * The store was sent an action recursively. This can occur when you run an effect \
+          directly in the reducer, rather than returning it from the reducer. Check the stack (⌘7) \
+          to find frames corresponding to one of your reducers. That code should be refactored to \
+          not invoke the effect directly.
 
           * The store has been sent actions from multiple threads. The `send` method is not \
-          thread-safe, and should only ever be used from a single thread (typically the main thread). 
-          Instead of calling `send` from multiple threads you should use effects to process expensive \
-          computations on background threads so that it can be fed back into the store.
+          thread-safe, and should only ever be used from a single thread (typically the main \
+          thread). Instead of calling `send` from multiple threads you should use effects to \
+          process expensive computations on background threads so that it can be fed back into the \
+          store.
           """
         )
       }

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -148,9 +148,9 @@ public final class Store<State, Action> {
         the effect directly.
 
         * The store has been sent actions from multiple threads. The `send` method is not \
-        thread-safe, and should only ever be used from a single thread (typically the main thread). 
-        Instead of calling `send` from multiple threads you should use effects to process expensive \
-        computations on background threads so that it can be fed back into the store.
+        thread-safe, and should only ever be used from a single thread (typically the main \
+        thread). Instead of calling `send` from multiple threads you should use effects to process \
+        expensive computations on background threads so that it can be fed back into the store.
         """
       )
     }


### PR DESCRIPTION
This was spurred after a bunch discussions today: #152, #153, #154, #155.

Right now, `optional` reducers will happily toss actions they like to process into the void. This can lead to very subtle bugs where we are sending actions to the reducer and expecting things to happen, but because some sub-state is `nil` nothing happens at all.

Adding this assertion even revealed a "bug" in our TicTacToe logic, where we handle `nil`ing out `LoginState` upon login _before_ letting the `loginReducer` handle its own action. If loginReducer were instrumented with some analytics, we'd be losing those. So I think this (or something like it) would be helpful in the future.

(cc @peterkovacs)