### PR TITLE
Added some tests for Shared State case study.

### DIFF
--- a/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
+++ b/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4F5AC11F24ECC7E4009DC50B /* 01-GettingStarted-SharedStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5AC11E24ECC7E4009DC50B /* 01-GettingStarted-SharedStateTests.swift */; };
 		CA0C0C4724B89BEC00CBDD8A /* 04-HigherOrderReducers-LifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C0C4624B89BEC00CBDD8A /* 04-HigherOrderReducers-LifecycleTests.swift */; };
 		CA0C51FB245389CC00A04EAB /* 04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C51FA245389CC00A04EAB /* 04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift */; };
 		CA25E5D224463AD700DA666A /* 01-GettingStarted-Bindings-Basics.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA25E5D124463AD700DA666A /* 01-GettingStarted-Bindings-Basics.swift */; };
@@ -144,6 +145,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4F5AC11E24ECC7E4009DC50B /* 01-GettingStarted-SharedStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-GettingStarted-SharedStateTests.swift"; sourceTree = "<group>"; };
 		CA0C0C4624B89BEC00CBDD8A /* 04-HigherOrderReducers-LifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-LifecycleTests.swift"; sourceTree = "<group>"; };
 		CA0C51FA245389CC00A04EAB /* 04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift"; sourceTree = "<group>"; };
 		CA25E5D124463AD700DA666A /* 01-GettingStarted-Bindings-Basics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-GettingStarted-Bindings-Basics.swift"; sourceTree = "<group>"; };
@@ -419,6 +421,7 @@
 			children = (
 				CA50BE5F24A8F46500FE7DBA /* 01-GettingStarted-AlertsAndActionSheetsTests.swift */,
 				CA34170724A4E89500FAF950 /* 01-GettingStarted-AnimationsTests.swift */,
+				4F5AC11E24ECC7E4009DC50B /* 01-GettingStarted-SharedStateTests.swift */,
 				CAA9ADC324465AB00003A984 /* 02-Effects-BasicsTests.swift */,
 				CAA9ADC724465D950003A984 /* 02-Effects-CancellationTests.swift */,
 				CAA9ADCB2446615B0003A984 /* 02-Effects-LongLivingTests.swift */,
@@ -778,6 +781,7 @@
 				DC07231724465D1E003A8B65 /* 02-Effects-TimersTests.swift in Sources */,
 				CA50BE6024A8F46500FE7DBA /* 01-GettingStarted-AlertsAndActionSheetsTests.swift in Sources */,
 				CAA9ADC424465AB00003A984 /* 02-Effects-BasicsTests.swift in Sources */,
