### PR TITLE
Fix voice memos crasher

### DIFF
--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -28,6 +28,7 @@ struct VoiceMemo: Equatable {
 enum VoiceMemoAction: Equatable {
   case audioPlayerClient(Result<AudioPlayerClient.Action, AudioPlayerClient.Failure>)
   case playButtonTapped
+  case remove
   case timerUpdated(TimeInterval)
   case titleTextFieldChanged(String)
 }
@@ -56,7 +57,8 @@ let voiceMemoReducer = Reducer<VoiceMemo, VoiceMemoAction, VoiceMemoEnvironment>
         environment.audioPlayerClient
           .play(PlayerId(), memo.url)
           .catchToEffect()
-          .map(VoiceMemoAction.audioPlayerClient),
+          .map(VoiceMemoAction.audioPlayerClient)
+          .cancellable(id: PlayerId()),
 
         Effect.timer(id: TimerId(), every: 0.5, on: environment.mainQueue)
           .map {
@@ -76,6 +78,12 @@ let voiceMemoReducer = Reducer<VoiceMemo, VoiceMemoAction, VoiceMemoEnvironment>
           .fireAndForget()
       )
     }
+
+  case .remove:
+    return .merge(
+      .cancel(id: PlayerId()),
+      .cancel(id: TimerId())
+    )
 
   case let .timerUpdated(time):
     switch memo.mode {
@@ -121,7 +129,6 @@ enum VoiceMemosAction: Equatable {
   case alertDismissed
   case audioRecorderClient(Result<AudioRecorderClient.Action, AudioRecorderClient.Failure>)
   case currentRecordingTimerUpdated
-  case deleteVoiceMemo(IndexSet)
   case finalRecordingTime(TimeInterval)
   case openSettingsButtonTapped
   case recordButtonTapped
@@ -140,6 +147,12 @@ struct VoiceMemosEnvironment {
 }
 
 let voiceMemosReducer = Reducer<VoiceMemosState, VoiceMemosAction, VoiceMemosEnvironment>.combine(
+  voiceMemoReducer.forEach(
+    state: \.voiceMemos,
+    action: /VoiceMemosAction.voiceMemo(index:action:),
+    environment: {
+      VoiceMemoEnvironment(audioPlayerClient: $0.audioPlayerClient, mainQueue: $0.mainQueue)
+  }),
   .init { state, action, environment in
     struct RecorderId: Hashable {}
     struct RecorderTimerId: Hashable {}
@@ -194,10 +207,6 @@ let voiceMemosReducer = Reducer<VoiceMemosState, VoiceMemosAction, VoiceMemosEnv
 
     case .currentRecordingTimerUpdated:
       state.currentRecording?.duration += 1
-      return .none
-
-    case let .deleteVoiceMemo(indexSet):
-      state.voiceMemos.remove(atOffsets: indexSet)
       return .none
 
     case let .finalRecordingTime(duration):
@@ -262,16 +271,14 @@ let voiceMemosReducer = Reducer<VoiceMemosState, VoiceMemosAction, VoiceMemosEnv
       }
       return .none
 
+    case let .voiceMemo(index: index, action: .remove):
+      state.voiceMemos.remove(at: index)
+      return .none
+
     case .voiceMemo:
       return .none
     }
-  },
-  voiceMemoReducer.forEach(
-    state: \.voiceMemos,
-    action: /VoiceMemosAction.voiceMemo(index:action:),
-    environment: {
-      VoiceMemoEnvironment(audioPlayerClient: $0.audioPlayerClient, mainQueue: $0.mainQueue)
-    })
+  }
 )
 
 struct VoiceMemosView: View {
@@ -289,7 +296,11 @@ struct VoiceMemosView: View {
               id: \.url,
               content: VoiceMemoView.init(store:)
             )
-            .onDelete { viewStore.send(.deleteVoiceMemo($0)) }
+            .onDelete { indexSet in
+              for index in indexSet {
+                viewStore.send(.voiceMemo(index: index, action: .remove))
+              }
+            }
           }
           VStack {
             ZStack {

--- a/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
+++ b/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
@@ -281,7 +281,7 @@ class VoiceMemosTests: XCTestCase {
     )
 
     store.assert(
-      .send(.voiceMemo(index: 0, action: .remove)) {
+      .send(.voiceMemo(index: 0, action: .delete)) {
         $0.voiceMemos = []
       }
     )
@@ -313,7 +313,7 @@ class VoiceMemosTests: XCTestCase {
       .send(.voiceMemo(index: 0, action: .playButtonTapped)) {
         $0.voiceMemos[0].mode = .playing(progress: 0)
       },
-      .send(.voiceMemo(index: 0, action: .remove)) {
+      .send(.voiceMemo(index: 0, action: .delete)) {
         $0.voiceMemos = []
       },
       .do { self.scheduler.run() }

--- a/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
+++ b/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
@@ -281,8 +281,7 @@ class VoiceMemosTests: XCTestCase {
     )
 
     store.assert(
-      .send(.deleteVoiceMemo(IndexSet(integer: 1))),
-      .send(.deleteVoiceMemo(IndexSet(integer: 0))) {
+      .send(.voiceMemo(index: 0, action: .remove)) {
         $0.voiceMemos = []
       }
     )
@@ -314,7 +313,7 @@ class VoiceMemosTests: XCTestCase {
       .send(.voiceMemo(index: 0, action: .playButtonTapped)) {
         $0.voiceMemos[0].mode = .playing(progress: 0)
       },
-      .send(.deleteVoiceMemo(IndexSet(integer: 0))) {
+      .send(.voiceMemo(index: 0, action: .remove)) {
         $0.voiceMemos = []
       },
 

--- a/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
+++ b/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
@@ -309,18 +309,15 @@ class VoiceMemosTests: XCTestCase {
       )
     )
 
-    store.assert([
+    store.assert(
       .send(.voiceMemo(index: 0, action: .playButtonTapped)) {
         $0.voiceMemos[0].mode = .playing(progress: 0)
       },
       .send(.voiceMemo(index: 0, action: .remove)) {
         $0.voiceMemos = []
       },
-
-      // Uncomment these lines to reproduce the crash:
-      // .do { self.scheduler.advance(by: .milliseconds(500)) },
-      // .receive(.voiceMemo(index: 0, action: .timerUpdated(0.5)))
-    ])
+      .do { self.scheduler.run() }
+    )
   }
 }
 


### PR DESCRIPTION
As reported in #182, we have a crash in the voice memos demo when you delete a memo while it is playing. This is happening because there is an in-flight timer effect that keeps running even after the data is removed, and hence we try to run the reducer logic on a row that no longer exists.

The fix is easy enough, we just need to cancel some effects when removing the row, and in fact the assertion we have in `forEach` precisely describes what the problem is, so that's nice!