### PR TITLE
Add more permissive fire-and-forget effect

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -333,4 +333,23 @@ extension Publisher {
       .catch { Just(.failure($0)) }
       .eraseToEffect()
   }
+
+  /// Turns any publisher into an `Effect<T, Never>` for any type `T` by ignoring all output and
+  /// failures.
+  ///
+  /// This is useful for times you want to fire off an effect but don't want to feed any data back
+  /// into the system.
+  ///
+  ///     case .buttonTapped:
+  ///       return analyticsClient.track("Button Tapped")
+  ///         .fireAndForget()
+  ///
+  /// - Returns: An effect that never produces output or errors.
+  public func fireAndForget<T>() -> Effect<T, Never> {
+    func absurd<A>(_ never: Never) -> A {}
+    return self
+      .flatMap { _ in Empty() }
+      .catch { _ in Empty() }
+      .eraseToEffect()
+  }
 }

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -334,8 +334,8 @@ extension Publisher {
       .eraseToEffect()
   }
 
-  /// Turns any publisher into an `Effect<T, Never>` for any type `T` by ignoring all output and
-  /// failures.
+  /// Turns any publisher into an `Effect` for any output and failure type by ignoring all output
+  /// and any failure.
   ///
   /// This is useful for times you want to fire off an effect but don't want to feed any data back
   /// into the system.
@@ -345,7 +345,7 @@ extension Publisher {
   ///         .fireAndForget()
   ///
   /// - Returns: An effect that never produces output or errors.
-  public func fireAndForget<T>() -> Effect<T, Never> {
+  public func fireAndForget<NewOutput, NewFailure>() -> Effect<NewOutput, NewFailure> {
     return self
       .flatMap { _ in Empty() }
       .catch { _ in Empty() }

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -346,7 +346,6 @@ extension Publisher {
   ///
   /// - Returns: An effect that never produces output or errors.
   public func fireAndForget<T>() -> Effect<T, Never> {
-    func absurd<A>(_ never: Never) -> A {}
     return self
       .flatMap { _ in Empty() }
       .catch { _ in Empty() }


### PR DESCRIPTION
We've experimented with this and it is a bit nicer to iterate on features without having to do the extra dance of ignoring output and failure all the time.