+				4F5AC11F24ECC7E4009DC50B /* 01-GettingStarted-SharedStateTests.swift in Sources */,
 				CAA9ADCC2446615B0003A984 /* 02-Effects-LongLivingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
@@ -67,19 +67,19 @@ struct SharedState: Equatable {
   }
 }
 
-enum SharedStateAction {
+enum SharedStateAction: Equatable {
   case counter(CounterAction)
   case profile(ProfileAction)
   case selectTab(SharedState.Tab)
 
-  enum CounterAction {
+  enum CounterAction: Equatable {
     case alertDismissed
     case decrementButtonTapped
     case incrementButtonTapped
     case isPrimeButtonTapped
   }
 
-  enum ProfileAction {
+  enum ProfileAction: Equatable {
     case resetCounterButtonTapped
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-SharedStateTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-SharedStateTests.swift
@@ -1,0 +1,77 @@
+import Combine
+import ComposableArchitecture
+import XCTest
+
+@testable import SwiftUICaseStudies
+
+class SharedStateTests: XCTestCase {
+  func testTabRestoredOnReset() {
+    let store = TestStore(
+      initialState: SharedState(),
+      reducer: sharedStateReducer,
+      environment: ()
+    )
+    
+    store.assert(
+      .send(.selectTab(.profile)) {
+        $0.currentTab = .profile
+      },
+      .send(.profile(.resetCounterButtonTapped)) {
+        $0.currentTab = .counter
+      })
+  }
+
+  func testTabSelection() {
+    let store = TestStore(
+      initialState: SharedState(),
+      reducer: sharedStateReducer,
+      environment: ()
+    )
+
+    store.assert(
+      .send(.selectTab(.profile)) {
+        $0.currentTab = .profile
+      },
+      .send(.selectTab(.counter)) {
+        $0.currentTab = .counter
+      })
+  }
+
+  func testIsPrimeWhenPrime() {
+    let store = TestStore(
+      initialState: SharedState.CounterState(alert: nil, count: 3, maxCount: 0, minCount: 0, numberOfCounts: 0),
+      reducer: sharedStateCounterReducer,
+      environment: ()
+    )
+
+    store.assert(
+      .send(.isPrimeButtonTapped) {
+        $0.alert = .init(
+          title: "👍 The number \($0.count) is prime!"
+        )
+      },
+      .send(.alertDismissed) {
+        $0.alert = nil
+      }
+    )
+  }
+
+  func testIsPrimeWhenNotPrime() {
+    let store = TestStore(
+      initialState: SharedState.CounterState(alert: nil, count: 6, maxCount: 0, minCount: 0, numberOfCounts: 0),
+      reducer: sharedStateCounterReducer,
+      environment: ()
+    )
+
+    store.assert(
+      .send(.isPrimeButtonTapped) {
+        $0.alert = .init(
+          title: "👎 The number \($0.count) is not prime :("
+        )
+      },
+      .send(.alertDismissed) {
+        $0.alert = nil
+      }
+    )
+  }
+}

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-SharedStateTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-SharedStateTests.swift
@@ -15,9 +15,11 @@ class SharedStateTests: XCTestCase {
     store.assert(
       .send(.selectTab(.profile)) {
         $0.currentTab = .profile
+        $0.profile = .init(currentTab: .profile, count: 0, maxCount: 0, minCount: 0, numberOfCounts: 0)
       },
       .send(.profile(.resetCounterButtonTapped)) {
         $0.currentTab = .counter
+        $0.profile = .init(currentTab: .counter, count: 0, maxCount: 0, minCount: 0, numberOfCounts: 0)
       })
   }
 
@@ -31,9 +33,33 @@ class SharedStateTests: XCTestCase {
     store.assert(
       .send(.selectTab(.profile)) {
         $0.currentTab = .profile
+        $0.profile = .init(currentTab: .profile, count: 0, maxCount: 0, minCount: 0, numberOfCounts: 0)
       },
       .send(.selectTab(.counter)) {
         $0.currentTab = .counter
+        $0.profile = .init(currentTab: .counter, count: 0, maxCount: 0, minCount: 0, numberOfCounts: 0)
+      })
+  }
+
+  func testSharedCounts() {
+    let store = TestStore(
+      initialState: SharedState(),
+      reducer: sharedStateReducer,
+      environment: ()
+    )
+
+    store.assert(
+      .send(.counter(.incrementButtonTapped)) {
+        $0.counter = .init(alert: nil, count: 1, maxCount: 1, minCount: 0, numberOfCounts: 1)
+        $0.profile = .init(currentTab: .counter, count: 1, maxCount: 1, minCount: 0, numberOfCounts: 1)
+      },
+      .send(.counter(.decrementButtonTapped)) {
+        $0.counter = .init(alert: nil, count: 0, maxCount: 1, minCount: 0, numberOfCounts: 2)
+        $0.profile = .init(currentTab: .counter, count: 0, maxCount: 1, minCount: 0, numberOfCounts: 2)
+      },
+      .send(.counter(.decrementButtonTapped)) {
+        $0.counter = .init(alert: nil, count: -1, maxCount: 1, minCount: -1, numberOfCounts: 3)
+        $0.profile = .init(currentTab: .counter, count: -1, maxCount: 1, minCount: -1, numberOfCounts: 3)
       })
   }
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-SharedStateTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-SharedStateTests.swift
@@ -50,16 +50,18 @@ class SharedStateTests: XCTestCase {
 
     store.assert(
       .send(.counter(.incrementButtonTapped)) {
-        $0.counter = .init(alert: nil, count: 1, maxCount: 1, minCount: 0, numberOfCounts: 1)
-        $0.profile = .init(currentTab: .counter, count: 1, maxCount: 1, minCount: 0, numberOfCounts: 1)
+        $0.counter.count = 1
+        $0.counter.maxCount = 1
+        $0.counter.numberOfCounts = 1
       },
       .send(.counter(.decrementButtonTapped)) {
-        $0.counter = .init(alert: nil, count: 0, maxCount: 1, minCount: 0, numberOfCounts: 2)
-        $0.profile = .init(currentTab: .counter, count: 0, maxCount: 1, minCount: 0, numberOfCounts: 2)
+        $0.counter.count = 0
+        $0.counter.numberOfCounts = 2
       },
       .send(.counter(.decrementButtonTapped)) {
-        $0.counter = .init(alert: nil, count: -1, maxCount: 1, minCount: -1, numberOfCounts: 3)
-        $0.profile = .init(currentTab: .counter, count: -1, maxCount: 1, minCount: -1, numberOfCounts: 3)
+        $0.counter.count = -1
+        $0.counter.minCount = -1
+        $0.counter.numberOfCounts = 3
       })
   }
 


### PR DESCRIPTION
This is a follow up to #260 - rather than removing something that I (erroneously) thought was unused, I've added tests to verify it's behaviour.

I attempted to write some other tests for the shared behaviour, for example by incrementing the counter, then asserting that the profile's `count` has the correct value, but was unable to test this because the setters for `ProfileState` are private. I had two ideas to address this:
1. Remove the private access modifier (but they may be there for some reason - ex. to further indicate that these should just "mirror" state from elsewhere rather than being changed directly)
2. Add a new type of Step that allows you to delegate to XCTAssert, similar to `do` but it would pass in the current state, allowing you to assert it's current values without having to construct a new instance of the state. Not sure how feasible/desirable this is however.