### PR TITLE
Fix warning when handling numberFactResponse action in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ let appReducer = Reducer<AppState, AppAction, AppEnvironment> { state, action, e
     state.numberFactAlert = fact
     return .none
 
-  case let .numberFactResponse(.failure):
+  case .numberFactResponse(.failure):
     state.numberFactAlert = "Could not load a number fact :("
     return .none
   }


### PR DESCRIPTION
This is something I noticed when using the code from the documentation:
<img width="689" alt="Screenshot 2020-08-08 at 17 55 33" src="https://user-images.githubusercontent.com/2045823/89714640-66264400-d9a0-11ea-86e5-ec823af923d3.png">

There's also an option that the warning was left there intentionally, but I'll take my chance 😄