### PR TITLE
State-driven URL opening reducer

### DIFF
--- a/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
+++ b/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		4F5AC11F24ECC7E4009DC50B /* 01-GettingStarted-SharedStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5AC11E24ECC7E4009DC50B /* 01-GettingStarted-SharedStateTests.swift */; };
+		A370BB3D25F94F7B00EBF637 /* 01-GettingStarted-OpeningURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A370BB3C25F94F7B00EBF637 /* 01-GettingStarted-OpeningURLs.swift */; };
 		CA0C0C4724B89BEC00CBDD8A /* 04-HigherOrderReducers-LifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C0C4624B89BEC00CBDD8A /* 04-HigherOrderReducers-LifecycleTests.swift */; };
 		CA0C51FB245389CC00A04EAB /* 04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C51FA245389CC00A04EAB /* 04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift */; };
 		CA25E5D224463AD700DA666A /* 01-GettingStarted-Bindings-Basics.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA25E5D124463AD700DA666A /* 01-GettingStarted-Bindings-Basics.swift */; };
@@ -148,6 +149,7 @@
 
 /* Begin PBXFileReference section */
 		4F5AC11E24ECC7E4009DC50B /* 01-GettingStarted-SharedStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-GettingStarted-SharedStateTests.swift"; sourceTree = "<group>"; };
+		A370BB3C25F94F7B00EBF637 /* 01-GettingStarted-OpeningURLs.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = "01-GettingStarted-OpeningURLs.swift"; sourceTree = "<group>"; tabWidth = 2; };
 		CA0C0C4624B89BEC00CBDD8A /* 04-HigherOrderReducers-LifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-LifecycleTests.swift"; sourceTree = "<group>"; };
 		CA0C51FA245389CC00A04EAB /* 04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift"; sourceTree = "<group>"; };
 		CA25E5D124463AD700DA666A /* 01-GettingStarted-Bindings-Basics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-GettingStarted-Bindings-Basics.swift"; sourceTree = "<group>"; };
@@ -169,7 +171,7 @@
 		CAA9ADC92446605B0003A984 /* 02-Effects-LongLiving.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "02-Effects-LongLiving.swift"; sourceTree = "<group>"; };
 		CAA9ADCB2446615B0003A984 /* 02-Effects-LongLivingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "02-Effects-LongLivingTests.swift"; sourceTree = "<group>"; };
 		CAE962FC24A7F7BE00EFC025 /* 01-GettingStarted-AlertsAndActionSheets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-GettingStarted-AlertsAndActionSheets.swift"; sourceTree = "<group>"; };
-		CAF069CF24ACC5AF00A1AAEF /* 00-Core.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "00-Core.swift"; sourceTree = "<group>"; };
+		CAF069CF24ACC5AF00A1AAEF /* 00-Core.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = "00-Core.swift"; sourceTree = "<group>"; tabWidth = 2; };
 		CAF88E7024B8E26D00539345 /* tvOSCaseStudies.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = tvOSCaseStudies.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CAF88E7224B8E26D00539345 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CAF88E7424B8E26D00539345 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
@@ -396,6 +398,7 @@
 				DC89C4432446111B006900B9 /* 01-GettingStarted-Counter.swift */,
 				DCC68EDC2447A5B00037F998 /* 01-GettingStarted-OptionalState.swift */,
 				CA7BC8ED245CCFE4001FB69F /* 01-GettingStarted-SharedState.swift */,
+				A370BB3C25F94F7B00EBF637 /* 01-GettingStarted-OpeningURLs.swift */,
 				CAA9ADC12446587C0003A984 /* 02-Effects-Basics.swift */,
 				CAA9ADC524465C810003A984 /* 02-Effects-Cancellation.swift */,
 				CAA9ADC92446605B0003A984 /* 02-Effects-LongLiving.swift */,
@@ -765,6 +768,7 @@
 				DC88D8A6245341EC0077F427 /* 01-GettingStarted-Animations.swift in Sources */,
 				DC89C44D244621A5006900B9 /* 03-Navigation-NavigateAndLoad.swift in Sources */,
 				DC89C4442446111B006900B9 /* 01-GettingStarted-Counter.swift in Sources */,
