### PR TITLE
Add ViewStore &  WithViewStore initializers to remove duplicates using a keyPath

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -96,6 +96,26 @@ extension WithViewStore where Content: View, State == Void {
   }
 }
 
+extension WithViewStore where Content: View {
+  /// Initializes a structure that transforms a store into an observable view store in order to
+  /// compute views from store state.
+  
+  /// - Parameters:
+  ///   - store: A store.
+  ///   - equatingKeyPath: A keypath from `State` to some `Equatable` value.  When these values are
+  ///     equal, repeat view computations are removed,
+  ///   - content: A function that can generate content from a view store.
+  public init<Equated: Equatable>(
+    _ store: Store<State, Action>,
+    removeDuplicates equatingKeyPath: KeyPath<State, Equated>,
+    @ViewBuilder content: @escaping (ViewStore<State, Action>) -> Content
+  ) {
+    self.init(store,
+              removeDuplicates: { $0[keyPath: equatingKeyPath] == $1[keyPath: equatingKeyPath] },
+              content: content)
+  }
+}
+
 extension WithViewStore: DynamicViewContent where State: Collection, Content: DynamicViewContent {
   public typealias Data = State
 

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -230,3 +230,17 @@ extension ViewStore where State: Equatable {
     self.init(store, removeDuplicates: ==)
   }
 }
+
+extension ViewStore {
+  /// Initializes a view store from a store.
+  ///
+  /// - Parameters:
+  ///   - store: A store.
+  ///   - equatingKeyPath: A keypath from `State` to some `Equatable` value.  When these values are
+  ///     equal, repeat view computations are removed.
+  public convenience init<Equated: Equatable>(_ store: Store<State, Action>,
+                                              removeDuplicates equatingKeyPath: KeyPath<State, Equated>) {
+    self.init(store,
+              removeDuplicates: { $0[keyPath: equatingKeyPath] == $1[keyPath:equatingKeyPath] })
+  }
+}


### PR DESCRIPTION
*EDIT: I've just tested and it turns out I can scope a Store with some read-only KeyPath. Maybe I mixed this up with pullbacks. In this case, this PR is less relevant as scoping the store does the trick. I'm keeping it open for now if you want to discuss, but you can close it if you think it doesn't fit.*

This implements convenience initializers for ViewStore and WithViewStore allowing to specify a keyPath to some `Equatable` value instead of an explicit function to remove duplicates.

This syntactic sugar allows to use
```swift
WithViewStore(store, removeDuplicates: \.viewState) { …
```
instead of the equivalent
```swift
WithViewStore(store, removeDuplicates: { $0.viewState == $1.viewState }) { …
```
when `viewState` is an `Equatable` field of `State`.

This is especially convenient when `State` is "difficult" to equate and one can derive a read-only equatable sub-state `viewState` containing only UI-relevant fields. If the sub-state is read-write, a scoped store `store.scope(state: \.viewState)` can be used instead without explicit deduplication, but it is bothersome to define `viewState`'s setter when its only purpose is to alleviate state's equation. This PR allows to use read-only `viewState`s with a nice syntax when creating `ViewStore`s.

I'm defining these as overloads to the existing initializers. Maybe some dedicated parameter name other than `removeDuplicates` would be preferable.