### PR TITLE
Add tests for "Effect cancellation retains publisher" issue

### DIFF
--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -312,13 +312,13 @@ final class EffectCancellationTests: XCTestCase {
       .store(in: &cancellables)
     publisher = nil
 
-    XCTAssertNotNil(weakPublisher, "should not release publisher after subscribing")
+    XCTAssertNotNil(weakPublisher, "should retain publisher after subscribing")
     XCTAssertEqual(receivedRequests, 1, "should receive request after subscribing")
     XCTAssertEqual(receivedCancels, 0, "should not receive cancel after subscribing")
 
     cancellables.removeAll()
 
-    XCTAssertNil(weakPublisher, "should release publisher after cancellation")
+    XCTAssertNil(weakPublisher, "should not retain publisher after cancellation")
     XCTAssertEqual(receivedRequests, 1, "should not receive request after cancellation")
     XCTAssertEqual(receivedCancels, 1, "should receive cancel after cancellation")
   }

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -328,9 +328,9 @@ final class EffectCancellationTests: XCTestCase {
     struct State: Equatable {}
 
     enum Action: Equatable {
-      case start
-      case stop
-      case action
+      case subscribe
+      case cancel
+      case event
     }
 
     var store: Store<State, Action>!
@@ -345,7 +345,7 @@ final class EffectCancellationTests: XCTestCase {
       struct EffectId: Hashable {}
 
       switch action {
-      case .start:
+      case .subscribe:
         let publisher = CustomPublisher()
         weakPublisher = publisher
         createdPublishers += 1
@@ -355,14 +355,14 @@ final class EffectCancellationTests: XCTestCase {
           }, receiveRequest: { _ in
             receivedRequests += 1
           })
-          .map { Action.action }
+          .map { Action.event }
           .eraseToEffect()
           .cancellable(id: EffectId(), cancelInFlight: true)
 
-      case .stop:
+      case .cancel:
         return .cancel(id: EffectId())
 
-      case .action:
+      case .event:
         return .none
       }
     }
@@ -374,29 +374,29 @@ final class EffectCancellationTests: XCTestCase {
     )
     weakStore = store
 
-    XCTAssertEqual(createdPublishers, 0, "should not create publisher before sending start action")
-    XCTAssertEqual(receivedRequests, 0, "should not receive requests before sending start action")
-    XCTAssertEqual(receivedCancels, 0, "should not receive cancels before sending start action")
+    XCTAssertEqual(createdPublishers, 0, "should not create publisher before subscribing")
+    XCTAssertEqual(receivedRequests, 0, "should not receive requests before subscribing")
+    XCTAssertEqual(receivedCancels, 0, "should not receive cancels before subscribing")
 
-    ViewStore(store).send(.start)
+    ViewStore(store).send(.subscribe)
 
-    XCTAssertEqual(createdPublishers, 1, "should create publisher after sending start action")
-    XCTAssertNotNil(weakPublisher, "should retain publisher after sending start action")
-    XCTAssertEqual(receivedRequests, 1, "should receive request after sending start action")
-    XCTAssertEqual(receivedCancels, 0, "should not receive cancel after sending start action")
+    XCTAssertEqual(createdPublishers, 1, "should create publisher when subscribing")
+    XCTAssertNotNil(weakPublisher, "should retain publisher when subscribing")
+    XCTAssertEqual(receivedRequests, 1, "should receive request when subscribing")
+    XCTAssertEqual(receivedCancels, 0, "should not receive cancel when subscribing")
 
-    ViewStore(store).send(.stop)
+    ViewStore(store).send(.cancel)
 
