### PR TITLE
Fixes small `viewStore` ⇒ `self.store` typo in `AlertState`’s docs.

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -59,7 +59,7 @@ import SwiftUI
 ///
 ///     Button("Delete") { viewStore.send(.deleteTapped) }
 ///       .alert(
-///         viewStore.scope(state: \.alert),
+///         self.store.scope(state: \.alert),
 ///         dismiss: .cancelTapped
 ///       )
 ///


### PR DESCRIPTION
And a PR for the blog post — https://github.com/pointfreeco/pointfreeco/pull/673.