### PR TITLE
Drive Test Store with a real Store

### DIFF
--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
@@ -63,19 +63,19 @@ let voiceMemoReducer = Reducer<VoiceMemo, VoiceMemoAction, VoiceMemoEnvironment>
       memo.mode = .playing(progress: 0)
       let start = environment.mainQueue.now
       return .merge(
-        environment.audioPlayerClient
-          .play(PlayerId(), memo.url)
-          .catchToEffect()
-          .map(VoiceMemoAction.audioPlayerClient)
-          .cancellable(id: PlayerId()),
-
         Effect.timer(id: TimerId(), every: 0.5, on: environment.mainQueue)
           .map {
             .timerUpdated(
               TimeInterval($0.dispatchTime.uptimeNanoseconds - start.dispatchTime.uptimeNanoseconds)
                 / TimeInterval(NSEC_PER_SEC)
             )
-          }
+          },
+        
+        environment.audioPlayerClient
+          .play(PlayerId(), memo.url)
+          .catchToEffect()
+          .map(VoiceMemoAction.audioPlayerClient)
+          .cancellable(id: PlayerId())
       )
 
     case .playing:

--- a/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
+++ b/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
@@ -178,9 +178,13 @@ class VoiceMemosTests: XCTestCase {
       .send(.voiceMemo(index: 0, action: .playButtonTapped)) {
         $0.voiceMemos[0].mode = VoiceMemo.Mode.playing(progress: 0)
       },
-      .do { self.scheduler.advance(by: 1) },
+      .do { self.scheduler.advance(by: 0.5) },
       .receive(VoiceMemosAction.voiceMemo(index: 0, action: VoiceMemoAction.timerUpdated(0.5))) {
         $0.voiceMemos[0].mode = .playing(progress: 0.5)
+      },
+      .do { self.scheduler.advance(by: 0.5) },
+      .receive(VoiceMemosAction.voiceMemo(index: 0, action: VoiceMemoAction.timerUpdated(1))) {
+        $0.voiceMemos[0].mode = .playing(progress: 1)
       },
       .receive(
         .voiceMemo(
@@ -188,9 +192,6 @@ class VoiceMemosTests: XCTestCase {
           action: .audioPlayerClient(.success(.didFinishPlaying(successfully: true)))
         )
       ) {
-        $0.voiceMemos[0].mode = .notPlaying
-      },
-      .receive(VoiceMemosAction.voiceMemo(index: 0, action: VoiceMemoAction.timerUpdated(1))) {
         $0.voiceMemos[0].mode = .notPlaying
       }
     )

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -220,6 +220,7 @@
       file: StaticString = #file,
       line: UInt = #line
     ) {
+      var stateAfterSend = self.state
       var receivedActions: [(action: Action, state: State)] = []
       var longLivingEffects: [String: Set<UUID>] = [:]
 
@@ -230,6 +231,7 @@
           switch action {
           case let .send(localAction):
             effects = self.reducer.run(&state, self.fromLocalAction(localAction), self.environment)
+            stateAfterSend = state
 
           case let .receive(action):
             effects = self.reducer.run(&state, action, self.environment)
@@ -290,7 +292,7 @@
           }
           viewStore.send(action)
           update(&expectedState)
-          expectedStateShouldMatch(actualState: viewStore.state)
+          expectedStateShouldMatch(actualState: toLocalState(stateAfterSend))
 
         case let .receive(expectedAction, update):
           guard !receivedActions.isEmpty else {

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -163,8 +163,8 @@
   public final class TestStore<State, LocalState, Action: Equatable, LocalAction, Environment> {
     private var environment: Environment
     private let fromLocalAction: (LocalAction) -> Action
-    private var state: State
     private let reducer: Reducer<State, Action, Environment>
+    private var state: State
     private let toLocalState: (State) -> LocalState
 
     private init(

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -238,7 +238,8 @@
 
           let key = debugCaseOutput(action)
           let id = UUID()
-          return effects
+          return
+            effects
             .handleEvents(
               receiveSubscription: { _ in longLivingEffects[key, default: []].insert(id) },
               receiveCompletion: { _ in longLivingEffects[key]?.remove(id) },
@@ -269,8 +270,7 @@
               """
               State change does not match expectation\(diff)
               """,
-              file: step.file,
-              line: step.line
+              file: step.file, line: step.line
             )
           }
         }
@@ -298,8 +298,7 @@
               """
               Expected to receive an action, but received none.
               """,
-              file: step.file,
-              line: step.line
+              file: step.file, line: step.line
             )
             break
           }
@@ -313,8 +312,7 @@
               """
               Received unexpected action\(diff)
               """,
-              file: step.file,
-              line: step.line
+              file: step.file, line: step.line
             )
           }
           update(&expectedState)
