### PR TITLE
Convenience initialised for stateless ViewStore

### DIFF
--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -230,3 +230,9 @@ extension ViewStore where State: Equatable {
     self.init(store, removeDuplicates: ==)
   }
 }
+
+extension ViewStore where State == Void {
+  public convenience init(_ store: Store<Void, Action>) {
+    self.init(store, removeDuplicates: ==)
+  }
+}


### PR DESCRIPTION
Adding convenience initialiser for `ViewStore` when state is `Void`.

Rationale for change:
1. It simplifies the creation of `ViewStore` from `store.stateless` allowing for `ViewStore(store.stateless)`
2. It mirrors the available initialisers for `WithViewStore` SwiftUI helper view, so that you can both use `WithViewStore(store.stateless)` and `ViewStore(store.stateless)`