### PR TITLE
Fix TicTacToe auth error localization

### DIFF
--- a/Examples/TicTacToe/Sources/Core/AuthenticationClient.swift
+++ b/Examples/TicTacToe/Sources/Core/AuthenticationClient.swift
@@ -40,12 +40,12 @@ public struct AuthenticationResponse: Equatable {
   }
 }
 
-public enum AuthenticationError: Equatable, Error {
+public enum AuthenticationError: Equatable, LocalizedError {
   case invalidUserPassword
   case invalidTwoFactor
   case invalidIntermediateToken
 
-  var localizedDescription: String {
+  public var errorDescription: String? {
     switch self {
     case .invalidUserPassword:
       return "Unknown user or invalid password."


### PR DESCRIPTION
# Observed Behavior

The alert for authentication errors in the TicTacToe example displays messages like this:

```The operation couldn’t be completed. (AuthenticationClient.AuthenticationError error 0.)```

# Expected Behavior

The alert should display the strings defined in `AuthenticationError.localizedDescription`, such as

```Unknown user or invalid password.```

# Fix

`AuthenticationError` conforms to `Error`, and implements `localizedDescription`. But this property is not a protocol requirement for `Error`. It is added to `Error` via an extension, and is therefore not a customization point.

This PR modifies `AuthenticationError` to conform to `LocalizedError`, and implements `errorDescription` instead of `localizedDescription`. When the alert asks for `error.localizedDescription`, the default implementation will call through to `errorDescription` and the expected error message will be shown.