### PR TITLE
Only include actions in TestStore debug output

### DIFF
--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -295,7 +295,7 @@
               Must handle \(receivedActions.count) received \
               action\(receivedActions.count == 1 ? "" : "s") before sending an action: …
 
-              Unhandled actions: \(debugOutput(receivedActions))
+              Unhandled actions: \(debugOutput(receivedActions.map { $0.action }))
               """,
               file: step.file, line: step.line
             )
@@ -355,7 +355,7 @@
               Must handle \(receivedActions.count) received \
               action\(receivedActions.count == 1 ? "" : "s") before performing this work: …
 
-              Unhandled actions: \(debugOutput(receivedActions))
+              Unhandled actions: \(debugOutput(receivedActions.map { $0.action }))
               """,
               file: step.file, line: step.line
             )
@@ -373,7 +373,7 @@
               Must handle \(receivedActions.count) received \
               action\(receivedActions.count == 1 ? "" : "s") before performing this work: …
 
-              Unhandled actions: \(debugOutput(receivedActions))
+              Unhandled actions: \(debugOutput(receivedActions.map { $0.action }))
               """,
               file: step.file, line: step.line
             )
@@ -392,7 +392,7 @@
           Received \(receivedActions.count) unexpected \
           action\(receivedActions.count == 1 ? "" : "s"): …
 
-          Unhandled actions: \(debugOutput(receivedActions))
+          Unhandled actions: \(debugOutput(receivedActions.map { $0.action }))
           """,
           file: file, line: line
         )


### PR DESCRIPTION
This broke a lil when we refactored the TestStore to use a real store under the hood.