### PR TITLE
Improve debugging info when some effects are still running issue happen

### DIFF
--- a/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
@@ -13,6 +13,7 @@ struct SignpostData {
           \(log.joined(separator: "\n"))
       """
     }
+    return ""
   }
   
   var unfinishedContent : String {
@@ -23,6 +24,7 @@ struct SignpostData {
           \(unfinished)
       """
     }
+    return ""
   }
 }
 

--- a/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
@@ -1,6 +1,33 @@
 import Combine
 import os.signpost
 
+struct SignpostData {
+  var log : [String] = []
+  var unfinished : [String:String] = [:]
+  
+  var logContent : String {
+    if !log.isEmpty {
+      return """
+
+          Log:
+          \(log.joined(separator: "\n"))
+      """
+    }
+  }
+  
+  var unfinishedContent : String {
+    if !unfinished.isEmpty {
+      return """
+
+          Not Finished Effects:
+          \(unfinished)
+      """
+    }
+  }
+}
+
+var signpostData = SignpostData()
+
 extension Reducer {
   /// Instruments the reducer with
   /// [signposts](https://developer.apple.com/documentation/os/logging/recording_performance_data).
@@ -40,10 +67,15 @@ extension Reducer {
       if log.signpostsEnabled {
         actionOutput = debugCaseOutput(action)
         os_signpost(.begin, log: log, name: "Action", "%s%s", prefix, actionOutput)
+        let content = "Begin: Action \(prefix)\(actionOutput ?? "<no action output>")"
+        signpostData.log.append(content)
+        signpostData.unfinished[actionOutput] = content
       }
       let effects = self.run(&state, action, environment)
       if log.signpostsEnabled {
         os_signpost(.end, log: log, name: "Action")
+        signpostData.log.append("End: Action")
+        signpostData.unfinished[actionOutput] = nil
         return
           effects
           .effectSignpost(prefix, log: log, actionOutput: actionOutput)
@@ -69,19 +101,24 @@ extension Publisher where Failure == Never {
           os_signpost(
             .begin, log: log, name: "Effect", signpostID: sid, "%sStarted from %s", prefix,
             actionOutput)
+          signpostData.log.append("Begin: Effect(\(sid)) \(prefix)Started from \(actionOutput)")
+
         },
         receiveOutput: { value in
           os_signpost(
             .event, log: log, name: "Effect Output", "%sOutput from %s", prefix, actionOutput)
+          signpostData.log.append("Event: Effect \(prefix)Output from \(actionOutput)")
         },
         receiveCompletion: { completion in
           switch completion {
           case .finished:
             os_signpost(.end, log: log, name: "Effect", signpostID: sid, "%sFinished", prefix)
+            signpostData.log.append("End: Effect(\(sid)) \(prefix)Finished")
           }
         },
         receiveCancel: {
           os_signpost(.end, log: log, name: "Effect", signpostID: sid, "%sCancelled", prefix)
+          signpostData.log.append("End: Effect(\(sid)) \(prefix)Cancelled")
         })
   }
 }

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -335,6 +335,20 @@
         )
       }
       if !cancellables.isEmpty {
+        var actionDebugContent = ""
+        if signpostData.logContent.isEmpty {
+          actionDebugContent = """
+          Enable signpost on you reducer will help you debug this. To enable it just add \
+          `.signpost()` behind your reducer.
+          """
+        } else {
+          actionDebugContent = """
+          Look closely at the actions that are not in `Finished` state immediatly.
+          \(signpostData.unfinishedContent)
+          \(signpostData.logContent)
+          """
+        }
+
         _XCTFail(
           """
           Some effects are still running. All effects must complete by the end of the assertion.
@@ -348,6 +362,8 @@
           • If you are using long-living effects (for example timers, notifications, etc.), then \
           ensure those effects are completed by returning an `Effect.cancel` effect from a \
           particular action in your reducer, and sending that action in the test.
+
+          \(actionDebugContent)
           """,
           file: file,
           line: line


### PR DESCRIPTION
When you have a `Some effects are still running issue` error it can be really hard to debug.

In order to help understand what is happening I'm using the signpost data in order to have a better understanding of the Effect and Action that has been happening and that are not finished.

FWIW the implementation is pretty naive but working if you are interest in it I will take more time to improve it.

### What I have tried before making this

I have tried a various way to know witch was the effect that poses an issue for me but this way was the only really precise way to give me this info.

When I tried:
- to add `.debug()` on my reducer it was printing Effect that had the issue as if they where working normally
- or use the `.signpost()` I discover that I can't record a test when using the profiler and in normal mode it was working
- backtrace, breakpoint and the classic debug method didn't help either

### What it look like

As you can see on the image below `EngineContainerAction.searchEngineView(.launchLRSearch)` never finishes. 

| signpost(disabled) | signpost(enabled) | signpost(enabled) with a prefix(💥) | 
| --- | --- | --- |
| <img width="1730" alt="Capture d’écran 2020-08-18 à 01 04 20" src="https://user-images.githubusercontent.com/661647/90453171-283bc500-e0f0-11ea-9ce1-df92d53847c9.png"> | <img width="1729" alt="Capture d’écran 2020-08-18 à 01 18 06" src="https://user-images.githubusercontent.com/661647/90453447-f1b27a00-e0f0-11ea-8d0e-33f1d76ff410.png"> | <img width="1730" alt="Capture d’écran 2020-08-18 à 01 19 03" src="https://user-images.githubusercontent.com/661647/90454034-633ef800-e0f2-11ea-9b48-ebee23c5acb1.png"> | 

_I did remove the extra space above the new text on the first snapshot and the Optional()_

### How to use it

**signpost(disabled)**
```swift
    let localTestStore = TestStore(
      initialState: engineState,
      reducer: engineContainerReducer,
      environment: env
    )
``` 

**signpost(enabled)**
```swift
    let localTestStore = TestStore(
      initialState: engineState,
      reducer: engineContainerReducer.signpost(),
      environment: env
    )
```

Have a great day.
