### PR TITLE
Better error messages for uncompleted effects.

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
@@ -28,7 +28,7 @@ class LongLivingEffectsTests: XCTestCase {
 
       .send(.onDisappear),
 
-      // Simulate a screenshot being taken to show not effects
+      // Simulate a screenshot being taken to show no effects
       // are executed.
       .do { screenshotTaken.send() }
     )


### PR DESCRIPTION
Inspired by @mackoj's PR #263 we wanted to take a pass at making the error messaging better for when you get a test failure due to unfinished effects. We can now tell you what action started the uncompleted effect, which should help you track down what is going on:

<img width="983" alt="image" src="https://user-images.githubusercontent.com/135203/91455511-2a202980-e850-11ea-9394-6949e2f87880.png">
