### PR TITLE
Make WithViewStore Equatable where State is Equatable

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -96,6 +96,12 @@ extension WithViewStore where Content: View, State == Void {
   }
 }
 
+extension WithViewStore: Equatable where State: Equatable {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.viewStore.state == rhs.viewStore.state
+  }
+}
+
 extension WithViewStore: DynamicViewContent where State: Collection, Content: DynamicViewContent {
   public typealias Data = State
 


### PR DESCRIPTION
## Problem

This change has helped me to significantly reduce body re-evaluations in a rather large and complex SwiftUI-only application.

I've seen a significantly large number of body re-evaluations for `WithViewStore` in particular, having a measurable performance impact. (Probably because it affected UIViewRepresentables in leaf nodes of the tree, which have a tendency to be re-created more often.) I would have expected that SwiftUI's diffing algorithm would have ended up with comparing the states on its own. It does seem from my experimentation though as it relies for class objects on pointer equality.

I expect that the SwiftUI diffing algorithm does something more involved for an `@ObservedObject`. Originally I would have expected that I'd ultimately only rely on the published values and not consider the ObservableObject's identity. However with using the synthesized `objectWillChange` publisher (which is a publisher of `Void`) for `ViewStore` in a custom property observer for `State`, the object will appear opaque at runtime and there is little chance to know when the actual value changes, so I guess it does make for SwiftUI to rely on the object identity here.


## Solution

To workaround this, I've implemented `Equatable` on `WithViewStore`, when its `State` is `Equatable`.
This does not require to explicitly call `.equatable()` on `WithViewStore`.

Given how `WithViewStore` is thought to be used, this leads for me to the behavior I would have expected and limiting the updates to whenever actual changes do occur. (But maybe I'm holding something else wrong, with SwiftUI I'm never quite sure. I could see significant changes with just this change vs. without.) From all I could observe it does seem to work fine with the sample applications in the TCA workspace.


## Background Info

The best information I've found so far on SwiftUI's diffing and the topic of `EquatableView` in particular is Javier's [blog post](https://swiftui-lab.com/equatableview/) whichalso links these [two tweets](https://twitter.com/jsh8080/status/1206617106160246784) by John Harper, which does seem authoritative:
>SwiftUI assumes any Equatable.== is a true equality check, so for POD views it compares each field directly instead (via reflection). For non-POD views it prefers the view’s == but falls back to its own field compare if no ==. EqView is a way to force the use of ==.

>When it does the per-field comparison the same rules are applied recursively to each field (to choose direct comparison or == if defined). (POD = plain data, see Swift’s _isPOD() function.)


## Implementation Notes

This equatable implementation is only including the `ViewStore.state`. It is not including...
* ... the `prefix`: which I would expect as an invariant to stay the same through `WithViewStore` values with the same identity, as in the same tree node of the SwiftUI view hierarchy, which I would suspect could be safely assumed as a precondition of SwiftUI calling the equal function in the first place. (e.g. assuming a `ForEach` of `WithViewStore` is always at least implicitly `.id()`-ed) If this is necessary nevertheless though, it should be cheap to add.
* ... the `content` closure: which I would not expect to change in its value. This does seem to fall in the category "holding it wrong." e.g. if someone would have written in red, what could and should have written in green in the following diff:
    ```diff
    -WithViewStore(store, removeDuplicates, someBool ? contentA: contentB)
    +WithViewStore(store, removeDuplicates) {
    +  if someBool {
    +    contentA
    +  } else {
    +    contentB
    +  }
    +}
    ```
    As Swift closures are not equatable, I would suggest documenting that the closure needs to be something like a closure literal / "static closure" as an invariant of how `WithViewStore` is supposed to be used.


## Alternatives considered

1. Make `ViewStore` itself equatable. I tried this and it turned out to be not sufficient.
2. Document this as limitation and advise to implement an own version of `WithViewStore` – which is doable, as it is using only public APIs.
3. Document this as limitation and advise to externally extend `WithViewStore` as Equatable in user-code – which I'd consider generally a bad practise, if not at least explicitly allowed, e.g. compare with [how SwiftNIO documents what's allowed with their public API](https://github.com/apple/swift-nio/blob/main/docs/public-api.md#what-are-acceptable-uses-of-nios-public-api).


## Impact of Change

⚠️  This is a semantic breaking change. This might improve performance of user projects, but it might as well surface previously missing observations of state elsewhere, which were hidden by additional eager body re-evaluations and so lead to newly missing view updates. If this is the right change to go forward, this would need to be well communicated in the release notes.