### PR TITLE
Merge debug reducer to avoid Combine leak

### DIFF
--- a/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
@@ -106,7 +106,7 @@ extension Reducer {
         guard let localAction = toLocalAction.extract(from: action) else { return effects }
         let nextState = toLocalState(state)
         let debugEnvironment = toDebugEnvironment(environment)
-        return .concatenate(
+        return .merge(
           .fireAndForget {
             debugEnvironment.queue.async {
               let actionOutput =

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -170,6 +170,12 @@ public struct Effect<Output, Failure: Error>: Publisher {
   /// Concatenates a variadic list of effects together into a single effect, which runs the effects
   /// one after the other.
   ///
+  /// - Warning: Combine's `Publishers.Concatenate` operator, which this function uses, can leak
+  ///   when its suffix is a `Publishers.MergeMany` operator, which is used throughout the
+  ///   Composable Architecture in functions like `Reducer.combine`.
+  ///
+  ///   Feedback filed: <https://gist.github.com/mbrandonw/611c8352e1bd1c22461bd505e320ab58>
+  ///
   /// - Parameter effects: A variadic list of effects.
   /// - Returns: A new effect
   public static func concatenate(_ effects: Effect...) -> Effect {
@@ -178,6 +184,12 @@ public struct Effect<Output, Failure: Error>: Publisher {
 
   /// Concatenates a collection of effects together into a single effect, which runs the effects one
   /// after the other.
+  ///
+  /// - Warning: Combine's `Publishers.Concatenate` operator, which this function uses, can leak
+  ///   when its suffix is a `Publishers.MergeMany` operator, which is used throughout the
+  ///   Composable Architecture in functions like `Reducer.combine`.
+  ///
+  ///   Feedback filed: <https://gist.github.com/mbrandonw/611c8352e1bd1c22461bd505e320ab58>
   ///
   /// - Parameter effects: A collection of effects.
   /// - Returns: A new effect


### PR DESCRIPTION
This PR updates the `debug` higher-order reducer to use `merge` instead of `concatenate` in order to avoid a bug in the Combine framework.

It doesn't "fix" #194, but it does prevent a very common manifestation of the bug.