### PR TITLE
Update TestStore.swift

### DIFF
--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -325,7 +325,7 @@
               .map { "\($0.indent(by: 4))\n\n(Expected: −, Received: +)" }
               ?? """
               Expected:
-              \(String(describing: expectedState).indent(by: 2))
+              \(String(describing: expectedAction).indent(by: 2))
 
               Received:
               \(String(describing: receivedAction).indent(by: 2))


### PR DESCRIPTION
Introduced a copy-paste typo when we refactored TestStore to use a live Store. This should fix!