### PR TITLE
DEBUG flag defined in package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,8 @@ let package = Package(
       dependencies: [
         "CasePaths",
         "CombineSchedulers",
-      ]
+      ],
+      swiftSettings: [.define("DEBUG")]
     ),
     .testTarget(
       name: "ComposableArchitectureTests",


### PR DESCRIPTION
It appears that for a flag to be properly evaluated as a SWIFT_ACTIVE_COMPILATION_CONDITION it has to be explicitly defined in Package.swift.

More info: [docs.swift.org](https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html)

This resolves the issue I was having when I tried to use custom configurations at my project (#274). The same fix might have to be applied to `ComposableCoreLocation` & `ComposableCoreMotion` but since I haven't used them yet I decided not to apply it.  

To validate that the fix is working you can use the [repo](https://github.com/gkaimakas/CADebugBug) I created to demonstrate the issue. You have to use the TCA package as a local dependency ([instructions](https://developer.apple.com/documentation/swift_packages/editing_a_package_dependency_as_a_local_package)) and define the flag there.