### PR TITLE
Adds Codable support to Location wrapper in ComposableCoreLocation

### DIFF
--- a/Examples/LocationManager/CommonTests/CommonTests.swift
+++ b/Examples/LocationManager/CommonTests/CommonTests.swift
@@ -57,7 +57,6 @@ class LocationManagerTests: XCTestCase {
       altitude: 0,
       coordinate: CLLocationCoordinate2D(latitude: 10, longitude: 20),
       course: 0,
-      floor: nil,
       horizontalAccuracy: 0,
       speed: 0,
       timestamp: Date(timeIntervalSince1970: 1_234_567_890),

--- a/Sources/ComposableCoreLocation/Models/Location.swift
+++ b/Sources/ComposableCoreLocation/Models/Location.swift
@@ -2,80 +2,131 @@ import CoreLocation
 
 /// A value type wrapper for `CLLocation`. This type is necessary so that we can do equality checks
 /// and write tests against its values.
-public struct Location: Equatable {
-  public let rawValue: CLLocation?
 
-  public var altitude: CLLocationDistance
-  public var coordinate: CLLocationCoordinate2D
-  public var course: CLLocationDirection
-  public var courseAccuracy: Double
-  public var floor: CLFloor?
-  public var horizontalAccuracy: CLLocationAccuracy
-  public var speed: CLLocationSpeed
-  public var speedAccuracy: Double
-  public var timestamp: Date
-  public var verticalAccuracy: CLLocationAccuracy
+@dynamicMemberLookup
+public struct Location: Equatable {
+  public let rawValue: CLLocation
 
   public init(
     altitude: CLLocationDistance = 0,
     coordinate: CLLocationCoordinate2D = CLLocationCoordinate2D(latitude: 0, longitude: 0),
     course: CLLocationDirection = 0,
     courseAccuracy: Double = 0,
-    floor: CLFloor? = nil,
     horizontalAccuracy: CLLocationAccuracy = 0,
     speed: CLLocationSpeed = 0,
     speedAccuracy: Double = 0,
     timestamp: Date = Date(),
     verticalAccuracy: CLLocationAccuracy = 0
   ) {
-    self.rawValue = nil
-    self.altitude = altitude
-    self.coordinate = coordinate
-    self.course = course
-    self.courseAccuracy = courseAccuracy
-    self.floor = floor
-    self.horizontalAccuracy = horizontalAccuracy
-    self.speed = speed
-    self.speedAccuracy = speedAccuracy
-    self.timestamp = timestamp
-    self.verticalAccuracy = verticalAccuracy
+    if #available(iOS 13.4, macCatalyst 13.4, macOS 10.15.4, tvOS 13.4, watchOS 6.2, *) {
+      self.rawValue = CLLocation(
+        coordinate: coordinate,
+        altitude: altitude,
+        horizontalAccuracy: horizontalAccuracy,
+        verticalAccuracy: verticalAccuracy,
+        course: course,
+        courseAccuracy: courseAccuracy,
+        speed: speed,
+        speedAccuracy: speedAccuracy,
+        timestamp: timestamp
+      )
+    } else {
+      self.rawValue = CLLocation(
+        coordinate: coordinate,
+        altitude: altitude,
+        horizontalAccuracy: horizontalAccuracy,
+        verticalAccuracy: verticalAccuracy,
+        course: course,
+        speed: speed,
+        timestamp: timestamp
+      )
+    }
   }
 
   public init(rawValue: CLLocation) {
     self.rawValue = rawValue
-
-    self.altitude = rawValue.altitude
-    self.coordinate = rawValue.coordinate
-    self.course = rawValue.course
-    self.floor = rawValue.floor
-    self.horizontalAccuracy = rawValue.horizontalAccuracy
-    self.speed = rawValue.speed
-    self.timestamp = rawValue.timestamp
-    self.verticalAccuracy = rawValue.verticalAccuracy
-    #if compiler(>=5.2)
-      if #available(iOS 13.4, macCatalyst 13.4, macOS 10.15.4, tvOS 13.4, watchOS 6.2, *) {
-        self.courseAccuracy = rawValue.courseAccuracy
-      } else {
-        self.courseAccuracy = 0
-      }
-      self.speedAccuracy = rawValue.speedAccuracy
-    #else
-      self.courseAccuracy = 0
-      self.speedAccuracy = 0
-    #endif
   }
 
   public static func == (lhs: Self, rhs: Self) -> Bool {
-    lhs.altitude == rhs.altitude
+    let courseAccuracyIsEqual: Bool
+    if #available(iOS 13.4, macCatalyst 13.4, macOS 10.15.4, tvOS 13.4, watchOS 6.2, *) {
+      courseAccuracyIsEqual = lhs.courseAccuracy == rhs.courseAccuracy
+    } else {
+      courseAccuracyIsEqual = true
+    }
+
+    return lhs.altitude == rhs.altitude
       && lhs.coordinate.latitude == rhs.coordinate.latitude
       && lhs.coordinate.longitude == rhs.coordinate.longitude
       && lhs.course == rhs.course
-      && lhs.courseAccuracy == rhs.courseAccuracy
       && lhs.floor == rhs.floor
       && lhs.horizontalAccuracy == rhs.horizontalAccuracy
       && lhs.speed == rhs.speed
       && lhs.speedAccuracy == rhs.speedAccuracy
       && lhs.timestamp == rhs.timestamp
       && lhs.verticalAccuracy == rhs.verticalAccuracy
+      && courseAccuracyIsEqual
+  }
+
+  public subscript<T>(dynamicMember keyPath: KeyPath<CLLocation, T>) -> T {
+    self.rawValue[keyPath: keyPath]
+  }
+}
+
+extension Location: Codable {
+  public init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+    let altitude = try values.decode(CLLocationDistance.self, forKey: .altitude)
+    let latitude = try values.decode(CLLocationDegrees.self, forKey: .latitude)
+    let longitude = try values.decode(CLLocationDegrees.self, forKey: .longitude)
+    let course = try values.decode(CLLocationDirection.self, forKey: .course)
+    let courseAccuracy = try values.decode(Double.self, forKey: .courseAccuracy)
+    let horizontalAccuracy = try values.decode(Double.self, forKey: .horizontalAccuracy)
+    let speed = try values.decode(CLLocationSpeed.self, forKey: .speed)
+    let speedAccuracy = try values.decode(Double.self, forKey: .speedAccuracy)
+    let timestamp = try values.decode(Date.self, forKey: .timestamp)
+    let verticalAccuracy = try values.decode(CLLocationAccuracy.self, forKey: .verticalAccuracy)
+
+    self.init(
+      altitude: altitude,
+      coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude),
+      course: course,
+      courseAccuracy: courseAccuracy,
+      horizontalAccuracy: horizontalAccuracy,
+      speed: speed,
+      speedAccuracy: speedAccuracy,
+      timestamp: timestamp,
+      verticalAccuracy: verticalAccuracy
+    )
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(rawValue.altitude, forKey: .altitude)
+    try container.encode(rawValue.coordinate.latitude, forKey: .latitude)
+    try container.encode(rawValue.coordinate.longitude, forKey: .longitude)
+    try container.encode(rawValue.course, forKey: .course)
+    try container.encode(rawValue.horizontalAccuracy, forKey: .horizontalAccuracy)
+    try container.encode(rawValue.speed, forKey: .speed)
+    try container.encode(rawValue.speedAccuracy, forKey: .speedAccuracy)
+    try container.encode(rawValue.timestamp, forKey: .timestamp)
+    try container.encode(rawValue.verticalAccuracy, forKey: .verticalAccuracy)
+
+    if #available(iOS 13.4, macCatalyst 13.4, macOS 10.15.4, tvOS 13.4, watchOS 6.2, *) {
+      try container.encode(rawValue.courseAccuracy, forKey: .courseAccuracy)
+    }
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case latitude
+    case longitude
+    case altitude
+    case course
+    case courseAccuracy
+    case horizontalAccuracy
+    case speed
+    case speedAccuracy
+    case timestamp
+    case verticalAccuracy
   }
 }

