### PR TITLE
Make deprecated interfaces unavailable

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -3,7 +3,7 @@ import Combine
 // NB: Deprecated after 0.1.4:
 
 extension Reducer {
-  @available(*, deprecated, renamed: "debug(_:environment:)")
+  @available(*, unavailable, renamed: "debug(_:environment:)")
   public func debug(
     prefix: String,
     environment toDebugEnvironment: @escaping (Environment) -> DebugEnvironment = { _ in
@@ -13,7 +13,7 @@ extension Reducer {
     self.debug(prefix, state: { $0 }, action: .self, environment: toDebugEnvironment)
   }
 
-  @available(*, deprecated, renamed: "debugActions(_:environment:)")
+  @available(*, unavailable, renamed: "debugActions(_:environment:)")
   public func debugActions(
     prefix: String,
     environment toDebugEnvironment: @escaping (Environment) -> DebugEnvironment = { _ in
@@ -23,7 +23,7 @@ extension Reducer {
     self.debug(prefix, state: { _ in () }, action: .self, environment: toDebugEnvironment)
   }
 
-  @available(*, deprecated, renamed: "debug(_:state:action:environment:)")
+  @available(*, unavailable, renamed: "debug(_:state:action:environment:)")
   public func debug<LocalState, LocalAction>(
     prefix: String,
     state toLocalState: @escaping (State) -> LocalState,
@@ -37,7 +37,7 @@ extension Reducer {
 }
 
 extension WithViewStore {
-  @available(*, deprecated, renamed: "debug(_:)")
+  @available(*, unavailable, renamed: "debug(_:)")
   public func debug(prefix: String) -> Self {
     self.debug(prefix)
   }
@@ -46,7 +46,7 @@ extension WithViewStore {
 // NB: Deprecated after 0.1.3:
 
 extension Effect {
-  @available(*, deprecated, renamed: "run")
+  @available(*, unavailable, renamed: "run")
   public static func async(
     _ work: @escaping (Effect.Subscriber) -> Cancellable
   ) -> Self {
@@ -55,7 +55,7 @@ extension Effect {
 }
 
 extension Effect where Failure == Swift.Error {
-  @available(*, deprecated, renamed: "catching")
+  @available(*, unavailable, renamed: "catching")
   public static func sync(_ work: @escaping () throws -> Output) -> Self {
     self.catching(work)
   }


### PR DESCRIPTION
Thinking we can make these warnings errors since we've had a bunch of releases. All should be auto-fixable still.