### PR TITLE
Debug printing for action labels

### DIFF
--- a/Sources/ComposableArchitecture/Debugging/ActionDebugging.swift
+++ b/Sources/ComposableArchitecture/Debugging/ActionDebugging.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Prints out a short label of given action leaving out large structs and arrays:
+/// Like .action1(.action2(...))
+func shortActionLabel(_ a: Any) -> String {
+  let m = Mirror(reflecting: a)
+  switch m.displayStyle {
+  case .enum:
+    if let child = m.children.first {
+      let childLabel = child.label ?? ""
+      let valueLabel = shortActionLabel(child.value)
+      return "." + childLabel + "(" + valueLabel + ")"
+    }
+    
+    return ".\(a)"
+    
+  case .tuple:
+    let arguments = m.children.map { label, value in
+      let childOutput = shortActionLabel(value)
+      return "\(label.map { "\($0):" } ?? "")\(childOutput.isEmpty ? "" : " \(childOutput)")"
+    }
+    .joined(separator: ", ")
+    return arguments
+    
+  case .collection:
+    return "[...]"
+    
+  case .set:
+    return  "{...}"
+    
+  case .dictionary:
+    return "[ : ]"
+    
+  case .struct:
+    return " \(m.subjectType)(...) "
+    
+  case .class:
+    return " \(m.subjectType)(...) "
+    
+  case .optional:
+    return " \(m.subjectType)(...) "
+    
+  case .none:
+    return String(describing: a)
+    
+  case .some:
+    return "..."
+  }
+}

--- a/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
@@ -42,6 +42,49 @@ extension Reducer {
     self.debug(prefix, state: { _ in () }, action: .self, environment: toDebugEnvironment)
   }
 
+  /// Prints debug messages describing all received actions by their label. Leaves
+  /// out structs and collections for readability. To get more complete output,
+  /// please use `.debugActions()`
+  ///
+  /// Printing is only done in debug (`#if DEBUG`) builds.
+  ///
+  /// - Parameters:
+  ///   - prefix: A string with which to prefix all debug messages.
+  ///   - toDebugEnvironment: A function that transforms an environment into a debug environment by
+  ///     describing a print function and a queue to print from. Defaults to a function that ignores
+  ///     the environment and returns a default `DebugEnvironment` that uses Swift's `print`
+  ///     function and a background queue.
+  /// - Returns: A reducer that prints debug messages for all received actions.
+  public func debugActionLabels(
+    _ prefix: String = "",
+    environment toDebugEnvironment: @escaping (Environment) -> DebugEnvironment = { _ in
+    DebugEnvironment()
+    }
+  ) -> Reducer {
+    #if DEBUG
+    return .init { state, action, environment in
+      let effects = self.run(&state, action, environment)
+      let debugEnvironment = toDebugEnvironment(environment)
+      return .concatenate(
+        .fireAndForget {
+          debugEnvironment.queue.async {
+            let actionOutput = shortActionLabel(action)
+            debugEnvironment.printer(
+              """
+              \(prefix.isEmpty ? "" : "\(prefix): ")Action: \(actionOutput)
+              """
+            )
+          }
+        },
+        effects
+      )
+    }
+    #else
+    return self
+    #endif
+  }
+  
+
   /// Prints debug messages describing all received local actions and local state mutations.
   ///
   /// Printing is only done in debug (`#if DEBUG`) builds.

--- a/Tests/ComposableArchitectureTests/Internal/DebugActionsTests.swift
+++ b/Tests/ComposableArchitectureTests/Internal/DebugActionsTests.swift
@@ -1,0 +1,44 @@
+import Combine
+import XCTest
+
+@testable import ComposableArchitecture
+
+private enum Action: Equatable {
+  case one
+  case two(a: Int)
+  case three(b: [Int])
+}
+
+
+final class DebugActionsTests: XCTestCase {
+
+  func testThrottleLatest() {
+
+    var prints = [String]()
+    let expectWait1 = expectation(description: "Waiting...")
+    let expectWait2 = expectation(description: "Waiting...")
+    let expectWait3 = expectation(description: "Waiting...")
+
+    let reducer = Reducer<Int, Action, Void>{ (state, _, _) in
+      state += 1
+      return .none
+    }
+      .debugActionLabels(environment: { DebugEnvironment(printer: { prints.append($0) }) })
+
+    let store = TestStore(initialState: 0, reducer: reducer, environment: ())
+
+    store.assert(
+      .send(.one) { $0 = 1},
+      .do { XCTWaiter().wait(for: [expectWait1], timeout: 0.02) },
+      .do { XCTAssertEqual(prints, ["Action: .one"]) },
+
+      .send(.two(a: 2)) { $0 = 2},
+      .do { XCTWaiter().wait(for: [expectWait2], timeout: 0.02) },
+      .do { XCTAssertEqual(prints, ["Action: .one", "Action: .two(a: 2)"]) },
+
+      .send(.three(b: [1, 2, 3])) { $0 = 3},
+      .do { XCTWaiter().wait(for: [expectWait3], timeout: 0.02) },
+      .do { XCTAssertEqual(prints, ["Action: .one", "Action: .two(a: 2)", "Action: .three(b: [...])"]) }
+    )
+  }
+}


### PR DESCRIPTION
I made a small debug print helper to provide action label printing. Idea was to make actions one-liners so they are a bit easier to read than using the regular debug() reducer. This is specially helpful if one is interested in the action sequence order and not so much on the state changes.