### PR TITLE
Fix Binding animations

### DIFF
--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -125,10 +125,15 @@ public final class ViewStore<State, Action>: ObservableObject {
     Binding(
       get: { get(self.state) },
       set: { newLocalState, transaction in
-        withAnimation(transaction.disablesAnimations ? nil : transaction.animation) {
+        if transaction.animation != nil {
+          withTransaction(transaction) {
+            self.send(localStateToViewAction(newLocalState))
+          }
+        } else {
           self.send(localStateToViewAction(newLocalState))
         }
-      })
+      }
+    )
   }
 
   /// Derives a binding from the store that prevents direct writes to state and instead sends


### PR DESCRIPTION
This PR fixes #325, where view store-derived bindings cannot be animated in `withAnimation` blocks. The behavior is as follows:

- If a binding has been made animatable via the `.animation` modifier, it will always favor this animation.
- If a binding is not animatable, it will animate when mutated in a `withAnimation` block.
- If a binding has been made animatable via the `.animation` modifier and is mutated in a `withAnimation` block, it will always favor the animation passed to the `.animation` modifier.

This is unfortunately the opposite behavior of bindings derived from Swift UI constructs like `@State`, where `withAnimation` can be used to override the `.animation` modifier. It does not seem possible to reproduce Swift UI's built-in behavior, though (filed feedback FB8965154), so this seems like the best compromise in the meantime.
