### PR TITLE
Display a correct error when the ForEachStore is empty

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -84,7 +84,7 @@ where Data: Collection, ID: Hashable, Content: View {
     self.data = data
     self.content = {
       WithViewStore(store.scope(state: { $0.map { $0[keyPath: id] } })) { viewStore in
-        if viewStore.state.isEmpty { fatalError("viewStore.state should not be empty") }
+        if viewStore.state.isEmpty { fatalError("State should not be empty") }
         return ForEach(Array(viewStore.state.enumerated()), id: \.element) { index, _ in
           content(
             store.scope(
@@ -138,7 +138,7 @@ where Data: Collection, ID: Hashable, Content: View {
     self.data = data
     self.content = {
       WithViewStore(store.scope(state: { $0.ids })) { viewStore in
-        if viewStore.state.isEmpty { fatalError("viewStore.state should not be empty") }
+        if viewStore.state.isEmpty { fatalError("State should not be empty") }
         return ForEach(viewStore.state, id: \.self) { id in
           content(
             store.scope(

--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -84,7 +84,7 @@ where Data: Collection, ID: Hashable, Content: View {
     self.data = data
     self.content = {
       WithViewStore(store.scope(state: { $0.map { $0[keyPath: id] } })) { viewStore in
-        if viewStore.state.isEmpty { fatalError("State(\(type(of: store))) passed to ForEachStore should not be empty") }
+        if viewStore.state.isEmpty { fatalError("\(type(of: store)) passed to ForEachStore should not be empty.") }
         return ForEach(Array(viewStore.state.enumerated()), id: \.element) { index, _ in
           content(
             store.scope(
@@ -138,7 +138,7 @@ where Data: Collection, ID: Hashable, Content: View {
     self.data = data
     self.content = {
       WithViewStore(store.scope(state: { $0.ids })) { viewStore in
-        if viewStore.state.isEmpty { fatalError("State(\(type(of: store))) passed to ForEachStore should not be empty") }
+        if viewStore.state.isEmpty { fatalError("\(type(of: store)) passed to ForEachStore should not be empty.") }
         return ForEach(viewStore.state, id: \.self) { id in
           content(
             store.scope(

--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -85,7 +85,7 @@ where Data: Collection, ID: Hashable, Content: View {
     self.content = {
       WithViewStore(store.scope(state: { $0.map { $0[keyPath: id] } })) { viewStore in
         if viewStore.state.isEmpty { fatalError("viewStore.state should not be empty") }
-        ForEach(Array(viewStore.state.enumerated()), id: \.element) { index, _ in
+        return ForEach(Array(viewStore.state.enumerated()), id: \.element) { index, _ in
           content(
             store.scope(
               state: { index < $0.endIndex ? $0[index] : data[index] },
@@ -139,7 +139,7 @@ where Data: Collection, ID: Hashable, Content: View {
     self.content = {
       WithViewStore(store.scope(state: { $0.ids })) { viewStore in
         if viewStore.state.isEmpty { fatalError("viewStore.state should not be empty") }
-        ForEach(viewStore.state, id: \.self) { id in
+        return ForEach(viewStore.state, id: \.self) { id in
           content(
             store.scope(
               state: { $0[id: id] ?? data[id: id]! },

--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -84,7 +84,7 @@ where Data: Collection, ID: Hashable, Content: View {
     self.data = data
     self.content = {
       WithViewStore(store.scope(state: { $0.map { $0[keyPath: id] } })) { viewStore in
-        if viewStore.state.isEmpty { fatalError("State should not be empty") }
+        if viewStore.state.isEmpty { fatalError("State(\(type(of: store))) passed to ForEachStore should not be empty") }
         return ForEach(Array(viewStore.state.enumerated()), id: \.element) { index, _ in
           content(
             store.scope(
@@ -138,7 +138,7 @@ where Data: Collection, ID: Hashable, Content: View {
     self.data = data
     self.content = {
       WithViewStore(store.scope(state: { $0.ids })) { viewStore in
-        if viewStore.state.isEmpty { fatalError("State should not be empty") }
+        if viewStore.state.isEmpty { fatalError("State(\(type(of: store))) passed to ForEachStore should not be empty") }
         return ForEach(viewStore.state, id: \.self) { id in
           content(
             store.scope(

--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -84,6 +84,7 @@ where Data: Collection, ID: Hashable, Content: View {
     self.data = data
     self.content = {
       WithViewStore(store.scope(state: { $0.map { $0[keyPath: id] } })) { viewStore in
+        if viewStore.state.isEmpty { fatalError("viewStore.state should not be empty") }
         ForEach(Array(viewStore.state.enumerated()), id: \.element) { index, _ in
           content(
             store.scope(
@@ -137,6 +138,7 @@ where Data: Collection, ID: Hashable, Content: View {
     self.data = data
     self.content = {
       WithViewStore(store.scope(state: { $0.ids })) { viewStore in
+        if viewStore.state.isEmpty { fatalError("viewStore.state should not be empty") }
         ForEach(viewStore.state, id: \.self) { id in
           content(
             store.scope(


### PR DESCRIPTION
When we move to 0.15.0 from  0.14.0 our codebase broke because of https://github.com/pointfreeco/swift-composable-architecture/pull/386 the `!` at [line 143](https://github.com/pointfreeco/swift-composable-architecture/blob/65a0c6321fbb2884234f69df08f7ffa8c4cf0de8/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift#L143).

This PR add a simple error message to prevent this issue.