### PR TITLE
TextState: DebugOutputConvertible

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/TextState.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/TextState.swift
@@ -321,11 +321,24 @@ extension TextState: CustomDebugOutputConvertible {
           output = "<baseline-offset=\(baselineOffset)>\(output)</baseline-offset>"
         case .bold, .fontWeight(.some(.bold)):
           output = "**\(output)**"
-        case let .font(.some):
+        case .font(.some):
           // TODO: Better describe fonts?
           output = "<font>\(output)</font>"
         case let .fontWeight(.some(weight)):
-          output = "<font-weight=\(weight)>\(output)</font-weight>"
+          func describe(weight: Font.Weight) -> String {
+            switch weight {
+            case .black: return "black"
+            case .bold: return "bold"
+            case .heavy: return "heavy"
+            case .light: return "light"
+            case .medium: return "medium"
+            case .regular: return "regular"
+            case .semibold: return "semibold"
+            case .thin: return "thin"
+            default: return "\(weight)"
+            }
+          }
+          output = "<font-weight=\(describe(weight: weight))>\(output)</font-weight>"
         case let .foregroundColor(.some(color)):
           output = "<foreground-color=\(color)>\(output)</foreground-color>"
         case .italic:

--- a/Sources/ComposableArchitecture/SwiftUI/TextState.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/TextState.swift
@@ -317,26 +317,34 @@ extension TextState: CustomDebugOutputConvertible {
       }
       for modifier in textState.modifiers {
         switch modifier {
-        case .bold,
-             // TODO: Distinguish
-             .fontWeight(.some(.semibold)),
-             .fontWeight(.some(.bold)),
-             .fontWeight(.some(.heavy)),
-             .fontWeight(.some(.black)):
+        case let .baselineOffset(baselineOffset):
+          output = "<baseline-offset=\(baselineOffset)>\(output)</baseline-offset>"
+        case .bold, .fontWeight(.some(.bold)):
           output = "**\(output)**"
+        case let .font(.some):
+          // TODO: Better describe fonts?
+          output = "<font>\(output)</font>"
+        case let .fontWeight(.some(weight)):
+          output = "<font-weight=\(weight)>\(output)</font-weight>"
+        case let .foregroundColor(.some(color)):
+          output = "<foreground-color=\(color)>\(output)</foreground-color>"
         case .italic:
           output = "_\(output)_"
-        case .strikethrough:
+        case let .kerning(kerning):
+          output = "<kerning=\(kerning)>\(output)</kerning>"
+        case let .strikethrough(active: true, color: .some(color)):
+          output = "<s color=\(color)>\(output)</s>"
+        case .strikethrough(active: true, color: .none):
           output = "~~\(output)~~"
-
-        // TODO:
-        case .baselineOffset,
-             .font,
-             .fontWeight,
-             .foregroundColor,
-             .kerning,
-             .tracking,
-             .underline:
+        case let .tracking(tracking):
+          output = "<tracking=\(tracking)>\(output)</tracking>"
+        case let .underline(active: true, color):
+          output = "<u\(color.map { " color=\($0)" } ?? "")>\(output)</u>"
+        case .font(.none),
+             .fontWeight(.none),
+             .foregroundColor(.none),
+             .strikethrough(active: false, color: _),
+             .underline(active: false, color: _):
           break
         }
       }

--- a/Sources/ComposableArchitecture/SwiftUI/TextState.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/TextState.swift
@@ -322,8 +322,7 @@ extension TextState: CustomDebugOutputConvertible {
         case .bold, .fontWeight(.some(.bold)):
           output = "**\(output)**"
         case .font(.some):
-          // TODO: Better describe fonts?
-          output = "<font>\(output)</font>"
+          break // TODO: capture Font description using DSL similar to TextState and print here
         case let .fontWeight(.some(weight)):
           func describe(weight: Font.Weight) -> String {
             switch weight {

--- a/Sources/ComposableArchitecture/SwiftUI/TextState.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/TextState.swift
@@ -302,3 +302,51 @@ extension LocalizedStringKey: CustomDebugOutputConvertible {
     self.formatted().debugDescription
   }
 }
+
+extension TextState: CustomDebugOutputConvertible {
+  public var debugOutput: String {
+    func debugOutputHelp(_ textState: Self) -> String {
+      var output: String
+      switch textState.storage {
+      case let .concatenated(lhs, rhs):
+        output = debugOutputHelp(lhs) + debugOutputHelp(rhs)
+      case let .localized(key, tableName, bundle, comment):
+        output = key.formatted(tableName: tableName, bundle: bundle, comment: comment)
+      case let .verbatim(string):
+        output = string
+      }
+      for modifier in textState.modifiers {
+        switch modifier {
+        case .bold,
+             // TODO: Distinguish
+             .fontWeight(.some(.semibold)),
+             .fontWeight(.some(.bold)),
+             .fontWeight(.some(.heavy)),
+             .fontWeight(.some(.black)):
+          output = "**\(output)**"
+        case .italic:
+          output = "_\(output)_"
+        case .strikethrough:
+          output = "~~\(output)~~"
+
+        // TODO:
+        case .baselineOffset,
+             .font,
+             .fontWeight,
+             .foregroundColor,
+             .kerning,
+             .tracking,
+             .underline:
+          break
+        }
+      }
+      return output
+    }
+
+    return #"""
+      \#(Self.self)(
+      \#(debugOutputHelp(self).indent(by: 2))
+      )
+      """#
+  }
+}

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -345,6 +345,32 @@ final class DebugTests: XCTestCase {
     )
   }
 
+  func testTextState() {
+    XCTAssertEqual(
+      debugOutput(
+        TextState("Hello, world!")
+      ),
+      """
+      TextState(
+        Hello, world!
+      )
+      """
+    )
+
+    XCTAssertEqual(
+      debugOutput(
+        TextState("Hello, ")
+          + TextState("world").bold()
+          + TextState("!")
+      ),
+      """
+      TextState(
+        Hello, **world**!
+      )
+      """
+    )
+  }
+
   func testEffectOutput() {
     //    XCTAssertEqual(
     //      Effect<Int, Never>(value: 42)

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -360,12 +360,53 @@ final class DebugTests: XCTestCase {
     XCTAssertEqual(
       debugOutput(
         TextState("Hello, ")
-          + TextState("world").bold()
+          + TextState("world").bold().italic()
           + TextState("!")
       ),
       """
       TextState(
-        Hello, **world**!
+        Hello, _**world**_!
+      )
+      """
+    )
+
+    XCTAssertEqual(
+      debugOutput(
+        TextState("Offset by 10.5").baselineOffset(10.5)
+          + TextState("\n") + TextState("Headline").font(.headline)
+          + TextState("\n") + TextState("No font").font(nil)
+          + TextState("\n") + TextState("Light font weight").fontWeight(.light)
+          + TextState("\n") + TextState("No font weight").fontWeight(nil)
+          + TextState("\n") + TextState("Red").foregroundColor(.red)
+          + TextState("\n") + TextState("No color").foregroundColor(nil)
+          + TextState("\n") + TextState("Italic").italic()
+          + TextState("\n") + TextState("Kerning of 2.5").kerning(2.5)
+          + TextState("\n") + TextState("Stricken").strikethrough()
+          + TextState("\n") + TextState("Stricken green").strikethrough(color: .green)
+          + TextState("\n") + TextState("Not stricken blue").strikethrough(false, color: .blue)
+          + TextState("\n") + TextState("Tracking of 5.5").tracking(5.5)
+          + TextState("\n") + TextState("Underlined").underline()
+          + TextState("\n") + TextState("Underlined pink").underline(color: .pink)
+          + TextState("\n") + TextState("Not underlined purple").underline(false, color: .pink)
+      ),
+      """
+      TextState(
+        <baseline-offset=10.5>Offset by 10.5</baseline-offset>
+        <font ...>Headline</font>
+        No font
+        <font-weight=Weight(value: -0.4)>Light font weight</font-weight>
+        No font weight
+        <foreground-color=red>Red</foreground-color>
+        No color
+        _Italic_
+        <kerning=2.5>Kerning of 2.5</kerning>
+        ~~Stricken~~
+        <s color=green>Stricken green</s>
+        Not stricken blue
+        <tracking=5.5>Tracking of 5.5</tracking>
+        <u>Underlined</u>
+        <u color=pink>Underlined pink</u>
+        Not underlined purple
       )
       """
     )

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -392,7 +392,7 @@ final class DebugTests: XCTestCase {
       """
       TextState(
         <baseline-offset=10.5>Offset by 10.5</baseline-offset>
-        <font>Headline</font>
+        Headline
         No font
         <font-weight=light>Light font weight</font-weight>
         No font weight

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -392,7 +392,7 @@ final class DebugTests: XCTestCase {
       """
       TextState(
         <baseline-offset=10.5>Offset by 10.5</baseline-offset>
-        <font ...>Headline</font>
+        <font>Headline</font>
         No font
         <font-weight=Weight(value: -0.4)>Light font weight</font-weight>
         No font weight

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -394,7 +394,7 @@ final class DebugTests: XCTestCase {
         <baseline-offset=10.5>Offset by 10.5</baseline-offset>
         <font>Headline</font>
         No font
-        <font-weight=Weight(value: -0.4)>Light font weight</font-weight>
+        <font-weight=light>Light font weight</font-weight>
         No font weight
         <foreground-color=red>Red</foreground-color>
         No color


### PR DESCRIPTION
TextState currently dumps a lot of info when fed through TCA's debug output system. This shortens things up to make it more readable in tests.