### PR TITLE
Addresses a couple of documentation issues for IdentifiedArray

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/IdentifiedArray.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/IdentifiedArray.swift
@@ -14,7 +14,7 @@ import Foundation
 ///
 /// This domain can be pulled back to a larger domain with the `forEach` method:
 ///
-///     struct AppState { var counters = IdentifiedArray<UUID, CounterState>() }
+///     struct AppState { var counters = IdentifiedArrayOf<CounterState>() }
 ///     enum AppAction { case counter(id: UUID, action: CounterAction) }
 ///     let appReducer = counterReducer.forEach(
 ///       state: \AppState.counters,

--- a/Sources/ComposableArchitecture/SwiftUI/IdentifiedArray.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/IdentifiedArray.swift
@@ -14,7 +14,7 @@ import Foundation
 ///
 /// This domain can be pulled back to a larger domain with the `forEach` method:
 ///
-///     struct AppState { var counters = IdentifiedArray<Int>(id: \.self) }
+///     struct AppState { var counters = IdentifiedArray<UUID, CounterState>() }
 ///     enum AppAction { case counter(id: UUID, action: CounterAction) }
 ///     let appReducer = counterReducer.forEach(
 ///       state: \AppState.counters,
@@ -30,7 +30,7 @@ import Foundation
 ///       var body: some View {
 ///         List {
 ///           ForEachStore(
-///             self.store.scope(state: \.counters, action: AppAction.counter(id:action))
+///             self.store.scope(state: \.counters, action: AppAction.counter(id:action:)),
 ///             content: CounterView.init(store:)
 ///           )
 ///         }


### PR DESCRIPTION
1. The AppState example is missing a generic. Based on the context of the documentation, I filled in what I thought would be appropriate
2. The ForEachStore example was missing a colon and comma.