### PR TITLE
Custom pullbacks for Void-State && Void-Environment reducers

### DIFF
--- a/Tests/ComposableArchitectureTests/File.swift
+++ b/Tests/ComposableArchitectureTests/File.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Maxim Krouk on 8/17/20.
+//
+
+import Foundation

--- a/Tests/ComposableArchitectureTests/ReducerPullbackTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerPullbackTests.swift
@@ -1,0 +1,122 @@
+import Combine
+import CombineSchedulers
+import ComposableArchitecture
+import XCTest
+import os.signpost
+
+final class ReducerPullbackTests: XCTestCase {
+  var cancellables: Set<AnyCancellable> = []
+
+  func testVoidPullbacks() {
+    class Counter {
+      var count: Int = 0
+      func inc() {
+        count += 1
+      }
+    }
+    
+    struct CounterClient {
+      var inc: () -> Effect<Never, Never>
+    }
+    
+    struct GlobalState: Equatable {
+      var local: LocalState
+    }
+    
+    enum GlobalAction: Equatable {
+      case local(LocalAction)
+      
+      var local: LocalAction? {
+        if case let .local(action) = self { return action }
+        return nil
+      }
+    }
+    
+    struct GlobalEnvironment {
+      var counterClient: CounterClient
+    }
+    
+    struct LocalState: Equatable {
+      var flag: Bool
+    }
+    
+    enum LocalAction: Equatable {
+      case inc
+      case makeTrue
+    }
+    
+    let localIncActionReducer = Reducer<Void, LocalAction, GlobalEnvironment>.combine(
+      Reducer { state, action, environment in
+        switch action {
+        case .inc:
+          state = () // no crash check
+          return environment.counterClient.inc()
+            .fireAndForget()
+          
+        default:
+          return .none
+        }
+      }
+    )
+    
+    let localMakeTrueActionReducer = Reducer<LocalState, LocalAction, Void>.combine(
+      Reducer { state, action, _ in
+        switch action {
+        case .makeTrue:
+          state.flag = true
+          return .none
+          
+        default:
+          return .none
+        }
+      }
+    )
+    
+    let globalReducer = Reducer<GlobalState, GlobalAction, GlobalEnvironment>.combine(
+      // Test reducer with void state
+      localIncActionReducer.pullback(
+        action: /GlobalAction.local,
+        environment: { $0 }
+      ),
+      
+      // Test reducer with void environment
+      localMakeTrueActionReducer.pullback(
+        state: \.local,
+        action: /GlobalAction.local
+      ),
+      
+      // Global reducer
+      Reducer { state, action, environment in
+        return .none
+      }
+    )
+    
+    let counter = Counter()
+    let counterClient = CounterClient {
+      .fireAndForget { counter.inc() }
+    }
+    
+    let initialState = GlobalState(local: .init(flag: false))
+    let store = TestStore(
+      initialState: initialState,
+      reducer: globalReducer,
+      environment: GlobalEnvironment(counterClient: counterClient)
+    )
+    
+    store.assert(
+      .send(.local(.inc)) { state in
+        XCTAssertEqual(counter.count, 1)
+        state = initialState
+      },
+      .send(.local(.inc)) { state in
+        XCTAssertEqual(counter.count, 2)
+        state = initialState
+      },
+      .send(.local(.makeTrue)) { state in
+        XCTAssertEqual(counter.count, 2)
+        state.local.flag = true
+      }
+    )
+  }
+
+}


### PR DESCRIPTION
Related to [that disscusion](https://github.com/pointfreeco/swift-composable-architecture/issues/47). I think it can be handy, but whether to do it first-class stuff or not is up to you 🙂
(_Tests I wrote are more like the proof of concept, they check if code is compiling and not crushing at runtime, but they don't follow dependency injection principles_)