### PR TITLE
Fix issue with `ifLet` where `else` was being called too often

### DIFF
--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -281,7 +281,7 @@ final class StoreTests: XCTestCase {
     var stores: [Any] = []
 
     parentStore
-      .scope(state: \.count)
+      .scope(state: { $0.count })
       .ifLet(
         then: { store in
           stores.append(store)

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -233,4 +233,117 @@ final class StoreTests: XCTestCase {
     store.send(.incr)
     XCTAssertEqual(ViewStore(store).state, 100_000)
   }
+
+  func testPublisherScope() {
+    let appReducer = Reducer<Int, Bool, Void> { state, action, _ in
+      state += action ? 1 : 0
+      return .none
+    }
+
+    let parentStore = Store(initialState: 0, reducer: appReducer, environment: ())
+
+    var outputs: [Int] = []
+
+    parentStore
+      .scope { $0.removeDuplicates() }
+      .sink { outputs.append($0.state.value) }
+      .store(in: &self.cancellables)
+
+    XCTAssertEqual(outputs, [0])
+
+    parentStore.send(true)
+    XCTAssertEqual(outputs, [0, 1])
+
+    parentStore.send(false)
+    XCTAssertEqual(outputs, [0, 1])
+    parentStore.send(false)
+    XCTAssertEqual(outputs, [0, 1])
+    parentStore.send(false)
+    XCTAssertEqual(outputs, [0, 1])
+    parentStore.send(false)
+    XCTAssertEqual(outputs, [0, 1])
+  }
+
+  func testIfLetAfterScope() {
+    struct AppState {
+      var count: Int?
+    }
+
+    let appReducer = Reducer<AppState, Int?, Void> { state, action, _ in
+      state.count = action
+      return .none
+    }
+
+    let parentStore = Store(initialState: AppState(), reducer: appReducer, environment: ())
+
+    // NB: This test needs to hold a strong reference to the emitted stores
+    var outputs: [Int?] = []
+    var stores: [Any] = []
+
+    parentStore
+      .scope(state: \.count)
+      .ifLet(
+        then: { store in
+          stores.append(store)
+          outputs.append(store.state.value)
+        },
+        else: {
+          print(1)
+          outputs.append(nil)
+        })
+      .store(in: &self.cancellables)
+
+    XCTAssertEqual(outputs, [nil])
+
+    parentStore.send(1)
+    XCTAssertEqual(outputs, [nil, 1])
+
+    parentStore.send(nil)
+    XCTAssertEqual(outputs, [nil, 1, nil])
+
+    parentStore.send(1)
+    XCTAssertEqual(outputs, [nil, 1, nil, 1])
+
+    parentStore.send(nil)
+    XCTAssertEqual(outputs, [nil, 1, nil, 1, nil])
+
+    parentStore.send(1)
+    XCTAssertEqual(outputs, [nil, 1, nil, 1, nil, 1])
+
+    parentStore.send(nil)
+    XCTAssertEqual(outputs, [nil, 1, nil, 1, nil, 1, nil])
+  }
+
+  func testIfLetTwo() {
+    let parentStore = Store(
+      initialState: 0,
+      reducer: Reducer<Int?, Bool, Void> { state, action, _ in
+        if action {
+          state? += 1
+          return .none
+        } else {
+          return Just(true).receive(on: DispatchQueue.main).eraseToEffect()
+        }
+      },
+      environment: ()
+    )
+
+    parentStore.ifLet { childStore in
+      let vs = ViewStore(childStore)
+
+      vs
+        .publisher
+        .sink { print($0) }
+        .store(in: &self.cancellables)
+
+      vs.send(false)
+      _ = XCTWaiter.wait(for: [.init()], timeout: 0.1)
+      vs.send(false)
+      _ = XCTWaiter.wait(for: [.init()], timeout: 0.1)
+      vs.send(false)
+      _ = XCTWaiter.wait(for: [.init()], timeout: 0.1)
+      XCTAssertEqual(vs.state, 3)
+    }
+    .store(in: &self.cancellables)
+  }
 }

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -288,7 +288,6 @@ final class StoreTests: XCTestCase {
           outputs.append(store.state.value)
         },
         else: {
-          print(1)
           outputs.append(nil)
         })
       .store(in: &self.cancellables)
@@ -333,7 +332,7 @@ final class StoreTests: XCTestCase {
 
       vs
         .publisher
-        .sink { print($0) }
+        .sink { _ in }
         .store(in: &self.cancellables)
 
       vs.send(false)


### PR DESCRIPTION
Pretty sure this fixes #216. 

I took the liberty of adding in the tests that @mbrandonw and @stephencelis added in [this branch](https://github.com/pointfreeco/swift-composable-architecture/compare/iflet) and they are now all passing 🎉 

FYI I got this working first in my ReactiveSwift port (not yet pushed) and then back ported it to here 😄 

cc: @fonkadelic 
