### PR TITLE
fireAndCatch - For ignoring Output, while catching Failures

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -338,4 +338,24 @@ extension Publisher {
       .catch { _ in Empty() }
       .eraseToEffect()
   }
+
+  /// Turns any publisher into an `Effect` for any output and failure type by ignoring all output,
+  /// but retaining any failure.
+  ///
+  ///     case let .saveUser(user):
+  ///       return environment.saveUser(user)
+  ///         .fireAndCatch()
+  ///         .map(UserAction.saveFailure)
+  ///
+  /// This is useful for times you want to fire off an effect, and only want to feed data back into the
+  /// system if the effect fails.
+  ///
+  /// - Returns: An `Effect` which completes immediately upon receiving successful output, and only publishes errors
+  public func fireAndCatch() -> Effect<Failure, Never> {
+    flatMap { _ in
+      Empty<Failure, Failure>()
+    }
+    .catch(Just.init)
+    .eraseToEffect()
+  }
 }

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -352,10 +352,9 @@ extension Publisher {
   ///
   /// - Returns: An `Effect` which completes immediately upon receiving successful output, and only publishes errors
   public func fireAndCatch() -> Effect<Failure, Never> {
-    flatMap { _ in
-      Empty<Failure, Failure>()
-    }
-    .catch(Just.init)
-    .eraseToEffect()
+    ignoreOutput()
+      .map { _ -> Failure in }
+      .catch(Just.init)
+      .eraseToEffect()
   }
 }

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -169,7 +169,7 @@ final class EffectTests: XCTestCase {
     }
       .fireAndCatch()
       .receive(on: scheduler)
-      .sink(receiveValue: { error = $0 })
+      .sink { error = $0 }
       .store(in: &self.cancellables)
 
     self.scheduler.advance(by: 1)


### PR DESCRIPTION
`fireAndCatch` is a way to perform an `Effect` which may return some output, but the user only needs to handle the cases where the `Effect` fails.

An example of where this might be desirable is when subscribing to a `Publisher` where the `Output` type is `Void`. There's nothing to send back to the store, no data to persist in the `State`, but the publisher might fail. It's useful to be able to catch the error. A useful - but verbose - pattern to follow is to flatMap the `Void` publisher to an `Empty<Never, Failure>` to ensure the `Output` type is `Never`, and catch this to an `Effect`, before mapping into an `Action` which takes a `Result<Never, Failure>`. With `fireAndCatch`, the ignoring is all handled, and the `Failure` is routed to the `Output` of the publisher, allowing it to map to an `Action` which just takes a `Failure`.

As discussed here: https://github.com/pointfreeco/swift-composable-architecture/discussions/435