-    XCTAssertEqual(createdPublishers, 1, "should not create another publisher after sending stop action")
-    XCTAssertNil(weakPublisher, "should not retain publisher after sending stop action")
-    XCTAssertEqual(receivedRequests, 1, "should not receive requests after sending stop action")
-    XCTAssertEqual(receivedCancels, 1, "should receive cancel after sending stop action")
+    XCTAssertEqual(createdPublishers, 1, "should not create another publisher when canceled")
+    XCTAssertNil(weakPublisher, "should not retain publisher when canceled")
+    XCTAssertEqual(receivedRequests, 1, "should not receive requests when canceled")
+    XCTAssertEqual(receivedCancels, 1, "should receive cancel when canceled")
 
     store = nil
 
     XCTAssertNil(weakStore, "should not retain store when it's no longer referenced")
     XCTAssertNil(weakPublisher, "should not retain publisher when store is no longer referenced")
-    XCTAssertEqual(receivedRequests, 1, "should not receive actions when store is no longer referenced")
+    XCTAssertEqual(receivedRequests, 1, "should not receive requests when store is no longer referenced")
     XCTAssertEqual(receivedCancels, 1, "should not receive cancels when store is no longer referenced")
   }
 
@@ -405,9 +405,9 @@ final class EffectCancellationTests: XCTestCase {
     struct State: Equatable {}
 
     enum Action: Equatable {
-      case start
-      case stop
-      case action
+      case subscribe
+      case cancel
+      case event
     }
 
     var store: Store<State, Action>!
@@ -422,7 +422,7 @@ final class EffectCancellationTests: XCTestCase {
       struct EffectId: Hashable {}
 
       switch action {
-      case .start:
+      case .subscribe:
         let publisher = CustomPublisher()
         weakPublisher = publisher
         createdPublishers += 1
@@ -432,14 +432,14 @@ final class EffectCancellationTests: XCTestCase {
           }, receiveRequest: { _ in
             receivedRequests += 1
           })
-          .map { Action.action }
+          .map { Action.event }
           .eraseToEffect()
           .cancellable(id: EffectId(), cancelInFlight: true)
 
-      case .stop:
+      case .cancel:
         return .cancel(id: EffectId())
 
-      case .action:
+      case .event:
         return .none
       }
     }
@@ -451,29 +451,29 @@ final class EffectCancellationTests: XCTestCase {
     )
     weakStore = store
 
-    XCTAssertEqual(createdPublishers, 0, "should not create publisher before sending start action")
-    XCTAssertEqual(receivedRequests, 0, "should not receive requests before sending start action")
-    XCTAssertEqual(receivedCancels, 0, "should not receive cancels before sending start action")
+    XCTAssertEqual(createdPublishers, 0, "should not create publisher before subscribing")
+    XCTAssertEqual(receivedRequests, 0, "should not receive requests before subscribing")
+    XCTAssertEqual(receivedCancels, 0, "should not receive cancels before subscribing")
 
-    ViewStore(store).send(.start)
+    ViewStore(store).send(.subscribe)
 
-    XCTAssertEqual(createdPublishers, 1, "should create publisher after sending start action")
-    XCTAssertNotNil(weakPublisher, "should retain publisher after sending start action")
-    XCTAssertEqual(receivedRequests, 1, "should receive request after sending start action")
-    XCTAssertEqual(receivedCancels, 0, "should not receive cancel after sending start action")
+    XCTAssertEqual(createdPublishers, 1, "should create publisher when subscribing")
+    XCTAssertNotNil(weakPublisher, "should retain publisher when subscribing")
+    XCTAssertEqual(receivedRequests, 1, "should receive request when subscribing")
+    XCTAssertEqual(receivedCancels, 0, "should not receive cancel when subscribing")
 
-    ViewStore(store).send(.stop)
+    ViewStore(store).send(.cancel)
 
