### PR TITLE
Implement heading methods for core location library

### DIFF
--- a/Sources/ComposableCoreLocation/Live.swift
+++ b/Sources/ComposableCoreLocation/Live.swift
@@ -122,6 +122,18 @@ extension LocationManager {
       }
     #endif
 
+    #if os(iOS) || os(watchOS) || targetEnvironment(macCatalyst)
+    manager.startUpdatingHeading = { id in
+      .fireAndForget { dependencies[id]?.manager.startUpdatingHeading() }
+    }
+    #endif
+
+    #if os(iOS) || os(watchOS) || targetEnvironment(macCatalyst)
+    manager.stopUpdatingHeading = { id in
+      .fireAndForget { dependencies[id]?.manager.stopUpdatingHeading() }
+    }
+    #endif
+
     manager.stopUpdatingLocation = { id in
       .fireAndForget { dependencies[id]?.manager.stopUpdatingLocation() }
     }


### PR DESCRIPTION
The start/stop heading methods were not implemented in the live core location manager. I added them!