### PR TITLE
Add reverse implementation in IdentifiedArray

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/IdentifiedArray.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/IdentifiedArray.swift
@@ -199,6 +199,10 @@ where ID: Hashable {
     var rng = SystemRandomNumberGenerator()
     self.shuffle(using: &rng)
   }
+
+  public mutating func reverse() {
+    ids.reverse()
+  }
 }
 
 extension IdentifiedArray: CustomDebugStringConvertible {

--- a/Tests/ComposableArchitectureTests/IdentifiedArrayTests.swift
+++ b/Tests/ComposableArchitectureTests/IdentifiedArrayTests.swift
@@ -227,4 +227,22 @@ final class IdentifiedArrayTests: XCTestCase {
       XCTAssertEqual([1, 3, 5, 4, 2], array.ids)
     }
   #endif
+
+  func testReverse() {
+    var array: IdentifiedArray = [
+      ComparableValue(id: 1, value: 100),
+      ComparableValue(id: 2, value: 50),
+      ComparableValue(id: 3, value: 75),
+    ]
+
+    array.reverse()
+
+    XCTAssertEqual([3, 2, 1], array.ids)
+    XCTAssertEqual(
+      [
+        ComparableValue(id: 3, value: 75),
+        ComparableValue(id: 2, value: 50),
+        ComparableValue(id: 1, value: 100),
+      ], array)
+  }
 }


### PR DESCRIPTION
# Why
IdentifiedArray.reverse() just reverse the elements but doesn't reverse the `ids`.