### PR TITLE
Display more informations about unfinished Effect

### DIFF
--- a/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
@@ -1,6 +1,35 @@
 import Combine
 import os.signpost
 
+struct SignpostData {
+  var log : [String] = []
+  var unfinished : [String:String] = [:]
+  
+  var logContent : String {
+    if !log.isEmpty {
+      return """
+
+          Log:
+          \(log.joined(separator: "\n"))
+      """
+    }
+    return ""
+  }
+  
+  var unfinishedContent : String {
+    if !unfinished.isEmpty {
+      return """
+
+          Not Finished Effects:
+          \(unfinished)
+      """
+    }
+    return ""
+  }
+}
+
+var signpostData = SignpostData()
+
 extension Reducer {
   /// Instruments the reducer with
   /// [signposts](https://developer.apple.com/documentation/os/logging/recording_performance_data).
@@ -40,10 +69,15 @@ extension Reducer {
       if log.signpostsEnabled {
         actionOutput = debugCaseOutput(action)
         os_signpost(.begin, log: log, name: "Action", "%s%s", prefix, actionOutput)
+        let content = "Begin: Action \(prefix)\(actionOutput ?? "<no action output>")"
+        signpostData.log.append(content)
+        signpostData.unfinished[actionOutput] = content
       }
       let effects = self.run(&state, action, environment)
       if log.signpostsEnabled {
         os_signpost(.end, log: log, name: "Action")
+        signpostData.log.append("End: Action")
+        signpostData.unfinished[actionOutput] = nil
         return
           effects
           .effectSignpost(prefix, log: log, actionOutput: actionOutput)
@@ -69,19 +103,24 @@ extension Publisher where Failure == Never {
           os_signpost(
             .begin, log: log, name: "Effect", signpostID: sid, "%sStarted from %s", prefix,
             actionOutput)
+          signpostData.log.append("Begin: Effect(\(sid)) \(prefix)Started from \(actionOutput)")
+
         },
         receiveOutput: { value in
           os_signpost(
             .event, log: log, name: "Effect Output", "%sOutput from %s", prefix, actionOutput)
+          signpostData.log.append("Event: Effect \(prefix)Output from \(actionOutput)")
         },
         receiveCompletion: { completion in
           switch completion {
           case .finished:
             os_signpost(.end, log: log, name: "Effect", signpostID: sid, "%sFinished", prefix)
+            signpostData.log.append("End: Effect(\(sid)) \(prefix)Finished")
           }
         },
         receiveCancel: {
           os_signpost(.end, log: log, name: "Effect", signpostID: sid, "%sCancelled", prefix)
+          signpostData.log.append("End: Effect(\(sid)) \(prefix)Cancelled")
         })
   }
 }

