### PR TITLE
Test Store Ergonomics

### DIFF
--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -290,8 +290,11 @@
               file: step.file, line: step.line
             )
           }
-          viewStore.send(action)
-          update(&expectedState)
+          do {
+            try update(&expectedState)
+          } catch {
+            _XCTFail("Threw error: \(error)", file: step.file, line: step.line)
+          }
           expectedStateShouldMatch(actualState: toLocalState(snapshotState))
 
         case let .receive(expectedAction, update):
@@ -308,16 +311,29 @@
           if expectedAction != receivedAction {
             let diff =
               debugDiff(expectedAction, receivedAction)
-              .map { ": …\n\n\($0.indent(by: 4))\n\n(Expected: −, Actual: +)" }
-              ?? ""
+              .map { "\($0.indent(by: 4))\n\n(Expected: −, Received: +)" }
+              ?? """
+              Expected:
+              \(String(describing: expectedState).indent(by: 2))
+
+              Received:
+              \(String(describing: receivedAction).indent(by: 2))
+              """
+
             _XCTFail(
               """
-              Received unexpected action\(diff)
+              Received unexpected action: …
+
+              \(diff)
               """,
               file: step.file, line: step.line
             )
           }
-          update(&expectedState)
+          do {
+            try update(&expectedState)
+          } catch {
+            _XCTFail("Threw error: \(error)", file: step.file, line: step.line)
+          }
           expectedStateShouldMatch(actualState: toLocalState(state))
           snapshotState = state
 
@@ -333,7 +349,11 @@
               file: step.file, line: step.line
             )
           }
-          work(&self.environment)
+          do {
+            try work(&self.environment)
+          } catch {
+            _XCTFail("Threw error: \(error)", file: step.file, line: step.line)
+          }
 
         case let .do(work):
           if !receivedActions.isEmpty {
@@ -347,7 +367,35 @@
               file: step.file, line: step.line
             )
           }
-          work()
+          do {
+            try work()
+          } catch {
+            _XCTFail("Threw error: \(error)", file: step.file, line: step.line)
+          }
+        }
+
+        let actualState = self.toLocalState(self.state)
+        if expectedState != actualState {
+          let diff =
+            debugDiff(expectedState, actualState)
+            .map { "\($0.indent(by: 4))\n\n(Expected: −, Actual: +)" }
+            ?? """
+            Expected:
+            \(String(describing: expectedState).indent(by: 2))
+
+            Actual:
+            \(String(describing: actualState).indent(by: 2))
+            """
+
+          _XCTFail(
+            """
+            State change does not match expectation: …
+
+            \(diff)
+            """,
+            file: step.file,
+            line: step.line
+          )
         }
       }
 
@@ -456,7 +504,7 @@
         _ action: LocalAction,
         file: StaticString = #file,
         line: UInt = #line,
-        _ update: @escaping (inout LocalState) -> Void = { _ in }
+        _ update: @escaping (inout LocalState) throws -> Void = { _ in }
       ) -> Step {
         Step(.send(action, update), file: file, line: line)
       }
@@ -473,7 +521,7 @@
         _ action: Action,
         file: StaticString = #file,
         line: UInt = #line,
-        _ update: @escaping (inout LocalState) -> Void = { _ in }
+        _ update: @escaping (inout LocalState) throws -> Void = { _ in }
       ) -> Step {
         Step(.receive(action, update), file: file, line: line)
       }
@@ -486,7 +534,7 @@
       public static func environment(
         file: StaticString = #file,
         line: UInt = #line,
-        _ update: @escaping (inout Environment) -> Void
+        _ update: @escaping (inout Environment) throws -> Void
       ) -> Step {
         Step(.environment(update), file: file, line: line)
       }
@@ -498,16 +546,16 @@
       public static func `do`(
         file: StaticString = #file,
         line: UInt = #line,
-        _ work: @escaping () -> Void
+        _ work: @escaping () throws -> Void
       ) -> Step {
         Step(.do(work), file: file, line: line)
       }
 
       fileprivate enum StepType {
-        case send(LocalAction, (inout LocalState) -> Void)
-        case receive(Action, (inout LocalState) -> Void)
-        case environment((inout Environment) -> Void)
-        case `do`(() -> Void)
+        case send(LocalAction, (inout LocalState) throws -> Void)
+        case receive(Action, (inout LocalState) throws -> Void)
+        case environment((inout Environment) throws -> Void)
+        case `do`(() throws -> Void)
       }
     }
 

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -266,13 +266,23 @@
           if expectedState != actualState {
             let diff =
               debugDiff(expectedState, actualState)
-              .map { ": …\n\n\($0.indent(by: 4))\n\n(Expected: −, Actual: +)" }
-              ?? ""
+              .map { "\($0.indent(by: 4))\n\n(Expected: −, Actual: +)" }
+              ?? """
+              Expected:
+              \(String(describing: expectedState).indent(by: 2))
+
+              Actual:
+              \(String(describing: actualState).indent(by: 2))
+              """
+
             _XCTFail(
               """
-              State change does not match expectation\(diff)
+              State change does not match expectation: …
+
+              \(diff)
               """,
-              file: step.file, line: step.line
+              file: step.file,
+              line: step.line
             )
           }
         }
@@ -290,6 +300,7 @@
               file: step.file, line: step.line
             )
           }
+          viewStore.send(action)
           do {
             try update(&expectedState)
           } catch {
@@ -372,30 +383,6 @@
           } catch {
             _XCTFail("Threw error: \(error)", file: step.file, line: step.line)
           }
-        }
-
-        let actualState = self.toLocalState(self.state)
-        if expectedState != actualState {
-          let diff =
-            debugDiff(expectedState, actualState)
-            .map { "\($0.indent(by: 4))\n\n(Expected: −, Actual: +)" }
-            ?? """
-            Expected:
-            \(String(describing: expectedState).indent(by: 2))
-
-            Actual:
-            \(String(describing: actualState).indent(by: 2))
-            """
-
-          _XCTFail(
-            """
-            State change does not match expectation: …
-
-            \(diff)
-            """,
-            file: step.file,
-            line: step.line
-          )
         }
       }
 

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -117,10 +117,7 @@ final class ComposableArchitectureTests: XCTestCase {
     store.assert(
       .send(.start),
       .send(.incr) { $0 = 1 },
-      .do {
-        subject.send()
-//        throw NSError(domain: "co.pointfree", code: -1)
-      },
+      .do(subject.send),
       .receive(.incr) { $0 = 2 },
       .send(.end)
     )

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -117,7 +117,10 @@ final class ComposableArchitectureTests: XCTestCase {
     store.assert(
       .send(.start),
       .send(.incr) { $0 = 1 },
-      .do { subject.send() },
+      .do {
+        subject.send()
+//        throw NSError(domain: "co.pointfree", code: -1)
+      },
       .receive(.incr) { $0 = 2 },
       .send(.end)
     )


### PR DESCRIPTION
PR adds `throws` support to test store assertions, and attempts to show the raw string representations of data that doesn't diff.