### PR TITLE
Reflect repo rename of ReactiveSwift fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ If you are interested in contributing a wrapper library for a framework that we 
   
 ## Requirements
 
-The Composable Architecture depends on the Combine framework, so it requires minimum deployment targets of iOS 13, macOS 10.15, Mac Catalyst 13, tvOS 13, and watchOS 6. If your application must support older OSes, there is [a ReactiveSwift fork](https://github.com/trading-point/swift-composable-architecture) that you can adopt!
+The Composable Architecture depends on the Combine framework, so it requires minimum deployment targets of iOS 13, macOS 10.15, Mac Catalyst 13, tvOS 13, and watchOS 6. If your application must support older OSes, there is [a ReactiveSwift fork](https://github.com/trading-point/reactiveswift-composable-architecture) that you can adopt!
 
 ## Installation
 


### PR DESCRIPTION
The fork was renamed to `reactiveswift-composable-architecture` to avoid confusion.

It's not urgent as GitHub nicely redirects on renamed repos.