### PR TITLE
Make location getter work like Corelocation.location getter

### DIFF
--- a/Sources/ComposableCoreLocation/Interface.swift
+++ b/Sources/ComposableCoreLocation/Interface.swift
@@ -272,7 +272,7 @@ public struct LocationManager {
   @available(watchOS, unavailable)
   public var isRangingAvailable: () -> Bool = { _unimplemented("isRangingAvailable") }
 
-  var location: (AnyHashable) -> Location = { _ in _unimplemented("location") }
+  var location: (AnyHashable) -> Location? = { _ in nil }
 
   public var locationServicesEnabled: () -> Bool = { _unimplemented("locationServicesEnabled") }
 
@@ -393,7 +393,7 @@ public struct LocationManager {
   @available(tvOS, unavailable)
   public func heading(id: AnyHashable) -> Heading? { self.heading(id) }
 
-  public func location(id: AnyHashable) -> Location { self.location(id) }
+  public func location(id: AnyHashable) -> Location? { self.location(id) }
 
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)

--- a/Sources/ComposableCoreLocation/Interface.swift
+++ b/Sources/ComposableCoreLocation/Interface.swift
@@ -272,7 +272,7 @@ public struct LocationManager {
   @available(watchOS, unavailable)
   public var isRangingAvailable: () -> Bool = { _unimplemented("isRangingAvailable") }
 
-  var location: (AnyHashable) -> Location? = { _ in nil }
+  var location: (AnyHashable) -> Location? = { _ in _unimplemented("location") }
 
   public var locationServicesEnabled: () -> Bool = { _unimplemented("locationServicesEnabled") }
 

--- a/Sources/ComposableCoreLocation/Live.swift
+++ b/Sources/ComposableCoreLocation/Live.swift
@@ -48,6 +48,8 @@ extension LocationManager {
 
     manager.locationServicesEnabled = CLLocationManager.locationServicesEnabled
 
+    manager.location = { id in dependencies[id]?.manager.location.map(Location.init(rawValue:)) }
+    
     manager.requestLocation = { id in
       .fireAndForget { dependencies[id]?.manager.requestLocation() }
     }


### PR DESCRIPTION
In CoreLocation the location getter is optional and here it raise a fatal error.

https://developer.apple.com/documentation/corelocation/cllocationmanager/1423687-location

This PR make it optional.