@@ -353,13 +351,12 @@
       if !receivedActions.isEmpty {
         _XCTFail(
           """
-            Received \(receivedActions.count) unexpected \
-            action\(receivedActions.count == 1 ? "" : "s"): …
+          Received \(receivedActions.count) unexpected \
+          action\(receivedActions.count == 1 ? "" : "s"): …
 
-            Unhandled actions: \(debugOutput(receivedActions))
-            """,
-          file: file,
-          line: line
+          Unhandled actions: \(debugOutput(receivedActions))
+          """,
+          file: file, line: line
         )
       }
 
@@ -370,26 +367,25 @@
 
         _XCTFail(
           """
-            Some effects are still running. All effects must complete by the end of the assertion.
+          Some effects are still running. All effects must complete by the end of the assertion.
 
-            The effects that are still running were started by the following action\(pluralSuffix):
+          The effects that are still running were started by the following action\(pluralSuffix):
 
-            \(initiatingActions)
+          \(initiatingActions)
 
-            To fix you need to inspect the effects returned from the above action\(pluralSuffix) and \
-            make sure that all of them are completed by the end of your assertion. There are a few \
-            reasons why your effects may not have completed:
+          To fix you need to inspect the effects returned from the above action\(pluralSuffix) and \
+          make sure that all of them are completed by the end of your assertion. There are a few \
+          reasons why your effects may not have completed:
 
-            • If you are using a scheduler in your effect, then make sure that you wait enough time \
-            for the effect to finish. If you are using a test scheduler, then make sure you advance \
-            the scheduler so that the effects complete.
+          • If you are using a scheduler in your effect, then make sure that you wait enough time \
+          for the effect to finish. If you are using a test scheduler, then make sure you advance \
+          the scheduler so that the effects complete.
 
-            • If you are using long-living effects (for example timers, notifications, etc.), then \
-            ensure those effects are completed by returning an `Effect.cancel` effect from a \
-            particular action in your reducer, and sending that action in the test.
-            """,
-          file: file,
-          line: line
+          • If you are using long-living effects (for example timers, notifications, etc.), then \
+          ensure those effects are completed by returning an `Effect.cancel` effect from a \
+          particular action in your reducer, and sending that action in the test.
+          """,
+          file: file, line: line
         )
       }
     }
@@ -526,8 +522,8 @@
     else {
       assertionFailure(
         """
-          Couldn't load XCTest. Are you using a test store in application code?"
-          """,
+        Couldn't load XCTest. Are you using a test store in application code?"
+        """,
         file: file,
         line: line
       )

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -304,7 +304,7 @@
             )
             break
           }
-          let (receivedAction, snapshotState) = receivedActions.removeFirst()
+          let (receivedAction, state) = receivedActions.removeFirst()
           if expectedAction != receivedAction {
             let diff =
               debugDiff(expectedAction, receivedAction)
@@ -318,7 +318,8 @@
             )
           }
           update(&expectedState)
-          expectedStateShouldMatch(actualState: toLocalState(snapshotState))
+          expectedStateShouldMatch(actualState: toLocalState(state))
+          snapshotState = state
 
         case let .environment(work):
           if !receivedActions.isEmpty {

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -24,10 +24,12 @@ class TestStoreTests: XCTestCase {
             .cancellable(id: 1)
         )
       case .b1:
-        return Effect
+        return
+          Effect
           .concatenate(.init(value: .b2), .init(value: .b3))
       case .c1:
-        return Effect
+        return
+          Effect
           .concatenate(.init(value: .c2), .init(value: .c3))
       case .b2, .b3, .c2, .c3:
         return .none

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -1,0 +1,62 @@
+import CombineSchedulers
+import ComposableArchitecture
+import XCTest
+
+class TestStoreTests: XCTestCase {
+  func testEffectConcatenation() {
+    struct State: Equatable {}
+
+    enum Action: Equatable {
+      case a, b1, b2, b3, c1, c2, c3
+    }
+
+    let testScheduler = DispatchQueue.testScheduler
+
+    let reducer = Reducer<State, Action, AnySchedulerOf<DispatchQueue>> { _, action, scheduler in
+      switch action {
+      case .a:
+        return Effect
+          .concatenate(.init(value: .b1), .init(value: .c1))
+          .delay(for: 1, scheduler: scheduler)
+          .eraseToEffect()
+      case .b1:
+        return Effect
+          .concatenate(.init(value: .b2), .init(value: .b3))
+      case .c1:
+        return Effect
+          .concatenate(.init(value: .c2), .init(value: .c3))
+      case .b2, .b3, .c2, .c3:
+        return .none
+      }
+    }
+
+    let s = Store(
+      initialState: State(),
+      reducer: reducer.debug(),
+      environment: testScheduler.eraseToAnyScheduler()
+    )
+    ViewStore(s).send(.a)
+
+    testScheduler.advance(by: 1)
+
+    let store = TestStore(
+      initialState: State(),
+      reducer: reducer,
+      environment: testScheduler.eraseToAnyScheduler()
+    )
+
+    store.assert(
+      .send(.a),
+
+      .do { testScheduler.advance(by: 1) },
+
+      .receive(.b1),
+      .receive(.b2),
+      .receive(.b3),
+
+      .receive(.c1),
+      .receive(.c2),
+      .receive(.c3)
+    )
+  }
+}


### PR DESCRIPTION
Previously, test stores maintained similar logic to real stores, but we can take advantage of higher-order reducers and local mutable state to drive test stores with real stores under the hood.

Fixes #277.