### PR TITLE
Add Loading UI case study

### DIFF
--- a/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
+++ b/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		36DBEC47247BFFFD00AF9C80 /* 04-HigherOrderReducers-LoadingUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36DBEC46247BFFFD00AF9C80 /* 04-HigherOrderReducers-LoadingUI.swift */; };
 		CA0C51FB245389CC00A04EAB /* 04-HigherOrderReducers-ResuableOfflineDownloadsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C51FA245389CC00A04EAB /* 04-HigherOrderReducers-ResuableOfflineDownloadsTests.swift */; };
 		CA25E5D224463AD700DA666A /* 01-GettingStarted-Bindings-Basics.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA25E5D124463AD700DA666A /* 01-GettingStarted-Bindings-Basics.swift */; };
 		CA27C0B7245780CE00CB1E59 /* 03-Effects-SystemEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA27C0B6245780CE00CB1E59 /* 03-Effects-SystemEnvironment.swift */; };
@@ -122,6 +123,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		36DBEC46247BFFFD00AF9C80 /* 04-HigherOrderReducers-LoadingUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-LoadingUI.swift"; sourceTree = "<group>"; };
 		CA0C51FA245389CC00A04EAB /* 04-HigherOrderReducers-ResuableOfflineDownloadsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-ResuableOfflineDownloadsTests.swift"; sourceTree = "<group>"; };
 		CA25E5D124463AD700DA666A /* 01-GettingStarted-Bindings-Basics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-GettingStarted-Bindings-Basics.swift"; sourceTree = "<group>"; };
 		CA27C0B6245780CE00CB1E59 /* 03-Effects-SystemEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "03-Effects-SystemEnvironment.swift"; sourceTree = "<group>"; };
@@ -323,6 +325,7 @@
 				DCE63B70245CC0B90080A23D /* 04-HigherOrderReducers-Recursion.swift */,
 				DCC68EE22447C8540037F998 /* 04-HigherOrderReducers-ReusableFavoriting.swift */,
 				DC2E370C24573ACB00B94699 /* 04-HigherOrderReducers-StrictReducers.swift */,
+				36DBEC46247BFFFD00AF9C80 /* 04-HigherOrderReducers-LoadingUI.swift */,
 				DC89C41824460F95006900B9 /* SceneDelegate.swift */,
 				DC89C41C24460F96006900B9 /* Assets.xcassets */,
 				CA6AC25F2451131C00C71CB3 /* 04-HigherOrderReducers-ResuableOfflineDownloads */,
@@ -572,6 +575,7 @@
 				CAA9ADC624465C810003A984 /* 02-Effects-Cancellation.swift in Sources */,
 				DC2E370D24573ACB00B94699 /* 04-HigherOrderReducers-StrictReducers.swift in Sources */,
 				DC9EB4172450CBD2005F413B /* UIViewRepresented.swift in Sources */,
+				36DBEC47247BFFFD00AF9C80 /* 04-HigherOrderReducers-LoadingUI.swift in Sources */,
 				DC89C41924460F95006900B9 /* SceneDelegate.swift in Sources */,
 				CA6AC2652451135C00C71CB3 /* CircularProgressView.swift in Sources */,
 				CA6AC2642451135C00C71CB3 /* ReusableComponents-Download.swift in Sources */,

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -301,6 +301,23 @@ struct RootView: View {
               )
             )
           )
