### PR TITLE
Replace 'receive(subscriber:)' with 'subscribe()'

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -40,7 +40,7 @@ public struct Effect<Output, Failure: Error>: Publisher {
   public func receive<S>(
     subscriber: S
   ) where S: Combine.Subscriber, Failure == S.Failure, Output == S.Input {
-    self.upstream.receive(subscriber: subscriber)
+    self.upstream.subscribe(subscriber)
   }
 
   /// Initializes an effect that immediately emits the value passed in.

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -217,7 +217,7 @@ public struct StorePublisher<State>: Publisher {
 
   public func receive<S>(subscriber: S)
   where S: Subscriber, Failure == S.Failure, Output == S.Input {
-    self.upstream.receive(subscriber: subscriber)
+    self.upstream.subscribe(subscriber)
   }
 
   init<P>(_ upstream: P) where P: Publisher, Failure == P.Failure, Output == P.Output {


### PR DESCRIPTION
Hey! Huge fan of PointFree videos and TCA in particular, thanks for you great work 👏 

According to apple docs it is preferred to call `.subscribe()` instead of `.receive(subscriber:)`. I know, this looks super counterintuitive, did same on my project at first.

`.receive(subscriber:)` is function that is required by protocol, and `.subscribe()` is some function that is implemented inside Combine that eventually  calls `.receive(subscriber:)`. So this fix shouldn't break anything

https://developer.apple.com/documentation/combine/publisher/3204756-subscribe
> Always call this function instead of receive(subscriber:). Adopters of Publisher must implement receive(subscriber:). The implementation of subscribe(_:) provided by Publisher calls through to receive(subscriber:).