-    XCTAssertEqual(createdPublishers, 1, "should not create another publisher after sending stop action")
-    XCTAssertNil(weakPublisher, "should not retain publisher after sending stop action")
-    XCTAssertEqual(receivedRequests, 1, "should not receive requests after sending stop action")
-    XCTAssertEqual(receivedCancels, 1, "should receive cancel after sending stop action")
+    XCTAssertEqual(createdPublishers, 1, "should not create another publisher when canceled")
+    XCTAssertNil(weakPublisher, "should not retain publisher when canceled")
+    XCTAssertEqual(receivedRequests, 1, "should not receive requests when canceled")
+    XCTAssertEqual(receivedCancels, 1, "should receive cancel when canceled")
 
     store = nil
 
     XCTAssertNil(weakStore, "should not retain store when it's no longer referenced")
     XCTAssertNil(weakPublisher, "should not retain publisher when store is no longer referenced")
-    XCTAssertEqual(receivedRequests, 1, "should not receive actions when store is no longer referenced")
+    XCTAssertEqual(receivedRequests, 1, "should not receive requests when store is no longer referenced")
     XCTAssertEqual(receivedCancels, 1, "should not receive cancels when store is no longer referenced")
   }
 }

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -390,7 +390,7 @@ final class EffectCancellationTests: XCTestCase {
       .send(.stop),
       .do {
         XCTAssertEqual(createdPublishers, 1, "should not create another publisher after sending stop action")
-        XCTAssertNil(weakPublisher, "should release publisher after sending stop action")
+        XCTAssertNil(weakPublisher, "should not retain publisher after sending stop action")
         XCTAssertEqual(receivedRequests, 1, "should not receive requests after sending stop action")
         XCTAssertEqual(receivedCancels, 1, "should receive cancel after sending stop action")
       }

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -332,14 +332,14 @@ final class EffectCancellationTests: XCTestCase {
     }
 
     struct ParentState: Equatable {
-      var state: State?
+      var state: State
     }
 
     enum ParentAction: Equatable {
       case action(Action)
     }
 
-    let parentReducer: Reducer<ParentState, ParentAction, Void> = reducer.optional.pullback(
+    let parentReducer: Reducer<ParentState, ParentAction, Void> = reducer.pullback(
       state: \.state,
       action: /ParentAction.action,
       environment: { $0 }


### PR DESCRIPTION
I've created this PR as advised by @stephencelis. The issue is also described in a [thread on Swift Forums](https://forums.swift.org/t/ifletstore-effect-cancellation-retains-publisher/38306).

## Issue description

When creating an `Effect` from a custom publisher and later canceling it, the subscription is correctly canceled, but the publisher instance is retained in the memory. Even after releasing a `Store`, the publisher still seems to be held in the memory for some reason.

## Reproducing the issue

I've added a very basic `CustomPublisher` class that is used in three new tests:

- `testCustomPublisherRelease` - checks if `CustomPublisher` is correctly released from the memory after canceling the subscription
- `testEffectCancellationPublisherRelease` - checks if `CustomPublisher` is correctly released from the memory after canceling an `Effect` originating from it
- `testCombinedReducerEffectCancellationPublisherRelease` - checks if `CustomPublisher` is correctly released from the memory after canceling an `Effect` originating from it, when the `Effect` is returned from combined reducer

The first two tests pass without an issue, so I assume the problem is not connected to `CustomPublisher` implementation.

The second and the third test have exactly the same assertions and differs in how reducer is created (directly, or with `.combine` function).

The third test fails, because after `Effect` is canceled, the `CustomPublisher` instance still sits in the memory:

> ❌ should not retain publisher when canceled

...and even after releasing the store, the publisher is still retained:

> ❌ should not retain publisher when store is no longer referenced

## Discussion

I'm not 100% sure where exactly the source of the problem is located. It could be an issue not related to `TCA` at all. I am open to all ideas and hints that could help resolve the issue, either here or on [Swift Forums](https://forums.swift.org/t/ifletstore-effect-cancellation-retains-publisher/38306). There is also a demo project showcasing this issue [open-sourced on GitHub](https://github.com/darrarski/tca-ifletstore-effect-cancellation-retains-publisher-demo).