+				A370BB3D25F94F7B00EBF637 /* 01-GettingStarted-OpeningURLs.swift in Sources */,
 				DCE63B71245CC0B90080A23D /* 04-HigherOrderReducers-Recursion.swift in Sources */,
 				CA27C0B7245780CE00CB1E59 /* 03-Effects-SystemEnvironment.swift in Sources */,
 				CAA9ADCA2446605B0003A984 /* 02-Effects-LongLiving.swift in Sources */,

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
@@ -24,6 +24,7 @@ struct RootState {
   var navigateAndLoad = NavigateAndLoadState()
   var navigateAndLoadList = NavigateAndLoadListState()
   var nested = NestedState.mock
+  var openingURLBasics = OpeningURLBasicsState()
   var optionalBasics = OptionalBasicsState()
   var presentAndLoad = PresentAndLoadState()
   var shared = SharedState()
@@ -53,6 +54,7 @@ enum RootAction {
   case navigateAndLoad(NavigateAndLoadAction)
   case navigateAndLoadList(NavigateAndLoadListAction)
   case nested(NestedAction)
+  case openingURLBasics(OpeningURLBasicsAction)
   case optionalBasics(OptionalBasicsAction)
   case onAppear
   case presentAndLoad(PresentAndLoadAction)
@@ -223,6 +225,12 @@ let rootReducer = Reducer<RootState, RootAction, RootEnvironment>.combine(
       state: \.nested,
       action: /RootAction.nested,
       environment: { .init(uuid: $0.uuid) }
+    ),
+  openingURLBasicsReducer
+    .pullback(
+      state: \.openingURLBasics,
+      action: /RootAction.openingURLBasics,
+      environment: { .init(mainQueue: $0.mainQueue) }
     ),
   optionalBasicsReducer
     .pullback(

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -89,6 +89,16 @@ struct RootView: View {
                 )
               )
             )
+
+            NavigationLink(
+              "Opening URLs",
+              destination: OpeningURLBasicsView(
+                store: self.store.scope(
+                  state: { $0.openingURLBasics },
+                  action: RootAction.openingURLBasics
+                )
+              )
+            )
           }
 
           Section(header: Text("Effects")) {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OpeningURLs.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OpeningURLs.swift
@@ -1,0 +1,124 @@
+import ComposableArchitecture
+import SwiftUI
+
+private let readMe = """
+  This file demonstrates how to open external URLs using state and a SwiftUI view modifier.
+
+  SwiftUI and UIKit provide some simple tools for opening external URLs, such as the `Link`
+  view and `UIApplication.shared.OpeningURL` and sometimes that is all you need for simple static
+  links within your app.
+
+  Sometimes however, you might need to trigger the opening of a URL as the result of some
+  explicit action sent to the store, such as an action on an `AlertState` button or received
+  from some `Effect`.
+
+  The library comes with a utility to embed the functionality of opening URLs directly within
+  your feature domain with minimal setup and allows you to trigger the opening of a URL with
+  a simple state mutation, which also makes it really easy to test.
+  """
+
+// The state for this screen holds a bunch of values that will drive
+struct OpeningURLBasicsState: Equatable {
+  var urlToOpen: URL?
+  var errorAlert: AlertState<OpeningURLBasicsAction>?
+}
+
+enum OpeningURLBasicsAction: Equatable {
+  case tappedToOpen(URL?)
+  case openAfterDelay(URL?, TimeInterval)
+  case dismissErrorAlert
+  case openURL(OpenURLViewAction)
+}
+
+struct OpeningURLBasicsEnvironment {
+  let mainQueue: AnySchedulerOf<DispatchQueue>
+}
+
+let openingURLBasicsReducer = Reducer<
+  OpeningURLBasicsState, OpeningURLBasicsAction, OpeningURLBasicsEnvironment
+> {
+  state, action, environment in
+  switch action {
+  case let .tappedToOpen(url):
+    state.urlToOpen = url
+    return .none
+  case let .openAfterDelay(url, delay):
+    return Effect(value: url)
+      .delay(for: .seconds(delay), scheduler: environment.mainQueue)
+      .eraseToEffect()
+      .map(OpeningURLBasicsAction.tappedToOpen)
+  case .openURL(.openedURL(false)):
+    state.errorAlert = .init(
+      title: .init("URL Error"),
+      message: .init("The URL failed to open."),
+      dismissButton: .cancel()
+    )
+    return .none
+  case .openURL(.urlNotSupported):
+    state.errorAlert = .init(
+      title: .init("URL Error"),
+      message: .init("The URL is not supported and cannot be opened."),
+      dismissButton: .cancel()
+    )
+    return .none
+  case .dismissErrorAlert:
+    state.errorAlert = nil
+    return .none
+  case .openURL:
+    return .none
+  }
+}
+.opensURL(
+  state: \.urlToOpen,
+  action: /OpeningURLBasicsAction.openURL
+)
+
+struct OpeningURLBasicsView: View {
+  let store: Store<OpeningURLBasicsState, OpeningURLBasicsAction>
+
+  var body: some View {
+    WithViewStore(self.store) { viewStore in
+      VStack(spacing: 20) {
+        Button("Open Pointfree.co") {
+          viewStore.send(.tappedToOpen(URL(string: "https://pointfree.co")))
+        }
+        Button("Open TCA Github Repo") {
+          viewStore.send(.tappedToOpen(URL(string: "https://github.com/pointfreeco/swift-composable-architecture")))
+        }
+        Button("Open URL with delayed effect") {
+          viewStore.send(.openAfterDelay(URL(string: "http://example.com"), 2))
+        }
+        Button("Open unsupported URL") {
+          viewStore.send(.tappedToOpen(URL(string: "gopher://localhost:10000")))
+        }
+      }
+    }
+    .navigationBarTitle("Opening URLs")
+    .alert(
+      store.scope(state: \.errorAlert),
+      dismiss: .dismissErrorAlert
+    )
+    .opensURL(
+      store.scope(
+        state: \.urlToOpen,
+        action: OpeningURLBasicsAction.openURL
+      )
+    )
+  }
+}
+
+struct OpeningURLBasicsView_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationView {
+      OpeningURLBasicsView(
+        store: Store(
+          initialState: OpeningURLBasicsState(),
+          reducer: openingURLBasicsReducer,
+          environment: OpeningURLBasicsEnvironment(
+            mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+          )
+        )
+      )
+    }
+  }
+}

