### PR TITLE
Specify action formatting when using `.debug`

### DIFF
--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -131,7 +131,8 @@ let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
     environment: { _ in TodoEnvironment() }
   )
 )
-.debug()
+
+.debugActions(actionFormat: .labelsOnly)
 
 struct AppView: View {
   struct ViewState: Equatable {

--- a/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
@@ -96,8 +96,9 @@ extension Reducer {
               let actionOutput = actionFormat == .prettyPrint
                 ? debugOutput(localAction).indent(by: 2)
                 : debugCaseOutput(localAction).indent(by: 2)
-              let stateOutput =
-                debugDiff(previousState, nextState).map { "\($0)\n" } ?? "  (No state changes)\n"
+              let stateOutput = LocalState.self == Void.self
+                ? ""
+                : debugDiff(previousState, nextState).map { "\($0)\n" } ?? "  (No state changes)\n"
               debugEnvironment.printer(
                 """
                 \(prefix.isEmpty ? "" : "\(prefix): ")received action:

--- a/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
@@ -4,9 +4,21 @@ import Dispatch
 /// Determines how the string description of an action should be printed when using the `.debug()`
 /// higher-order reducer.
 public enum ActionFormat {
-  /// asdf
+  /// Prints the action in a single line by only specifying the labels of the associated values:
+  ///
+  ///     Action.screenA(.row(index:, action: .textChanged(query:)))
   case labelsOnly
-  /// asdfadsf
+  /// Prints the action in a multiline, pretty-printed format, including all the labels of
+  /// any associated values, as well as the data held in the associated values:
+  ///
+  ///     Action.screenA(
+  ///       ScreenA.row(
+  ///         index: 1,
+  ///         action: RowAction.textChanged(
+  ///           query: "Hi"
+  ///         )
+  ///       )
+  ///     )
   case prettyPrint
 }
 

--- a/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
@@ -1,8 +1,12 @@
 import CasePaths
 import Dispatch
 
+/// Determines how the string description of an action should be printed when using the `.debug()`
+/// higher-order reducer.
 public enum ActionFormat {
+  /// asdf
   case labelsOnly
+  /// asdfadsf
   case prettyPrint
 }
 

--- a/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
@@ -87,22 +87,26 @@ extension Publisher where Failure == Never {
 }
 
 func debugCaseOutput(_ value: Any) -> String {
-  let mirror = Mirror(reflecting: value)
-  switch mirror.displayStyle {
-  case .enum:
-    guard let child = mirror.children.first else {
-      let childOutput = "\(value)"
-      return childOutput == "\(type(of: value))" ? "" : ".\(childOutput)"
+  func debugCaseOutputHelp(_ value: Any) -> String {
+    let mirror = Mirror(reflecting: value)
+    switch mirror.displayStyle {
+    case .enum:
+      guard let child = mirror.children.first else {
+        let childOutput = "\(value)"
+        return childOutput == "\(type(of: value))" ? "" : ".\(childOutput)"
+      }
+      let childOutput = debugCaseOutputHelp(child.value)
+      return ".\(child.label ?? "")\(childOutput.isEmpty ? "" : "(\(childOutput))")"
+    case .tuple:
+      return mirror.children.map { label, value in
+        let childOutput = debugCaseOutputHelp(value)
+        return "\(label.map { "\($0):" } ?? "")\(childOutput.isEmpty ? "" : " \(childOutput)")"
+      }
+      .joined(separator: ", ")
+    default:
+      return ""
     }
-    let childOutput = debugCaseOutput(child.value)
-    return ".\(child.label ?? "")\(childOutput.isEmpty ? "" : "(\(childOutput))")"
-  case .tuple:
-    return mirror.children.map { label, value in
-      let childOutput = debugCaseOutput(value)
-      return "\(label.map { "\($0):" } ?? "")\(childOutput.isEmpty ? "" : " \(childOutput)")"
-    }
-    .joined(separator: ", ")
-  default:
-    return ""
   }
+
+  return "\(type(of: value))\(debugCaseOutputHelp(value))"
 }

--- a/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
@@ -100,7 +100,7 @@ func debugCaseOutput(_ value: Any) -> String {
     case .tuple:
       return mirror.children.map { label, value in
         let childOutput = debugCaseOutputHelp(value)
-        return "\(label.map { "\($0):" } ?? "")\(childOutput.isEmpty ? "" : " \(childOutput)")"
+        return "\(label.map { isUnlabeledArgument($0) ? "_:" : "\($0):" } ?? "")\(childOutput.isEmpty ? "" : " \(childOutput)")"
       }
       .joined(separator: ", ")
     default:
@@ -109,4 +109,8 @@ func debugCaseOutput(_ value: Any) -> String {
   }
 
   return "\(type(of: value))\(debugCaseOutputHelp(value))"
+}
+
+private func isUnlabeledArgument(_ label: String) -> Bool {
+  label.firstIndex(where: { $0 != "." && !$0.isNumber }) == nil
 }

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -835,6 +835,8 @@ final class DebugTests: XCTestCase {
 
   func testDebugCaseOutput() {
     enum Action {
+      case action1(Bool, label: String)
+      case action2(Bool, Int, String)
       case screenA(ScreenA)
 
       enum ScreenA {
@@ -848,13 +850,23 @@ final class DebugTests: XCTestCase {
     }
 
     XCTAssertEqual(
+      debugCaseOutput(Action.action1(true, label: "Blob")),
+      "Action.action(_:, label:)"
+    )
+
+    XCTAssertEqual(
+      debugCaseOutput(Action.action2(true, 1, "Blob")),
+      "Action.action(_:, _:, _:)"
+    )
+
+    XCTAssertEqual(
       debugCaseOutput(Action.screenA(.row(index: 1, action: .tapped))),
-      ".screenA(.row(index:, action: .tapped))"
+      "Action.screenA(.row(index:, action: .tapped))"
     )
 
     XCTAssertEqual(
       debugCaseOutput(Action.screenA(.row(index: 1, action: .textChanged(query: "Hi")))),
-      ".screenA(.row(index:, action: .textChanged(query:)))"
+      "Action.screenA(.row(index:, action: .textChanged(query:)))"
     )
   }
 }

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -851,12 +851,12 @@ final class DebugTests: XCTestCase {
 
     XCTAssertEqual(
       debugCaseOutput(Action.action1(true, label: "Blob")),
-      "Action.action(_:, label:)"
+      "Action.action1(_:, label:)"
     )
 
     XCTAssertEqual(
       debugCaseOutput(Action.action2(true, 1, "Blob")),
-      "Action.action(_:, _:, _:)"
+      "Action.action2(_:, _:, _:)"
     )
 
     XCTAssertEqual(

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -869,4 +869,68 @@ final class DebugTests: XCTestCase {
       "Action.screenA(.row(index:, action: .textChanged(query:)))"
     )
   }
+
+  func testDebugOutput() {
+    enum Action {
+      case action1(Bool, label: String)
+      case action2(Bool, Int, String)
+      case screenA(ScreenA)
+
+      enum ScreenA {
+        case row(index: Int, action: RowAction)
+
+        enum RowAction {
+          case tapped
+          case textChanged(query: String)
+        }
+      }
+    }
+
+    XCTAssertEqual(
+      debugOutput(Action.action1(true, label: "Blob")),
+      """
+      Action.action1(
+        true,
+        label: "Blob"
+      )
+      """
+    )
+
+    XCTAssertEqual(
+      debugOutput(Action.action2(true, 1, "Blob")),
+      """
+      Action.action2(
+        true,
+        1,
+        "Blob"
+      )
+      """
+    )
+
+    XCTAssertEqual(
+      debugOutput(Action.screenA(.row(index: 1, action: .tapped))),
+      """
+      Action.screenA(
+        ScreenA.row(
+          index: 1,
+          action: RowAction.tapped
+        )
+      )
+      """
+    )
+
+    XCTAssertEqual(
+      debugOutput(Action.screenA(.row(index: 1, action: .textChanged(query: "Hi")))),
+      """
+      Action.screenA(
+        ScreenA.row(
+          index: 1,
+          action: RowAction.textChanged(
+            query: "Hi"
+          )
+        )
+      )
+      """
+    )
+  }
 }

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -832,4 +832,29 @@ final class DebugTests: XCTestCase {
       """
     )
   }
+
+  func testDebugCaseOutput() {
+    enum Action {
+      case screenA(ScreenA)
+
+      enum ScreenA {
+        case row(index: Int, action: RowAction)
+
+        enum RowAction {
+          case tapped
+          case textChanged(query: String)
+        }
+      }
+    }
+
+    XCTAssertEqual(
+      debugCaseOutput(Action.screenA(.row(index: 1, action: .tapped))),
+      ".screenA(.row(index:, action: .tapped))"
+    )
+
+    XCTAssertEqual(
+      debugCaseOutput(Action.screenA(.row(index: 1, action: .textChanged(query: "Hi")))),
+      ".screenA(.row(index:, action: .textChanged(query:)))"
+    )
+  }
 }

--- a/Tests/ComposableArchitectureTests/Internal/EffectThrottleTests.swift
+++ b/Tests/ComposableArchitectureTests/Internal/EffectThrottleTests.swift
@@ -1,4 +1,5 @@
 import Combine
+import CombineSchedulers
 import XCTest
 
 @testable import ComposableArchitecture

--- a/Tests/ComposableArchitectureTests/Internal/EffectThrottleTests.swift
+++ b/Tests/ComposableArchitectureTests/Internal/EffectThrottleTests.swift
@@ -1,5 +1,4 @@
 import Combine
-import CombineSchedulers
 import XCTest
 
 @testable import ComposableArchitecture


### PR DESCRIPTION
Inspired by #185 we wanted to provide more customization for printing actions because sometimes we may want to only know the action being sent but not all of the associated values that were packaged into the action.