### PR TITLE
Print offending action on Store.send assertion

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -144,8 +144,10 @@ public final class Store<State, Action> {
       if self.isSending {
         assertionFailure(
           """
-          The store was sent an action while it was already processing another action. This can \
-          happen for a few reasons:
+          The store was sent an action while it was already processing another action.
+          Sent action: \(debugCaseOutput(action))
+
+          This can happen for a few reasons:
 
           * The store was sent an action recursively. This can occur when you run an effect \
           directly in the reducer, rather than returning it from the reducer. Check the stack (⌘7) \

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -144,8 +144,8 @@ public final class Store<State, Action> {
       if self.isSending {
         assertionFailure(
           """
-          The store was sent an action while it was already processing another action.
-          Sent action: \(debugCaseOutput(action))
+          The store was sent the action \(debugCaseOutput(action)) while it was already 
+          processing another action.
 
           This can happen for a few reasons:
 


### PR DESCRIPTION
Added a debug print of an action sent recursively to the store. Useful if the stacktrace is long or Xcode does not show the action in the debug-tooltip (nothing to do with this library, but a bug that happens to me quite frequently).