### PR TITLE
Remove --quiet so that we can diagnose test failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,67 +16,51 @@ test-workspace:
 	xcodebuild test \
 		-scheme ComposableArchitecture \
 		-destination platform="$(PLATFORM_IOS)" \
-		-quiet
 	xcodebuild test \
 		-scheme ComposableArchitecture \
 		-destination platform="$(PLATFORM_MACOS)" \
-		-quiet
 	xcodebuild test \
 		-scheme ComposableArchitecture \
 		-destination platform="$(PLATFORM_TVOS)" \
-		-quiet
 	xcodebuild test \
 		-scheme ComposableCoreLocation \
 		-destination platform="$(PLATFORM_IOS)" \
-		-quiet
 	xcodebuild test \
 		-scheme ComposableCoreLocation \
 		-destination platform="$(PLATFORM_MACOS)" \
-		-quiet
 	xcodebuild test \
 		-scheme ComposableCoreLocation \
 		-destination platform="$(PLATFORM_TVOS)" \
-		-quiet
 	xcodebuild test \
 		-scheme "CaseStudies (SwiftUI)" \
 		-destination platform="$(PLATFORM_IOS)" \
-		-quiet
 	xcodebuild test \
 		-scheme "CaseStudies (UIKit)" \
 		-destination platform="$(PLATFORM_IOS)" \
-		-quiet
 	xcodebuild test \
 		-scheme MotionManager \
 		-destination platform="$(PLATFORM_IOS)" \
-		-quiet
 	xcodebuild test \
 		-scheme LocationManagerDesktop \
 		-destination platform="$(PLATFORM_MACOS)" \
-		-quiet
 	xcodebuild test \
 		-scheme LocationManagerMobile \
 		-destination platform="$(PLATFORM_IOS)" \
-		-quiet
 	xcodebuild test \
 		-scheme Search \
 		-destination platform="$(PLATFORM_IOS)" \
-		-quiet
 	xcodebuild test \
 		-scheme SpeechRecognition \
 		-destination platform="$(PLATFORM_IOS)" \
-		-quiet
 	xcodebuild test \
 		-scheme TicTacToe \
 		-destination platform="$(PLATFORM_IOS)" \
-		-quiet
 	xcodebuild test \
 		-scheme Todos \
 		-destination platform="$(PLATFORM_IOS)" \
-		-quiet
 	xcodebuild test \
 		-scheme VoiceMemos \
 		-destination platform="$(PLATFORM_IOS)" \
-		-quiet
 
 format:
 	swift format --in-place --recursive ./Package.swift ./Sources ./Tests

--- a/Makefile
+++ b/Makefile
@@ -15,52 +15,52 @@ test-swift:
 test-workspace:
 	xcodebuild test \
 		-scheme ComposableArchitecture \
-		-destination platform="$(PLATFORM_IOS)" \
+		-destination platform="$(PLATFORM_IOS)"
 	xcodebuild test \
 		-scheme ComposableArchitecture \
-		-destination platform="$(PLATFORM_MACOS)" \
+		-destination platform="$(PLATFORM_MACOS)"
 	xcodebuild test \
 		-scheme ComposableArchitecture \
-		-destination platform="$(PLATFORM_TVOS)" \
+		-destination platform="$(PLATFORM_TVOS)"
 	xcodebuild test \
 		-scheme ComposableCoreLocation \
-		-destination platform="$(PLATFORM_IOS)" \
+		-destination platform="$(PLATFORM_IOS)"
 	xcodebuild test \
 		-scheme ComposableCoreLocation \
-		-destination platform="$(PLATFORM_MACOS)" \
+		-destination platform="$(PLATFORM_MACOS)"
 	xcodebuild test \
 		-scheme ComposableCoreLocation \
-		-destination platform="$(PLATFORM_TVOS)" \
+		-destination platform="$(PLATFORM_TVOS)"
 	xcodebuild test \
 		-scheme "CaseStudies (SwiftUI)" \
-		-destination platform="$(PLATFORM_IOS)" \
+		-destination platform="$(PLATFORM_IOS)"
 	xcodebuild test \
 		-scheme "CaseStudies (UIKit)" \
-		-destination platform="$(PLATFORM_IOS)" \
+		-destination platform="$(PLATFORM_IOS)"
 	xcodebuild test \
 		-scheme MotionManager \
-		-destination platform="$(PLATFORM_IOS)" \
+		-destination platform="$(PLATFORM_IOS)"
 	xcodebuild test \
 		-scheme LocationManagerDesktop \
-		-destination platform="$(PLATFORM_MACOS)" \
+		-destination platform="$(PLATFORM_MACOS)"
 	xcodebuild test \
 		-scheme LocationManagerMobile \
-		-destination platform="$(PLATFORM_IOS)" \
+		-destination platform="$(PLATFORM_IOS)"
 	xcodebuild test \
 		-scheme Search \
-		-destination platform="$(PLATFORM_IOS)" \
+		-destination platform="$(PLATFORM_IOS)"
 	xcodebuild test \
 		-scheme SpeechRecognition \
-		-destination platform="$(PLATFORM_IOS)" \
+		-destination platform="$(PLATFORM_IOS)"
 	xcodebuild test \
 		-scheme TicTacToe \
-		-destination platform="$(PLATFORM_IOS)" \
+		-destination platform="$(PLATFORM_IOS)"
 	xcodebuild test \
 		-scheme Todos \
-		-destination platform="$(PLATFORM_IOS)" \
+		-destination platform="$(PLATFORM_IOS)"
 	xcodebuild test \
 		-scheme VoiceMemos \
-		-destination platform="$(PLATFORM_IOS)" \
+		-destination platform="$(PLATFORM_IOS)"
 
 format:
 	swift format --in-place --recursive ./Package.swift ./Sources ./Tests


### PR DESCRIPTION
The `--quiet` flag hides a little too much information from us. 