### PR TITLE
Fix fireAndForget on iOS 13.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,32 +9,20 @@ on:
       - '*'
 
 jobs:
-  library:
-    runs-on: macOS-latest
-    strategy:
-      matrix:
-        xcode:
-          - 11.3
-          - 11.6_beta
-          - 12_beta
-    steps:
-      - uses: actions/checkout@v2
-      - name: Select Xcode ${{ matrix.xcode }}
-        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
-      - name: Run tests
-        run: make test-swift
-
   examples:
     runs-on: macOS-latest
     strategy:
       matrix:
         xcode:
+          - 11.2.1
           - 11.3
-          - 11.6_beta
+          - 11.4
+          - 11.5
+          - 11.6
           - 12_beta
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode ${{ matrix.xcode }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Run tests
-        run: make test-workspace
+        run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         xcode:
-          - 11.2.1
           - 11.3
           - 11.4
           - 11.5

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,9 @@ PLATFORM_IOS = iOS Simulator,name=iPhone 11 Pro Max
 PLATFORM_MACOS = macOS
 PLATFORM_TVOS = tvOS Simulator,name=Apple TV 4K (at 1080p)
 
-default: test-all
+default: test
 
-test-all: test-swift test-workspace
-
-test-swift:
-	swift test \
-		--enable-test-discovery \
-		--parallel
-
-test-workspace:
+test:
 	instruments -s devices
 	xcodebuild test \
 		-scheme ComposableArchitecture \


### PR DESCRIPTION
This fixes a bug in iOS 13.2 when it comes to `fireAndForget` effects. Apparently they don't ever complete due to a bug in `Deferred` wrapping an `Empty`. So I've fixed that and added more CI coverage on older iOS versions.