--- a/Sources/ComposableArchitecture/TestSupport/ReducerLogEffect.swift
+++ b/Sources/ComposableArchitecture/TestSupport/ReducerLogEffect.swift
@@ -5,7 +5,7 @@ var loggedEffect = Log()
 
 struct Log {
   var log : [String] = []
-  var unfinishedActions = Set<String>()
+  var ongoingActions = Set<String>()
 
   var logContent : String {
     if !log.isEmpty {
@@ -18,12 +18,12 @@ struct Log {
     return ""
   }
   
-  var unfinishedActionsContent : String {
-    if !unfinishedActions.isEmpty {
+  var ongoingActionsContent : String {
+    if !ongoingActions.isEmpty {
       return """
 
-          Not Finished Actions:
-          \(unfinishedActions)
+          Not Finished Actions(\(ongoingActions.count)):
+          \(ongoingActions)
       """
     }
     return ""
@@ -43,7 +43,7 @@ extension Reducer {
       let actionOutput = debugCaseOutput(action)
       let content = "Begin: Action \(prefix)\(actionOutput)"
       loggedEffect.log.append(content)
-      loggedEffect.unfinishedActions.insert(actionOutput)
+      loggedEffect.ongoingActions.insert(actionOutput)
       
       return
         self.run(&state, action, environment)
@@ -59,8 +59,8 @@ extension Publisher where Failure == Never {
     actionOutput: String
   ) -> Publishers.HandleEvents<Self> {
     let endAction = {
-      loggedEffect.log.append("End: Action")
-      loggedEffect.unfinishedActions.remove(actionOutput)
+      loggedEffect.log.append("End: Action \(prefix)\(actionOutput)"
+      loggedEffect.ongoingActions.remove(actionOutput)
     }
     return
       self

--- a/Sources/ComposableArchitecture/TestSupport/ReducerLogEffect.swift
+++ b/Sources/ComposableArchitecture/TestSupport/ReducerLogEffect.swift
@@ -66,20 +66,20 @@ extension Publisher where Failure == Never {
       self
       .handleEvents(
         receiveSubscription: { _ in
-          loggedEffect.log.append("Begin: Effect \(prefix)Started from \(actionOutput)")
+          loggedEffect.log.append("\tBegin: Effect Started from \(prefix)\(actionOutput)")
         },
         receiveOutput: { value in
-          loggedEffect.log.append("Event: Effect \(prefix)Output from \(actionOutput)")
+          loggedEffect.log.append("\t\tEvent: Effect Output from \(prefix)\(actionOutput)")
         },
         receiveCompletion: { completion in
           switch completion {
           case .finished:
-            loggedEffect.log.append("End: Effect \(prefix)Finished")
+            loggedEffect.log.append("\t\t\tEnd: Effect Finished from \(prefix)\(actionOutput)")
             endAction()
           }
         },
         receiveCancel: {
-          loggedEffect.log.append("End: Effect \(prefix)Cancelled")
+          loggedEffect.log.append("\t\t\tEnd: Effect Cancelled from \(prefix)\(actionOutput)")
           endAction()
         })
   }

--- a/Sources/ComposableArchitecture/TestSupport/ReducerLogEffect.swift
+++ b/Sources/ComposableArchitecture/TestSupport/ReducerLogEffect.swift
@@ -12,6 +12,7 @@ struct Log {
       return """
 
           Log:
+
           \(log.joined(separator: "\n"))
       """
     }
@@ -23,6 +24,7 @@ struct Log {
       return """
 
           Not Finished Actions(\(ongoingActions.count)):
+
           - \(ongoingActions.joined(separator: "\n- "))
       """
     }
@@ -66,20 +68,20 @@ extension Publisher where Failure == Never {
       self
       .handleEvents(
         receiveSubscription: { _ in
-          loggedEffect.log.append("\tBegin: Effect Started from \(prefix)\(actionOutput)")
+          loggedEffect.log.append("\tBegin: Effect Started")
         },
         receiveOutput: { value in
-          loggedEffect.log.append("\t\tEvent: Effect Output from \(prefix)\(actionOutput)")
+          loggedEffect.log.append("\tEvent: Effect Receive Output")
         },
         receiveCompletion: { completion in
           switch completion {
           case .finished:
-            loggedEffect.log.append("\t\t\tEnd: Effect Finished from \(prefix)\(actionOutput)")
+            loggedEffect.log.append("\tEnd: Effect Finished")
             endAction()
           }
         },
         receiveCancel: {
-          loggedEffect.log.append("\t\t\tEnd: Effect Cancelled from \(prefix)\(actionOutput)")
+          loggedEffect.log.append("\tEnd: Effect Cancelled")
           endAction()
         })
   }

--- a/Sources/ComposableArchitecture/TestSupport/ReducerLogEffect.swift
+++ b/Sources/ComposableArchitecture/TestSupport/ReducerLogEffect.swift
@@ -26,6 +26,7 @@ struct Log {
           Not Finished Actions(\(ongoingActions.count)):
 
           - \(ongoingActions.joined(separator: "\n- "))
+
       """
     }
     return ""

--- a/Sources/ComposableArchitecture/TestSupport/ReducerLogEffect.swift
+++ b/Sources/ComposableArchitecture/TestSupport/ReducerLogEffect.swift
@@ -43,7 +43,7 @@ extension Reducer {
     
     return Self { state, action, environment in
       let actionOutput = debugCaseOutput(action)
-      let content = "Begin: Action \(prefix)\(actionOutput)"
+      let content = "\tBegin: Action \(prefix)\(actionOutput)"
       loggedEffect.log.append(content)
       loggedEffect.ongoingActions.insert(actionOutput)
       
@@ -61,27 +61,27 @@ extension Publisher where Failure == Never {
     actionOutput: String
   ) -> Publishers.HandleEvents<Self> {
     let endAction = {
-      loggedEffect.log.append("End: Action \(prefix)\(actionOutput)")
+      loggedEffect.log.append("\tEnd: Action \(prefix)\(actionOutput)")
       loggedEffect.ongoingActions.remove(actionOutput)
     }
     return
       self
       .handleEvents(
         receiveSubscription: { _ in
-          loggedEffect.log.append("\tBegin: Effect Started")
+          loggedEffect.log.append("\t\tBegin: Effect Started")
         },
         receiveOutput: { value in
-          loggedEffect.log.append("\tEvent: Effect Receive Output")
+          loggedEffect.log.append("\t\tEvent: Effect Receive Output")
         },
         receiveCompletion: { completion in
           switch completion {
           case .finished:
-            loggedEffect.log.append("\tEnd: Effect Finished")
+            loggedEffect.log.append("\t\tEnd: Effect Finished")
             endAction()
           }
         },
         receiveCancel: {
-          loggedEffect.log.append("\tEnd: Effect Cancelled")
+          loggedEffect.log.append("\t\tEnd: Effect Cancelled")
           endAction()
         })
   }

--- a/Sources/ComposableArchitecture/TestSupport/ReducerLogEffect.swift
+++ b/Sources/ComposableArchitecture/TestSupport/ReducerLogEffect.swift
@@ -23,7 +23,7 @@ struct Log {
       return """
 
           Not Finished Actions(\(ongoingActions.count)):
-          \(ongoingActions)
+          - \(ongoingActions.joined(separator: "\n- "))
       """
     }
     return ""

--- a/Sources/ComposableArchitecture/TestSupport/ReducerLogEffect.swift
+++ b/Sources/ComposableArchitecture/TestSupport/ReducerLogEffect.swift
@@ -59,7 +59,7 @@ extension Publisher where Failure == Never {
     actionOutput: String
   ) -> Publishers.HandleEvents<Self> {
     let endAction = {
-      loggedEffect.log.append("End: Action \(prefix)\(actionOutput)"
+      loggedEffect.log.append("End: Action \(prefix)\(actionOutput)")
       loggedEffect.ongoingActions.remove(actionOutput)
     }
     return

--- a/Sources/ComposableArchitecture/TestSupport/ReducerLogEffect.swift
+++ b/Sources/ComposableArchitecture/TestSupport/ReducerLogEffect.swift
@@ -1,0 +1,86 @@
+import Combine
+import os.signpost
+
+var loggedEffect = Log()
+
+struct Log {
+  var log : [String] = []
+  var unfinishedActions = Set<String>()
+
+  var logContent : String {
+    if !log.isEmpty {
+      return """
+
+          Log:
+          \(log.joined(separator: "\n"))
+      """
+    }
+    return ""
+  }
+  
+  var unfinishedActionsContent : String {
+    if !unfinishedActions.isEmpty {
+      return """
+
+          Not Finished Actions:
+          \(unfinishedActions)
+      """
+    }
+    return ""
+  }
+}
+
+extension Reducer {
+  public func logEffect(
+    _ prefix: String = ""
+  ) -> Self {
+    // NB: Prevent rendering as "N/A" in Instruments
+    let zeroWidthSpace = "\u{200B}"
+    
+    let prefix = prefix.isEmpty ? zeroWidthSpace : "[\(prefix)] "
+    
+    return Self { state, action, environment in
+      let actionOutput = debugCaseOutput(action)
+      let content = "Begin: Action \(prefix)\(actionOutput)"
+      loggedEffect.log.append(content)
+      loggedEffect.unfinishedActions.insert(actionOutput)
+      
+      return
+        self.run(&state, action, environment)
+        .logger(prefix, actionOutput: actionOutput)
+        .eraseToEffect()
+    }
+  }
+}
+
+extension Publisher where Failure == Never {
+  func logger(
+    _ prefix: String,
+    actionOutput: String
+  ) -> Publishers.HandleEvents<Self> {
+    let endAction = {
+      loggedEffect.log.append("End: Action")
+      loggedEffect.unfinishedActions.remove(actionOutput)
+    }
+    return
+      self
+      .handleEvents(
+        receiveSubscription: { _ in
+          loggedEffect.log.append("Begin: Effect \(prefix)Started from \(actionOutput)")
+        },
+        receiveOutput: { value in
+          loggedEffect.log.append("Event: Effect \(prefix)Output from \(actionOutput)")
+        },
+        receiveCompletion: { completion in
+          switch completion {
+          case .finished:
+            loggedEffect.log.append("End: Effect \(prefix)Finished")
+            endAction()
+          }
+        },
+        receiveCancel: {
+          loggedEffect.log.append("End: Effect \(prefix)Cancelled")
+          endAction()
+        })
+  }
+}

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -338,13 +338,13 @@
         var actionDebugContent = ""
         if loggedEffect.logContent.isEmpty {
           actionDebugContent = """
-          Enable signpost on you reducer will help you debug this. To enable it just add \
+          Enable logEffect on you reducer will help you debug this. To enable it just add \
           `.logEffect()` behind your reducer.
           """
         } else {
           actionDebugContent = """
           Look closely at the actions that are not in `Finished` or `Cancel` state. 
-          \(loggedEffect.unfinishedActionsContent)
+          \(loggedEffect.ongoingActionsContent)
           \(loggedEffect.logContent)
           """
         }

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -336,16 +336,16 @@
       }
       if !cancellables.isEmpty {
         var actionDebugContent = ""
-        if signpostData.logContent.isEmpty {
+        if loggedEffect.logContent.isEmpty {
           actionDebugContent = """
           Enable signpost on you reducer will help you debug this. To enable it just add \
-          `.signpost()` behind your reducer.
+          `.logEffect()` behind your reducer.
           """
         } else {
           actionDebugContent = """
-          Look closely at the actions that are not in `Finished` state immediatly.
-          \(signpostData.unfinishedContent)
-          \(signpostData.logContent)
+          Look closely at the actions that are not in `Finished` or `Cancel` state. 
+          \(loggedEffect.unfinishedActionsContent)
+          \(loggedEffect.logContent)
           """
         }
 

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -335,6 +335,20 @@
         )
       }
       if !cancellables.isEmpty {
+        var actionDebugContent = ""
+        if signpostData.logContent.isEmpty {
+          actionDebugContent = """
+          Enable signpost on you reducer will help you debug this. To enable it just add \
+          `.signpost()` behind your reducer.
+          """
+        } else {
+          actionDebugContent = """
+          Look closely at the actions that are not in `Finished` state immediatly.
+          \(signpostData.unfinishedContent)
+          \(signpostData.logContent)
+          """
+        }
+
         _XCTFail(
           """
           Some effects are still running. All effects must complete by the end of the assertion.
@@ -348,6 +362,8 @@
           • If you are using long-living effects (for example timers, notifications, etc.), then \
           ensure those effects are completed by returning an `Effect.cancel` effect from a \
           particular action in your reducer, and sending that action in the test.
+
+          \(actionDebugContent)
           """,
           file: file,
           line: line


### PR DESCRIPTION
When you are writing your tests sometimes you have a `Some effects are still running issue` error and it can be really hard to debug.

In order to understand what is happening I add log to all actions and effects in order to be able to see what is finished and what is still pending.

FWIW the implementation is pretty naive but working if you are interest in it I will take more time to improve it.

### What I have tried before making this

I have tried a various way to know witch was the effect that poses an issue for me but this way was the only really precise way to give me this info.

When I tried:
- to add `.debug()` on my reducer it was printing Effect that had the issue as if they where working normally
- or use the `.signpost()` I discover that I can't record a test when using the profiler and in normal mode it was working
- backtrace, breakpoint and the classic debug method didn't help either

### What it look like

As you can see on the image below `HomeContainerAction.overlayContainer(.cardContainer(.getFD(establishmentCode:, activityCode:)))` never finishes.  

**Before enabling .logEffect()**

```
Some effects are still running. All effects must complete by the end of the assertion.

This can happen for a few reasons:

• If you are using a scheduler in your effect, then make sure that you wait enough time for the effect to finish. If you are using a test scheduler, then make sure you advance the scheduler so that the effects complete.

• If you are using long-living effects (for example timers, notifications, etc.), then ensure those effects are completed by returning an `Effect.cancel` effect from a particular action in your reducer, and sending that action in the test.

Enable logEffect on you reducer will help you debug this. To enable it just add `.logEffect()` behind your reducer.
```

**After enabling .logEffect()**
```
Some effects are still running. All effects must complete by the end of the assertion.

This can happen for a few reasons:

• If you are using a scheduler in your effect, then make sure that you wait enough time for the effect to finish. If you are using a test scheduler, then make sure you advance the scheduler so that the effects complete.

• If you are using long-living effects (for example timers, notifications, etc.), then ensure those effects are completed by returning an `Effect.cancel` effect from a particular action in your reducer, and sending that action in the test.

Look closely at the actions that are not in `Finished` or `Cancel` state. 

    Not Finished Actions(1):

    - HomeContainerAction.overlayContainer(.cardContainer(.getFD(establishmentCode:, activityCode:)))

    Log:

    	Begin: Action ​HomeContainerAction.mapContainer(.mapView(.userTap))
		Begin: Effect Started
		Event: Effect Receive Output
		Event: Effect Receive Output
		End: Effect Finished
	End: Action ​HomeContainerAction.mapContainer(.mapView(.userTap))
	Begin: Action ​HomeContainerAction.overlayContainer(.overlayLocal(.updateLevelReceived(.minimum)))
		Begin: Effect Started
		Event: Effect Receive Output
		Event: Effect Receive Output
		End: Effect Finished
	End: Action ​HomeContainerAction.overlayContainer(.overlayLocal(.updateLevelReceived(.minimum)))
	Begin: Action ​HomeContainerAction.mapContainer(.floatingButtonView(.disableCenterMapOnUserButton))
		Begin: Effect Started
		End: Effect Finished
	End: Action ​HomeContainerAction.mapContainer(.floatingButtonView(.disableCenterMapOnUserButton))
	Begin: Action ​HomeContainerAction.mapContainer(.mapView(.currentLayoutMarginsReceived(.minimum)))
		Begin: Effect Started
		End: Effect Finished
	End: Action ​HomeContainerAction.mapContainer(.mapView(.currentLayoutMarginsReceived(.minimum)))
	Begin: Action ​HomeContainerAction.overlayContainer(.overlayLocal(.refreshPositionReceived))
		Begin: Effect Started
		End: Effect Finished
	End: Action ​HomeContainerAction.overlayContainer(.overlayLocal(.refreshPositionReceived))
	Begin: Action ​HomeContainerAction.overlayContainer(.overlayLocal(.updateLevelReceived(.first_third)))
		Begin: Effect Started
		Event: Effect Receive Output
		Event: Effect Receive Output
		End: Effect Finished
	End: Action ​HomeContainerAction.overlayContainer(.overlayLocal(.updateLevelReceived(.first_third)))
	Begin: Action ​HomeContainerAction.mapContainer(.mapView(.currentLayoutMarginsReceived(.first_third)))
		Begin: Effect Started
		End: Effect Finished
	End: Action ​HomeContainerAction.mapContainer(.mapView(.currentLayoutMarginsReceived(.first_third)))
	Begin: Action ​HomeContainerAction.overlayContainer(.overlayLocal(.refreshPositionReceived))
		Begin: Effect Started
		End: Effect Finished
	End: Action ​HomeContainerAction.overlayContainer(.overlayLocal(.refreshPositionReceived))
	Begin: Action ​HomeContainerAction.mapContainer(.mapView(.userTapPOI))
		Begin: Effect Started
		Event: Effect Receive Output
		Event: Effect Receive Output
		Event: Effect Receive Output
		Event: Effect Receive Output
		Event: Effect Receive Output
		Event: Effect Receive Output
		Event: Effect Receive Output
		Event: Effect Receive Output
		End: Effect Finished
	End: Action ​HomeContainerAction.mapContainer(.mapView(.userTapPOI))
	Begin: Action ​HomeContainerAction.overlayContainer(.updateContent(.fd))
		Begin: Effect Started
		End: Effect Finished
	End: Action ​HomeContainerAction.overlayContainer(.updateContent(.fd))
	Begin: Action ​HomeContainerAction.mapContainer(.mapView(.overlayContentReceived(.fd)))
		Begin: Effect Started
		End: Effect Finished
	End: Action ​HomeContainerAction.mapContainer(.mapView(.overlayContentReceived(.fd)))
	Begin: Action ​HomeContainerAction.overlayContainer(.overlayLocal(.backupLevelReceived))
		Begin: Effect Started
		End: Effect Finished
	End: Action ​HomeContainerAction.overlayContainer(.overlayLocal(.backupLevelReceived))
	Begin: Action ​HomeContainerAction.overlayContainer(.overlayLocal(.updateLevelReceived(.half)))
		Begin: Effect Started
		Event: Effect Receive Output
		Event: Effect Receive Output
		End: Effect Finished
	End: Action ​HomeContainerAction.overlayContainer(.overlayLocal(.updateLevelReceived(.half)))
	Begin: Action ​HomeContainerAction.overlayContainer(.cardContainer(.getFD(establishmentCode:, activityCode:)))
		Begin: Effect Started
	Begin: Action ​HomeContainerAction.mapContainer(.floatingButtonView(.hideSearchAgainReceived))
		Begin: Effect Started
		End: Effect Finished
	End: Action ​HomeContainerAction.mapContainer(.floatingButtonView(.hideSearchAgainReceived))
	Begin: Action ​HomeContainerAction.mapContainer(.floatingButtonView(.disableCenterMapOnUserButton))
		Begin: Effect Started
		End: Effect Finished
	End: Action ​HomeContainerAction.mapContainer(.floatingButtonView(.disableCenterMapOnUserButton))
	Begin: Action ​HomeContainerAction.mapContainer(.mapView(.centerOnSelectedProReceived))
		Begin: Effect Started
		End: Effect Finished
	End: Action ​HomeContainerAction.mapContainer(.mapView(.centerOnSelectedProReceived))
	Begin: Action ​HomeContainerAction.mapContainer(.mapView(.currentLayoutMarginsReceived(.half)))
		Begin: Effect Started
		End: Effect Finished
	End: Action ​HomeContainerAction.mapContainer(.mapView(.currentLayoutMarginsReceived(.half)))
	Begin: Action ​HomeContainerAction.overlayContainer(.overlayLocal(.refreshPositionReceived))
		Begin: Effect Started
		End: Effect Finished
	End: Action ​HomeContainerAction.overlayContainer(.overlayLocal(.refreshPositionReceived))
	Begin: Action ​HomeContainerAction.overlayContainer(.cardContainer(.proFDReceived(.success)))
		Begin: Effect Started
		End: Effect Finished
	End: Action ​HomeContainerAction.overlayContainer(.cardContainer(.proFDReceived(.success)))
	Begin: Action ​HomeContainerAction.mapContainer(.mapView(.userTap))
		Begin: Effect Started
		Event: Effect Receive Output
		Event: Effect Receive Output
		Event: Effect Receive Output
		Event: Effect Receive Output
		End: Effect Finished
	End: Action ​HomeContainerAction.mapContainer(.mapView(.userTap))
	Begin: Action ​HomeContainerAction.overlayContainer(.updateContent(.lr))
		Begin: Effect Started
		End: Effect Finished
	End: Action ​HomeContainerAction.overlayContainer(.updateContent(.lr))
	Begin: Action ​HomeContainerAction.mapContainer(.mapView(.overlayContentReceived(.lr)))
		Begin: Effect Started
		End: Effect Finished
	End: Action ​HomeContainerAction.mapContainer(.mapView(.overlayContentReceived(.lr)))
	Begin: Action ​HomeContainerAction.overlayContainer(.overlayLocal(.updateLevelReceived(.first_third)))
		Begin: Effect Started
		Event: Effect Receive Output
		Event: Effect Receive Output
		End: Effect Finished
	End: Action ​HomeContainerAction.overlayContainer(.overlayLocal(.updateLevelReceived(.first_third)))
	Begin: Action ​HomeContainerAction.mapContainer(.floatingButtonView(.disableCenterMapOnUserButton))
		Begin: Effect Started
		End: Effect Finished
	End: Action ​HomeContainerAction.mapContainer(.floatingButtonView(.disableCenterMapOnUserButton))
	Begin: Action ​HomeContainerAction.mapContainer(.mapView(.currentLayoutMarginsReceived(.first_third)))
		Begin: Effect Started
		End: Effect Finished
	End: Action ​HomeContainerAction.mapContainer(.mapView(.currentLayoutMarginsReceived(.first_third)))
	Begin: Action ​HomeContainerAction.overlayContainer(.overlayLocal(.refreshPositionReceived))
		Begin: Effect Started
		End: Effect Finished
	End: Action ​HomeContainerAction.overlayContainer(.overlayLocal(.refreshPositionReceived))
```

### How to use it

**signpost(disabled)**
```swift
    let localTestStore = TestStore(
      initialState: engineState,
      reducer: engineContainerReducer,
      environment: env
    )
``` 

**signpost(enabled)**
```swift
    let localTestStore = TestStore(
      initialState: engineState,
      reducer: engineContainerReducer.signpost(),
      environment: env
    )
```

_Note that in some case you might need to enabled `.logEffect()` to the main reducer of the app if the issue is higher._

Have a great day.
