### PR TITLE
feat(Reducer.pullback): introducing lens for pullbacks

### DIFF
--- a/Sources/ComposableArchitecture/Lens.swift
+++ b/Sources/ComposableArchitecture/Lens.swift
@@ -1,0 +1,60 @@
+import CasePaths
+
+public struct Lens<Root, Value> {
+  public init(
+    extract: @escaping (Root) -> Value,
+    embed: @escaping (Value, inout Root) -> Void
+  ) {
+    self._extract = extract
+    self._embed = embed
+  }
+  
+  public init(_ keyPath: WritableKeyPath<Root, Value>) {
+    self.init(
+      extract: { $0[keyPath: keyPath] },
+      embed: { $1[keyPath: keyPath] = $0 }
+    )
+  }
+  
+  public static func readonly(_ keyPath: KeyPath<Root, Value>) -> Self {
+    self.init(
+      extract: { $0[keyPath: keyPath] },
+      embed: { _, _ in }
+    )
+  }
+  
+  private var _extract: (Root) -> Value
+  private var _embed: (Value, inout Root) -> Void
+  
+  public func extract(from root: Root) -> Value { _extract(root) }
+  public func embed(_ value: Value, in root: inout Root) { _embed(value, &root) }
+  
+  public subscript(
+    provider: ((inout Root) -> Void) -> Void
+  ) -> Value {
+    get {
+      var root: Root?
+      withoutActuallyEscaping(provider) { rootProvider in
+        rootProvider { accessor in
+          root = accessor
+        }
+      }
+      return extract(from: root!)
+    }
+    nonmutating set {
+      provider({ embed(newValue, in: &$0) })
+    }
+  }
+  
+  public subscript(
+    read read: () -> Root,
+    write write: (Root) -> Void
+  ) -> Value {
+    get { extract(from: read()) }
+    nonmutating set {
+      var root = read()
+      embed(newValue, in: &root)
+      write(root)
+    }
+  }
+}


### PR DESCRIPTION
Hi, there is no ability to share state between child modules, but it's a great feature and I implemented it using custom lens

Btw i need to create something like this
```swift
struct ParentState {
    var items: [ChildState]
    var collectionViewConfig: CollectionViewConfiguration
}

struct CollectionViewConfiguration {
    var isPaginationEnabled: Bool
    var ignoresSafeAreaInsets: Bool
}

struct CollectionViewState<Element> {
    var items: [Element]
    var config: CollectionViewConfiguration
}

parentReducer = .combine(
    childReducer.forEach(state: \.items)
    collectionViewReducer.pullback(state: Lens(
        extract: { state in 
            CollectionViewState(
                items: state.items
                config: state.collectionViewConfig
            )
        },
        embed: { collection, state
            state.items = collection.items
            state.collectionViewConfig = collection.config
        }
    ))
)
```

- I had to implement inout behavior using subscript to avoid escapes of inout globalState
- I'm not sure about the performance
- I implemented it before I saw reply for my message here https://forums.swift.org/t/how-can-the-composable-architecture-really-become-composable/43045/17

So maybe discuss if TCA needs these pullbacks, my job was just to make it 🌚