--- a/Tests/ComposableCoreLocationTests/ComposableCoreLocationTests.swift
+++ b/Tests/ComposableCoreLocationTests/ComposableCoreLocationTests.swift
@@ -5,4 +5,23 @@ class ComposableCoreLocationTests: XCTestCase {
   func testMockHasDefaultsForAllEndpoints() {
     _ = LocationManager.mock()
   }
+
+  func testLocationEncodeDecode() {
+    let value = Location(
+      altitude: 50,
+      coordinate: CLLocationCoordinate2D(latitude: 10, longitude: 20),
+      course: 9,
+      courseAccuracy: 1,
+      horizontalAccuracy: 3,
+      speed: 5,
+      speedAccuracy: 2,
+      timestamp: Date.init(timeIntervalSince1970: 0),
+      verticalAccuracy: 6
+    )
+
+    let data = try? JSONEncoder().encode(value)
+    let decoded = try? JSONDecoder().decode(Location.self, from: data ?? Data())
+
+    XCTAssertEqual(value, decoded)
+  }
 }

--- a/Tests/ComposableCoreLocationTests/ComposableCoreLocationTests.swift
+++ b/Tests/ComposableCoreLocationTests/ComposableCoreLocationTests.swift
@@ -7,21 +7,118 @@ class ComposableCoreLocationTests: XCTestCase {
   }
 
   func testLocationEncodeDecode() {
-    let value = Location(
-      altitude: 50,
-      coordinate: CLLocationCoordinate2D(latitude: 10, longitude: 20),
-      course: 9,
-      courseAccuracy: 1,
-      horizontalAccuracy: 3,
-      speed: 5,
-      speedAccuracy: 2,
-      timestamp: Date.init(timeIntervalSince1970: 0),
-      verticalAccuracy: 6
-    )
+    let value: Location
+
+    #if compiler(>=5.2)
+      if #available(iOS 13.4, macCatalyst 13.4, macOS 10.15.4, tvOS 13.4, watchOS 6.2, *) {
+        value = Location(
+          altitude: 50,
+          coordinate: CLLocationCoordinate2D(latitude: 10, longitude: 20),
+          course: 9,
+          courseAccuracy: 1,
+          horizontalAccuracy: 3,
+          speed: 5,
+          speedAccuracy: 2,
+          timestamp: Date.init(timeIntervalSince1970: 0),
+          verticalAccuracy: 6
+        )
+      } else {
+        value = Location(
+          altitude: 50,
+          coordinate: CLLocationCoordinate2D(latitude: 10, longitude: 20),
+          course: 9,
+          horizontalAccuracy: 3,
+          speed: 5,
+          timestamp: Date.init(timeIntervalSince1970: 0),
+          verticalAccuracy: 6
+        )
+    }
+    #else
+      value = Location(
+        altitude: 50,
+        coordinate: CLLocationCoordinate2D(latitude: 10, longitude: 20),
+        course: 9,
+        horizontalAccuracy: 3,
+        speed: 5,
+        timestamp: Date.init(timeIntervalSince1970: 0),
+        verticalAccuracy: 6
+      )
+    #endif
 
     let data = try? JSONEncoder().encode(value)
     let decoded = try? JSONDecoder().decode(Location.self, from: data ?? Data())
 
     XCTAssertEqual(value, decoded)
   }