--- a/Sources/ComposableArchitecture/SwiftUI/OpenURL.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/OpenURL.swift
@@ -3,70 +3,75 @@ import CasePaths
 import SwiftUI
 import UIKit
 
-/// Can be used in conjunction with the `.opensURL` view modifier to automatically open
-/// external URLs driven by your application state.
-///
-/// To use this high-level reducer, you first need to embed it into your feature. This requires:
-///
-/// * A `URL?` property  on your state that represents the URL you want to open.
-/// * An action in your feature's action enum that wraps `OpenURLViewAction`
-///
-/// For example, given the following domain:
-///
-///     struct FeatureState: Equatable {
-///         var urlToOpen: URL?
-///     }
-///
-///     enum FeatureAction: Equatable {
-///         case tappedOpenLinkButton
-///         case openURL(OpenURLViewAction)
-///     }
-///
-/// You can then attach the open URL reducer to your feature's reducer, providing a key path
-/// to the URL and a case path for the action:
-///
-///     let featureReducer = Reducer<FeatureState, FeatureAction, Void> { state, action in
-///         switch action {
-///         case .tappedOpenLinkButton:
-///             state.urlToOpen = URL(string: "http://www.example.com")
-///             return .none
-///         case .openURL:
-///             return .none
-///         }
-///     }
-///     .opensURL(\.urlToOpen, action: /FeatureAction.openURL)
-///
-/// The above reducer will set the URL to be opened when the feature's view sends the `tappedOpenLinkButton`.
-///
-/// To actually open the URL, the corresponding feature view needs to use the `.opensURL` view modifier, passing
-/// in a store scoped to the `URL` state and `OpenURLViewAction` action:
-///
-///     struct FeatureView: View {
-///         let store: Store<FeatureState, FeatureAction>
-///
-///         var body: some View {
-///             WithViewStore(store) { viewStore in
-///                 Button("Open example.com") {
-///                     viewStore.send(.tappedOpenLinkButton)
-///                 }
-///             }
-///             .opensURL(
-///                 store.scope(
-///                     state: \.urlToOpen,
-///                     action: /FeatureAction.openURL
-///                 )
-///             )
-///         }
-///     }
-///
-/// Now, when the `urlToOpen` property is set to a `URL` value, it will automatically open and fire an action
-/// back into the store to indicate it was opened, which will set the `urlToOpen` property back to `nil`.
-///
 public extension Reducer where State: Equatable {
   /// Attaches the `opensURL` logic to your existing feature reducer, returning a new reducer.
   ///
+  /// Can be used in conjunction with the `.opensURL` view modifier to automatically open
+  /// external URLs driven by your application state.
+  ///
+  /// To use this high-level reducer, you first need to embed it into your feature. This requires:
+  ///
+  /// * A `URL?` property  on your state that represents the URL you want to open.
+  /// * An action in your feature's action enum that wraps `OpenURLViewAction`
+  ///
+  /// For example, given the following domain:
+  ///
+  ///     struct FeatureState: Equatable {
+  ///         var urlToOpen: URL?
+  ///     }
+  ///
+  ///     enum FeatureAction: Equatable {
+  ///         case tappedOpenLinkButton
+  ///         case openURL(OpenURLViewAction)
+  ///     }
+  ///
+  /// You can then attach the open URL reducer to your feature's reducer, providing a key path
+  /// to the URL and a case path for the action:
+  ///
+  ///     let featureReducer = Reducer<FeatureState, FeatureAction, Void> { state, action in
+  ///         switch action {
+  ///         case .tappedOpenLinkButton:
+  ///             state.urlToOpen = URL(string: "http://www.example.com")
+  ///             return .none
+  ///         case .openURL:
+  ///             return .none
+  ///         }
+  ///     }
+  ///     .opensURL(\.urlToOpen, action: /FeatureAction.openURL)
+  ///
+  /// The above reducer will set the URL to be opened when the feature's view sends the `tappedOpenLinkButton`.
+  ///
+  /// To actually open the URL, the corresponding feature view needs to use the `.opensURL` view modifier, passing
+  /// in a store scoped to the `URL` state and `OpenURLViewAction` action:
+  ///
+  ///     struct FeatureView: View {
+  ///         let store: Store<FeatureState, FeatureAction>
+  ///
+  ///         var body: some View {
+  ///             WithViewStore(store) { viewStore in
+  ///                 Button("Open example.com") {
+  ///                     viewStore.send(.tappedOpenLinkButton)
+  ///                 }
+  ///             }
+  ///             .opensURL(
+  ///                 store.scope(
+  ///                     state: \.urlToOpen,
+  ///                     action: /FeatureAction.openURL
+  ///                 )
+  ///             )
+  ///         }
+  ///     }
+  ///
+  /// Now, when the `urlToOpen` property is set to a `URL` value, it will automatically open and fire an action
+  /// back into the store to indicate it was opened, which will set the `urlToOpen` property back to `nil`.
+  ///
+  /// - Note: A check will be made before attempting to open the URL that opening that URL is supported - if not, the action
+  /// `OpenURLViewAction.urlNotSupported` will be sent to the store.
+  ///
+  /// You can handle this action in your own feature reducer if you want to provide some kind of fallback option.
+  ///
   /// - Parameters:
-  ///     - toLocalState: either a `WritableKeyPath` or `CasePath` to the `URL?` you want to open.
+  ///     - state: a key path to the URL that should be opened.
   ///     - action: the `CasePath` to the action that embeds the `OpenURLViewAction` in your domain.
   ///
   func opensURL(
@@ -94,13 +99,10 @@ public extension Reducer where State: Equatable {
 /// Represents the domain of opening URLs and can be embedded in your feature domain actions.
 ///
 public enum OpenURLViewAction: Equatable {
-  /// Sent by the component to the store to indicate the URL was opened.
-  ///
-  /// The `Bool` value indicates whether or not the URL was opened successfully.
+  /// Sent by the component to the store to indicate if URL was opened.
   case openedURL(Bool)
 
-  /// Indicates the URL given cannot be opened on this platform. Your own feature reducer
-  /// can hook into this action to provide some backup behaviour.
+  /// Indicates the URL given cannot be opened on this platform.
   case urlNotSupported
 }
 

--- a/Sources/ComposableArchitecture/SwiftUI/OpenURL.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/OpenURL.swift
@@ -120,10 +120,10 @@ private struct OpenURLViewModifier: ViewModifier {
     // `.onAppear()` modifier first.
     content.onAppear().onReceive(viewStore.publisher) { newValue in
       if let url = newValue {
-        if canOpenURL(url) {
-          openURL(url) { viewStore.send(.openedURL($0)) }
+        if self.canOpenURL(url) {
+          self.openURL(url) { self.viewStore.send(.openedURL($0)) }
         } else {
-          viewStore.send(.urlNotSupported)
+          self.viewStore.send(.urlNotSupported)
         }
       }
     }

--- a/Sources/ComposableArchitecture/SwiftUI/OpenURL.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/OpenURL.swift
@@ -1,0 +1,176 @@
+import CasePaths
+import UIKit
+import SwiftUI
+
+/// Can be used in conjunction with the `.opensURL` view modifier to automatically open
+/// external URLs driven by your application state.
+///
+/// To use this high-level reducer, you first need to embed it into your feature. This requires:
+///
+/// * A `URL?` property  on your state that represents the URL you want to open.
+/// * An action in your feature's action enum that wraps `OpenURLViewAction`
+///
+/// For example, given the following domain:
+///
+///     struct FeatureState: Equatable {
+///         var urlToOpen: URL?
+///     }
+///
+///     enum FeatureAction: Equatable {
+///         case tappedOpenLinkButton
+///         case openURL(OpenURLViewAction)
+///     }
+///
+/// You can then attach the open URL reducer to your feature's reducer, providing a key path
+/// to the URL and a case path for the action:
+///
+///     let featureReducer = Reducer<FeatureState, FeatureAction, Void> { state, action in
+///         switch action {
+///         case .tappedOpenLinkButton:
+///             state.urlToOpen = URL(string: "http://www.example.com")
+///             return .none
+///         case .openURL:
+///             return .none
+///         }
+///     }
+///     .opensURL(\.urlToOpen, action: /FeatureAction.openURL)
+///
+/// The above reducer will set the URL to be opened when the feature's view sends the `tappedOpenLinkButton`.
+///
+/// To actually open the URL, the corresponding feature view needs to use the `.opensURL` view modifier, passing
+/// in a store scoped to the `URL` state and `OpenURLViewAction` action:
+///
+///     struct FeatureView: View {
+///         let store: Store<FeatureState, FeatureAction>
+///
+///         var body: some View {
+///             WithViewStore(store) { viewStore in
+///                 Button("Open example.com") {
+///                     viewStore.send(.tappedOpenLinkButton)
+///                 }
+///             }
+///             .opensURL(
+///                 store.scope(
+///                     state: \.urlToOpen,
+///                     action: /FeatureAction.openURL
+///                 )
+///             )
+///         }
+///     }
+///
+/// Now, when the `urlToOpen` property is set to a `URL` value, it will automatically open and fire an action
+/// back into the store to indicate it was opened, which will set the `urlToOpen` property back to `nil`.
+///
+public extension Reducer where State: Equatable {
+  /// Attaches the `opensURL` logic to your existing feature reducer, returning a new reducer.
+  ///
+  /// - Parameters:
+  ///     - toLocalState: either a `WritableKeyPath` or `CasePath` to the `URL?` you want to open.
+  ///     - action: the `CasePath` to the action that embeds the `OpenURLViewAction` in your domain.
+  ///
+  func opensURL(
+    state: WritableKeyPath<State, URL?>,
+    action: CasePath<Action, OpenURLViewAction>
+  ) -> Self {
+    Reducer<URL?, OpenURLViewAction, Void> { state, action, _ in
+      switch action {
+      case .openedURL:
+        state = nil
+        return .none
+      case .urlNotSupported:
+        return .none
+      }
+    }
+    .pullback(
+      state: state,
+      action: action,
+      environment: { _ in () }
+    )
+    .combined(with: self)
+  }
+}
+
+/// Represents the domain of opening URLs and can be embedded in your feature domain actions.
+///
+public enum OpenURLViewAction: Equatable {
+  /// Sent by the component to the store to indicate the URL was opened.
+  ///
+  /// The `Bool` value indicates whether or not the URL was opened successfully.
+  case openedURL(Bool)
+
+  /// Indicates the URL given cannot be opened on this platform. Your own feature reducer
+  /// can hook into this action to provide some backup behaviour.
+  case urlNotSupported
+}
+
+private struct OpenURLViewModifier: ViewModifier {
+  let store: Store<URL?, OpenURLViewAction>
+  let viewStore: ViewStore<URL?, OpenURLViewAction>
+
+  init(store: Store<URL?, OpenURLViewAction>) {
+    self.store = store
+    viewStore = ViewStore(store)
+  }
+
+  func body(content: Content) -> some View {
+    // There appears to be a bug with `.onReceive` in a ViewModifier,
+    // where it doesn't seem to fire correctly unless you append the
+    // `.onAppear()` modifier first.
+    content.onAppear().onReceive(viewStore.publisher) { newValue in
+      if let url = newValue {
+        if canOpenURL(url) {
+          openURL(url) { viewStore.send(.openedURL($0)) }
+        } else {
+          viewStore.send(.urlNotSupported)
+        }
+      }
+    }
+  }
+
+  private func openURL(_ url: URL, completion: @escaping (Bool) -> Void) {
+    if #available(iOS 14, *) {
+      URLOpener_iOS14(url: url).open(completion: completion)
+    } else {
+      URLOpener_iOS13(url: url).open(completion: completion)
+    }
+  }
+
+  private func canOpenURL(_ url: URL) -> Bool {
+    UIApplication.shared.canOpenURL(url)
+  }
+
+  @available(iOS 13, *)
+  struct URLOpener_iOS13 {
+    let url: URL
+
+    func open(completion: @escaping (Bool) -> Void) {
+      UIApplication.shared.open(url, completionHandler: completion)
+    }
+  }
+
+  @available(iOS 14, *)
+  struct URLOpener_iOS14 {
+    let url: URL
+
+    @Environment(\.openURL) var openURL
+
+    func open(completion: @escaping (Bool) -> Void) {
+      openURL(url, completion: completion)
+    }
+  }
+}
+
+public extension View {
+  /// Attaches automatic URL opening behaviour to your view.
+  ///
+  /// This will attach a view modifier to your view that observes the `URL` state on the provided store and
+  /// automatically opens it when the `URL` becomes non-nil, before dispatching an action back to the store
+  /// to indicate the URL was opened and reset the `URL` back to `nil`.
+  ///
+  /// - Parameters:
+  ///     - store: A store scoped to the `URL` and `OpenURLViewAction` embedded in your feature domain.
+  ///
+  func opensURL(_ store: Store<URL?, OpenURLViewAction>) -> some View {
+    modifier(OpenURLViewModifier(store: store))
+  }
+}

--- a/Sources/ComposableArchitecture/SwiftUI/OpenURL.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/OpenURL.swift
@@ -1,6 +1,7 @@
+#if !os(macOS)
 import CasePaths
-import UIKit
 import SwiftUI
+import UIKit
 
 /// Can be used in conjunction with the `.opensURL` view modifier to automatically open
 /// external URLs driven by your application state.
@@ -103,6 +104,7 @@ public enum OpenURLViewAction: Equatable {
   case urlNotSupported
 }
 
+@available(macOS, unavailable)
 private struct OpenURLViewModifier: ViewModifier {
   let store: Store<URL?, OpenURLViewAction>
   let viewStore: ViewStore<URL?, OpenURLViewAction>
@@ -128,10 +130,10 @@ private struct OpenURLViewModifier: ViewModifier {
   }
 
   private func openURL(_ url: URL, completion: @escaping (Bool) -> Void) {
-    if #available(iOS 14, *) {
-      URLOpener_iOS14(url: url).open(completion: completion)
+    if #available(iOS 14, macCatalyst 14, tvOS 14, *) {
+      URLOpener_OpenURLAction(url: url).open(completion: completion)
     } else {
-      URLOpener_iOS13(url: url).open(completion: completion)
+      URLOpener_UIApplication(url: url).open(completion: completion)
     }
   }
 
@@ -139,8 +141,7 @@ private struct OpenURLViewModifier: ViewModifier {
     UIApplication.shared.canOpenURL(url)
   }
 
-  @available(iOS 13, *)
-  struct URLOpener_iOS13 {
+  struct URLOpener_UIApplication {
     let url: URL
 
     func open(completion: @escaping (Bool) -> Void) {
@@ -149,7 +150,9 @@ private struct OpenURLViewModifier: ViewModifier {
   }
 
   @available(iOS 14, *)
-  struct URLOpener_iOS14 {
+  @available(macCatalyst 14, *)
+  @available(tvOS 14, *)
+  struct URLOpener_OpenURLAction {
     let url: URL
 
     @Environment(\.openURL) var openURL
@@ -174,3 +177,4 @@ public extension View {
     modifier(OpenURLViewModifier(store: store))
   }
 }
+#endif

--- a/Sources/ComposableArchitecture/SwiftUI/OpenURL.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/OpenURL.swift
@@ -80,10 +80,8 @@ public extension Reducer where State: Equatable {
   ) -> Self {
     Reducer<URL?, OpenURLViewAction, Void> { state, action, _ in
       switch action {
-      case .openedURL:
+      case .openedURL, .urlNotSupported:
         state = nil
-        return .none
-      case .urlNotSupported:
         return .none
       }
     }

--- a/Tests/ComposableArchitectureTests/OpenURLTests.swift
+++ b/Tests/ComposableArchitectureTests/OpenURLTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+
+@testable import ComposableArchitecture
+
+class OpenURLTests: XCTestCase {
+  struct AppState: Equatable {
+    var url: URL?
+  }
+
+  enum AppAction: Equatable {
+    case tappedToOpen
+    case openURL(OpenURLViewAction)
+  }
+
+  let store = TestStore(
+    initialState: AppState(),
+    reducer: Reducer<AppState, AppAction, Void> { state, action, _ in
+      switch action {
+      case .tappedToOpen:
+        state.url = URL(string: "http://example.com")
+        return .none
+      case .openURL:
+        return .none
+      }
+    }.opensURL(
+      state: \.url,
+      action: /AppAction.openURL
+    ),
+    environment: ()
+  )
+
+  func testOpeningSupportedURL() {
+    store.assert(
+      .send(.tappedToOpen) {
+        $0.url = URL(string: "http://example.com")
+      },
+      .send(.openURL(.openedURL(true))) {
+        $0.url = nil
+      }
+    )
+  }
+
+  func testOpeningUnsupportedURL() {
+    store.assert(
+      .send(.tappedToOpen) {
+        $0.url = URL(string: "http://example.com")
+      },
+      .send(.openURL(.urlNotSupported))
+    )
+  }
+
+  func testOpeningURLFails() {
+    store.assert(
+      .send(.tappedToOpen) {
+        $0.url = URL(string: "http://example.com")
+      },
+      .send(.openURL(.openedURL(true))) {
+        $0.url = nil
+      }
+    )
+  }
+}

--- a/Tests/ComposableArchitectureTests/OpenURLTests.swift
+++ b/Tests/ComposableArchitectureTests/OpenURLTests.swift
@@ -45,7 +45,9 @@ class OpenURLTests: XCTestCase {
       .send(.tappedToOpen) {
         $0.url = URL(string: "http://example.com")
       },
-      .send(.openURL(.urlNotSupported))
+      .send(.openURL(.urlNotSupported)) {
+        $0.url = nil
+      }
     )
   }
 

--- a/Tests/ComposableArchitectureTests/OpenURLTests.swift
+++ b/Tests/ComposableArchitectureTests/OpenURLTests.swift
@@ -1,3 +1,4 @@
+#if !os(macOS)
 import XCTest
 
 @testable import ComposableArchitecture
@@ -62,3 +63,4 @@ class OpenURLTests: XCTestCase {
     )
   }
 }
+#endif


### PR DESCRIPTION
# State-driven URL opening

I’d like to present a reusable component for opening external URLs in your app, driven by state. I think it would make a good candidate for inclusion within TCA and would complement existing re-usable components like `Alert` and `ActionSheet`. This component has been designed for use with SwiftUI but a UIKit version could be implemented as a future enhancement.

## What’s the problem this solves?

There are a number of ways to open external URLs. UIKit provides `UIApplication.shared.open` and iOS 14/macOS provides `OpenURLAction` which can be accessed from the SwiftUI Environment using the `\.openURL` environment key. In addition to this, on macOS 11/iOS 14 etc. there is the SwiftUI `Link` component.

For very simple use cases where you just want to display a link to some external URL then `Link` (or a `Button` if you need to support older platforms) is absolutely fine and probably what you need in a lot of cases. You can’t easily write an automated test for it but that might be an acceptable trade-off if you’re literally just opening some fixed external URL.

Sometimes however, you want to be able to trigger the opening of a URL as a result of some store action - this could be an action you explicitly send from your view which triggers the URL opening (perhaps alongside some other behaviour), or it could be an action sent from a button in an alert or action sheet (using TCA’s `AlertState` and `ActionSheetState` components). It could also be an action sent as the result of an `Effect`. The URL could be dynamic, or computed based on some other part of your state. It could just be the case that you want to test the behaviour.

In these cases it would be really useful to trigger an external URL opening from your reducer itself.

## Alternatives considered - an effect-based approach

My first thought on how to implement this was to treat the opening of an external URL as an `Effect`. This is probably a reasonable approach as it does feel like a side-effect. You could probably implement it something like this:

```swift
struct FeatureEnvironment {
  var openURL: (URL) -> Effect<Never, Never>
}

enum FeatureAction {
  case tappedOpenURLButton
}

let featureReducer = Reducer<FeatureState, FeatureAction, FeatureEnvironment> { state, action environment in
  switch action {
  case .tappedOpenURLButton:
    return environment
      .openURL("http://example.com")
      .fireAndForget()  
  }
}
```

Whilst this fairly straightforward and not a lot of code, it does have some downsides:

* You need to pass around the `openURL` dependency to every feature that needs to be able to open a URL (you could potentially address this using the `SystemEnvironment` idea in the TCA examples folder but its still a fair amount of boilerplate).
* Testing fire-and-forget effects is not the most ergonomic and often requires some kind of mock dependency with some mutable local state that you assert on in a `.do` block, e.g.:

```swift
var openedURL: URL?

let store = TestStore(
  initialState: ...,
  reducer: ...,
  environment: FeatureEnvironment(
    openURL: { url in openedURL = url }
  )
)

store.assert(
  .send(.tappedOpenURLButton),
  .do { _ in
    XCTAssertEqual(.some("http://example.com"), openedURL)
  }
)
```

For these reasons, inspired by the existing `TextState`, `AlertState` and `ActionSheetState` components I took a more state-base approach.

## State-based URL opening

The way this component works is around a feature domain based on a single value of type `URL?` - the idea is that you have some URL property in your feature domain that you set to a value you need opening and it just opens. Conceptually, our feature is saying “this is the URL that should be opened” and the actual effect of opening it in whatever external application should handle it is handled entirely in the view layer, using a SwiftUI view modifier.

There are a number of advantages to this approach:

* Minimal boilerplate - just three lines of code to integrate the URL opening domain into your feature domain, and a single SwiftUI view modifier to attach the URL opening behaviour to your view.
* Opening a URL is a one-line state mutation and you don’t even need to take care of setting it back to `nil` again once the URL has been opened as the component handles it for you.
* Easy to test - its just a state mutation so you can test this like any other state mutation using `TestStore`.

So with all this said, what does it actually look like? Lets adapt our previous example to use the new component.

Firstly we need to embed the URL opening domain in our feature domain:

```swift
struct FeatureState {
  var urlToOpen: URL? // 1. An optional URL property
}

enum FeatureAction {
  case tappedOpenURLButton
  case openURL(OpenURLViewAction) // 2. Embed the components domain actions
}

let featureReducer = Reducer<FeatureState, FeatureAction, Void> { state, action, _ in
  switch action {
  case .tappedOpenURLButton:
    state.urlToOpen = URL(string: "http://example.com") // 3. Set the URL when you want to open it
  }
}
.opensURL( // 4. Attach the component's high-level reducer
  \FeatureState.urlToOpen,
  action: /FeatureAction.openURL
)
```

Next, we need to attach the view modifier to our view:

```swift
struct FeatureView: View {
  let store: Store<FeatureState, FeatureAction>
  
  var body: some View {
    WithViewStore(store) { viewStore in
      Button("Open URL") {
        viewStore.send(.tappedOpenURLButton)
      }
    }
    .opensURL(
      store.scope(
        state: \.urlToOpen,
        action: FeatureAction.openURL
      )
    )
  }
}
```

And that’s it!

We can test this behaviour, including simulating the URL actually being opened, without the need for any mocks:

```swift
class FeatureTests: XCTestCase {
  func testOpeningURL() {
    let store = TestStore(
      initialState: FeatureState(),
      reducer: featureReducer,
      environment: ()
    )
    
    store.assert(
      .send(.tappedOpenURLButton) {
        $0.urlToOpen = "http://example.com"
      },
      .send(.openURL(.openedURL)) {
        $0.urlToOpen = nil
      }
    )
  }
}
```

No mocks, no dependencies, no mutable local state and no raw assertions in `.do` blocks.

## Caveats

This is designed for use with SwiftUI but it does have a dependency on UIKit and specifically `UIApplication` - I'm not sure there is a SwiftUI only API for checking if URLs can be opened.

## Copyright and License

This was developed out of work on our app here at Community.com and the code in this PR is Copyright 2021 Community.com, Inc. and licensed for use under the same MIT terms as the rest of this repo.

@stephencelis @mbrandonw do you have any preferred way of showing copyright notices for contributed code? I could add an MIT License header to each file but that seems a bit overkill - could something be added to the LICENSE file in the repo perhaps?