### PR TITLE
Replace deprecated optional with optional()

### DIFF
--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -84,7 +84,7 @@ public struct Reducer<State, Action, Environment> {
   ///
   ///     let parentReducer = Reducer<ParentState, ParentAction, ParentEnvironment>.combine(
   ///       // Combined before parent so that it can react to `.dismiss` while state is non-`nil`.
-  ///       childReducer.optional.pullback(
+  ///       childReducer.optional().pullback(
   ///         state: \.child,
   ///         action: /ParentAction.child,
   ///         environment: { $0.child }
@@ -134,7 +134,7 @@ public struct Reducer<State, Action, Environment> {
   ///
   ///     let parentReducer = Reducer<ParentState, ParentAction, ParentEnvironment>.combine(
   ///       // Combined before parent so that it can react to `.dismiss` while state is non-`nil`.
-  ///       childReducer.optional.pullback(
+  ///       childReducer.optional().pullback(
   ///         state: \.child,
   ///         action: /ParentAction.child,
   ///         environment: { $0.child }
@@ -187,7 +187,7 @@ public struct Reducer<State, Action, Environment> {
   ///     let parentReducer: Reducer<ParentState, ParentAction, ParentEnvironment> =
   ///       // Run before parent so that it can react to `.dismiss` while state is non-`nil`.
   ///       childReducer
-  ///         .optional
+  ///         .optional()
   ///         .pullback(
   ///           state: \.child,
   ///           action: /ParentAction.child,


### PR DESCRIPTION
Replace deprecated `optional` with `optional()`
