### PR TITLE
Don't use @Published for ViewStore state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,7 +3,7 @@ name: Format
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   swift_format:

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -66,7 +66,11 @@ public final class ViewStore<State, Action>: ObservableObject {
   }
 
   /// The current state.
-  @Published public internal(set) var state: State
+  public private(set) var state: State {
+    willSet {
+      self.objectWillChange.send()
+    }
+  }
 
   let _send: (Action) -> Void
 


### PR DESCRIPTION
Combine's beta includes a new `assign(to:)` on publisher that can feed state updates to a `@Published` publisher. We don't want this, so let's ping `objectWillChange` directly.

https://developer.apple.com/documentation/combine/publisher/assign(to:)