### PR TITLE
Store can use @Published again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         xcode:
           - 11.3
           - 11.6_beta
-          - 12_beta
+          #- 12_beta
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode ${{ matrix.xcode }}

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -7,7 +7,7 @@ import Foundation
 /// You will typically construct a single one of these at the root of your application, and then use
 /// the `scope` method to derive more focused stores that can be passed to subviews.
 public final class Store<State, Action> {
-  var state: CurrentValueSubject<State, Never>
+  @Published private(set) var state: State
   var effectCancellables: [UUID: AnyCancellable] = [:]
   private var isSending = false
   private var parentCancellable: AnyCancellable?
@@ -60,15 +60,15 @@ public final class Store<State, Action> {
     action fromLocalAction: @escaping (LocalAction) -> Action
   ) -> Store<LocalState, LocalAction> {
     let localStore = Store<LocalState, LocalAction>(
-      initialState: toLocalState(self.state.value),
+      initialState: toLocalState(self.state),
       reducer: { localState, localAction in
         self.send(fromLocalAction(localAction))
-        localState = toLocalState(self.state.value)
+        localState = toLocalState(self.state)
         return .none
       }
     )
-    localStore.parentCancellable = self.state
-      .sink { [weak localStore] newValue in localStore?.state.value = toLocalState(newValue) }
+    localStore.parentCancellable = self.$state
+      .sink { [weak localStore] newValue in localStore?.state = toLocalState(newValue) }
     return localStore
   }
 
@@ -102,20 +102,20 @@ public final class Store<State, Action> {
       return localState
     }
 
-    return toLocalState(self.state.eraseToAnyPublisher())
+    return toLocalState(self.$state.eraseToAnyPublisher())
       .map { localState in
         let localStore = Store<LocalState, LocalAction>(
           initialState: localState,
           reducer: { localState, localAction in
             self.send(fromLocalAction(localAction))
-            localState = extractLocalState(self.state.value) ?? localState
+            localState = extractLocalState(self.state) ?? localState
             return .none
           })
 
-        localStore.parentCancellable = self.state
+        localStore.parentCancellable = self.$state
           .sink { [weak localStore] state in
             guard let localStore = localStore else { return }
-            localStore.state.value = extractLocalState(state) ?? localStore.state.value
+            localStore.state = extractLocalState(state) ?? localStore.state
           }
         return localStore
       }
@@ -163,7 +163,7 @@ public final class Store<State, Action> {
         )
       }
       self.isSending = true
-      let effect = self.reducer(&self.state.value, action)
+      let effect = self.reducer(&self.state, action)
       self.isSending = false
 
       var didComplete = false
@@ -207,7 +207,7 @@ public final class Store<State, Action> {
     reducer: @escaping (inout State, Action) -> Effect<Action, Never>
   ) {
     self.reducer = reducer
-    self.state = CurrentValueSubject(initialState)
+    self.state = initialState
   }
 }
 

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -52,7 +52,7 @@ extension Store {
         }
       )
       .sink { store in
-        if store.state.value == nil { `else`() }
+        if store.state == nil { `else`() }
       }
 
     let unwrapCancellable =

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -58,9 +58,9 @@ public final class ViewStore<State, Action>: ObservableObject {
     _ store: Store<State, Action>,
     removeDuplicates isDuplicate: @escaping (State, State) -> Bool
   ) {
-    let publisher = store.state.removeDuplicates(by: isDuplicate)
+    let publisher = store.$state.removeDuplicates(by: isDuplicate)
     self.publisher = StorePublisher(publisher)
-    self.state = store.state.value
+    self.state = store.state
     self._send = store.send
     self.viewCancellable = publisher.sink { [weak self] in self?.state = $0 }
   }

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -57,7 +57,7 @@ final class StoreTests: XCTestCase {
     let childStore = parentStore.scope(state: String.init)
 
     var values: [String] = []
-    childStore.state
+    childStore.$state
       .sink(receiveValue: { values.append($0) })
       .store(in: &self.cancellables)
 
@@ -79,7 +79,7 @@ final class StoreTests: XCTestCase {
     let childViewStore = ViewStore(childStore)
 
     var values: [Int] = []
-    parentStore.state
+    parentStore.$state
       .sink(receiveValue: { values.append($0) })
       .store(in: &self.cancellables)
 
@@ -102,7 +102,7 @@ final class StoreTests: XCTestCase {
     parentStore
       .scope(state: { $0.map { "\($0)" }.removeDuplicates() })
       .sink { childStore in
-        childStore.state
+        childStore.$state
           .sink { outputs.append($0) }
           .store(in: &self.cancellables)
       }
@@ -246,7 +246,7 @@ final class StoreTests: XCTestCase {
 
     parentStore
       .scope { $0.removeDuplicates() }
-      .sink { outputs.append($0.state.value) }
+      .sink { outputs.append($0.state) }
       .store(in: &self.cancellables)
 
     XCTAssertEqual(outputs, [0])
@@ -285,7 +285,7 @@ final class StoreTests: XCTestCase {
       .ifLet(
         then: { store in
           stores.append(store)
-          outputs.append(store.state.value)
+          outputs.append(store.state)
         },
         else: {
           outputs.append(nil)


### PR DESCRIPTION
As of the third beta, assign(to:) takes an `inout Publisher.Publisher`, so it no longer surfaces an escape hatch through which one could mutate a store's state.

Fixes #238.