### PR TITLE
[Experiementation] Change the diff algo

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "0.1.0"),
     .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.1.1"),
+    .package(url: "https://github.com/krzysztofzablocki/Difference.git", .branch("master")),
   ],
   targets: [
     .target(
@@ -34,6 +35,7 @@ let package = Package(
       dependencies: [
         "CasePaths",
         "CombineSchedulers",
+        "Difference",
       ]
     ),
     .testTarget(

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -1,6 +1,7 @@
 #if DEBUG
   import Combine
   import Foundation
+  import Difference
 
   /// A testable runtime for a reducer.
   ///
@@ -225,13 +226,21 @@
           }
           let receivedAction = receivedActions.removeFirst()
           if expectedAction != receivedAction {
-            let diff =
-              debugDiff(expectedAction, receivedAction)
-              .map { ": …\n\n\($0.indent(by: 4))\n\n(Expected: −, Actual: +)" }
-              ?? ""
+//            let diff =
+//              debugDiff(expectedAction, receivedAction)
+//              .map { ": …\n\n\($0.indent(by: 4))\n\n(Expected: −, Actual: +)" }
+//              ?? ""
+            let nDiff : [String] = diff(
+              expectedAction,
+              receivedAction,
+              indentationType: Difference.IndentationType.tab,
+              skipPrintingOnDiffCount: false
+            )
+            let jDiff = nDiff.joined(separator: "\n")
+
             _XCTFail(
               """
-              Received unexpected action\(diff)
+              Received unexpected action\(jDiff)
               """,
               file: step.file,
               line: step.line
@@ -258,13 +267,21 @@
 
         let actualState = self.toLocalState(self.state)
         if expectedState != actualState {
-          let diff =
-            debugDiff(expectedState, actualState)
-            .map { ": …\n\n\($0.indent(by: 4))\n\n(Expected: −, Actual: +)" }
-            ?? ""
+//          let diff =
+//            debugDiff(expectedState, actualState)
+//            .map { ": …\n\n\($0.indent(by: 4))\n\n(Expected: −, Actual: +)" }
+//            ?? ""
+          let nDiff : [String] = diff(
+            expectedState,
+            actualState,
+            indentationType: Difference.IndentationType.tab,
+            skipPrintingOnDiffCount: false
+          )
+          let jDiff = nDiff.joined(separator: "\n")
+
           _XCTFail(
             """
-            State change does not match expectation\(diff)
+            State change does not match expectation\(jDiff)
             """,
             file: step.file,
             line: step.line


### PR DESCRIPTION
##  Please do not merge this

Hi,

This is an experiment where I tried another [diff algo](https://github.com/krzysztofzablocki/Difference).

## Issue

When you have big and complex state, Xcode inlined red test error popup don't display the whole state. And that long time to 
open.

| description | image |
| --- | --- |
| the popup is not completely visible | <img width="500" alt="Capture d’écran 2020-07-06 à 14 49 35" src="https://user-images.githubusercontent.com/661647/86595250-bfade400-bf98-11ea-97bd-8b2fdad63370.png"> |
| it is impossible to go to the bottom of the popup | <img width="500" alt="Capture d’écran 2020-07-06 à 14 49 51" src="https://user-images.githubusercontent.com/661647/86595294-d0f6f080-bf98-11ea-8573-52ed101d2ccb.png"> |
| the only way is to go to the test navigator | <img width="500" alt="Capture d’écran 2020-07-06 à 14 50 07" src="https://user-images.githubusercontent.com/661647/86595303-d48a7780-bf98-11ea-812d-6fac80f37c21.png"> |


## Solution

Only display what changed inside the Xcode inlined red test error popup.

I tried using https://github.com/krzysztofzablocki/Difference for that.

<img width="500" alt="Capture d’écran 2020-07-06 à 14 54 05" src="https://user-images.githubusercontent.com/661647/86595308-d6543b00-bf98-11ea-8272-bed4ebc88763.png">