### PR TITLE
Speed up TestScheduler work removal

### DIFF
--- a/Sources/ComposableArchitecture/Scheduling/TestScheduler.swift
+++ b/Sources/ComposableArchitecture/Scheduling/TestScheduler.swift
@@ -37,7 +37,9 @@ where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeInte
 
     while let (id, _, date, action) = self.scheduled.first, date == nextDate {
       action()
-      self.scheduled.removeAll(where: { $0.id == id })
+      if let idx = self.scheduled.firstIndex(where: { $0.id == id }) {
+        self.scheduled.remove(at: idx)
+      }
     }
 
     self.advance(by: stride - delta)

--- a/Sources/ComposableArchitecture/Scheduling/TestScheduler.swift
+++ b/Sources/ComposableArchitecture/Scheduling/TestScheduler.swift
@@ -8,7 +8,7 @@ where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeInte
   private var lastSequence: UInt = 0
   public let minimumTolerance: SchedulerTimeType.Stride = .zero
   public private(set) var now: SchedulerTimeType
-  private var scheduled: [(id: UUID, sequence: UInt, date: SchedulerTimeType, action: () -> Void)] =
+  private var scheduled: [(sequence: UInt, date: SchedulerTimeType, action: () -> Void)] =
     []
 
   /// Creates a test scheduler with the given date.
@@ -35,11 +35,9 @@ where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeInte
     let delta = self.now.distance(to: nextDate)
     self.now = nextDate
 
-    while let (id, _, date, action) = self.scheduled.first, date == nextDate {
+    while let (_, date, action) = self.scheduled.first, date == nextDate {
+      self.scheduled.removeFirst()
       action()
-      if let idx = self.scheduled.firstIndex(where: { $0.id == id }) {
-        self.scheduled.remove(at: idx)
-      }
     }
 
     self.advance(by: stride - delta)
@@ -64,12 +62,12 @@ where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeInte
     func scheduleAction(for date: SchedulerTimeType) -> () -> Void {
       return { [weak self] in
         let nextDate = date.advanced(by: interval)
-        self?.scheduled.append((UUID(), sequence, nextDate, scheduleAction(for: nextDate)))
+        self?.scheduled.append((sequence, nextDate, scheduleAction(for: nextDate)))
         action()
       }
     }
 
-    self.scheduled.append((UUID(), sequence, date, scheduleAction(for: date)))
+    self.scheduled.append((sequence, date, scheduleAction(for: date)))
 
     return AnyCancellable { [weak self] in
       self?.scheduled.removeAll(where: { $0.sequence == sequence })
@@ -82,11 +80,11 @@ where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeInte
     options _: SchedulerOptions?,
     _ action: @escaping () -> Void
   ) {
-    self.scheduled.append((UUID(), self.nextSequence(), date, action))
+    self.scheduled.append((self.nextSequence(), date, action))
   }
 
   public func schedule(options _: SchedulerOptions?, _ action: @escaping () -> Void) {
-    self.scheduled.append((UUID(), self.nextSequence(), self.now, action))
+    self.scheduled.append((self.nextSequence(), self.now, action))
   }
 
   private func nextSequence() -> UInt {


### PR DESCRIPTION
This probably will have a negligible effect on most test code, but it could improve larger stress tests.