+
+  func testLocationEquatable() {
+    let a = Location(
+      altitude: 1,
+      coordinate: CLLocationCoordinate2D(latitude: 1, longitude: 1),
+      course: 1,
+      horizontalAccuracy: 1,
+      speed: 1,
+      timestamp: Date.init(timeIntervalSince1970: 0),
+      verticalAccuracy: 1
+    )
+
+    let b = Location(
+      altitude: 2,
+      coordinate: CLLocationCoordinate2D(latitude: 2, longitude: 2),
+      course: 2,
+      horizontalAccuracy: 2,
+      speed: 2,
+      timestamp: Date.init(timeIntervalSince1970: 1),
+      verticalAccuracy: 2
+    )
+
+    XCTAssertTrue(a == a)
+    XCTAssertFalse(a == b)
+  }
+
+  #if compiler(>=5.2)
+  func testLocationEquatable_5_2() {
+    if #available(iOS 13.4, macCatalyst 13.4, macOS 10.15.4, tvOS 13.4, watchOS 6.2, *) {
+      let a = Location(
+        altitude: 1,
+        coordinate: CLLocationCoordinate2D(latitude: 1, longitude: 1),
+        course: 1,
+        courseAccuracy: 1,
+        horizontalAccuracy: 1,
+        speed: 1,
+        speedAccuracy: 1,
+        timestamp: Date.init(timeIntervalSince1970: 0),
+        verticalAccuracy: 1
+      )
+
+      let b = Location(
+        altitude: 1,
+        coordinate: CLLocationCoordinate2D(latitude: 1, longitude: 1),
+        course: 1,
+        courseAccuracy: 1,
+        horizontalAccuracy: 1,
+        speed: 1,
+        speedAccuracy: 2,
+        timestamp: Date.init(timeIntervalSince1970: 0),
+        verticalAccuracy: 1
+      )
+
+      let c = Location(
+        altitude: 1,
+        coordinate: CLLocationCoordinate2D(latitude: 1, longitude: 1),
+        course: 1,
+        courseAccuracy: 2,
+        horizontalAccuracy: 1,
+        speed: 1,
+        speedAccuracy: 1,
+        timestamp: Date.init(timeIntervalSince1970: 0),
+        verticalAccuracy: 1
+      )
+
+      XCTAssertTrue(a == a)
+      XCTAssertFalse(a == b)
+      XCTAssertFalse(a == c)
+    }
+  }
+  #endif
 }


### PR DESCRIPTION
I needed to persist Location data, so thought it'd be useful if the `Location` wrapper was `Codable`.

In this implementation the wrapper just proxies the properties of `CLLocation` using `@dynamicMemberLookup`. Let me know what you think.

(Note: I removed the `floor` init parameter as it seems to be a computed property with no useful way of creating one from scratch)