### PR TITLE
Ensure objectWillChange.send() is called from the main thread.

### DIFF
--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -68,7 +68,9 @@ public final class ViewStore<State, Action>: ObservableObject {
   /// The current state.
   public private(set) var state: State {
     willSet {
-      self.objectWillChange.send()
+      DispatchQueue.main.async { [weak self] in
+        self?.objectWillChange.send()
+      }
     }
   }
 


### PR DESCRIPTION
> stephencelis > We try to note this in the README's FAQ, but TCA does not have an opinion on threading, and does no work to run on the main thread. The fact that it typically runs on the main thread in SwiftUI applications is due to the fact that most SwiftUI actions are sent on the main thread. If you want to run TCA on a background queue, you need to send actions to the store on that queue, and your reducer must receive effects on that queue.

If we are sending actions to the store from a background queue and receiving effects on that queue, we must also ensure that objectWillChange.send() will always be called from the main thread. 

>Publishing changes from background threads is not allowed.