### PR TITLE
Add keyFrames Effect in animations case study

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -1,3 +1,4 @@
+import Combine
 import ComposableArchitecture
 import SwiftUI
 
@@ -15,6 +16,25 @@ private let readMe = """
   Try it out by tapping or dragging anywhere on the screen to move the dot, and by flipping the \
   toggle at the bottom of the screen.
   """
+
+extension Effect where Failure == Never {
+  public static func keyFrames<S>(
+    values: [(output: Output, duration: S.SchedulerTimeType.Stride)],
+    scheduler: S
+  ) -> Effect where S: Scheduler {
+    .concatenate(
+      values
+      .enumerated()
+      .map { index, animationState in
+        index == 0
+        ? Effect(value: animationState.output)
+        : Just(animationState.output)
+        .delay(for: values[index - 1].duration, scheduler: scheduler)
+        .eraseToEffect()
+      }
+    )
+  }
+}
 
 struct AnimationsState: Equatable {
   var circleCenter = CGPoint.zero
@@ -42,16 +62,10 @@ let animationsReducer = Reducer<AnimationsState, AnimationsAction, AnimationsEnv
     return .none
 
   case .rainbowButtonTapped:
-    return .concatenate(
-      [Color.red, .blue, .green, .orange, .pink, .purple, .yellow, .white]
-        .enumerated()
-        .map { index, color in
-          index == 0
-            ? Effect(value: .setColor(color))
-            : Effect(value: .setColor(color))
-              .delay(for: 1, scheduler: environment.mainQueue)
-              .eraseToEffect()
-        }
+    return .keyFrames(
+        values: [Color.red, .blue, .green, .orange, .pink, .purple, .yellow, .white]
+            .map { (output: .setColor($0), duration: 1) },
+        scheduler: environment.mainQueue
     )
 
   case let .setColor(color):


### PR DESCRIPTION
As discussed in this [topic](https://forums.swift.org/t/animation-effect/38617) on the Swift Forums, it would be nice to have an Effect to handle animation keyframes like demonstrated in the animation case study. It makes implementing animations more ergonomic by avoiding duplication for each animation.

This PR shows how to implement such Effect in the case study rather than adding it to the core library.