### PR TITLE
Add support for annotating steps in .assert()

### DIFF
--- a/Sources/ComposableArchitecture/TestSupport/Annotating.swift
+++ b/Sources/ComposableArchitecture/TestSupport/Annotating.swift
@@ -11,7 +11,7 @@ import XCTest
 
 extension TestStore.Annotating {
   public static var activity: Self {
-    Self { step, callback in
+    Self { step, _, callback in
       var activityName: String!
       
       switch step.type {
@@ -33,20 +33,25 @@ extension TestStore.Annotating {
   }
   
   public static var console: Self {
-    Self { step, callback in
+    Self { step, groupLevel, callback in
+      func console(_ string: String) {
+        let indent = String(repeating: "\t", count: groupLevel)
+        print("\(indent)\(string)")
+      }
+      
       switch step.type {
       case let .send(action, _):
-        print("\t send: \(action)")
+        console("send: \(action)")
       case let .receive(action, _):
-        print("\t receive: \(action)")
+        console("receive: \(action)")
       case let .group(name, _):
-        print("TestStore assert group: '\(name)' started at \(Date())")
+        console("TestStore assert group: '\(name)' started at \(Date())")
       default:
         return
       }
       
       callback() { stepPassed in
-        print("\t\t [\(stepPassed ? "PASS" : "FAIL")]")
+        console("\t [\(stepPassed ? "PASS" : "FAIL")]")
       }
     }
   }

--- a/Sources/ComposableArchitecture/TestSupport/Annotating.swift
+++ b/Sources/ComposableArchitecture/TestSupport/Annotating.swift
@@ -16,18 +16,18 @@ extension TestStore.Annotating {
       
       switch step.type {
       case let .send(action, _):
-        activityName = "send: \(action)"
+        activityName = "--> send: \(action)"
       case let .receive(action, _):
-        activityName = "receive: \(action)"
+        activityName = "<-- receive: \(action)"
       case let .group(name, _):
         activityName = name
       default:
-        callback()
+        callback() { _ in }
         return
       }
       
       XCTContext.runActivity(named: activityName) { _ in
-        callback()
+        callback() { _ in }
       }
     }
   }
@@ -45,7 +45,9 @@ extension TestStore.Annotating {
         return
       }
       
-      callback()
+      callback() { stepPassed in
+        print("\t\t [\(stepPassed ? "PASS" : "FAIL")]")
+      }
     }
   }
 }

--- a/Sources/ComposableArchitecture/TestSupport/Annotating.swift
+++ b/Sources/ComposableArchitecture/TestSupport/Annotating.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//  
-//
-//  Created by Luke Redpath on 25/06/2020.
-//
-
 #if DEBUG
 
 import XCTest

--- a/Sources/ComposableArchitecture/TestSupport/Annotating.swift
+++ b/Sources/ComposableArchitecture/TestSupport/Annotating.swift
@@ -1,0 +1,53 @@
+//
+//  File.swift
+//  
+//
+//  Created by Luke Redpath on 25/06/2020.
+//
+
+#if DEBUG
+
+import XCTest
+
+extension TestStore.Annotating {
+  public static var activity: Self {
+    Self { step, callback in
+      var activityName: String!
+      
+      switch step.type {
+      case let .send(action, _):
+        activityName = "send: \(action)"
+      case let .receive(action, _):
+        activityName = "receive: \(action)"
+      case let .group(name, _):
+        activityName = name
+      default:
+        callback()
+        return
+      }
+      
+      XCTContext.runActivity(named: activityName) { _ in
+        callback()
+      }
+    }
+  }
+  
+  public static var console: Self {
+    Self { step, callback in
+      switch step.type {
+      case let .send(action, _):
+        print("\t send: \(action)")
+      case let .receive(action, _):
+        print("\t receive: \(action)")
+      case let .group(name, _):
+        print("TestStore assert group: '\(name)' started at \(Date())")
+      default:
+        return
+      }
+      
+      callback()
+    }
+  }
+}
+
+#endif

--- a/Sources/ComposableArchitecture/TestSupport/Annotating.swift
+++ b/Sources/ComposableArchitecture/TestSupport/Annotating.swift
@@ -11,23 +11,24 @@ import XCTest
 
 extension TestStore.Annotating {
   public static var activity: Self {
-    Self { step, _, callback in
-      var activityName: String!
+    Self { step, groupLevel, callback in
+      func runActivity(named name: String) {
+        let indent = String(repeating: "\t", count: groupLevel)
+        XCTContext.runActivity(named: "\(indent)\(name)") { _ in
+          callback() { _ in }
+        }
+      }
       
       switch step.type {
       case let .send(action, _):
-        activityName = "--> send: \(action)"
+        runActivity(named: "send: \(action)")
       case let .receive(action, _):
-        activityName = "<-- receive: \(action)"
+        runActivity(named: "recv: \(action)")
       case let .group(name, _):
-        activityName = name
+        runActivity(named: name)
       default:
         callback() { _ in }
         return
-      }
-      
-      XCTContext.runActivity(named: activityName) { _ in
-        callback() { _ in }
       }
     }
   }

--- a/Sources/ComposableArchitecture/TestSupport/Annotating.swift
+++ b/Sources/ComposableArchitecture/TestSupport/Annotating.swift
@@ -1,15 +1,16 @@
 #if DEBUG
 
-import XCTest
-
 extension TestStore.Annotating {
   public static var activity: Self {
     Self { step, groupLevel, callback in
       func runActivity(named name: String) {
         let indent = String(repeating: "\t", count: groupLevel)
-        XCTContext.runActivity(named: "\(indent)\(name)") { _ in
-          callback() { _ in }
-        }
+        let callback: (@convention(block) () -> Void) = { callback() { _ in } }
+        _XCTContext.perform(
+          Selector(("runActivityNamed:block:")),
+          with: "\(indent)\(name)",
+          with: callback
+        )
       }
       
       switch step.type {
@@ -50,5 +51,7 @@ extension TestStore.Annotating {
     }
   }
 }
+
+private let _XCTContext = (NSClassFromString("XCTContext") as Any) as! NSObjectProtocol
 
 #endif

--- a/Sources/ComposableArchitecture/TestSupport/Annotating.swift
+++ b/Sources/ComposableArchitecture/TestSupport/Annotating.swift
@@ -4,6 +4,9 @@ extension TestStore.Annotating {
   public static var activity: Self {
     Self { step, groupLevel, callback in
       func runActivity(named name: String) {
+        // NB: `swift test` does not support XCTActivity, so do not run this code.
+        guard ProcessInfo.processInfo.environment["_"] == nil else { return }
+
         let indent = String(repeating: "\t", count: groupLevel)
         let callback: (@convention(block) () -> Void) = { callback() { _ in } }
         _XCTContext.perform(

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -199,7 +199,7 @@
 
       for step in steps {
         annotating.annotate(step, groupLevel) { stepResultCallback in
-          var expectedState = toLocalState(state)
+          var expectedState = self.toLocalState(self.state)
 
           switch step.type {
           case let .send(action, update):
@@ -455,9 +455,9 @@
     public struct Annotating {
       public typealias StepResultCallback = (Bool) -> Void
       
-      public var annotate: (Step, Int, (@escaping StepResultCallback) -> Void) -> Void
+      public var annotate: (Step, Int, @escaping (@escaping StepResultCallback) -> Void) -> Void
       
-      public init(annotate: @escaping (Step, Int, (@escaping StepResultCallback) -> Void) -> Void) {
+      public init(annotate: @escaping (Step, Int, @escaping (@escaping StepResultCallback) -> Void) -> Void) {
         self.annotate = annotate
       }
       

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -180,10 +180,12 @@ final class ComposableArchitectureTests: XCTestCase {
     )
   }
     
-  func testAssertWithActivitySteps() {
+  func testAssertWithAnnotations() {
     enum CounterAction {
       case increment
       case decrement
+      case produceEffect
+      case effectProduced
     }
     
     let counterReducer = Reducer<Int, CounterAction, Void> { state, action, _ in
@@ -192,6 +194,10 @@ final class ComposableArchitectureTests: XCTestCase {
         state += 1
       case .decrement:
         state -= 1
+      case .produceEffect:
+        return Effect(value: .effectProduced)
+      case .effectProduced:
+        break
       }
       return .none
     }
@@ -219,7 +225,14 @@ final class ComposableArchitectureTests: XCTestCase {
           $0 = 0
         }
       ),
-      annotateTo: .console
+      .group("Send and receive with effects",
+        .send(.produceEffect),
+        .receive(.effectProduced)
+      ),
+      .send(.increment) {
+        $0 = 1
+      },
+      annotateTo: .combine(.console, .activity)
     )
   }
 }

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -203,7 +203,7 @@ final class ComposableArchitectureTests: XCTestCase {
     )
     
     store.assert(
-      .activity("Incrementing steps",
+      .group("Incrementing steps",
         .send(.increment) {
           $0 = 1
         },
@@ -211,14 +211,16 @@ final class ComposableArchitectureTests: XCTestCase {
           $0 = 2
         }
       ),
-      .activity("Decrementing steps",
+      .group("Decrementing steps",
         .send(.decrement) {
           $0 = 1
         },
         .send(.decrement) {
           $0 = 0
         }
-      )
+      ),
+      annotateTo: .console
     )
   }
 }
+

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -179,4 +179,46 @@ final class ComposableArchitectureTests: XCTestCase {
       .do { scheduler.run() }
     )
   }
+    
+  func testAssertWithActivitySteps() {
+    enum CounterAction {
+      case increment
+      case decrement
+    }
+    
+    let counterReducer = Reducer<Int, CounterAction, Void> { state, action, _ in
+      switch action {
+      case .increment:
+        state += 1
+      case .decrement:
+        state -= 1
+      }
+      return .none
+    }
+    
+    let store = TestStore(
+      initialState: 0,
+      reducer: counterReducer,
+      environment: ()
+    )
+    
+    store.assert(
+      .activity("Incrementing steps",
+        .send(.increment) {
+          $0 = 1
+        },
+        .send(.increment) {
+          $0 = 2
+        }
+      ),
+      .activity("Decrementing steps",
+        .send(.decrement) {
+          $0 = 1
+        },
+        .send(.decrement) {
+          $0 = 0
+        }
+      )
+    )
+  }
 }


### PR DESCRIPTION
This PR adds support for passing in a custom step annotation that allows steps to be logged in the test console output and also as `XCTActivity` for a nice display in the Xcode test results window.

The PR includes the console and XCTActivity implementations as well as a null implementation (the default) and the ability to combine annotations.

In addition, I've added a new `.group` step which allows you to logically group some of your steps which I think can be useful in longer, integration-style asserts. Groups can be nested and the group level is available to annotations so they can format appropriately.

I'm reasonably happy with the underlying implementation but I think there's a few issues that need addressing:

* I'm not sure if the API of passing in the annotators to the `.assert()` method in the `annotateTo:` parameter is ideal ergonomically. Could it be passed into the initialiser of the store instead?

* The `Annotating.swift` file which defines the activity implementation imports `XCTest` which I've noticed you've gone to an effort to avoid doing in `TestStore.swift` - some advice on how to clean this up would be appreciated.

The proof of the pudding as they say...here's the test case showing it's use:

```swift
store.assert(
  .group("Incrementing steps",
    .send(.increment) {
      $0 = 1
    },
    .send(.increment) {
      $0 = 2
    }
  ),
  .group("Decrementing steps",
    .send(.decrement) {
      $0 = 1
    },
    .send(.decrement) {
      $0 = 0
    }
  ),
  .group("Send and receive with effects",
    .send(.produceEffect),
    .receive(.effectProduced)
  ),
  .send(.increment) {
    $0 = 1
  },
  annotateTo: .combine(.console, .activity)
)
```

The console output:
<img width="915" alt="Screenshot 2020-06-25 at 13 22 21" src="https://user-images.githubusercontent.com/613/85720837-b5622f00-b6e8-11ea-845e-fa48ff938708.png">

The Xcode test report output using XCTActivity:
<img width="375" alt="Screenshot 2020-06-25 at 13 28 25" src="https://user-images.githubusercontent.com/613/85720887-bf842d80-b6e8-11ea-9da9-96f887757aba.png">
