### PR TITLE
Adds `StepType.sequence(Step)`

### DIFF
--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -54,9 +54,11 @@ class TestStoreTests: XCTestCase {
       .receive(.b2),
       .receive(.b3),
 
-      .receive(.c1),
-      .receive(.c2),
-      .receive(.c3),
+      .sequence([
+        .receive(.c1),
+        .receive(.c2),
+        .receive(.c3),
+      ]),
 
       .send(.d)
     )


### PR DESCRIPTION
This is a sketch towards making the testing suite a touch more composable.
Common user-journey steps can be abstracted into a `Step.sequence` and can be vended by helper functions in the test.

example usage:
```swift
testStore.assert([
   login2fa(),
   enter2faCode(),
   dismiss(),
])
```

where squirreled away elsewhere:
```swift
func login2fa() -> Step {
  .sequence([
     .send(.emailTextChanged) { ... },
     .send(.passwordTextChanged) { ... },
     .send(.loginButtonTapped) { ... },
  ])
}
```