### PR TITLE
Fix scheduling for debounce

### DIFF
--- a/Sources/ComposableArchitecture/Scheduling/TestScheduler.swift
+++ b/Sources/ComposableArchitecture/Scheduling/TestScheduler.swift
@@ -5,10 +5,10 @@ import Foundation
 public final class TestScheduler<SchedulerTimeType, SchedulerOptions>: Scheduler
 where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeIntervalConvertible {
 
-  private var lastId: UInt = 0
+  private var lastSequence: UInt = 0
   public let minimumTolerance: SchedulerTimeType.Stride = .zero
   public private(set) var now: SchedulerTimeType
-  private var scheduled: [(id: UInt, date: SchedulerTimeType, action: () -> Void)] = []
+  private var scheduled: [(id: UUID, sequence: UInt, date: SchedulerTimeType, action: () -> Void)] = []
 
   /// Creates a test scheduler with the given date.
   ///
@@ -21,7 +21,7 @@ where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeInte
   ///
   /// - Parameter stride: A stride.
   public func advance(by stride: SchedulerTimeType.Stride = .zero) {
-    self.scheduled.sort { ($0.date, $0.id) < ($1.date, $1.id) }
+    self.scheduled.sort { ($0.date, $0.sequence) < ($1.date, $1.sequence) }
 
     guard
       let nextDate = self.scheduled.first?.date,
@@ -34,9 +34,9 @@ where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeInte
     let delta = self.now.distance(to: nextDate)
     self.now = nextDate
 
-    while let (_, date, action) = self.scheduled.first, date == nextDate {
+    while let (id, _, date, action) = self.scheduled.first, date == nextDate {
       action()
-      self.scheduled.removeFirst()
+      self.scheduled.removeAll(where: { $0.id == id })
     }
 
     self.advance(by: stride - delta)
@@ -56,20 +56,20 @@ where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeInte
     options _: SchedulerOptions?,
     _ action: @escaping () -> Void
   ) -> Cancellable {
-    let id = self.nextId()
+    let sequence = self.nextSequence()
 
     func scheduleAction(for date: SchedulerTimeType) -> () -> Void {
       return { [weak self] in
-        action()
         let nextDate = date.advanced(by: interval)
-        self?.scheduled.append((id, nextDate, scheduleAction(for: nextDate)))
+        self?.scheduled.append((UUID(), sequence, nextDate, scheduleAction(for: nextDate)))
+        action()
       }
     }
 
-    self.scheduled.append((id, date, scheduleAction(for: date)))
+    self.scheduled.append((UUID(), sequence, date, scheduleAction(for: date)))
 
     return AnyCancellable { [weak self] in
-      self?.scheduled.removeAll(where: { $0.id == id })
+      self?.scheduled.removeAll(where: { $0.sequence == sequence })
     }
   }
 
@@ -79,16 +79,16 @@ where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeInte
     options _: SchedulerOptions?,
     _ action: @escaping () -> Void
   ) {
-    self.scheduled.append((self.nextId(), date, action))
+    self.scheduled.append((UUID(), self.nextSequence(), date, action))
   }
 
   public func schedule(options _: SchedulerOptions?, _ action: @escaping () -> Void) {
-    self.scheduled.append((self.nextId(), self.now, action))
+    self.scheduled.append((UUID(), self.nextSequence(), self.now, action))
   }
 
-  private func nextId() -> UInt {
-    self.lastId += 1
-    return self.lastId
+  private func nextSequence() -> UInt {
+    self.lastSequence += 1
+    return self.lastSequence
   }
 }
 

--- a/Tests/ComposableArchitectureTests/SchedulerTests.swift
+++ b/Tests/ComposableArchitectureTests/SchedulerTests.swift
@@ -132,4 +132,31 @@ final class SchedulerTests: XCTestCase {
     testScheduler.advance(by: 2)
     XCTAssertEqual(values, [1, 42, 42, 1, 42])
   }
+
+  func testDebounceReceiveOn() {
+    let scheduler = DispatchQueue.testScheduler
+
+    let subject = PassthroughSubject<Void, Never>()
+
+    var count = 0
+    subject
+      .debounce(for: 1, scheduler: scheduler)
+      .receive(on: scheduler)
+      .sink { count += 1 }
+      .store(in: &self.cancellables)
+
+    XCTAssertEqual(count, 0)
+
+    subject.send()
+    XCTAssertEqual(count, 0)
+
+    scheduler.advance(by: 1)
+    XCTAssertEqual(count, 1)
+
+    scheduler.advance(by: 1)
+    XCTAssertEqual(count, 1)
+
+    scheduler.run()
+    XCTAssertEqual(count, 1)
+  }
 }


### PR DESCRIPTION
Fixes the bug we just uncovered. Turns out that `debounce` works by scheduling interval work that is cancelled, and so if you are not careful about when such work is inserted into the queue it won't get properly removed and will just become recurring work forever. Easiest way to reproduce this is to do `.debounce` followed by `.receive(on:)`, because after the first trigger of the debounce the `receive(on:)` work is queued, and then accidentally removed, which leaves the debounce work around to execute ad infinitum 😬

The fix is to keep around a unique identifier for removing work after it is executed (instead of assuming `scheduled.removeFirst()` will remove the right thing), and to insert the next interval work into the queue immediately before executing the work.