### PR TITLE
Update Naming of Navigation Case Studies

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -143,11 +143,11 @@ struct RootView: View {
         Section(header: Text("Navigation")) {
           NavigationLink(
             "Navigate and load data",
-            destination: EagerNavigationView(
+            destination: NavigateAndLoadView(
               store: Store(
-                initialState: EagerNavigationState(),
-                reducer: eagerNavigationReducer,
-                environment: EagerNavigationEnvironment(
+                initialState: NavigateAndLoadState(),
+                reducer: navigateAndLoadReducer,
+                environment: NavigateAndLoadEnvironment(
                   mainQueue: DispatchQueue.main.eraseToAnyScheduler()
                 )
               )
@@ -156,11 +156,11 @@ struct RootView: View {
 
           NavigationLink(
             "Load data then navigate",
-            destination: LazyNavigationView(
+            destination: LoadThenNavigateView(
               store: Store(
-                initialState: LazyNavigationState(),
-                reducer: lazyNavigationReducer,
-                environment: LazyNavigationEnvironment(
+                initialState: LoadThenNavigateState(),
+                reducer: loadThenNavigateReducer,
+                environment: LoadThenNavigateEnvironment(
                   mainQueue: DispatchQueue.main.eraseToAnyScheduler()
                 )
               )
@@ -169,17 +169,17 @@ struct RootView: View {
 
           NavigationLink(
             "Lists: Navigate and load data",
-            destination: EagerListNavigationView(
+            destination: NavigateAndLoadListView(
               store: Store(
-                initialState: EagerListNavigationState(
+                initialState: NavigateAndLoadListState(
                   rows: [
                     .init(count: 1, id: UUID()),
                     .init(count: 42, id: UUID()),
                     .init(count: 100, id: UUID()),
                   ]
                 ),
-                reducer: eagerListNavigationReducer,
-                environment: EagerListNavigationEnvironment(
+                reducer: navigateAndLoadListReducer,
+                environment: NavigateAndLoadListEnvironment(
                   mainQueue: DispatchQueue.main.eraseToAnyScheduler()
                 )
               )
@@ -188,17 +188,17 @@ struct RootView: View {
 
           NavigationLink(
             "Lists: Load data then navigate",
-            destination: LazyListNavigationView(
+            destination: LoadThenNavigateListView(
               store: Store(
-                initialState: LazyListNavigationState(
+                initialState: LoadThenNavigateListState(
                   rows: [
                     .init(count: 1, id: UUID()),
                     .init(count: 42, id: UUID()),
                     .init(count: 100, id: UUID()),
                   ]
                 ),
-                reducer: lazyListNavigationReducer,
-                environment: LazyListNavigationEnvironment(
+                reducer: loadThenNavigateListReducer,
+                environment: LoadThenNavigateListEnvironment(
                   mainQueue: DispatchQueue.main.eraseToAnyScheduler()
                 )
               )
@@ -207,11 +207,11 @@ struct RootView: View {
 
           NavigationLink(
             "Sheets: Present and load data",
-            destination: EagerSheetView(
+            destination: PresentAndLoadView(
               store: Store(
-                initialState: EagerSheetState(),
-                reducer: eagerSheetReducer,
-                environment: EagerSheetEnvironment(
+                initialState: PresentAndLoadState(),
+                reducer: presentAndLoadReducer,
+                environment: PresentAndLoadEnvironment(
                   mainQueue: DispatchQueue.main.eraseToAnyScheduler()
                 )
               )
@@ -220,11 +220,11 @@ struct RootView: View {
 
           NavigationLink(
             "Sheets: Load data then present",
-            destination: LazySheetView(
+            destination: LoadThenPresentView(
               store: Store(
-                initialState: LazySheetState(),
-                reducer: lazySheetReducer,
-                environment: LazySheetEnvironment(
+                initialState: LoadThenPresentState(),
+                reducer: loadThenPresentReducer,
+                environment: LoadThenPresentEnvironment(
                   mainQueue: DispatchQueue.main.eraseToAnyScheduler()
                 )
               )

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -8,7 +8,7 @@ private let readMe = """
   and fires off an effect that will load this state a second later.
   """
 
-struct EagerListNavigationState: Equatable {
+struct NavigateAndLoadListState: Equatable {
   var rows: IdentifiedArrayOf<Row> = []
   var selection: Identified<Row.ID, CounterState?>?
 
@@ -18,28 +18,28 @@ struct EagerListNavigationState: Equatable {
   }
 }
 
-enum EagerListNavigationAction: Equatable {
+enum NavigateAndLoadListAction: Equatable {
   case counter(CounterAction)
   case setNavigation(selection: UUID?)
   case setNavigationSelectionDelayCompleted
 }
 
-struct EagerListNavigationEnvironment {
+struct NavigateAndLoadListEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-let eagerListNavigationReducer = counterReducer
+let navigateAndLoadListReducer = counterReducer
   .optional
   .pullback(state: \Identified.value, action: .self, environment: { $0 })
   .optional
   .pullback(
-    state: \EagerListNavigationState.selection,
-    action: /EagerListNavigationAction.counter,
+    state: \NavigateAndLoadListState.selection,
+    action: /NavigateAndLoadListAction.counter,
     environment: { _ in CounterEnvironment() }
   )
   .combined(
     with: Reducer<
-      EagerListNavigationState, EagerListNavigationAction, EagerListNavigationEnvironment
+      NavigateAndLoadListState, NavigateAndLoadListAction, NavigateAndLoadListEnvironment
     > { state, action, environment in
 
       struct CancelId: Hashable {}
@@ -71,8 +71,8 @@ let eagerListNavigationReducer = counterReducer
     }
   )
 
-struct EagerListNavigationView: View {
-  let store: Store<EagerListNavigationState, EagerListNavigationAction>
+struct NavigateAndLoadListView: View {
+  let store: Store<NavigateAndLoadListState, NavigateAndLoadListAction>
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
@@ -82,14 +82,14 @@ struct EagerListNavigationView: View {
             NavigationLink(
               destination: IfLetStore(
                 self.store.scope(
-                  state: { $0.selection?.value }, action: EagerListNavigationAction.counter),
+                  state: { $0.selection?.value }, action: NavigateAndLoadListAction.counter),
                 then: CounterView.init(store:),
                 else: ActivityIndicator()
               ),
               tag: row.id,
               selection: viewStore.binding(
                 get: { $0.selection?.id },
-                send: EagerListNavigationAction.setNavigation(selection:)
+                send: NavigateAndLoadListAction.setNavigation(selection:)
               )
             ) {
               Text("Load optional counter that starts from \(row.count)")
@@ -102,20 +102,20 @@ struct EagerListNavigationView: View {
   }
 }
 
-struct EagerListNavigationView_Previews: PreviewProvider {
+struct NavigateAndLoadListView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
-      EagerListNavigationView(
+      NavigateAndLoadListView(
         store: Store(
-          initialState: EagerListNavigationState(
+          initialState: NavigateAndLoadListState(
             rows: [
               .init(count: 1, id: UUID()),
               .init(count: 42, id: UUID()),
               .init(count: 100, id: UUID()),
             ]
           ),
-          reducer: eagerListNavigationReducer,
-          environment: EagerListNavigationEnvironment(
+          reducer: navigateAndLoadListReducer,
+          environment: NavigateAndLoadListEnvironment(
             mainQueue: DispatchQueue.main.eraseToAnyScheduler()
           )
         )

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -9,33 +9,33 @@ private let readMe = """
   that depends on this data.
   """
 
-struct LazyNavigationState: Equatable {
+struct LoadThenNavigateState: Equatable {
   var optionalCounter: CounterState?
   var isActivityIndicatorVisible = false
 
   var isNavigationActive: Bool { self.optionalCounter != nil }
 }
 
-enum LazyNavigationAction: Equatable {
+enum LoadThenNavigateAction: Equatable {
   case optionalCounter(CounterAction)
   case setNavigation(isActive: Bool)
   case setNavigationIsActiveDelayCompleted
 }
 
-struct LazyNavigationEnvironment {
+struct LoadThenNavigateEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-let lazyNavigationReducer = counterReducer
+let loadThenNavigateReducer = counterReducer
   .optional
   .pullback(
     state: \.optionalCounter,
-    action: /LazyNavigationAction.optionalCounter,
+    action: /LoadThenNavigateAction.optionalCounter,
     environment: { _ in CounterEnvironment() }
   )
   .combined(
     with: Reducer<
-      LazyNavigationState, LazyNavigationAction, LazyNavigationEnvironment
+      LoadThenNavigateState, LoadThenNavigateAction, LoadThenNavigateEnvironment
     > { state, action, environment in
       switch action {
       case .setNavigation(isActive: true):
@@ -59,8 +59,8 @@ let lazyNavigationReducer = counterReducer
     }
   )
 
-struct LazyNavigationView: View {
-  let store: Store<LazyNavigationState, LazyNavigationAction>
+struct LoadThenNavigateView: View {
+  let store: Store<LoadThenNavigateState, LoadThenNavigateAction>
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
@@ -69,12 +69,12 @@ struct LazyNavigationView: View {
           NavigationLink(
             destination: IfLetStore(
               self.store.scope(
-                state: { $0.optionalCounter }, action: LazyNavigationAction.optionalCounter),
+                state: { $0.optionalCounter }, action: LoadThenNavigateAction.optionalCounter),
               then: CounterView.init(store:)
             ),
             isActive: viewStore.binding(
               get: { $0.isNavigationActive },
-              send: LazyNavigationAction.setNavigation(isActive:)
+              send: LoadThenNavigateAction.setNavigation(isActive:)
             )
           ) {
             HStack {
@@ -92,14 +92,14 @@ struct LazyNavigationView: View {
   }
 }
 
-struct LazyNavigationView_Previews: PreviewProvider {
+struct LoadThenNavigateView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
-      LazyNavigationView(
+      LoadThenNavigateView(
         store: Store(
-          initialState: LazyNavigationState(),
-          reducer: lazyNavigationReducer,
-          environment: LazyNavigationEnvironment(
+          initialState: LoadThenNavigateState(),
+          reducer: loadThenNavigateReducer,
+          environment: LoadThenNavigateEnvironment(
             mainQueue: DispatchQueue.main.eraseToAnyScheduler()
           )
         )

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -10,31 +10,31 @@ private let readMe = """
   counter state and fires off an effect that will load this state a second later.
   """
 
-struct EagerNavigationState: Equatable {
+struct NavigateAndLoadState: Equatable {
   var isNavigationActive = false
   var optionalCounter: CounterState?
 }
 
-enum EagerNavigationAction: Equatable {
+enum NavigateAndLoadAction: Equatable {
   case optionalCounter(CounterAction)
   case setNavigation(isActive: Bool)
   case setNavigationIsActiveDelayCompleted
 }
 
-struct EagerNavigationEnvironment {
+struct NavigateAndLoadEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-let eagerNavigationReducer = counterReducer
+let navigateAndLoadReducer = counterReducer
   .optional
   .pullback(
     state: \.optionalCounter,
-    action: /EagerNavigationAction.optionalCounter,
+    action: /NavigateAndLoadAction.optionalCounter,
     environment: { _ in CounterEnvironment() }
   )
   .combined(
     with: Reducer<
-      EagerNavigationState, EagerNavigationAction, EagerNavigationEnvironment
+      NavigateAndLoadState, NavigateAndLoadAction, NavigateAndLoadEnvironment
     > { state, action, environment in
       switch action {
       case .setNavigation(isActive: true):
@@ -58,8 +58,8 @@ let eagerNavigationReducer = counterReducer
     }
   )
 
-struct EagerNavigationView: View {
-  let store: Store<EagerNavigationState, EagerNavigationAction>
+struct NavigateAndLoadView: View {
+  let store: Store<NavigateAndLoadState, NavigateAndLoadAction>
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
@@ -68,13 +68,13 @@ struct EagerNavigationView: View {
           NavigationLink(
             destination: IfLetStore(
               self.store.scope(
-                state: { $0.optionalCounter }, action: EagerNavigationAction.optionalCounter),
+                state: { $0.optionalCounter }, action: NavigateAndLoadAction.optionalCounter),
               then: CounterView.init(store:),
               else: ActivityIndicator()
             ),
             isActive: viewStore.binding(
               get: { $0.isNavigationActive },
-              send: EagerNavigationAction.setNavigation(isActive:)
+              send: NavigateAndLoadAction.setNavigation(isActive:)
             )
           ) {
             HStack {
@@ -88,14 +88,14 @@ struct EagerNavigationView: View {
   }
 }
 
-struct EagerNavigationView_Previews: PreviewProvider {
+struct NavigateAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
-      EagerNavigationView(
+      NavigateAndLoadView(
         store: Store(
-          initialState: EagerNavigationState(),
-          reducer: eagerNavigationReducer,
-          environment: EagerNavigationEnvironment(
+          initialState: NavigateAndLoadState(),
+          reducer: navigateAndLoadReducer,
+          environment: NavigateAndLoadEnvironment(
             mainQueue: DispatchQueue.main.eraseToAnyScheduler()
           )
         )

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -9,33 +9,33 @@ private let readMe = """
   depends on this data.
   """
 
-struct LazySheetState: Equatable {
+struct LoadThenPresentState: Equatable {
   var optionalCounter: CounterState?
   var isActivityIndicatorVisible = false
 
   var isSheetPresented: Bool { self.optionalCounter != nil }
 }
 
-enum LazySheetAction {
+enum LoadThenPresentAction {
   case optionalCounter(CounterAction)
   case setSheet(isPresented: Bool)
   case setSheetIsPresentedDelayCompleted
 }
 
-struct LazySheetEnvironment {
+struct LoadThenPresentEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-let lazySheetReducer = counterReducer
+let loadThenPresentReducer = counterReducer
   .optional
   .pullback(
     state: \.optionalCounter,
-    action: /LazySheetAction.optionalCounter,
+    action: /LoadThenPresentAction.optionalCounter,
     environment: { _ in CounterEnvironment() }
   )
   .combined(
     with: Reducer<
-      LazySheetState, LazySheetAction, LazySheetEnvironment
+      LoadThenPresentState, LoadThenPresentAction, LoadThenPresentEnvironment
     > { state, action, environment in
       switch action {
       case .setSheet(isPresented: true):
@@ -59,8 +59,8 @@ let lazySheetReducer = counterReducer
     }
   )
 
-struct LazySheetView: View {
-  let store: Store<LazySheetState, LazySheetAction>
+struct LoadThenPresentView: View {
+  let store: Store<LoadThenPresentState, LoadThenPresentAction>
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
@@ -80,11 +80,12 @@ struct LazySheetView: View {
       .sheet(
         isPresented: viewStore.binding(
           get: { $0.isSheetPresented },
-          send: LazySheetAction.setSheet(isPresented:)
+          send: LoadThenPresentAction.setSheet(isPresented:)
         )
       ) {
         IfLetStore(
-          self.store.scope(state: { $0.optionalCounter }, action: LazySheetAction.optionalCounter),
+          self.store.scope(
+            state: { $0.optionalCounter }, action: LoadThenPresentAction.optionalCounter),
           then: CounterView.init(store:)
         )
       }
@@ -93,14 +94,14 @@ struct LazySheetView: View {
   }
 }
 
-struct LazySheetView_Previews: PreviewProvider {
+struct LoadThenPresentView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
-      LazySheetView(
+      LoadThenPresentView(
         store: Store(
-          initialState: LazySheetState(),
-          reducer: lazySheetReducer,
-          environment: LazySheetEnvironment(
+          initialState: LoadThenPresentState(),
+          reducer: loadThenPresentReducer,
+          environment: LoadThenPresentEnvironment(
             mainQueue: DispatchQueue.main.eraseToAnyScheduler()
           )
         )

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -8,31 +8,31 @@ private let readMe = """
   state and fires off an effect that will load this state a second later.
   """
 
-struct EagerSheetState: Equatable {
+struct PresentAndLoadState: Equatable {
   var optionalCounter: CounterState?
   var isSheetPresented = false
 }
 
-enum EagerSheetAction {
+enum PresentAndLoadAction {
   case optionalCounter(CounterAction)
   case setSheet(isPresented: Bool)
   case setSheetIsPresentedDelayCompleted
 }
 
-struct EagerSheetEnvironment {
+struct PresentAndLoadEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-let eagerSheetReducer = counterReducer
+let presentAndLoadReducer = counterReducer
   .optional
   .pullback(
     state: \.optionalCounter,
-    action: /EagerSheetAction.optionalCounter,
+    action: /PresentAndLoadAction.optionalCounter,
     environment: { _ in CounterEnvironment() }
   )
   .combined(
     with: Reducer<
-      EagerSheetState, EagerSheetAction, EagerSheetEnvironment
+      PresentAndLoadState, PresentAndLoadAction, PresentAndLoadEnvironment
     > { state, action, environment in
       switch action {
       case .setSheet(isPresented: true):
@@ -56,8 +56,8 @@ let eagerSheetReducer = counterReducer
     }
   )
 
-struct EagerSheetView: View {
-  let store: Store<EagerSheetState, EagerSheetAction>
+struct PresentAndLoadView: View {
+  let store: Store<PresentAndLoadState, PresentAndLoadAction>
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
@@ -71,11 +71,12 @@ struct EagerSheetView: View {
       .sheet(
         isPresented: viewStore.binding(
           get: { $0.isSheetPresented },
-          send: EagerSheetAction.setSheet(isPresented:)
+          send: PresentAndLoadAction.setSheet(isPresented:)
         )
       ) {
         IfLetStore(
-          self.store.scope(state: { $0.optionalCounter }, action: EagerSheetAction.optionalCounter),
+          self.store.scope(
+            state: { $0.optionalCounter }, action: PresentAndLoadAction.optionalCounter),
           then: CounterView.init(store:),
           else: ActivityIndicator()
         )
@@ -85,14 +86,14 @@ struct EagerSheetView: View {
   }
 }
 
-struct EagerSheetView_Previews: PreviewProvider {
+struct PresentAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
-      EagerSheetView(
+      PresentAndLoadView(
         store: Store(
-          initialState: EagerSheetState(),
-          reducer: eagerSheetReducer,
-          environment: EagerSheetEnvironment(
+          initialState: PresentAndLoadState(),
+          reducer: presentAndLoadReducer,
+          environment: PresentAndLoadEnvironment(
             mainQueue: DispatchQueue.main.eraseToAnyScheduler()
           )
         )

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,6 @@ test-workspace:
 		-quiet
 
 format:
-	swift format --in-place --recursive .
+	swift format --in-place --recursive ./Package.swift ./Sources ./Tests
 
 .PHONY: format test-all test-swift test-workspace

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -188,7 +188,7 @@ public struct Effect<Output, Failure: Error>: Publisher {
 
     return
       effects
-      .suffix(effects.count - 1)
+      .dropFirst()
       .reduce(into: first) { effects, effect in
         effects = effects.append(effect).eraseToEffect()
       }


### PR DESCRIPTION
The naming of the types in these case studies no longer reflect the language we use in describing them, so seems worth updating.