### PR TITLE
Added file and line to optional assert

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -23,8 +23,9 @@ enum OptionalBasicsAction: Equatable {
 
 struct OptionalBasicsEnvironment {}
 
-let optionalBasicsReducer = counterReducer
-  .optional
+let optionalBasicsReducer =
+  counterReducer
+  .optional()
   .pullback(
     state: \.optionalCounter,
     action: /OptionalBasicsAction.optionalCounter,

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -41,7 +41,7 @@ let loadThenNavigateListReducer =
     action: .self,
     environment: { $0 }
   )
-  .optional
+  .optional()
   .pullback(
     state: \LoadThenNavigateListState.selection,
     action: /LoadThenNavigateListAction.counter,

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -32,10 +32,11 @@ struct NavigateAndLoadListEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-let navigateAndLoadListReducer = counterReducer
-  .optional
+let navigateAndLoadListReducer =
+  counterReducer
+  .optional()
   .pullback(state: \Identified.value, action: .self, environment: { $0 })
-  .optional
+  .optional()
   .pullback(
     state: \NavigateAndLoadListState.selection,
     action: /NavigateAndLoadListAction.counter,

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -26,8 +26,9 @@ struct LoadThenNavigateEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-let loadThenNavigateReducer = counterReducer
-  .optional
+let loadThenNavigateReducer =
+  counterReducer
+  .optional()
   .pullback(
     state: \.optionalCounter,
     action: /LoadThenNavigateAction.optionalCounter,

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -25,8 +25,9 @@ struct NavigateAndLoadEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-let navigateAndLoadReducer = counterReducer
-  .optional
+let navigateAndLoadReducer =
+  counterReducer
+  .optional()
   .pullback(
     state: \.optionalCounter,
     action: /NavigateAndLoadAction.optionalCounter,

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -26,8 +26,9 @@ struct LoadThenPresentEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-let loadThenPresentReducer = counterReducer
-  .optional
+let loadThenPresentReducer =
+  counterReducer
+  .optional()
   .pullback(
     state: \.optionalCounter,
     action: /LoadThenPresentAction.optionalCounter,

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -23,8 +23,9 @@ struct PresentAndLoadEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-let presentAndLoadReducer = counterReducer
-  .optional
+let presentAndLoadReducer =
+  counterReducer
+  .optional()
   .pullback(
     state: \.optionalCounter,
     action: /PresentAndLoadAction.optionalCounter,

--- a/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
@@ -18,8 +18,9 @@ struct LazyNavigationEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-let lazyNavigationReducer = counterReducer
-  .optional
+let lazyNavigationReducer =
+  counterReducer
+  .optional()
   .pullback(
     state: \.optionalCounter,
     action: /LazyNavigationAction.optionalCounter,

--- a/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
@@ -18,8 +18,9 @@ struct EagerNavigationEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-let eagerNavigationReducer = counterReducer
-  .optional
+let eagerNavigationReducer =
+  counterReducer
+  .optional()
   .pullback(
     state: \.optionalCounter,
     action: /EagerNavigationAction.optionalCounter,

--- a/Examples/TicTacToe/Sources/Core/AppCore.swift
+++ b/Examples/TicTacToe/Sources/Core/AppCore.swift
@@ -30,7 +30,7 @@ public struct AppEnvironment {
 }
 
 public let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
-  loginReducer.optional.pullback(
+  loginReducer.optional().pullback(
     state: \.login,
     action: /AppAction.login,
     environment: {
@@ -40,7 +40,7 @@ public let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
       )
     }
   ),
-  newGameReducer.optional.pullback(
+  newGameReducer.optional().pullback(
     state: \.newGame,
     action: /AppAction.newGame,
     environment: { _ in NewGameEnvironment() }

--- a/Examples/TicTacToe/Sources/Core/LoginCore.swift
+++ b/Examples/TicTacToe/Sources/Core/LoginCore.swift
@@ -39,7 +39,7 @@ public struct LoginEnvironment {
 }
 
 public let loginReducer = twoFactorReducer
-  .optional
+  .optional()
   .pullback(
     state: \.twoFactor,
     action: /LoginAction.twoFactor,

--- a/Examples/TicTacToe/Sources/Core/LoginCore.swift
+++ b/Examples/TicTacToe/Sources/Core/LoginCore.swift
@@ -38,7 +38,8 @@ public struct LoginEnvironment {
   }
 }
 
-public let loginReducer = twoFactorReducer
+public let loginReducer =
+  twoFactorReducer
   .optional()
   .pullback(
     state: \.twoFactor,

--- a/Examples/TicTacToe/Sources/Core/NewGameCore.swift
+++ b/Examples/TicTacToe/Sources/Core/NewGameCore.swift
@@ -23,7 +23,8 @@ public struct NewGameEnvironment {
   public init() {}
 }
 
-public let newGameReducer = gameReducer
+public let newGameReducer =
+  gameReducer
   .optional()
   .pullback(
     state: \.game,

--- a/Examples/TicTacToe/Sources/Core/NewGameCore.swift
+++ b/Examples/TicTacToe/Sources/Core/NewGameCore.swift
@@ -24,7 +24,7 @@ public struct NewGameEnvironment {
 }
 
 public let newGameReducer = gameReducer
-  .optional
+  .optional()
   .pullback(
     state: \.game,
     action: /NewGameAction.game,

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -34,7 +34,7 @@ extension Reducer {
   ) -> Reducer {
     self.debug(prefix, state: toLocalState, action: toLocalAction, environment: toDebugEnvironment)
   }
-    
+
   @available(*, deprecated, renamed: "optional()")
   public var optional: Reducer<State?, Action, Environment> {
     self.optional()

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -34,6 +34,11 @@ extension Reducer {
   ) -> Reducer {
     self.debug(prefix, state: toLocalState, action: toLocalAction, environment: toDebugEnvironment)
   }
+    
+  @available(*, deprecated, renamed: "optional()")
+  public var optional: Reducer<State?, Action, Environment> {
+    self.optional()
+  }
 }
 
 extension WithViewStore {

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -1,5 +1,14 @@
 import Combine
 
+// NB: Deprecated after 0.6.0:
+
+extension Reducer {
+  @available(*, deprecated, renamed: "optional()")
+  public var optional: Reducer<State?, Action, Environment> {
+    self.optional()
+  }
+}
+
 // NB: Deprecated after 0.1.4:
 
 extension Reducer {
@@ -33,11 +42,6 @@ extension Reducer {
     }
   ) -> Reducer {
     self.debug(prefix, state: toLocalState, action: toLocalAction, environment: toDebugEnvironment)
-  }
-
-  @available(*, deprecated, renamed: "optional()")
-  public var optional: Reducer<State?, Action, Environment> {
-    self.optional()
   }
 }
 

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -216,7 +216,7 @@ public struct Reducer<State, Action, Environment> {
     ///   store on non-optional state.
     /// - See also: `Store.ifLet`, a UIKit helper for doing imperative work with a store on optional
     ///   state.
-    public func optional(_ file: String = #file, _ line: Int = #line) -> Reducer<State?, Action, Environment> {
+    public func optional(_ file: StaticString = #file, _ line: UInt = #line) -> Reducer<State?, Action, Environment> {
       .init { state, action, environment in
         guard state != nil else {
           assertionFailure(
@@ -235,7 +235,9 @@ public struct Reducer<State, Action, Environment> {
             * This action was sent to the store while state was "nil". Make sure that actions for \
             this reducer can only be sent to a view store when state is non-"nil". In SwiftUI \
             applications, use "IfLetStore".
-            """
+            """,
+            file: file,
+            line: line
           )
           return .none
         }

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -189,6 +189,59 @@ public struct Reducer<State, Action, Environment> {
       return self.reducer(&state!, action, environment)
     }
   }
+    
+    /// Transforms a reducer that works on non-optional state into one that works on optional state by
+    /// only running the non-optional reducer when state is non-nil.
+    ///
+    /// Often used in tandem with `pullback` to transform a reducer on a non-optional local domain
+    /// into a reducer on a global domain that contains an optional local domain:
+    ///
+    ///     // Global domain that holds an optional local domain:
+    ///     struct AppState { var modal: ModalState? }
+    ///     struct AppAction { case modal(ModalAction) }
+    ///     struct AppEnvironment { var mainQueue: AnySchedulerOf<DispatchQueue> }
+    ///
+    ///     // A reducer that works on the non-optional local domain:
+    ///     let modalReducer = Reducer<ModalState, ModalAction, ModalEnvironment { ... }
+    ///
+    ///     // Pullback the local modal reducer so that it works on all of the app domain:
+    ///     let appReducer: Reducer<AppState, AppAction, AppEnvironment> =
+    ///       modalReducer.optional().pullback(
+    ///         state: \.modal,
+    ///         action: /AppAction.modal,
+    ///         environment: { ModalEnvironment(mainQueue: $0.mainQueue) }
+    ///       )
+    ///
+    /// - See also: `IfLetStore`, a SwiftUI helper for transforming a store on optional state into a
+    ///   store on non-optional state.
+    /// - See also: `Store.ifLet`, a UIKit helper for doing imperative work with a store on optional
+    ///   state.
+    public func optional(_ file: String = #file, _ line: Int = #line) -> Reducer<State?, Action, Environment> {
+      .init { state, action, environment in
+        guard state != nil else {
+          assertionFailure(
+            """
+            "\(debugCaseOutput(action))" was received by an optional reducer at \(file):\(line) \
+            when its state was "nil". This can happen for a few reasons:
+
+            * The optional reducer was combined with or run from another reducer that set \
+            "\(State.self)" to "nil" before the optional reducer ran. Combine or run optional \
+            reducers before reducers that can set their state to "nil". This ensures that optional \
+            reducers can handle their actions while their state is still non-"nil".
+
+            * An active effect emitted this action while state was "nil". Make sure that effects for \
+            this optional reducer are canceled when optional state is set to "nil".
+
+            * This action was sent to the store while state was "nil". Make sure that actions for \
+            this reducer can only be sent to a view store when state is non-"nil". In SwiftUI \
+            applications, use "IfLetStore".
+            """
+          )
+          return .none
+        }
+        return self.reducer(&state!, action, environment)
+      }
+    }
 
   /// A version of `pullback` that transforms a reducer that works on an element into one that works
   /// on a collection of elements.


### PR DESCRIPTION
As [suggested in the forums](https://forums.swift.org/t/reducer-optional-assert-with-more-info/38281?u=alejandro_martinez) this PR adds #file and #line default parameters to an `optional()` reducer method to add the information into the assertion message.

Questions I would like to ask:
- Are you happy if the function replaces the property (breaking change) or do you want to keep both?
- Feel free to suggest edits on the wording of the message.
- What other places would you like to see this change? `forEach` maybe?

Once this is clarified I will update the examples and tests 😄 