### PR TITLE
Add a ViewStore convenience initializer for stateless stores

### DIFF
--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -230,3 +230,9 @@ extension ViewStore where State: Equatable {
     self.init(store, removeDuplicates: ==)
   }
 }
+
+extension ViewStore where State == Void {
+  public convenience init(_ store: Store<State, Action>) {
+    self.init(store, removeDuplicates: { _, _ in true })
+  }
+}


### PR DESCRIPTION
Because `Void` can't be `Equatable`, we cannot use the other convenience initializer.
This new initializer makes `removeDuplicate` to always returns `true`, and allows to quickly instantiate stateless `ViewStore`s as `ViewStore(store.stateless)`.