### PR TITLE
Verbatim Alerts and Action Sheets

### DIFF
--- a/Examples/TicTacToe/Sources/Views-UIKit/LoginViewController.swift
+++ b/Examples/TicTacToe/Sources/Views-UIKit/LoginViewController.swift
@@ -136,14 +136,29 @@ class LoginViewController: UIViewController {
         guard let self = self else { return }
         guard let alert = alert else { return }
 
+        let title: String
+        switch alert.title {
+        case let .localized(key):
+          title = key.formatted()
+        case let .verbatim(content):
+          title = content
+        }
+
         let alertController = UIAlertController(
-          title: alert.title.formatted(), message: nil, preferredStyle: .alert)
+          title: title,
+          message: nil,
+          preferredStyle: .alert
+        )
+
         alertController.addAction(
           UIAlertAction(
             title: "Ok", style: .default,
             handler: { _ in
               self.viewStore.send(.alertDismissed)
-            }))
+            }
+          )
+        )
+
         self.present(alertController, animated: true, completion: nil)
       }
       .store(in: &self.cancellables)

--- a/Examples/TicTacToe/Sources/Views-UIKit/TwoFactorViewController.swift
+++ b/Examples/TicTacToe/Sources/Views-UIKit/TwoFactorViewController.swift
@@ -92,14 +92,29 @@ public final class TwoFactorViewController: UIViewController {
         guard let self = self else { return }
         guard let alert = alert else { return }
 
+        let title: String
+        switch alert.title {
+        case let .localized(key):
+          title = key.formatted()
+        case let .verbatim(content):
+          title = content
+        }
+
         let alertController = UIAlertController(
-          title: alert.title.formatted(), message: nil, preferredStyle: .alert)
+          title: title,
+          message: nil,
+          preferredStyle: .alert
+        )
+
         alertController.addAction(
           UIAlertAction(
             title: "Ok", style: .default,
             handler: { _ in
               self.viewStore.send(.alertDismissed)
-            }))
+            }
+          )
+        )
+
         self.present(alertController, animated: true, completion: nil)
       }
       .store(in: &self.cancellables)

--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -109,7 +109,7 @@ public struct AlertState<Action> {
 
   public init(
     verbatim title: String,
-    verbatim message: String? = nil,
+    message: String? = nil,
     dismissButton: Button? = nil
   ) {
     self.title = .verbatim(title)
@@ -131,7 +131,7 @@ public struct AlertState<Action> {
 
   public init(
     verbatim title: String,
-    verbatim message: String? = nil,
+    message: String? = nil,
     primaryButton: Button,
     secondaryButton: Button
   ) {

--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -155,6 +155,17 @@ public struct AlertState<Action> {
       }
     }
 
+    public static func ==(lhs: Self, rhs: Self) -> Bool {
+      switch (lhs, rhs) {
+      case let (.localized(lhs), .localized(rhs)):
+        return lhs.formatted() == rhs.formatted()
+      case let (.verbatim(lhs), .verbatim(rhs)):
+        return lhs == rhs
+      case (.verbatim, .localized), (.localized, .verbatim):
+        return false
+      }
+    }
+
     public func hash(into hasher: inout Hasher) {
       switch self {
       case let .localized(key):

--- a/Tests/ComposableArchitectureTests/AlertStateTests.swift
+++ b/Tests/ComposableArchitectureTests/AlertStateTests.swift
@@ -1,0 +1,17 @@
+import ComposableArchitecture
+import XCTest
+
+final class AlertStateTests: XCTestCase {
+  func test_text_equatable() {
+    let values: [AlertState<Void>.Text] = [
+      .localized(.init("key")),
+      .verbatim("verbatim")
+    ]
+
+    values.enumerated().forEach { (lhsIndex, lhs) in
+      values.enumerated().forEach { (rhsIndex, rhs) in
+        XCTAssertEqual(lhsIndex == rhsIndex, lhs == rhs, "\(lhs) != \(rhs)")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Resolves #293.

@stephencelis introduced localizable Alerts and Actions sheets in #275. Unfortunately, this led to a breaking change for all library consumers that use localized, verbatim values directly. In order to avoid a breaking change, this PR introduces convenience initialisers for `AlertState<Action>` that allow to pass verbatim strings directly. Using `<S: StringProtocol>` (as mentioned in the original PR) instead of `String` directly was avoided as it would have lead to the generic type S bubbling up into the type definition (i.e. `AlertState<Action, S: StringProtocol>`). 

I'm not quite sure how we should handle UIKit interoperability, but this was already a problem with the previous approach as `NSLocalizedString` does not accept a `LocalizedStringKey` directly. The tic tac toe example fell back to using the formatted key as it's value, but this somehow doesn't feel right? 