+
+          NavigationLink(
+            "Loading UI for long-running actions",
+            destination: AppView(
+              store: Store(
+                initialState: AppState(),
+                reducer: combinedLoadingReducer,
+                environment: AppEnvironment(
+                  loadData: {
+                    Just(["some data"])
+                      .delay(for: 1, scheduler: DispatchQueue.main)
+                      .eraseToEffect()
+                  }
+                )
+              )
+            )
+          )
         }
       }
       .navigationBarTitle("Case Studies")

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-LoadingUI.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-LoadingUI.swift
@@ -59,13 +59,13 @@ extension Reducer {
   ) -> Reducer<AppState, AppAction, AppEnvironment> {
     Reducer<AppState, AppAction, AppEnvironment> { state, action, environment in
       if action.shouldShowLoadingUI {
-        return reducer(&state, action, environment)
+        return reducer.run(&state, action, environment)
           .prepend(.loadingAction(.show))
           .append(.loadingAction(.hide))
           .eraseToEffect()
       }
 
-      return reducer(&state, action, environment)
+      return reducer.run(&state, action, environment)
     }
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-LoadingUI.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-LoadingUI.swift
@@ -1,0 +1,160 @@
+import Combine
+import ComposableArchitecture
+import SwiftUI
+
+private let readMe = """
+  This screen demonstrates how the `Reducer` struct can be extended to enhance reducers with extra \
+  functionality.
+
+  In it we introduce an `loadingHandling` reducer that consumes the `appReducer`. \
+  It handles showing a loading UI for all actions that opt-in to this behaviour.
+
+  This form of reducer is useful if you want to centralize and handle loading in the same way. \
+  Without this, each routine executed in the `appReducer` would need to handle it's own loading UI.
+
+  Tapping the "Load Data" button will show the loading UI and hide it when the call completes.
+  """
+
+// MARK: - Loading Domain
+
+struct LoadingState: Equatable {
+  var isLoading: Bool = false
+}
+
+enum LoadingAction {
+  case show
+  case hide
+}
+
+let loadingReducer = Reducer<LoadingState, LoadingAction, Void> { state, action, _ in
+  switch action {
+  case .show:
+    state.isLoading = true
+    return .none
+
+  case .hide:
+    state.isLoading = false
+    return .none
+  }
+}
+
+struct LoadingView: View {
+  let store: Store<LoadingState, LoadingAction>
+
+  var body: some View {
+    WithViewStore(store) { viewStore in
+      if viewStore.isLoading {
+        Text("Loading...")
+          .padding()
+          .foregroundColor(.white)
+          .background(Color.gray.opacity(0.8))
+      }
+    }
+  }
+}
+
+extension Reducer {
+  static func loadingHandling(
+    _ reducer: Reducer<AppState, AppAction, AppEnvironment>
+  ) -> Reducer<AppState, AppAction, AppEnvironment> {
+    Reducer<AppState, AppAction, AppEnvironment> { state, action, environment in
+      if action.shouldShowLoadingUI {
+        return reducer(&state, action, environment)
+          .prepend(.loadingAction(.show))
+          .append(.loadingAction(.hide))
+          .eraseToEffect()
+      }
+
+      return reducer(&state, action, environment)
+    }
+  }
+}
+
+// MARK - Feature Domain
+
+struct AppState: Equatable {
+  var data: [String] = []
+  var loadingState = LoadingState()
+}
+
+enum AppAction {
+  case loadData
+  case didLoadData([String])
+  case loadingAction(LoadingAction)
+
+  var shouldShowLoadingUI: Bool {
+    switch self {
+    case .loadData: return true
+    default: return false
+    }
+  }
+}
+
+struct AppEnvironment {
+  var loadData: () -> Effect<[String], Never>
+}
+
+let appReducer = Reducer<AppState, AppAction, AppEnvironment> { state, action, environment in
+  switch action {
+  case .loadData:
+    return environment.loadData().map(AppAction.didLoadData)
+
+  case .didLoadData(let data):
+    state.data = data
+    return .none
+
+  case .loadingAction:
+    return .none
+  }
+}
+
+struct AppView: View {
+  let store: Store<AppState, AppAction>
+
+  var body: some View {
+    WithViewStore(store) { viewStore in
+      ZStack {
+        Form {
+          Section(header: Text(template: readMe, .caption)) {
+            Button("Load Data") { viewStore.send(.loadData) }
+            ForEach(viewStore.state.data, id: \.self) { Text($0) }
+          }
+        }
+        LoadingView(
+          store: self.store.scope(
+            state: { $0.loadingState },
+            action: AppAction.loadingAction
+          )
+        )
+      }
+      .navigationBarTitle("Loading UI")
+    }
+  }
+}
+
+let combinedLoadingReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
+  .loadingHandling(appReducer),
+  loadingReducer.pullback(
+    state: \AppState.loadingState,
+    action: /AppAction.loadingAction,
+    environment: { _ in () }
+  )
+)
+
+struct LoadingView_Previews: PreviewProvider {
+  static var previews: some View {
+    AppView(
+      store: Store(
+        initialState: AppState(),
+        reducer: combinedLoadingReducer,
+        environment: AppEnvironment(
+          loadData: {
+            Just(["some data"])
+              .delay(for: 1, scheduler: DispatchQueue.main)
+              .eraseToEffect()
+          }
+        )
+      )
+    )
+  }
+}


### PR DESCRIPTION
A case study that shows how a loading UI could be handled centrally for long-running actions. Any feedback is appreciated. 🙏 

![LoadingUI](https://user-images.githubusercontent.com/2365037/83685114-1dc06380-a5b6-11ea-97c2-089751f93169.gif)
