### PR TITLE
Add a simple way to reduce diff content to the bare minimum

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Debug.swift
+++ b/Sources/ComposableArchitecture/Internal/Debug.swift
@@ -144,9 +144,9 @@ func debugOutput(_ value: Any, indent: Int = 0) -> String {
   return debugOutputHelp(value, indent: indent)
 }
 
-func debugDiff<T>(_ before: T, _ after: T, printer: (T) -> String = { debugOutput($0) }) -> String?
+func debugDiff<T>(_ before: T, _ after: T, _ mode : DiffMode = .full, printer: (T) -> String = { debugOutput($0) }) -> String?
 {
-  diff(printer(before), printer(after))
+  diff(printer(before), printer(after), mode)
 }
 
 extension String {

--- a/Sources/ComposableArchitecture/Internal/Diff.swift
+++ b/Sources/ComposableArchitecture/Internal/Diff.swift
@@ -1,4 +1,9 @@
-func diff(_ first: String, _ second: String) -> String? {
+enum DiffMode {
+  case full
+  case filtered
+}
+
+func diff(_ first: String, _ second: String, _ mode : DiffMode = .full) -> String? {
   struct Difference {
     enum Which {
       case both
@@ -67,10 +72,19 @@ func diff(_ first: String, _ second: String) -> String? {
     }
   }
 
-  let differences = diffHelp(
+  let unfilteredDifferences = diffHelp(
     first.split(separator: "\n", omittingEmptySubsequences: false)[...],
     second.split(separator: "\n", omittingEmptySubsequences: false)[...]
   )
+  
+  let differences : [Difference]
+  switch mode {
+  case .full:
+    differences = unfilteredDifferences
+  case .filtered:
+    differences = unfilteredDifferences.filter { $0.which != .both }
+  }
+  
   if differences.count == 1, case .both = differences[0].which { return nil }
   var string = differences.reduce(into: "") { string, diff in
     diff.elements.forEach { line in

--- a/Sources/ComposableArchitecture/Internal/Diff.swift
+++ b/Sources/ComposableArchitecture/Internal/Diff.swift
@@ -1,4 +1,4 @@
-enum DiffMode {
+public enum DiffMode {
   case full
   case filtered
 }

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -166,6 +166,8 @@
     private let reducer: Reducer<State, Action, Environment>
     private var state: State
     private let toLocalState: (State) -> LocalState
+    public var stateDiffMode: DiffMode = .full
+    public var actionDiffMode: DiffMode = .full
 
     private init(
       initialState: State,
@@ -276,7 +278,7 @@
           let receivedAction = receivedActions.removeFirst()
           if expectedAction != receivedAction {
             let diff =
-              debugDiff(expectedAction, receivedAction)
+              debugDiff(expectedAction, receivedAction, actionDiffMode)
               .map { ": …\n\n\($0.indent(by: 4))\n\n(Expected: −, Actual: +)" }
               ?? ""
             _XCTFail(
@@ -309,7 +311,7 @@
         let actualState = self.toLocalState(self.state)
         if expectedState != actualState {
           let diff =
-            debugDiff(expectedState, actualState)
+            debugDiff(expectedState, actualState, stateDiffMode)
             .map { ": …\n\n\($0.indent(by: 4))\n\n(Expected: −, Actual: +)" }
             ?? ""
           _XCTFail(


### PR DESCRIPTION
When you have a huge state diff between two state is not practical if you have only a few changes it could take you a long time to find them and sometime if the content is too big it will not even been shown.

This implementation is pretty naive but working if you are interest in it I will take more time to improve it.

It basically add a diffMode for state and actions in order to reduce them to only what is different.

| before | after |
| --- | --- |
| [incompleteDiff_480.mov.zip](https://github.com/pointfreeco/swift-composable-architecture/files/5093246/incompleteDiff_480.mov.zip) | <img width="742" alt="Capture d’écran 2020-08-19 à 01 18 06" src="https://user-images.githubusercontent.com/661647/90574696-df504300-e1b9-11ea-89a8-65713884e49d.png"> |

I still need to add a way to show the path of the property above each difference.

Hope it helps.

Cheers,
