### PR TITLE
Restore original cancellation logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - 11.4
           - 11.5
           - 11.6
-          - 12_beta
+          #- 12_beta
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode ${{ matrix.xcode }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - 11.4
           - 11.5
           - 11.6
-          #- 12_beta
+          - 12_beta
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode ${{ matrix.xcode }}

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -29,58 +29,57 @@ extension Effect {
   public func cancellable(id: AnyHashable, cancelInFlight: Bool = false) -> Effect {
     // NB: This check intends to work around bugs over different versions of Combine
     #if swift(>=5.3) && !os(macOS)
-      let effect = Deferred<
-        Publishers.PrefixUntilOutput<Publishers.HandleEvents<Self>, PassthroughSubject<Void, Never>>
-      > {
-        let subject = PassthroughSubject<Void, Never>()
-        lock.sync { subjects[id, default: []].append(subject) }
-        let cleanup = {
-          lock.sync {
-            subjects[id]?.removeAll(where: { $0 === subject })
-            if subjects[id]?.isEmpty == true {
-              subjects[id] = nil
-            }
+    let effect = Deferred<
+      Publishers.PrefixUntilOutput<Publishers.HandleEvents<Self>, PassthroughSubject<Void, Never>>
+    > {
+      let subject = PassthroughSubject<Void, Never>()
+      lock.sync { subjects[id, default: []].append(subject) }
+      let cleanup = {
+        lock.sync {
+          subjects[id]?.removeAll(where: { $0 === subject })
+          if subjects[id]?.isEmpty == true {
+            subjects[id] = nil
           }
         }
-        return
-          self
-          .handleEvents(
-            receiveCompletion: { _ in cleanup() },
-            receiveCancel: cleanup
-          )
-          .prefix(untilOutputFrom: subject)
       }
-      .eraseToEffect()
+      return self
+        .handleEvents(
+          receiveCompletion: { _ in cleanup() },
+          receiveCancel: cleanup
+        )
+        .prefix(untilOutputFrom: subject)
+    }
+    .eraseToEffect()
     #else
-      let effect = Deferred { () -> Publishers.HandleEvents<PassthroughSubject<Output, Failure>> in
-        cancellablesLock.lock()
-        defer { cancellablesLock.unlock() }
+    let effect = Deferred { () -> Publishers.HandleEvents<PassthroughSubject<Output, Failure>> in
+      cancellablesLock.lock()
+      defer { cancellablesLock.unlock() }
 
-        let subject = PassthroughSubject<Output, Failure>()
-        let cancellable = self.subscribe(subject)
+      let subject = PassthroughSubject<Output, Failure>()
+      let cancellable = self.subscribe(subject)
 
-        var cancellationCancellable: AnyCancellable!
-        cancellationCancellable = AnyCancellable {
-          cancellablesLock.sync {
-            subject.send(completion: .finished)
-            cancellable.cancel()
-            cancellationCancellables[id]?.remove(cancellationCancellable)
-            if cancellationCancellables[id]?.isEmpty == .some(true) {
-              cancellationCancellables[id] = nil
-            }
+      var cancellationCancellable: AnyCancellable!
+      cancellationCancellable = AnyCancellable {
+        cancellablesLock.sync {
+          subject.send(completion: .finished)
+          cancellable.cancel()
+          cancellationCancellables[id]?.remove(cancellationCancellable)
+          if cancellationCancellables[id]?.isEmpty == .some(true) {
+            cancellationCancellables[id] = nil
           }
         }
-
-        cancellationCancellables[id, default: []].insert(
-          cancellationCancellable
-        )
-
-        return subject.handleEvents(
-          receiveCompletion: { _ in cancellationCancellable.cancel() },
-          receiveCancel: cancellationCancellable.cancel
-        )
       }
-      .eraseToEffect()
+
+      cancellationCancellables[id, default: []].insert(
+        cancellationCancellable
+      )
+
+      return subject.handleEvents(
+        receiveCompletion: { _ in cancellationCancellable.cancel() },
+        receiveCancel: cancellationCancellable.cancel
+      )
+    }
+    .eraseToEffect()
     #endif
 
     return cancelInFlight ? .concatenate(.cancel(id: id), effect) : effect
@@ -93,25 +92,25 @@ extension Effect {
   ///   identifier.
   public static func cancel(id: AnyHashable) -> Effect {
     #if swift(>=5.3) && !os(macOS)
-      return .fireAndForget {
-        lock.sync {
-          subjects[id]?.forEach { $0.send(()) }
-        }
+    return .fireAndForget {
+      lock.sync {
+        subjects[id]?.forEach { $0.send(()) }
       }
+    }
     #else
-      return .fireAndForget {
-        cancellablesLock.sync {
-          cancellationCancellables[id]?.forEach { $0.cancel() }
-        }
+    return .fireAndForget {
+      cancellablesLock.sync {
+        cancellationCancellables[id]?.forEach { $0.cancel() }
       }
+    }
     #endif
   }
 }
 
 #if swift(>=5.3) && !os(macOS)
-  var subjects: [AnyHashable: [PassthroughSubject<Void, Never>]] = [:]
-  let lock = NSRecursiveLock()
+var subjects: [AnyHashable: [PassthroughSubject<Void, Never>]] = [:]
+let lock = NSRecursiveLock()
 #else
-  var cancellationCancellables: [AnyHashable: Set<AnyCancellable>] = [:]
-  let cancellablesLock = NSRecursiveLock()
+var cancellationCancellables: [AnyHashable: Set<AnyCancellable>] = [:]
+let cancellablesLock = NSRecursiveLock()
 #endif

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -27,30 +27,6 @@ extension Effect {
   ///     canceled before starting this new one.
   /// - Returns: A new effect that is capable of being canceled by an identifier.
   public func cancellable(id: AnyHashable, cancelInFlight: Bool = false) -> Effect {
-    // NB: This check intends to work around bugs over different versions of Combine
-    #if swift(>=5.3) && !os(macOS)
-    let effect = Deferred<
-      Publishers.PrefixUntilOutput<Publishers.HandleEvents<Self>, PassthroughSubject<Void, Never>>
-    > {
-      let subject = PassthroughSubject<Void, Never>()
-      lock.sync { subjects[id, default: []].append(subject) }
-      let cleanup = {
-        lock.sync {
-          subjects[id]?.removeAll(where: { $0 === subject })
-          if subjects[id]?.isEmpty == true {
-            subjects[id] = nil
-          }
-        }
-      }
-      return self
-        .handleEvents(
-          receiveCompletion: { _ in cleanup() },
-          receiveCancel: cleanup
-        )
-        .prefix(untilOutputFrom: subject)
-    }
-    .eraseToEffect()
-    #else
     let effect = Deferred { () -> Publishers.HandleEvents<PassthroughSubject<Output, Failure>> in
       cancellablesLock.lock()
       defer { cancellablesLock.unlock() }
@@ -80,7 +56,6 @@ extension Effect {
       )
     }
     .eraseToEffect()
-    #endif
 
     return cancelInFlight ? .concatenate(.cancel(id: id), effect) : effect
   }
@@ -91,26 +66,13 @@ extension Effect {
   /// - Returns: A new effect that will cancel any currently in-flight effect with the given
   ///   identifier.
   public static func cancel(id: AnyHashable) -> Effect {
-    #if swift(>=5.3) && !os(macOS)
-    return .fireAndForget {
-      lock.sync {
-        subjects[id]?.forEach { $0.send(()) }
-      }
-    }
-    #else
     return .fireAndForget {
       cancellablesLock.sync {
         cancellationCancellables[id]?.forEach { $0.cancel() }
       }
     }
-    #endif
   }
 }
 
-#if swift(>=5.3) && !os(macOS)
-var subjects: [AnyHashable: [PassthroughSubject<Void, Never>]] = [:]
-let lock = NSRecursiveLock()
-#else
 var cancellationCancellables: [AnyHashable: Set<AnyCancellable>] = [:]
 let cancellablesLock = NSRecursiveLock()
-#endif

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -116,11 +116,7 @@ final class EffectCancellationTests: XCTestCase {
       .sink(receiveValue: { _ in })
       .store(in: &self.cancellables)
 
-    #if swift(>=5.3) && !os(macOS)
-    XCTAssertTrue(subjects.isEmpty)
-    #else
-    XCTAssertTrue(cancellationCancellables.isEmpty)
-    #endif
+    XCTAssertEqual([:], cancellationCancellables)
   }
 
   func testCancellablesCleanUp_OnCancel() {
@@ -136,11 +132,7 @@ final class EffectCancellationTests: XCTestCase {
       .sink(receiveValue: { _ in })
       .store(in: &self.cancellables)
 
-    #if swift(>=5.3) && !os(macOS)
-    XCTAssertTrue(subjects.isEmpty)
-    #else
-    XCTAssertTrue(cancellationCancellables.isEmpty)
-    #endif
+    XCTAssertEqual([:], cancellationCancellables)
   }
 
   func testDoubleCancellation() {
@@ -230,11 +222,7 @@ final class EffectCancellationTests: XCTestCase {
       .store(in: &self.cancellables)
     self.wait(for: [expectation], timeout: 999)
 
-    #if swift(>=5.3) && !os(macOS)
-    XCTAssertTrue(subjects.isEmpty)
-    #else
     XCTAssertTrue(cancellationCancellables.isEmpty)
-    #endif
   }
 
   func testNestedCancels() {
@@ -252,11 +240,7 @@ final class EffectCancellationTests: XCTestCase {
 
     cancellables.removeAll()
 
-    #if swift(>=5.3) && !os(macOS)
-    XCTAssertTrue(subjects.isEmpty)
-    #else
-    XCTAssertTrue(cancellationCancellables.isEmpty)
-    #endif
+    XCTAssertEqual([:], cancellationCancellables)
   }
 
   func testSharedId() {

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -117,9 +117,9 @@ final class EffectCancellationTests: XCTestCase {
       .store(in: &self.cancellables)
 
     #if swift(>=5.3) && !os(macOS)
-      XCTAssertTrue(subjects.isEmpty)
+    XCTAssertTrue(subjects.isEmpty)
     #else
-      XCTAssertTrue(cancellationCancellables.isEmpty)
+    XCTAssertTrue(cancellationCancellables.isEmpty)
     #endif
   }
 
@@ -137,9 +137,9 @@ final class EffectCancellationTests: XCTestCase {
       .store(in: &self.cancellables)
 
     #if swift(>=5.3) && !os(macOS)
-      XCTAssertTrue(subjects.isEmpty)
+    XCTAssertTrue(subjects.isEmpty)
     #else
-      XCTAssertTrue(cancellationCancellables.isEmpty)
+    XCTAssertTrue(cancellationCancellables.isEmpty)
     #endif
   }
 
@@ -231,9 +231,9 @@ final class EffectCancellationTests: XCTestCase {
     self.wait(for: [expectation], timeout: 999)
 
     #if swift(>=5.3) && !os(macOS)
-      XCTAssertTrue(subjects.isEmpty)
+    XCTAssertTrue(subjects.isEmpty)
     #else
-      XCTAssertTrue(cancellationCancellables.isEmpty)
+    XCTAssertTrue(cancellationCancellables.isEmpty)
     #endif
   }
 
@@ -253,9 +253,9 @@ final class EffectCancellationTests: XCTestCase {
     cancellables.removeAll()
 
     #if swift(>=5.3) && !os(macOS)
-      XCTAssertTrue(subjects.isEmpty)
+    XCTAssertTrue(subjects.isEmpty)
     #else
-      XCTAssertTrue(cancellationCancellables.isEmpty)
+    XCTAssertTrue(cancellationCancellables.isEmpty)
     #endif
   }
 


### PR DESCRIPTION
Xcode 12 beta 4 seems to have fixed all the problems we were seeing in beta 3, so we should be able to safely restore the old logic and we could maybe migrate to the new logic whenever we drop iOS 13 and macOS 10.15 support.

Also looks like GitHub already has beta 4 on its runners, so adding CI.