### PR TITLE
Fix crash in CaseStudies app when tapping on increment action from Alert

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndActionSheets.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndActionSheets.swift
@@ -21,6 +21,7 @@ private let readMe = """
 struct AlertAndSheetState: Equatable {
   var actionSheet: ActionSheetState<AlertAndSheetAction>?
   var alert: AlertState<AlertAndSheetAction>?
+  var resultAlert: AlertState<AlertAndSheetAction>?
   var count = 0
 }
 
@@ -31,6 +32,7 @@ enum AlertAndSheetAction: Equatable {
   case alertButtonTapped
   case alertCancelTapped
   case alertDismissed
+  case resultAlertDismissed
   case decrementButtonTapped
   case incrementButtonTapped
 }
@@ -77,13 +79,17 @@ let alertAndSheetReducer = Reducer<
     state.alert = nil
     return .none
 
+  case .resultAlertDismissed:
+    state.resultAlert = nil
+    return .none
+
   case .decrementButtonTapped:
-    state.alert = .init(title: "Decremented!")
+    state.resultAlert = .init(title: "Decremented!")
     state.count -= 1
     return .none
 
   case .incrementButtonTapped:
-    state.alert = .init(title: "Incremented!")
+    state.resultAlert = .init(title: "Incremented!")
     state.count += 1
     return .none
   }
@@ -112,6 +118,10 @@ struct AlertAndSheetView: View {
             )
         }
       }
+      .alert(
+        self.store.scope(state: { $0.resultAlert }),
+        dismiss: .resultAlertDismissed
+      )
     }
     .navigationBarTitle("Alerts & Action Sheets")
   }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndActionSheetsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndActionSheetsTests.swift
@@ -23,11 +23,11 @@ class AlertsAndActionSheetsTests: XCTestCase {
         )
       },
       .send(.incrementButtonTapped) {
-        $0.alert = .init(title: "Incremented!")
+        $0.resultAlert = .init(title: "Incremented!")
         $0.count = 1
       },
-      .send(.alertDismissed) {
-        $0.alert = nil
+      .send(.resultAlertDismissed) {
+        $0.resultAlert = nil
       }
     )
   }
@@ -52,7 +52,7 @@ class AlertsAndActionSheetsTests: XCTestCase {
         )
       },
       .send(.incrementButtonTapped) {
-        $0.alert = .init(title: "Incremented!")
+        $0.resultAlert = .init(title: "Incremented!")
         $0.count = 1
       },
       .send(.actionSheetDismissed) {


### PR DESCRIPTION
**CaseStudies app crashes when tapping on "Increment" action from Alert.**

According to my investigation, we cannot reuse `var alert: AlertState<AlertAndSheetAction>?` property to trigger new alert from the action of its button. This also doesn't work in vanilla SwiftUI.