### PR TITLE
Shared state management with StateBinding

### DIFF
--- a/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
+++ b/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
@@ -229,7 +229,7 @@
 		DCC68EE02447C4630037F998 /* 01-GettingStarted-Composition-TwoCounters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-GettingStarted-Composition-TwoCounters.swift"; sourceTree = "<group>"; };
 		DCC68EE22447C8540037F998 /* 04-HigherOrderReducers-ReusableFavoriting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-ReusableFavoriting.swift"; sourceTree = "<group>"; };
 		DCE63B70245CC0B90080A23D /* 04-HigherOrderReducers-Recursion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-Recursion.swift"; sourceTree = "<group>"; };
-		E91720D52605665C00D35505 /* 01-GettingStarted-SharedState-StateBindings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "01-GettingStarted-SharedState-StateBindings.swift"; sourceTree = "<group>"; };
+		E91720D52605665C00D35505 /* 01-GettingStarted-SharedState-StateBindings.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = "01-GettingStarted-SharedState-StateBindings.swift"; sourceTree = "<group>"; tabWidth = 2; };
 		E91720D72605734600D35505 /* StateBinding.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = StateBinding.swift; sourceTree = "<group>"; tabWidth = 2; };
 		E931BC852605B99C005E3C3B /* StateBindingTests.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = StateBindingTests.swift; sourceTree = "<group>"; tabWidth = 2; };
 /* End PBXFileReference section */

--- a/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
+++ b/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
@@ -431,7 +431,6 @@
 		DC89C42C24460F96006900B9 /* SwiftUICaseStudiesTests */ = {
 			isa = PBXGroup;
 			children = (
-				E931BC842605B989005E3C3B /* Internal */,
 				CA50BE5F24A8F46500FE7DBA /* 01-GettingStarted-AlertsAndActionSheetsTests.swift */,
 				CA34170724A4E89500FAF950 /* 01-GettingStarted-AnimationsTests.swift */,
 				DC27215525BF84FC00D9C8DB /* 01-GettingStarted-BindingBasicsTests.swift */,
@@ -444,6 +443,7 @@
 				DC634B242448D15B00DAA016 /* 04-HigherOrderReducers-ReusableFavoritingTests.swift */,
 				CA0C51FA245389CC00A04EAB /* 04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift */,
 				CA0C0C4624B89BEC00CBDD8A /* 04-HigherOrderReducers-LifecycleTests.swift */,
+				E931BC842605B989005E3C3B /* Internal */,
 			);
 			path = SwiftUICaseStudiesTests;
 			sourceTree = "<group>";

--- a/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
+++ b/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
@@ -77,6 +77,9 @@
 		DCC68EE12447C4630037F998 /* 01-GettingStarted-Composition-TwoCounters.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC68EE02447C4630037F998 /* 01-GettingStarted-Composition-TwoCounters.swift */; };
 		DCC68EE32447C8540037F998 /* 04-HigherOrderReducers-ReusableFavoriting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC68EE22447C8540037F998 /* 04-HigherOrderReducers-ReusableFavoriting.swift */; };
 		DCE63B71245CC0B90080A23D /* 04-HigherOrderReducers-Recursion.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE63B70245CC0B90080A23D /* 04-HigherOrderReducers-Recursion.swift */; };
+		E91720D62605665C00D35505 /* 01-GettingStarted-SharedState-StateBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91720D52605665C00D35505 /* 01-GettingStarted-SharedState-StateBindings.swift */; };
+		E91720D82605734600D35505 /* StateBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91720D72605734600D35505 /* StateBinding.swift */; };
+		E931BC862605B99C005E3C3B /* StateBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E931BC852605B99C005E3C3B /* StateBindingTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -226,6 +229,9 @@
 		DCC68EE02447C4630037F998 /* 01-GettingStarted-Composition-TwoCounters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-GettingStarted-Composition-TwoCounters.swift"; sourceTree = "<group>"; };
 		DCC68EE22447C8540037F998 /* 04-HigherOrderReducers-ReusableFavoriting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-ReusableFavoriting.swift"; sourceTree = "<group>"; };
 		DCE63B70245CC0B90080A23D /* 04-HigherOrderReducers-Recursion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-Recursion.swift"; sourceTree = "<group>"; };
+		E91720D52605665C00D35505 /* 01-GettingStarted-SharedState-StateBindings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "01-GettingStarted-SharedState-StateBindings.swift"; sourceTree = "<group>"; };
+		E91720D72605734600D35505 /* StateBinding.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = StateBinding.swift; sourceTree = "<group>"; tabWidth = 2; };
+		E931BC852605B99C005E3C3B /* StateBindingTests.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = StateBindingTests.swift; sourceTree = "<group>"; tabWidth = 2; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -396,6 +402,7 @@
 				DC89C4432446111B006900B9 /* 01-GettingStarted-Counter.swift */,
 				DCC68EDC2447A5B00037F998 /* 01-GettingStarted-OptionalState.swift */,
 				CA7BC8ED245CCFE4001FB69F /* 01-GettingStarted-SharedState.swift */,
+				E91720D52605665C00D35505 /* 01-GettingStarted-SharedState-StateBindings.swift */,
 				CAA9ADC12446587C0003A984 /* 02-Effects-Basics.swift */,
 				CAA9ADC524465C810003A984 /* 02-Effects-Cancellation.swift */,
 				CAA9ADC92446605B0003A984 /* 02-Effects-LongLiving.swift */,
@@ -424,6 +431,7 @@
 		DC89C42C24460F96006900B9 /* SwiftUICaseStudiesTests */ = {
 			isa = PBXGroup;
 			children = (
+				E931BC842605B989005E3C3B /* Internal */,
 				CA50BE5F24A8F46500FE7DBA /* 01-GettingStarted-AlertsAndActionSheetsTests.swift */,
 				CA34170724A4E89500FAF950 /* 01-GettingStarted-AnimationsTests.swift */,
 				DC27215525BF84FC00D9C8DB /* 01-GettingStarted-BindingBasicsTests.swift */,
@@ -454,6 +462,15 @@
 				CA6AC2612451135C00C71CB3 /* CircularProgressView.swift */,
 				DCC68EDE2447BC810037F998 /* TemplateText.swift */,
 				DC9EB4162450CBD2005F413B /* UIViewRepresented.swift */,
+				E91720D72605734600D35505 /* StateBinding.swift */,
+			);
+			path = Internal;
+			sourceTree = "<group>";
+		};
+		E931BC842605B989005E3C3B /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				E931BC852605B99C005E3C3B /* StateBindingTests.swift */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -737,10 +754,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E91720D62605665C00D35505 /* 01-GettingStarted-SharedState-StateBindings.swift in Sources */,
 				DC89C449244618D5006900B9 /* 03-Navigation-LoadThenNavigate.swift in Sources */,
 				DCC68EE12447C4630037F998 /* 01-GettingStarted-Composition-TwoCounters.swift in Sources */,
 				DC072322244663B1003A8B65 /* 03-Navigation-Sheet-LoadThenPresent.swift in Sources */,
 				DC89C45324465452006900B9 /* 03-Navigation-Lists-NavigateAndLoad.swift in Sources */,
+				E91720D82605734600D35505 /* StateBinding.swift in Sources */,
 				CAF069D024ACC5AF00A1AAEF /* 00-Core.swift in Sources */,
 				DCC68EE32447C8540037F998 /* 04-HigherOrderReducers-ReusableFavoriting.swift in Sources */,
 				DCC68EDF2447BC810037F998 /* TemplateText.swift in Sources */,
@@ -791,6 +810,7 @@
 				CAA9ADC424465AB00003A984 /* 02-Effects-BasicsTests.swift in Sources */,
 				4F5AC11F24ECC7E4009DC50B /* 01-GettingStarted-SharedStateTests.swift in Sources */,
 				CAA9ADCC2446615B0003A984 /* 02-Effects-LongLivingTests.swift in Sources */,
+				E931BC862605B99C005E3C3B /* StateBindingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
@@ -27,6 +27,7 @@ struct RootState {
   var optionalBasics = OptionalBasicsState()
   var presentAndLoad = PresentAndLoadState()
   var shared = SharedState()
+  var sharedWithBinding = SharedStateWithBinding()
   var timers = TimersState()
   var twoCounters = TwoCountersState()
   var webSocket = WebSocketState()
@@ -57,6 +58,7 @@ enum RootAction {
   case onAppear
   case presentAndLoad(PresentAndLoadAction)
   case shared(SharedStateAction)
+  case sharedWithBinding(SharedStateWithBindingAction)
   case timers(TimersAction)
   case twoCounters(TwoCountersAction)
   case webSocket(WebSocketAction)
@@ -241,6 +243,12 @@ let rootReducer = Reducer<RootState, RootAction, RootEnvironment>.combine(
       state: \.shared,
       action: /RootAction.shared,
       environment: { _ in () }
+    ),
+  sharedStateWithBindingReducer
+    .pullback(
+        state: \.sharedWithBinding,
+        action: /RootAction.sharedWithBinding,
+        environment: { _ in () }
     ),
   timersReducer
     .pullback(

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -71,6 +71,16 @@ struct RootView: View {
             )
 
             NavigationLink(
+              "Shared state with StateBinding",
+              destination: SharedStateWithBindingView(
+                store: self.store.scope(
+                  state: { $0.sharedWithBinding },
+                  action: RootAction.sharedWithBinding
+                )
+              )
+            )
+            
+            NavigationLink(
               "Alerts and Action Sheets",
               destination: AlertAndSheetView(
                 store: self.store.scope(

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -70,6 +70,7 @@ struct RootView: View {
               )
             )
 
+            #if swift(>=5.4)
             NavigationLink(
               "Shared state with StateBinding",
               destination: SharedStateWithBindingView(
@@ -79,6 +80,7 @@ struct RootView: View {
                 )
               )
             )
+            #endif
             
             NavigationLink(
               "Alerts and Action Sheets",

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -70,7 +70,6 @@ struct RootView: View {
               )
             )
 
-            #if swift(>=5.4)
             NavigationLink(
               "Shared state with StateBinding",
               destination: SharedStateWithBindingView(
@@ -80,7 +79,6 @@ struct RootView: View {
                 )
               )
             )
-            #endif
             
             NavigationLink(
               "Alerts and Action Sheets",

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
@@ -86,7 +86,7 @@ struct SharedStateWithBinding: Equatable {
   // All the properties of `Feature` are bound to some property of `self`. A new instance is created
   // from the provided `with:` argument. We use `Self.self` because we need to tie the first generic
   // parameter of `StateBinding` to `Self`.
-  fileprivate static let _feature4 = StateBinding(Self.self, with: FeatureState.init)
+  fileprivate static let _feature4 = StateBinding<Self, FeatureState> { .init() }
     .ro(\.feature4Name, \.name)
     .ro(\.isCountInternal, \.isCountInternal)
     .rw(\.content, \.text)
@@ -102,7 +102,11 @@ struct SharedStateWithBinding: Equatable {
   // instance is created from a function of `Self`. We use the `shouldShowFeature5` flag to decide if the
   // property is nil or not. Because it has no private storage, the `feature5` instance is completly set
   // when accessed and the flag is enough to condition its existence and content without ambiguity.
-  fileprivate static let _feature5 = StateBinding<SharedStateWithBinding, FeatureState?>(with: { $0.shouldShowFeature5 ? .init() : nil })
+  fileprivate static let _feature5 = StateBinding<SharedStateWithBinding, FeatureState?> {
+      $0.shouldShowFeature5
+      ? .init()
+      : nil
+    }
     .ro(\.feature5Name, \.name)
     .ro(\.isCountInternal, \.isCountInternal)
     .rw(\.count, \.count)

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
@@ -1,6 +1,6 @@
 import ComposableArchitecture
 import SwiftUI
-
+#if swift(>=5.4)
 private let readMe = """
 This screen demonstrates how to use StateBindings and PropertyBinding to ensure that sub-states are
 up-to-date with their parent state. They also provide a convenient way to specify fine-grained or coarse
@@ -11,323 +11,343 @@ deduplicated sub-state setters.
 """
 
 struct SharedStateWithBinding: Equatable {
-    
-    struct FeatureState: Equatable {
-        var name: String = "" // Used for this case study presentation
-        var isCountInternal: Bool = true // Used for this case study presentation
+  struct FeatureState: Equatable {
+    var name: String = "" // Used for this case study presentation
+    var isCountInternal: Bool = true // Used for this case study presentation
 
-        var text: String = ""
-        var count: Int = 0
-    }
-    
-    // This value is shared across all features.
-    var content: String = "Shared Content"
-
-    // This value is not used for cases with internal storage
+    var text: String = ""
     var count: Int = 0
+  }
 
-    // This flag is used to trigger the existence of the computed and optional `feature5`
-    var shouldShowFeature5: Bool = false
+  // This value is shared across all features.
+  var content: String = "Shared Content"
 
-    // MARK: Manual approach -
-    // We create a FeatureState on the fly each time it is requested.
-    // The global state needs to explicitly handle all FeatureState stored properties.
-    // The setter need to by synchronized with the getter for all readwrite properties.
-    var feature1: FeatureState {
-        get { FeatureState(name: feature1Name, // Read only
-                           isCountInternal: false, // Read only
-                           text: content,
-                           count: count)
-        }
-        set {
-            self.content = newValue.text
-            self.count = newValue.count
-        }
+  // This value is not used for cases with internal storage
+  var count: Int = 0
+
+  // This flag is used to trigger the existence of the computed and optional `feature5`
+  var shouldShowFeature5: Bool = false
+
+  // MARK: Manual approach -
+
+  // We create a FeatureState on the fly each time it is requested.
+  // The global state needs to explicitly handle all FeatureState stored properties.
+  // The setter need to by synchronized with the getter for all readwrite properties.
+  var feature1: FeatureState {
+    get { FeatureState(name: feature1Name, // Read only
+                       isCountInternal: false, // Read only
+                       text: content,
+                       count: count)
     }
-
-    // MARK: State Binding with internal storage -
-    // A private instance of FeatureState is stored.
-    // This instance will participate to state comparisons if any. In the binding, we only declare
-    // the relevant property `name`, bound with `self.content`. The private instance stores all the
-    // other internal properties.
-    fileprivate var _feature2: FeatureState = .init()
-    fileprivate static let _feature2 = StateBinding(\Self._feature2) {
-        (readonly: \.feature2Name, \.name) // self.feature2Name -> feature2.name
-        (\.content, \.text) // self.content and feature2.text are bound in both directions.
+    set {
+      self.content = newValue.text
+      self.count = newValue.count
     }
+  }
 
-    // Public accessor, proxying calls to the binding. The shape is always the same: One retrieves the
-    // binding and call `get` with `self` to return an up-to-date value of FeatureState. In the setter,
-    // we also retrieve the binding, but we call this time `set` with a pointer to `self` and `newValue`. This
-    // function updates `self` accordingly.
-    var feature2: FeatureState {
-        get { Self._feature2.get(self) }
-        set { Self._feature2.set(&self, newValue) }
+  // MARK: State Binding with internal storage -
+
+  // A private instance of FeatureState is stored.
+  // This instance will participate to state comparisons if any. In the binding, we only declare
+  // the relevant property `name`, bound with `self.content`. The private instance stores all the
+  // other internal properties.
+  fileprivate var _feature2: FeatureState = .init()
+  fileprivate static let _feature2 = StateBinding(\Self._feature2) {
+    (readonly: \.feature2Name, \.name) // self.feature2Name -> feature2.name
+    (\.content, \.text) // self.content and feature2.text are bound in both directions.
+  }
+
+  // Public accessor, proxying calls to the binding. The shape is always the same: One retrieves the
+  // binding and call `get` with `self` to return an up-to-date value of FeatureState. In the setter,
+  // we also retrieve the binding, but we call this time `set` with a pointer to `self` and `newValue`.
+  // This function updates `self` accordingly.
+  var feature2: FeatureState {
+    get { Self._feature2.get(self) }
+    set { Self._feature2.set(&self, newValue) }
+  }
+
+  // MARK: "Optional State Binding with internal storage" -
+
+  // A optional private instance of FeatureState is stored.
+  // This instance will participate to state comparisons if any. In the binding, we only declare
+  // the relevant property `name`, bound with `self.content`. The private instance stores all the
+  // other internal properties. The optionality of this value condition the optionality of the
+  // publicly accessed property. Please note that the `PropertyBindings` a defined between unwrapped
+  // values.
+  fileprivate var _feature3: FeatureState?
+  fileprivate static let _feature3 = StateBinding(\Self._feature3) {
+    (readonly: \.feature3Name, \.name)
+    (\.content, \.text)
+  }
+
+  /// Public accessor, same shape as `feature2`, but optional.
+  var feature3: FeatureState? {
+    get { Self._feature3.get(self) }
+    set { Self._feature3.set(&self, newValue) }
+  }
+
+  // MARK: "Computed State Binding" -
+
+  // This instance doesn't have internal properties (or they stay to their default value otherwise)
+  // All the properties of `Feature` are bound to some property of `self`. A new instance is created
+  // from the provided `with:` argument. We use `Self.self` because we need to tie the first generic
+  // parameter of `StateBinding` to `Self`.
+  fileprivate static let _feature4 = StateBinding(Self.self, with: FeatureState.init) {
+    (readonly: \.feature4Name, \.name)
+    (readOnly: \.isCountInternal, \.isCountInternal)
+    (\.content, \.text)
+    (\.count, \.count)
+  }
+
+  var feature4: FeatureState {
+    get { Self._feature4.get(self) }
+    set { Self._feature4.set(&self, newValue) }
+  }
+
+  // MARK: "Optional Computed State Binding" -
+
+  // Similar to the previous construction, but the value returned is now optional and is the `Feature`
+  // instance is created from a function of `Self`. We use the `shouldShowFeature5` flag to decide if the
+  // property is nil or not. Because it has no private storage, the `feature5` instance is completly set
+  // when accessed and the flag is enough to condition its existence and content without ambiguity.
+  fileprivate static let _feature5 = StateBinding<SharedStateWithBinding, FeatureState?>(with: {
+    $0.shouldShowFeature5
+      ? .init()
+      : nil
+  }
+  ) {
+    (readonly: \.feature5Name, \.name)
+    (readOnly: \.isCountInternal, \.isCountInternal)
+    (\.count, \.count)
+
+    // Explicit declaration, equivalent to
+    // PropertyBinding(\.content, \.text) or (\.content, \.text)
+    PropertyBinding { src, dest in
+      dest.text = src.content
+    } set: { src, dest in
+      src.content = dest.text
     }
+  }
 
-    // MARK: "Optional State Binding with internal storage" -
-    // A optional private instance of FeatureState is stored.
-    // This instance will participate to state comparisons if any. In the binding, we only declare
-    // the relevant property `name`, bound with `self.content`. The private instance stores all the
-    // other internal properties. The optionality of this value condition the optionality of the
-    // publicly accessed property. Please note that the `PropertyBindings` a defined between unwrapped
-    // values.
-    fileprivate var _feature3: FeatureState?
-    fileprivate static let _feature3 = StateBinding(\Self._feature3) {
-        (readonly: \.feature3Name, \.name)
-        (\.content, \.text)
-    }
+  var feature5: FeatureState? {
+    get { Self._feature5.get(self) }
+    set { Self._feature5.set(&self, newValue) }
+  }
 
-    /// Public accessor, same shape as `feature2`, but optional.
-    var feature3: FeatureState? {
-        get { Self._feature3.get(self) }
-        set { Self._feature3.set(&self, newValue) }
-    }
+  // MARK: "Computed State with deduplication" -
 
-    // MARK: "Computed State Binding" -
-    // This instance doesn't have internal properties (or they stay to their default value otherwise)
-    // All the properties of `Feature` are bound to some property of `self`. A new instance is created
-    // from the provided `with:` argument. We use `Self.self` because we need to tie the first generic
-    // parameter of `StateBinding` to `Self`.
-    fileprivate static let _feature4 = StateBinding(Self.self, with: FeatureState.init) {
-        (readonly: \.feature4Name, \.name)
-        (readOnly: \.isCountInternal, \.isCountInternal)
-        (\.content, \.text)
-        (\.count, \.count)
-    }
+  // In this example similar to feature1, we avoid writing the private storage if the value is unchanged.
+  // We also avoid to write `self.content` if it hasn't changed.
+  fileprivate var _feature6: FeatureState = .init()
+  // Will not update _feature6 if equal
+  fileprivate static let _feature6 = StateBinding(\Self._feature6, removeDuplicateStorage: ==) {
+    (readonly: \.feature6Name, \.name)
+    (\.content, \.text, removeDuplicates: ==) // Will not set `content` if equal to `text`
+  }
 
-    var feature4: FeatureState {
-        get { Self._feature4.get(self) }
-        set { Self._feature4.set(&self, newValue) }
-    }
+  var feature6: FeatureState {
+    get { Self._feature6.get(self) }
+    set { Self._feature6.set(&self, newValue) }
+  }
 
-    // MARK: "Optional Computed State Binding" -
-    // Similar to the previous construction, but the value returned is now optional and is the `Feature`
-    // instance is created from a function of `Self`. We use the `shouldShowFeature5` flag to decide if the
-    // property is nil or not. Because it has no private storage, the `feature5` instance is completly set
-    // when accessed and the flag is enough to condition its existence and content without ambiguity.
-    fileprivate static let _feature5 = StateBinding<SharedStateWithBinding, FeatureState?>(with: {
-                                                                                            $0.shouldShowFeature5
-                                                                                            ? .init()
-                                                                                            : nil }
-    ) {
-        (readonly: \.feature5Name, \.name)
-        (readOnly: \.isCountInternal, \.isCountInternal)
-        (\.count, \.count)
+  // MARK: Internal
 
-        // Explicit declaration, equivalent to
-        // PropertyBinding(\.content, \.text) or (\.content, \.text)
-        PropertyBinding { src, dest in
-            dest.text = src.content
-        } set: { src, dest in
-            src.content = dest.text
-        }
-    }
-
-    var feature5: FeatureState? {
-        get { Self._feature5.get(self) }
-        set { Self._feature5.set(&self, newValue) }
-    }
-
-    // MARK: "Computed State with deduplication" -
-    // In this example similar to feature1, we avoid writing the private storage if the value is unchanged.
-    // We also avoid to write `self.content` if it hasn't changed.
-    fileprivate var _feature6: FeatureState = .init()
-    // Will not update _feature6 if equal
-    fileprivate static let _feature6 = StateBinding(\Self._feature6, removeDuplicateStorage: ==) {
-        (readonly: \.feature6Name, \.name)
-        (\.content, \.text, removeDuplicates: ==) // Will not set `content` if equal to `text`
-    }
-
-    var feature6: FeatureState {
-        get { Self._feature6.get(self) }
-        set { Self._feature6.set(&self, newValue) }
-    }
-    
-    // MARK: Internal
-    // Used for this case study presentation
-    var feature1Name = "Manual binding"
-    var feature2Name = "State Binding with internal storage"
-    var feature3Name = "Optional State Binding with internal storage"
-    var feature4Name = "Computed State Binding"
-    var feature5Name = "Optional Computed State Binding"
-    var feature6Name = "Computed State with deduplication"
-    var isCountInternal: Bool = false
+  // Used for this case study presentation
+  var feature1Name = "Manual binding"
+  var feature2Name = "State Binding with internal storage"
+  var feature3Name = "Optional State Binding with internal storage"
+  var feature4Name = "Computed State Binding"
+  var feature5Name = "Optional Computed State Binding"
+  var feature6Name = "Computed State with deduplication"
+  var isCountInternal: Bool = false
 }
 
 // MARK: - Actions
-enum SharedStateWithBindingAction {
-    enum FeatureAction {
-        case text(String)
-        case count(Int)
-    }
-    
-    case feature1(FeatureAction)
-    case feature2(FeatureAction)
-    case feature3(FeatureAction)
-    case feature4(FeatureAction)
-    case feature5(FeatureAction)
-    case feature6(FeatureAction)
 
-    case toggleFeature3
-    case toggleFeature5
+enum SharedStateWithBindingAction {
+  enum FeatureAction {
+    case text(String)
+    case count(Int)
+  }
+
+  case feature1(FeatureAction)
+  case feature2(FeatureAction)
+  case feature3(FeatureAction)
+  case feature4(FeatureAction)
+  case feature5(FeatureAction)
+  case feature6(FeatureAction)
+
+  case toggleFeature3
+  case toggleFeature5
 }
 
 // MARK: - Reducers
 
 let boundFeatureReducer = Reducer<SharedStateWithBinding.FeatureState,
-    SharedStateWithBindingAction.FeatureAction,
-    Void> {
-    state, action, _ in
-    switch action {
-    case let .text(text):
-        state.text = text
-        return .none
-    case let .count(value):
-        state.count = value
-        return .none
-    }
+  SharedStateWithBindingAction.FeatureAction,
+  Void> {
+  state, action, _ in
+  switch action {
+  case let .text(text):
+    state.text = text
+    return .none
+  case let .count(value):
+    state.count = value
+    return .none
+  }
 }
 
 let sharedStateWithBindingReducer = Reducer<SharedStateWithBinding,
-    SharedStateWithBindingAction,
-    Void>
-    .combine(
-        boundFeatureReducer.pullback(state: \.feature1,
-                                     action: /SharedStateWithBindingAction.feature1,
-                                     environment: { _ in () }),
+  SharedStateWithBindingAction,
+  Void>
+  .combine(
+    boundFeatureReducer.pullback(state: \.feature1,
+                                 action: /SharedStateWithBindingAction.feature1,
+                                 environment: { _ in () }),
 
-        boundFeatureReducer.pullback(state: \.feature2,
-                                     action: /SharedStateWithBindingAction.feature2,
-                                     environment: { _ in () }),
+    boundFeatureReducer.pullback(state: \.feature2,
+                                 action: /SharedStateWithBindingAction.feature2,
+                                 environment: { _ in () }),
 
-        boundFeatureReducer.optional().pullback(state: \.feature3,
-                                                action: /SharedStateWithBindingAction.feature3,
-                                                environment: { _ in () }),
+    boundFeatureReducer.optional().pullback(state: \.feature3,
+                                            action: /SharedStateWithBindingAction.feature3,
+                                            environment: { _ in () }),
 
-        boundFeatureReducer.pullback(state: \.feature4,
-                                     action: /SharedStateWithBindingAction.feature4,
-                                     environment: { _ in () }),
+    boundFeatureReducer.pullback(state: \.feature4,
+                                 action: /SharedStateWithBindingAction.feature4,
+                                 environment: { _ in () }),
 
-        boundFeatureReducer.optional().pullback(state: \.feature5,
-                                                action: /SharedStateWithBindingAction.feature5,
-                                                environment: { _ in () }),
+    boundFeatureReducer.optional().pullback(state: \.feature5,
+                                            action: /SharedStateWithBindingAction.feature5,
+                                            environment: { _ in () }),
 
-        boundFeatureReducer.pullback(state: \.feature6,
-                                     action: /SharedStateWithBindingAction.feature6,
-                                     environment: { _ in () }),
+    boundFeatureReducer.pullback(state: \.feature6,
+                                 action: /SharedStateWithBindingAction.feature6,
+                                 environment: { _ in () }),
 
-        Reducer<SharedStateWithBinding, SharedStateWithBindingAction, Void> {
-            state, action, _ in
-            switch action {
-            case .toggleFeature3: // feature3 is a optional state with internal storage.
-                if state._feature3 == nil {
-                    // We set up a new instance of FeatureState() so its internal properties
-                    // can be stored by the feature itself.
-                    state._feature3 = .init()
-                } else {
-                    state._feature3 = nil
-                }
-                return .none
-            case .toggleFeature5: // feature5 is a optional computed state.
-                state.shouldShowFeature5.toggle()
-                return .none
-            default: return .none
-            }
+    Reducer<SharedStateWithBinding, SharedStateWithBindingAction, Void> {
+      state, action, _ in
+      switch action {
+      case .toggleFeature3: // feature3 is a optional state with internal storage.
+        if state._feature3 == nil {
+          // We set up a new instance of FeatureState() so its internal properties
+          // can be stored by the feature itself.
+          state._feature3 = .init()
+        } else {
+          state._feature3 = nil
         }
-    )
+        return .none
+      case .toggleFeature5: // feature5 is a optional computed state.
+        state.shouldShowFeature5.toggle()
+        return .none
+      default: return .none
+      }
+    }
+  )
 
 // MARK: - View
 
 struct SharedStateWithBindingView: View {
-    let store: Store<SharedStateWithBinding, SharedStateWithBindingAction>
+  let store: Store<SharedStateWithBinding, SharedStateWithBindingAction>
 
+  var body: some View {
+    WithViewStore(store) { viewStore in
+      List {
+        Section(header: Text(viewStore.feature1Name)) {
+          FeatureView(store: store.scope(state: \.feature1,
+                                         action: SharedStateWithBindingAction.feature1))
+        }
+
+        Section(header: Text(viewStore.feature2Name)) {
+          FeatureView(store: store.scope(state: \.feature2,
+                                         action: SharedStateWithBindingAction.feature2))
+        }
+
+        Section(header: Text(viewStore.feature3Name),
+                footer:
+                Button(action: { viewStore.send(.toggleFeature3, animation: .default) }) {
+                  Text(viewStore.feature3 == nil
+                    ? "Install Optional Feature"
+                    : "Remove Feature"
+                  )
+                }) {
+          IfLetStore(store.scope(state: \.feature3,
+                                 action: SharedStateWithBindingAction.feature3),
+                     then: FeatureView.init(store:))
+        }
+
+        Section(header: Text(viewStore.feature4Name)) {
+          FeatureView(store: store.scope(state: \.feature4,
+                                         action: SharedStateWithBindingAction.feature4))
+        }
+
+        Section(header: Text(viewStore.feature5Name),
+                footer:
+                Button(action: { viewStore.send(.toggleFeature5, animation: .default) }) {
+                  Text(viewStore.feature5 == nil
+                    ? "Install Optional Feature"
+                    : "Remove Feature"
+                  )
+                }) {
+          IfLetStore(store.scope(state: \.feature5,
+                                 action: SharedStateWithBindingAction.feature5),
+                     then: FeatureView.init(store:))
+        }
+
+        Section(header: Text(viewStore.feature6Name)) {
+          FeatureView(store: store.scope(state: \.feature6,
+                                         action: SharedStateWithBindingAction.feature6))
+        }
+      }
+    }
+    .listStyle(GroupedListStyle())
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  struct FeatureView: View {
+    let store: Store<SharedStateWithBinding.FeatureState, SharedStateWithBindingAction.FeatureAction>
     var body: some View {
-        WithViewStore(store) { viewStore in
-            List {
-                Section(header: Text(viewStore.feature1Name)) {
-                    FeatureView(store: store.scope(state: \.feature1,
-                                                   action: SharedStateWithBindingAction.feature1))
-                }
+      WithViewStore(store) { viewStore in
+        VStack {
+          HStack {
+            TextField(viewStore.name,
+                      text: viewStore.binding(get: \.text,
+                                              send: SharedStateWithBindingAction.FeatureAction.text))
+              .textFieldStyle(RoundedBorderTextFieldStyle())
 
-                Section(header: Text(viewStore.feature2Name)) {
-                    FeatureView(store: store.scope(state: \.feature2,
-                                                   action: SharedStateWithBindingAction.feature2))
-                }
-
-                Section(header: Text(viewStore.feature3Name),
-                        footer:
-                        Button(action: { viewStore.send(.toggleFeature3, animation: .default) }) {
-                            Text(viewStore.feature3 == nil
-                                ? "Install Optional Feature"
-                                : "Remove Feature"
-                            )
-                        }) {
-                    IfLetStore(store.scope(state: \.feature3,
-                                           action: SharedStateWithBindingAction.feature3),
-                               then: FeatureView.init(store:))
-                }
-
-                Section(header: Text(viewStore.feature4Name)) {
-                    FeatureView(store: store.scope(state: \.feature4,
-                                                   action: SharedStateWithBindingAction.feature4))
-                }
-                
-                Section(header: Text(viewStore.feature5Name),
-                        footer:
-                        Button(action: { viewStore.send(.toggleFeature5, animation: .default) }) {
-                            Text(viewStore.feature5 == nil
-                                ? "Install Optional Feature"
-                                : "Remove Feature"
-                            )}) {
-                    IfLetStore(store.scope(state: \.feature5,
-                                           action: SharedStateWithBindingAction.feature5),
-                               then: FeatureView.init(store:))
-                }
-
-                Section(header: Text(viewStore.feature6Name)) {
-                    FeatureView(store: store.scope(state: \.feature6,
-                                                   action: SharedStateWithBindingAction.feature6))
-                }
-            }
+            Stepper("\(viewStore.count)", value: viewStore.binding(get: \.count,
+                                                                   send: SharedStateWithBindingAction.FeatureAction.count),
+                    in: 0 ... 9).font(Font.system(.body).monospacedDigit())
+              .fixedSize()
+              .foregroundColor(viewStore.isCountInternal ? .red : .green)
+          }
+          Text("\"count\" value is \(viewStore.isCountInternal ? "internal" : "global")")
+            .font(.footnote)
+            .frame(maxWidth: .infinity, alignment: .trailing)
+            .foregroundColor(viewStore.isCountInternal ? .red : .green)
         }
-        .listStyle(GroupedListStyle())
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .id(viewStore.name)
+        .padding([.leading, .trailing])
+      }
     }
-
-    struct FeatureView: View {
-        let store: Store<SharedStateWithBinding.FeatureState, SharedStateWithBindingAction.FeatureAction>
-        var body: some View {
-            WithViewStore(store) { viewStore in
-                VStack {
-                    HStack {
-                        TextField(viewStore.name,
-                                  text: viewStore.binding(get: \.text,
-                                                          send: SharedStateWithBindingAction.FeatureAction.text))
-                            .textFieldStyle(RoundedBorderTextFieldStyle())
-                        
-                        Stepper("\(viewStore.count)", value: viewStore.binding(get: \.count,
-                                                                               send: SharedStateWithBindingAction.FeatureAction.count),
-                                in: 0 ... 9).font(Font.system(.body).monospacedDigit())
-                            .fixedSize()
-                            .foregroundColor(viewStore.isCountInternal ? .red : .green)
-                    }
-                    Text("\"count\" value is \(viewStore.isCountInternal ? "internal" : "global")")
-                        .font(.footnote)
-                        .frame(maxWidth: .infinity, alignment: .trailing)
-                        .foregroundColor(viewStore.isCountInternal ? .red : .green)
-                }
-                .id(viewStore.name)
-                .padding([.leading, .trailing])
-            }
-        }
-    }
+  }
 }
 
 // MARK: - Preview
 
 struct SharedStateWithBindingView_Previews: PreviewProvider {
-    static var previews: some View {
-        SharedStateWithBindingView(store: .init(initialState: .init(), reducer: sharedStateWithBindingReducer, environment: ()))
-    }
+  static var previews: some View {
+    SharedStateWithBindingView(store: .init(initialState: .init(), reducer: sharedStateWithBindingReducer, environment: ()))
+  }
 }
+
+#else
+struct SharedStateWithBinding {}
+
+enum SharedStateWithBindingAction {
+  case noop
+}
+
+let sharedStateWithBindingReducer =
+  Reducer<SharedStateWithBinding, SharedStateWithBindingAction, Void> { _, _, _ in .none }
+#endif

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
@@ -62,7 +62,6 @@ struct SharedStateWithBinding: Equatable {
   ] }
   #endif
   
-  
   // Public accessor, proxying calls to the binding. The shape is always the same: One retrieves the
   // binding and call `get` with `self` to return an up-to-date value of FeatureState. In the setter,
   // we also retrieve the binding, but we call this time `set` with a pointer to `self` and `newValue`.
@@ -163,7 +162,7 @@ struct SharedStateWithBinding: Equatable {
   }
 
   // MARK: "Computed State with deduplication" -
-  // In this example similar to feature1, we avoid writing the private storage if the value is unchanged.
+  // In this example similar to feature2, we avoid writing the private storage if the value is unchanged.
   // We also avoid to write `self.content` if it hasn't changed.
   fileprivate var _feature6: FeatureState = .init()
   // Will not update _feature6 if equal

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
@@ -1,0 +1,333 @@
+import ComposableArchitecture
+import SwiftUI
+
+private let readMe = """
+This screen demonstrates how to use StateBindings and PropertyBinding to ensure that sub-states are
+up-to-date with their parent state. They also provide a convenient way to specify fine-grained or coarse
+deduplication if needed.
+
+It demonstrates several use cases, like sub-states with internal properties, optional sub-states or
+deduplicated sub-state setters.
+"""
+
+struct SharedStateWithBinding: Equatable {
+    
+    struct FeatureState: Equatable {
+        var name: String = "" // Used for this case study presentation
+        var isCountInternal: Bool = true // Used for this case study presentation
+
+        var text: String = ""
+        var count: Int = 0
+    }
+    
+    // This value is shared across all features.
+    var content: String = "Shared Content"
+
+    // This value is not used for cases with internal storage
+    var count: Int = 0
+
+    // This flag is used to trigger the existence of the computed and optional `feature5`
+    var shouldShowFeature5: Bool = false
+
+    // MARK: Manual approach -
+    // We create a FeatureState on the fly each time it is requested.
+    // The global state needs to explicitly handle all FeatureState stored properties.
+    // The setter need to by synchronized with the getter for all readwrite properties.
+    var feature1: FeatureState {
+        get { FeatureState(name: feature1Name, // Read only
+                           isCountInternal: false, // Read only
+                           text: content,
+                           count: count)
+        }
+        set {
+            self.content = newValue.text
+            self.count = newValue.count
+        }
+    }
+
+    // MARK: State Binding with internal storage -
+    // A private instance of FeatureState is stored.
+    // This instance will participate to state comparisons if any. In the binding, we only declare
+    // the relevant property `name`, bound with `self.content`. The private instance stores all the
+    // other internal properties.
+    fileprivate var _feature2: FeatureState = .init()
+    fileprivate static let _feature2 = StateBinding(\Self._feature2) {
+        (readonly: \.feature2Name, \.name) // self.feature2Name -> feature2.name
+        (\.content, \.text) // self.content and feature2.text are bound in both directions.
+    }
+
+    // Public accessor, proxying calls to the binding. The shape is always the same: One retrieves the
+    // binding and call `get` with `self` to return an up-to-date value of FeatureState. In the setter,
+    // we also retrieve the binding, but we call this time `set` with a pointer to `self` and `newValue`. This
+    // function updates `self` accordingly.
+    var feature2: FeatureState {
+        get { Self._feature2.get(self) }
+        set { Self._feature2.set(&self, newValue) }
+    }
+
+    // MARK: "Optional State Binding with internal storage" -
+    // A optional private instance of FeatureState is stored.
+    // This instance will participate to state comparisons if any. In the binding, we only declare
+    // the relevant property `name`, bound with `self.content`. The private instance stores all the
+    // other internal properties. The optionality of this value condition the optionality of the
+    // publicly accessed property. Please note that the `PropertyBindings` a defined between unwrapped
+    // values.
+    fileprivate var _feature3: FeatureState?
+    fileprivate static let _feature3 = StateBinding(\Self._feature3) {
+        (readonly: \.feature3Name, \.name)
+        (\.content, \.text)
+    }
+
+    /// Public accessor, same shape as `feature2`, but optional.
+    var feature3: FeatureState? {
+        get { Self._feature3.get(self) }
+        set { Self._feature3.set(&self, newValue) }
+    }
+
+    // MARK: "Computed State Binding" -
+    // This instance doesn't have internal properties (or they stay to their default value otherwise)
+    // All the properties of `Feature` are bound to some property of `self`. A new instance is created
+    // from the provided `with:` argument. We use `Self.self` because we need to tie the first generic
+    // parameter of `StateBinding` to `Self`.
+    fileprivate static let _feature4 = StateBinding(Self.self, with: FeatureState.init) {
+        (readonly: \.feature4Name, \.name)
+        (readOnly: \.isCountInternal, \.isCountInternal)
+        (\.content, \.text)
+        (\.count, \.count)
+    }
+
+    var feature4: FeatureState {
+        get { Self._feature4.get(self) }
+        set { Self._feature4.set(&self, newValue) }
+    }
+
+    // MARK: "Optional Computed State Binding" -
+    // Similar to the previous construction, but the value returned is now optional and is the `Feature`
+    // instance is created from a function of `Self`. We use the `shouldShowFeature5` flag to decide if the
+    // property is nil or not. Because it has no private storage, the `feature5` instance is completly set
+    // when accessed and the flag is enough to condition its existence and content without ambiguity.
+    fileprivate static let _feature5 = StateBinding<SharedStateWithBinding, FeatureState?>(with: {
+                                                                                            $0.shouldShowFeature5
+                                                                                            ? .init()
+                                                                                            : nil }
+    ) {
+        (readonly: \.feature5Name, \.name)
+        (readOnly: \.isCountInternal, \.isCountInternal)
+        (\.count, \.count)
+
+        // Explicit declaration, equivalent to
+        // PropertyBinding(\.content, \.text) or (\.content, \.text)
+        PropertyBinding { src, dest in
+            dest.text = src.content
+        } set: { src, dest in
+            src.content = dest.text
+        }
+    }
+
+    var feature5: FeatureState? {
+        get { Self._feature5.get(self) }
+        set { Self._feature5.set(&self, newValue) }
+    }
+
+    // MARK: "Computed State with deduplication" -
+    // In this example similar to feature1, we avoid writing the private storage if the value is unchanged.
+    // We also avoid to write `self.content` if it hasn't changed.
+    fileprivate var _feature6: FeatureState = .init()
+    // Will not update _feature6 if equal
+    fileprivate static let _feature6 = StateBinding(\Self._feature6, removeDuplicateStorage: ==) {
+        (readonly: \.feature6Name, \.name)
+        (\.content, \.text, removeDuplicates: ==) // Will not set `content` if equal to `text`
+    }
+
+    var feature6: FeatureState {
+        get { Self._feature6.get(self) }
+        set { Self._feature6.set(&self, newValue) }
+    }
+    
+    // MARK: Internal
+    // Used for this case study presentation
+    var feature1Name = "Manual binding"
+    var feature2Name = "State Binding with internal storage"
+    var feature3Name = "Optional State Binding with internal storage"
+    var feature4Name = "Computed State Binding"
+    var feature5Name = "Optional Computed State Binding"
+    var feature6Name = "Computed State with deduplication"
+    var isCountInternal: Bool = false
+}
+
+// MARK: - Actions
+enum SharedStateWithBindingAction {
+    enum FeatureAction {
+        case text(String)
+        case count(Int)
+    }
+    
+    case feature1(FeatureAction)
+    case feature2(FeatureAction)
+    case feature3(FeatureAction)
+    case feature4(FeatureAction)
+    case feature5(FeatureAction)
+    case feature6(FeatureAction)
+
+    case toggleFeature3
+    case toggleFeature5
+}
+
+// MARK: - Reducers
+
+let boundFeatureReducer = Reducer<SharedStateWithBinding.FeatureState,
+    SharedStateWithBindingAction.FeatureAction,
+    Void> {
+    state, action, _ in
+    switch action {
+    case let .text(text):
+        state.text = text
+        return .none
+    case let .count(value):
+        state.count = value
+        return .none
+    }
+}
+
+let sharedStateWithBindingReducer = Reducer<SharedStateWithBinding,
+    SharedStateWithBindingAction,
+    Void>
+    .combine(
+        boundFeatureReducer.pullback(state: \.feature1,
+                                     action: /SharedStateWithBindingAction.feature1,
+                                     environment: { _ in () }),
+
+        boundFeatureReducer.pullback(state: \.feature2,
+                                     action: /SharedStateWithBindingAction.feature2,
+                                     environment: { _ in () }),
+
+        boundFeatureReducer.optional().pullback(state: \.feature3,
+                                                action: /SharedStateWithBindingAction.feature3,
+                                                environment: { _ in () }),
+
+        boundFeatureReducer.pullback(state: \.feature4,
+                                     action: /SharedStateWithBindingAction.feature4,
+                                     environment: { _ in () }),
+
+        boundFeatureReducer.optional().pullback(state: \.feature5,
+                                                action: /SharedStateWithBindingAction.feature5,
+                                                environment: { _ in () }),
+
+        boundFeatureReducer.pullback(state: \.feature6,
+                                     action: /SharedStateWithBindingAction.feature6,
+                                     environment: { _ in () }),
+
+        Reducer<SharedStateWithBinding, SharedStateWithBindingAction, Void> {
+            state, action, _ in
+            switch action {
+            case .toggleFeature3: // feature3 is a optional state with internal storage.
+                if state._feature3 == nil {
+                    // We set up a new instance of FeatureState() so its internal properties
+                    // can be stored by the feature itself.
+                    state._feature3 = .init()
+                } else {
+                    state._feature3 = nil
+                }
+                return .none
+            case .toggleFeature5: // feature5 is a optional computed state.
+                state.shouldShowFeature5.toggle()
+                return .none
+            default: return .none
+            }
+        }
+    )
+
+// MARK: - View
+
+struct SharedStateWithBindingView: View {
+    let store: Store<SharedStateWithBinding, SharedStateWithBindingAction>
+
+    var body: some View {
+        WithViewStore(store) { viewStore in
+            List {
+                Section(header: Text(viewStore.feature1Name)) {
+                    FeatureView(store: store.scope(state: \.feature1,
+                                                   action: SharedStateWithBindingAction.feature1))
+                }
+
+                Section(header: Text(viewStore.feature2Name)) {
+                    FeatureView(store: store.scope(state: \.feature2,
+                                                   action: SharedStateWithBindingAction.feature2))
+                }
+
+                Section(header: Text(viewStore.feature3Name),
+                        footer:
+                        Button(action: { viewStore.send(.toggleFeature3, animation: .default) }) {
+                            Text(viewStore.feature3 == nil
+                                ? "Install Optional Feature"
+                                : "Remove Feature"
+                            )
+                        }) {
+                    IfLetStore(store.scope(state: \.feature3,
+                                           action: SharedStateWithBindingAction.feature3),
+                               then: FeatureView.init(store:))
+                }
+
+                Section(header: Text(viewStore.feature4Name)) {
+                    FeatureView(store: store.scope(state: \.feature4,
+                                                   action: SharedStateWithBindingAction.feature4))
+                }
+                
+                Section(header: Text(viewStore.feature5Name),
+                        footer:
+                        Button(action: { viewStore.send(.toggleFeature5, animation: .default) }) {
+                            Text(viewStore.feature5 == nil
+                                ? "Install Optional Feature"
+                                : "Remove Feature"
+                            )}) {
+                    IfLetStore(store.scope(state: \.feature5,
+                                           action: SharedStateWithBindingAction.feature5),
+                               then: FeatureView.init(store:))
+                }
+
+                Section(header: Text(viewStore.feature6Name)) {
+                    FeatureView(store: store.scope(state: \.feature6,
+                                                   action: SharedStateWithBindingAction.feature6))
+                }
+            }
+        }
+        .listStyle(GroupedListStyle())
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    struct FeatureView: View {
+        let store: Store<SharedStateWithBinding.FeatureState, SharedStateWithBindingAction.FeatureAction>
+        var body: some View {
+            WithViewStore(store) { viewStore in
+                VStack {
+                    HStack {
+                        TextField(viewStore.name,
+                                  text: viewStore.binding(get: \.text,
+                                                          send: SharedStateWithBindingAction.FeatureAction.text))
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                        
+                        Stepper("\(viewStore.count)", value: viewStore.binding(get: \.count,
+                                                                               send: SharedStateWithBindingAction.FeatureAction.count),
+                                in: 0 ... 9).font(Font.system(.body).monospacedDigit())
+                            .fixedSize()
+                            .foregroundColor(viewStore.isCountInternal ? .red : .green)
+                    }
+                    Text("\"count\" value is \(viewStore.isCountInternal ? "internal" : "global")")
+                        .font(.footnote)
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                        .foregroundColor(viewStore.isCountInternal ? .red : .green)
+                }
+                .id(viewStore.name)
+                .padding([.leading, .trailing])
+            }
+        }
+    }
+}
+
+// MARK: - Preview
+
+struct SharedStateWithBindingView_Previews: PreviewProvider {
+    static var previews: some View {
+        SharedStateWithBindingView(store: .init(initialState: .init(), reducer: sharedStateWithBindingReducer, environment: ()))
+    }
+}

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
@@ -1,6 +1,6 @@
 import ComposableArchitecture
 import SwiftUI
-#if swift(>=5.4)
+
 private let readMe = """
 This screen demonstrates how to use StateBindings and PropertyBinding to ensure that sub-states are
 up-to-date with their parent state. They also provide a convenient way to specify fine-grained or coarse
@@ -29,7 +29,6 @@ struct SharedStateWithBinding: Equatable {
   var shouldShowFeature5: Bool = false
 
   // MARK: Manual approach -
-
   // We create a FeatureState on the fly each time it is requested.
   // The global state needs to explicitly handle all FeatureState stored properties.
   // The setter need to by synchronized with the getter for all readwrite properties.
@@ -46,17 +45,24 @@ struct SharedStateWithBinding: Equatable {
   }
 
   // MARK: State Binding with internal storage -
-
   // A private instance of FeatureState is stored.
   // This instance will participate to state comparisons if any. In the binding, we only declare
   // the relevant property `name`, bound with `self.content`. The private instance stores all the
   // other internal properties.
   fileprivate var _feature2: FeatureState = .init()
+  #if swift(>=5.4)
   fileprivate static let _feature2 = StateBinding(\Self._feature2) {
     (readonly: \.feature2Name, \.name) // self.feature2Name -> feature2.name
     (\.content, \.text) // self.content and feature2.text are bound in both directions.
   }
-
+  #else
+  fileprivate static let _feature2 = StateBinding(\Self._feature2) { [
+    PropertyBinding(readonly: \.feature2Name, \.name), // self.feature2Name -> feature2.name
+    PropertyBinding(\.content, \.text), // self.content and feature2.text are bound in both directions.
+  ] }
+  #endif
+  
+  
   // Public accessor, proxying calls to the binding. The shape is always the same: One retrieves the
   // binding and call `get` with `self` to return an up-to-date value of FeatureState. In the setter,
   // we also retrieve the binding, but we call this time `set` with a pointer to `self` and `newValue`.
@@ -67,7 +73,6 @@ struct SharedStateWithBinding: Equatable {
   }
 
   // MARK: "Optional State Binding with internal storage" -
-
   // A optional private instance of FeatureState is stored.
   // This instance will participate to state comparisons if any. In the binding, we only declare
   // the relevant property `name`, bound with `self.content`. The private instance stores all the
@@ -75,10 +80,17 @@ struct SharedStateWithBinding: Equatable {
   // publicly accessed property. Please note that the `PropertyBindings` a defined between unwrapped
   // values.
   fileprivate var _feature3: FeatureState?
+  #if swift(>=5.4)
   fileprivate static let _feature3 = StateBinding(\Self._feature3) {
     (readonly: \.feature3Name, \.name)
     (\.content, \.text)
   }
+  #else
+  fileprivate static let _feature3 = StateBinding(\Self._feature3) { [
+    PropertyBinding(readonly: \.feature3Name, \.name),
+    PropertyBinding(\.content, \.text),
+  ] }
+  #endif
 
   /// Public accessor, same shape as `feature2`, but optional.
   var feature3: FeatureState? {
@@ -87,17 +99,25 @@ struct SharedStateWithBinding: Equatable {
   }
 
   // MARK: "Computed State Binding" -
-
   // This instance doesn't have internal properties (or they stay to their default value otherwise)
   // All the properties of `Feature` are bound to some property of `self`. A new instance is created
   // from the provided `with:` argument. We use `Self.self` because we need to tie the first generic
   // parameter of `StateBinding` to `Self`.
+  #if swift(>=5.4)
   fileprivate static let _feature4 = StateBinding(Self.self, with: FeatureState.init) {
     (readonly: \.feature4Name, \.name)
-    (readOnly: \.isCountInternal, \.isCountInternal)
+    (readonly: \.isCountInternal, \.isCountInternal)
     (\.content, \.text)
     (\.count, \.count)
   }
+  #else
+  fileprivate static let _feature4 = StateBinding(Self.self, with: FeatureState.init) { [
+    PropertyBinding(readonly: \.feature4Name, \.name),
+    PropertyBinding(readonly: \.isCountInternal, \.isCountInternal),
+    PropertyBinding(\.content, \.text),
+    PropertyBinding(\.count, \.count),
+  ] }
+  #endif
 
   var feature4: FeatureState {
     get { Self._feature4.get(self) }
@@ -105,29 +125,37 @@ struct SharedStateWithBinding: Equatable {
   }
 
   // MARK: "Optional Computed State Binding" -
-
   // Similar to the previous construction, but the value returned is now optional and is the `Feature`
   // instance is created from a function of `Self`. We use the `shouldShowFeature5` flag to decide if the
   // property is nil or not. Because it has no private storage, the `feature5` instance is completly set
   // when accessed and the flag is enough to condition its existence and content without ambiguity.
-  fileprivate static let _feature5 = StateBinding<SharedStateWithBinding, FeatureState?>(with: {
-    $0.shouldShowFeature5
-      ? .init()
-      : nil
-  }
-  ) {
+  #if swift(>=5.4)
+  fileprivate static let _feature5 = StateBinding<SharedStateWithBinding, FeatureState?>(with:
+    { $0.shouldShowFeature5 ? .init() : nil }, properties: {
     (readonly: \.feature5Name, \.name)
-    (readOnly: \.isCountInternal, \.isCountInternal)
+    (readonly: \.isCountInternal, \.isCountInternal)
     (\.count, \.count)
+    
+    // Explicit declaration, equivalent to
+    // PropertyBinding(\.content, \.text) or (\.content, \.text)
+    PropertyBinding(
+      get: { src, dest in dest.text = src.content },
+      set: { src, dest in src.content = dest.text })
+  })
+  #else
+  fileprivate static let _feature5 = StateBinding<SharedStateWithBinding, FeatureState?>(with:
+    { $0.shouldShowFeature5 ? .init() : nil }) { [
+    PropertyBinding(readonly: \.feature5Name, \.name),
+    PropertyBinding(readonly: \.isCountInternal, \.isCountInternal),
+    PropertyBinding(\.count, \.count),
 
     // Explicit declaration, equivalent to
     // PropertyBinding(\.content, \.text) or (\.content, \.text)
-    PropertyBinding { src, dest in
-      dest.text = src.content
-    } set: { src, dest in
-      src.content = dest.text
-    }
-  }
+    PropertyBinding<SharedStateWithBinding, FeatureState>(
+      get: { src, dest in dest.text = src.content },
+      set: { src, dest in src.content = dest.text }),
+  ] }
+  #endif
 
   var feature5: FeatureState? {
     get { Self._feature5.get(self) }
@@ -135,15 +163,21 @@ struct SharedStateWithBinding: Equatable {
   }
 
   // MARK: "Computed State with deduplication" -
-
   // In this example similar to feature1, we avoid writing the private storage if the value is unchanged.
   // We also avoid to write `self.content` if it hasn't changed.
   fileprivate var _feature6: FeatureState = .init()
   // Will not update _feature6 if equal
+  #if swift(>=5.4)
   fileprivate static let _feature6 = StateBinding(\Self._feature6, removeDuplicateStorage: ==) {
     (readonly: \.feature6Name, \.name)
     (\.content, \.text, removeDuplicates: ==) // Will not set `content` if equal to `text`
   }
+  #else
+  fileprivate static let _feature6 = StateBinding(\Self._feature6, removeDuplicateStorage: ==) { [
+    PropertyBinding(readonly: \.feature6Name, \.name),
+    PropertyBinding(\.content, \.text, removeDuplicates: ==), // Will not set `content` if equal to `text`
+  ] }
+  #endif
 
   var feature6: FeatureState {
     get { Self._feature6.get(self) }
@@ -163,11 +197,9 @@ struct SharedStateWithBinding: Equatable {
 }
 
 // MARK: - Actions
-
 enum SharedStateWithBindingAction {
   enum FeatureAction {
-    case text(String)
-    case count(Int)
+    case binding(BindingAction<SharedStateWithBinding.FeatureState>)
   }
 
   case feature1(FeatureAction)
@@ -182,24 +214,13 @@ enum SharedStateWithBindingAction {
 }
 
 // MARK: - Reducers
+let boundFeatureReducer =
+  Reducer<SharedStateWithBinding.FeatureState, SharedStateWithBindingAction.FeatureAction, Void>
+    .empty
+    .binding(action: /SharedStateWithBindingAction.FeatureAction.binding)
 
-let boundFeatureReducer = Reducer<SharedStateWithBinding.FeatureState,
-  SharedStateWithBindingAction.FeatureAction,
-  Void> {
-  state, action, _ in
-  switch action {
-  case let .text(text):
-    state.text = text
-    return .none
-  case let .count(value):
-    state.count = value
-    return .none
-  }
-}
-
-let sharedStateWithBindingReducer = Reducer<SharedStateWithBinding,
-  SharedStateWithBindingAction,
-  Void>
+let sharedStateWithBindingReducer =
+  Reducer<SharedStateWithBinding, SharedStateWithBindingAction, Void>
   .combine(
     boundFeatureReducer.pullback(state: \.feature1,
                                  action: /SharedStateWithBindingAction.feature1,
@@ -254,13 +275,13 @@ struct SharedStateWithBindingView: View {
     WithViewStore(store) { viewStore in
       List {
         Section(header: Text(viewStore.feature1Name)) {
-          FeatureView(store: store.scope(state: \.feature1,
-                                         action: SharedStateWithBindingAction.feature1))
+          FeatureView(store: self.store.scope(state: { $0.feature1 },
+                                              action: SharedStateWithBindingAction.feature1))
         }
 
         Section(header: Text(viewStore.feature2Name)) {
-          FeatureView(store: store.scope(state: \.feature2,
-                                         action: SharedStateWithBindingAction.feature2))
+          FeatureView(store: self.store.scope(state: { $0.feature2 },
+                                              action: SharedStateWithBindingAction.feature2))
         }
 
         Section(header: Text(viewStore.feature3Name),
@@ -271,14 +292,15 @@ struct SharedStateWithBindingView: View {
                     : "Remove Feature"
                   )
                 }) {
-          IfLetStore(store.scope(state: \.feature3,
-                                 action: SharedStateWithBindingAction.feature3),
-                     then: FeatureView.init(store:))
+            IfLetStore(self.store.scope(state: { $0.feature3 },
+                                        action: SharedStateWithBindingAction.feature3),
+                                        then: FeatureView.init(store:)
+            )
         }
 
         Section(header: Text(viewStore.feature4Name)) {
-          FeatureView(store: store.scope(state: \.feature4,
-                                         action: SharedStateWithBindingAction.feature4))
+          FeatureView(store: self.store.scope(state: { $0.feature4 },
+                                              action: SharedStateWithBindingAction.feature4))
         }
 
         Section(header: Text(viewStore.feature5Name),
@@ -289,14 +311,16 @@ struct SharedStateWithBindingView: View {
                     : "Remove Feature"
                   )
                 }) {
-          IfLetStore(store.scope(state: \.feature5,
-                                 action: SharedStateWithBindingAction.feature5),
-                     then: FeatureView.init(store:))
+            IfLetStore(self.store.scope(state: { $0.feature5 },
+                                        action: SharedStateWithBindingAction.feature5),
+                                        then: FeatureView.init(store:)
+            )
         }
 
         Section(header: Text(viewStore.feature6Name)) {
-          FeatureView(store: store.scope(state: \.feature6,
-                                         action: SharedStateWithBindingAction.feature6))
+          FeatureView(store: self.store.scope(state: { $0.feature6 },
+                                              action: SharedStateWithBindingAction.feature6)
+          )
         }
       }
     }
@@ -305,19 +329,21 @@ struct SharedStateWithBindingView: View {
   }
 
   struct FeatureView: View {
-    let store: Store<SharedStateWithBinding.FeatureState, SharedStateWithBindingAction.FeatureAction>
+    typealias FeatureState = SharedStateWithBinding.FeatureState
+    typealias FeatureAction = SharedStateWithBindingAction.FeatureAction
+    let store: Store<FeatureState, FeatureAction>
     var body: some View {
       WithViewStore(store) { viewStore in
         VStack {
           HStack {
             TextField(viewStore.name,
-                      text: viewStore.binding(get: \.text,
-                                              send: SharedStateWithBindingAction.FeatureAction.text))
+                      text: viewStore.binding(keyPath: \.text, send: FeatureAction.binding))
               .textFieldStyle(RoundedBorderTextFieldStyle())
 
-            Stepper("\(viewStore.count)", value: viewStore.binding(get: \.count,
-                                                                   send: SharedStateWithBindingAction.FeatureAction.count),
-                    in: 0 ... 9).font(Font.system(.body).monospacedDigit())
+            Stepper("\(viewStore.count)",
+                    value: viewStore.binding(keyPath: \.count, send: FeatureAction.binding),
+                    in: 0...9)
+              .font(Font.system(.body).monospacedDigit())
               .fixedSize()
               .foregroundColor(viewStore.isCountInternal ? .red : .green)
           }
@@ -327,7 +353,7 @@ struct SharedStateWithBindingView: View {
             .foregroundColor(viewStore.isCountInternal ? .red : .green)
         }
         .id(viewStore.name)
-        .padding([.leading, .trailing])
+        .listRowInsets(EdgeInsets(top: 11, leading: 8, bottom: 8, trailing: 8))
       }
     }
   }
@@ -337,17 +363,8 @@ struct SharedStateWithBindingView: View {
 
 struct SharedStateWithBindingView_Previews: PreviewProvider {
   static var previews: some View {
-    SharedStateWithBindingView(store: .init(initialState: .init(), reducer: sharedStateWithBindingReducer, environment: ()))
+    SharedStateWithBindingView(store: .init(initialState: .init(),
+                                            reducer: sharedStateWithBindingReducer,
+                                            environment: ()))
   }
 }
-
-#else
-struct SharedStateWithBinding {}
-
-enum SharedStateWithBindingAction {
-  case noop
-}
-
-let sharedStateWithBindingReducer =
-  Reducer<SharedStateWithBinding, SharedStateWithBindingAction, Void> { _, _, _ in .none }
-#endif

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
@@ -9,9 +9,7 @@ deduplication if needed.
 It demonstrates several use cases, like sub-states with internal properties, optional sub-states or
 deduplicated sub-state setters.
 """
-
 struct SharedStateWithBinding: Equatable {
-    
     struct FeatureState: Equatable {
         var name: String = "" // Used for this case study presentation
         var isCountInternal: Bool = true // Used for this case study presentation
@@ -19,7 +17,7 @@ struct SharedStateWithBinding: Equatable {
         var text: String = ""
         var count: Int = 0
     }
-    
+
     // This value is shared across all features.
     var content: String = "Shared Content"
 
@@ -30,6 +28,7 @@ struct SharedStateWithBinding: Equatable {
     var shouldShowFeature5: Bool = false
 
     // MARK: Manual approach -
+
     // We create a FeatureState on the fly each time it is requested.
     // The global state needs to explicitly handle all FeatureState stored properties.
     // The setter need to by synchronized with the getter for all readwrite properties.
@@ -46,26 +45,35 @@ struct SharedStateWithBinding: Equatable {
     }
 
     // MARK: State Binding with internal storage -
+
     // A private instance of FeatureState is stored.
     // This instance will participate to state comparisons if any. In the binding, we only declare
     // the relevant property `name`, bound with `self.content`. The private instance stores all the
     // other internal properties.
     fileprivate var _feature2: FeatureState = .init()
     fileprivate static let _feature2 = StateBinding(\Self._feature2) {
+        #if swift(>=5.4)
         (readonly: \.feature2Name, \.name) // self.feature2Name -> feature2.name
         (\.content, \.text) // self.content and feature2.text are bound in both directions.
+        #else
+        return [
+            PropertyBinding(readonly: \.feature2Name, \.name), // self.feature2Name -> feature2.name
+            PropertyBinding(\.content, \.text) // self.content and feature2.text are bound in both directions.
+        ]
+        #endif
     }
 
     // Public accessor, proxying calls to the binding. The shape is always the same: One retrieves the
     // binding and call `get` with `self` to return an up-to-date value of FeatureState. In the setter,
-    // we also retrieve the binding, but we call this time `set` with a pointer to `self` and `newValue`. This
-    // function updates `self` accordingly.
+    // we also retrieve the binding, but we call this time `set` with a pointer to `self` and `newValue`.
+    // This function updates `self` accordingly.
     var feature2: FeatureState {
         get { Self._feature2.get(self) }
         set { Self._feature2.set(&self, newValue) }
     }
 
     // MARK: "Optional State Binding with internal storage" -
+
     // A optional private instance of FeatureState is stored.
     // This instance will participate to state comparisons if any. In the binding, we only declare
     // the relevant property `name`, bound with `self.content`. The private instance stores all the
@@ -73,10 +81,19 @@ struct SharedStateWithBinding: Equatable {
     // publicly accessed property. Please note that the `PropertyBindings` a defined between unwrapped
     // values.
     fileprivate var _feature3: FeatureState?
+    #if swift(>=5.4)
     fileprivate static let _feature3 = StateBinding(\Self._feature3) {
         (readonly: \.feature3Name, \.name)
         (\.content, \.text)
     }
+    #else
+    fileprivate static let _feature3 = StateBinding(optional: \Self._feature3) {
+        [
+            PropertyBinding(readonly: \.feature3Name, \.name),
+            PropertyBinding(\.content, \.text)
+        ]
+    }
+    #endif
 
     /// Public accessor, same shape as `feature2`, but optional.
     var feature3: FeatureState? {
@@ -85,15 +102,25 @@ struct SharedStateWithBinding: Equatable {
     }
 
     // MARK: "Computed State Binding" -
+
     // This instance doesn't have internal properties (or they stay to their default value otherwise)
     // All the properties of `Feature` are bound to some property of `self`. A new instance is created
     // from the provided `with:` argument. We use `Self.self` because we need to tie the first generic
     // parameter of `StateBinding` to `Self`.
     fileprivate static let _feature4 = StateBinding(Self.self, with: FeatureState.init) {
+        #if swift(>=5.4)
         (readonly: \.feature4Name, \.name)
         (readOnly: \.isCountInternal, \.isCountInternal)
         (\.content, \.text)
         (\.count, \.count)
+        #else
+        return [
+            PropertyBinding(readonly: \.feature4Name, \.name),
+            PropertyBinding(readonly: \.isCountInternal, \.isCountInternal),
+            PropertyBinding(\.content, \.text),
+            PropertyBinding(\.count, \.count)
+        ]
+        #endif
     }
 
     var feature4: FeatureState {
@@ -102,15 +129,18 @@ struct SharedStateWithBinding: Equatable {
     }
 
     // MARK: "Optional Computed State Binding" -
+
     // Similar to the previous construction, but the value returned is now optional and is the `Feature`
     // instance is created from a function of `Self`. We use the `shouldShowFeature5` flag to decide if the
     // property is nil or not. Because it has no private storage, the `feature5` instance is completly set
     // when accessed and the flag is enough to condition its existence and content without ambiguity.
     fileprivate static let _feature5 = StateBinding<SharedStateWithBinding, FeatureState?>(with: {
-                                                                                            $0.shouldShowFeature5
-                                                                                            ? .init()
-                                                                                            : nil }
+        $0.shouldShowFeature5
+            ? .init()
+            : nil
+    }
     ) {
+        #if swift(>=5.4)
         (readonly: \.feature5Name, \.name)
         (readOnly: \.isCountInternal, \.isCountInternal)
         (\.count, \.count)
@@ -122,6 +152,21 @@ struct SharedStateWithBinding: Equatable {
         } set: { src, dest in
             src.content = dest.text
         }
+        #else
+        return [
+            PropertyBinding(readonly: \.feature5Name, \.name),
+            PropertyBinding(readonly: \.isCountInternal, \.isCountInternal),
+            PropertyBinding(\.count, \.count),
+
+            // Explicit declaration, equivalent to
+            // PropertyBinding(\.content, \.text) or (\.content, \.text)
+            PropertyBinding<Self, FeatureState> { src, dest in
+                dest.text = src.content
+            } set: { src, dest in
+                src.content = dest.text
+            }
+        ]
+        #endif
     }
 
     var feature5: FeatureState? {
@@ -130,21 +175,30 @@ struct SharedStateWithBinding: Equatable {
     }
 
     // MARK: "Computed State with deduplication" -
-    // In this example similar to feature1, we avoid writing the private storage if the value is unchanged.
+
+    // In this example similar to feature2, we avoid writing the private storage if the value is unchanged.
     // We also avoid to write `self.content` if it hasn't changed.
     fileprivate var _feature6: FeatureState = .init()
     // Will not update _feature6 if equal
     fileprivate static let _feature6 = StateBinding(\Self._feature6, removeDuplicateStorage: ==) {
+        #if swift(>=5.4)
         (readonly: \.feature6Name, \.name)
         (\.content, \.text, removeDuplicates: ==) // Will not set `content` if equal to `text`
+        #else
+        return [
+            PropertyBinding(readonly: \.feature6Name, \.name),
+            PropertyBinding(\.content, \.text, removeDuplicates: ==) // Will not set `content` if equal to `text`
+        ]
+        #endif
     }
 
     var feature6: FeatureState {
         get { Self._feature6.get(self) }
         set { Self._feature6.set(&self, newValue) }
     }
-    
+
     // MARK: Internal
+
     // Used for this case study presentation
     var feature1Name = "Manual binding"
     var feature2Name = "State Binding with internal storage"
@@ -156,12 +210,13 @@ struct SharedStateWithBinding: Equatable {
 }
 
 // MARK: - Actions
+
 enum SharedStateWithBindingAction {
     enum FeatureAction {
         case text(String)
         case count(Int)
     }
-    
+
     case feature1(FeatureAction)
     case feature2(FeatureAction)
     case feature3(FeatureAction)
@@ -272,14 +327,15 @@ struct SharedStateWithBindingView: View {
                     FeatureView(store: store.scope(state: \.feature4,
                                                    action: SharedStateWithBindingAction.feature4))
                 }
-                
+
                 Section(header: Text(viewStore.feature5Name),
                         footer:
                         Button(action: { viewStore.send(.toggleFeature5, animation: .default) }) {
                             Text(viewStore.feature5 == nil
                                 ? "Install Optional Feature"
                                 : "Remove Feature"
-                            )}) {
+                            )
+                        }) {
                     IfLetStore(store.scope(state: \.feature5,
                                            action: SharedStateWithBindingAction.feature5),
                                then: FeatureView.init(store:))
@@ -305,7 +361,7 @@ struct SharedStateWithBindingView: View {
                                   text: viewStore.binding(get: \.text,
                                                           send: SharedStateWithBindingAction.FeatureAction.text))
                             .textFieldStyle(RoundedBorderTextFieldStyle())
-                        
+
                         Stepper("\(viewStore.count)", value: viewStore.binding(get: \.count,
                                                                                send: SharedStateWithBindingAction.FeatureAction.count),
                                 in: 0 ... 9).font(Font.system(.body).monospacedDigit())

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
@@ -112,10 +112,8 @@ struct SharedStateWithBinding: Equatable {
     .rw(\.count, \.count)
     // Explicit declaration, equivalent to .rw(\.content, \.text)
     .with(
-      .init(
-        get: { src, dest in dest.text = src.content },
-        set: { src, dest in src.content = dest.text }
-      )
+      get: { src, dest in dest.text = src.content },
+      set: { src, dest in src.content = dest.text }
     )
 
   var feature5: FeatureState? {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
@@ -9,7 +9,9 @@ deduplication if needed.
 It demonstrates several use cases, like sub-states with internal properties, optional sub-states or
 deduplicated sub-state setters.
 """
+
 struct SharedStateWithBinding: Equatable {
+    
     struct FeatureState: Equatable {
         var name: String = "" // Used for this case study presentation
         var isCountInternal: Bool = true // Used for this case study presentation
@@ -17,7 +19,7 @@ struct SharedStateWithBinding: Equatable {
         var text: String = ""
         var count: Int = 0
     }
-
+    
     // This value is shared across all features.
     var content: String = "Shared Content"
 
@@ -28,7 +30,6 @@ struct SharedStateWithBinding: Equatable {
     var shouldShowFeature5: Bool = false
 
     // MARK: Manual approach -
-
     // We create a FeatureState on the fly each time it is requested.
     // The global state needs to explicitly handle all FeatureState stored properties.
     // The setter need to by synchronized with the getter for all readwrite properties.
@@ -45,35 +46,26 @@ struct SharedStateWithBinding: Equatable {
     }
 
     // MARK: State Binding with internal storage -
-
     // A private instance of FeatureState is stored.
     // This instance will participate to state comparisons if any. In the binding, we only declare
     // the relevant property `name`, bound with `self.content`. The private instance stores all the
     // other internal properties.
     fileprivate var _feature2: FeatureState = .init()
     fileprivate static let _feature2 = StateBinding(\Self._feature2) {
-        #if swift(>=5.4)
         (readonly: \.feature2Name, \.name) // self.feature2Name -> feature2.name
         (\.content, \.text) // self.content and feature2.text are bound in both directions.
-        #else
-        return [
-            PropertyBinding(readonly: \.feature2Name, \.name), // self.feature2Name -> feature2.name
-            PropertyBinding(\.content, \.text) // self.content and feature2.text are bound in both directions.
-        ]
-        #endif
     }
 
     // Public accessor, proxying calls to the binding. The shape is always the same: One retrieves the
     // binding and call `get` with `self` to return an up-to-date value of FeatureState. In the setter,
-    // we also retrieve the binding, but we call this time `set` with a pointer to `self` and `newValue`.
-    // This function updates `self` accordingly.
+    // we also retrieve the binding, but we call this time `set` with a pointer to `self` and `newValue`. This
+    // function updates `self` accordingly.
     var feature2: FeatureState {
         get { Self._feature2.get(self) }
         set { Self._feature2.set(&self, newValue) }
     }
 
     // MARK: "Optional State Binding with internal storage" -
-
     // A optional private instance of FeatureState is stored.
     // This instance will participate to state comparisons if any. In the binding, we only declare
     // the relevant property `name`, bound with `self.content`. The private instance stores all the
@@ -81,19 +73,10 @@ struct SharedStateWithBinding: Equatable {
     // publicly accessed property. Please note that the `PropertyBindings` a defined between unwrapped
     // values.
     fileprivate var _feature3: FeatureState?
-    #if swift(>=5.4)
     fileprivate static let _feature3 = StateBinding(\Self._feature3) {
         (readonly: \.feature3Name, \.name)
         (\.content, \.text)
     }
-    #else
-    fileprivate static let _feature3 = StateBinding(optional: \Self._feature3) {
-        [
-            PropertyBinding(readonly: \.feature3Name, \.name),
-            PropertyBinding(\.content, \.text)
-        ]
-    }
-    #endif
 
     /// Public accessor, same shape as `feature2`, but optional.
     var feature3: FeatureState? {
@@ -102,25 +85,15 @@ struct SharedStateWithBinding: Equatable {
     }
 
     // MARK: "Computed State Binding" -
-
     // This instance doesn't have internal properties (or they stay to their default value otherwise)
     // All the properties of `Feature` are bound to some property of `self`. A new instance is created
     // from the provided `with:` argument. We use `Self.self` because we need to tie the first generic
     // parameter of `StateBinding` to `Self`.
     fileprivate static let _feature4 = StateBinding(Self.self, with: FeatureState.init) {
-        #if swift(>=5.4)
         (readonly: \.feature4Name, \.name)
         (readOnly: \.isCountInternal, \.isCountInternal)
         (\.content, \.text)
         (\.count, \.count)
-        #else
-        return [
-            PropertyBinding(readonly: \.feature4Name, \.name),
-            PropertyBinding(readonly: \.isCountInternal, \.isCountInternal),
-            PropertyBinding(\.content, \.text),
-            PropertyBinding(\.count, \.count)
-        ]
-        #endif
     }
 
     var feature4: FeatureState {
@@ -129,18 +102,15 @@ struct SharedStateWithBinding: Equatable {
     }
 
     // MARK: "Optional Computed State Binding" -
-
     // Similar to the previous construction, but the value returned is now optional and is the `Feature`
     // instance is created from a function of `Self`. We use the `shouldShowFeature5` flag to decide if the
     // property is nil or not. Because it has no private storage, the `feature5` instance is completly set
     // when accessed and the flag is enough to condition its existence and content without ambiguity.
     fileprivate static let _feature5 = StateBinding<SharedStateWithBinding, FeatureState?>(with: {
-        $0.shouldShowFeature5
-            ? .init()
-            : nil
-    }
+                                                                                            $0.shouldShowFeature5
+                                                                                            ? .init()
+                                                                                            : nil }
     ) {
-        #if swift(>=5.4)
         (readonly: \.feature5Name, \.name)
         (readOnly: \.isCountInternal, \.isCountInternal)
         (\.count, \.count)
@@ -152,21 +122,6 @@ struct SharedStateWithBinding: Equatable {
         } set: { src, dest in
             src.content = dest.text
         }
-        #else
-        return [
-            PropertyBinding(readonly: \.feature5Name, \.name),
-            PropertyBinding(readonly: \.isCountInternal, \.isCountInternal),
-            PropertyBinding(\.count, \.count),
-
-            // Explicit declaration, equivalent to
-            // PropertyBinding(\.content, \.text) or (\.content, \.text)
-            PropertyBinding<Self, FeatureState> { src, dest in
-                dest.text = src.content
-            } set: { src, dest in
-                src.content = dest.text
-            }
-        ]
-        #endif
     }
 
     var feature5: FeatureState? {
@@ -175,30 +130,21 @@ struct SharedStateWithBinding: Equatable {
     }
 
     // MARK: "Computed State with deduplication" -
-
-    // In this example similar to feature2, we avoid writing the private storage if the value is unchanged.
+    // In this example similar to feature1, we avoid writing the private storage if the value is unchanged.
     // We also avoid to write `self.content` if it hasn't changed.
     fileprivate var _feature6: FeatureState = .init()
     // Will not update _feature6 if equal
     fileprivate static let _feature6 = StateBinding(\Self._feature6, removeDuplicateStorage: ==) {
-        #if swift(>=5.4)
         (readonly: \.feature6Name, \.name)
         (\.content, \.text, removeDuplicates: ==) // Will not set `content` if equal to `text`
-        #else
-        return [
-            PropertyBinding(readonly: \.feature6Name, \.name),
-            PropertyBinding(\.content, \.text, removeDuplicates: ==) // Will not set `content` if equal to `text`
-        ]
-        #endif
     }
 
     var feature6: FeatureState {
         get { Self._feature6.get(self) }
         set { Self._feature6.set(&self, newValue) }
     }
-
+    
     // MARK: Internal
-
     // Used for this case study presentation
     var feature1Name = "Manual binding"
     var feature2Name = "State Binding with internal storage"
@@ -210,13 +156,12 @@ struct SharedStateWithBinding: Equatable {
 }
 
 // MARK: - Actions
-
 enum SharedStateWithBindingAction {
     enum FeatureAction {
         case text(String)
         case count(Int)
     }
-
+    
     case feature1(FeatureAction)
     case feature2(FeatureAction)
     case feature3(FeatureAction)
@@ -327,15 +272,14 @@ struct SharedStateWithBindingView: View {
                     FeatureView(store: store.scope(state: \.feature4,
                                                    action: SharedStateWithBindingAction.feature4))
                 }
-
+                
                 Section(header: Text(viewStore.feature5Name),
                         footer:
                         Button(action: { viewStore.send(.toggleFeature5, animation: .default) }) {
                             Text(viewStore.feature5 == nil
                                 ? "Install Optional Feature"
                                 : "Remove Feature"
-                            )
-                        }) {
+                            )}) {
                     IfLetStore(store.scope(state: \.feature5,
                                            action: SharedStateWithBindingAction.feature5),
                                then: FeatureView.init(store:))
@@ -361,7 +305,7 @@ struct SharedStateWithBindingView: View {
                                   text: viewStore.binding(get: \.text,
                                                           send: SharedStateWithBindingAction.FeatureAction.text))
                             .textFieldStyle(RoundedBorderTextFieldStyle())
-
+                        
                         Stepper("\(viewStore.count)", value: viewStore.binding(get: \.count,
                                                                                send: SharedStateWithBindingAction.FeatureAction.count),
                                 in: 0 ... 9).font(Font.system(.body).monospacedDigit())

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
@@ -130,7 +130,7 @@ struct SharedStateWithBinding: Equatable {
   // when accessed and the flag is enough to condition its existence and content without ambiguity.
   #if swift(>=5.4)
   fileprivate static let _feature5 = StateBinding<SharedStateWithBinding, FeatureState?>(with:
-    { $0.shouldShowFeature5 ? .init() : nil }, properties: {
+    { $0.shouldShowFeature5 ? .init() : nil }) {
     (readonly: \.feature5Name, \.name)
     (readonly: \.isCountInternal, \.isCountInternal)
     (\.count, \.count)
@@ -139,8 +139,9 @@ struct SharedStateWithBinding: Equatable {
     // PropertyBinding(\.content, \.text) or (\.content, \.text)
     PropertyBinding(
       get: { src, dest in dest.text = src.content },
-      set: { src, dest in src.content = dest.text })
-  })
+      set: { src, dest in src.content = dest.text }
+    )
+  }
   #else
   fileprivate static let _feature5 = StateBinding<SharedStateWithBinding, FeatureState?>(with:
     { $0.shouldShowFeature5 ? .init() : nil }) { [
@@ -152,7 +153,8 @@ struct SharedStateWithBinding: Equatable {
     // PropertyBinding(\.content, \.text) or (\.content, \.text)
     PropertyBinding<SharedStateWithBinding, FeatureState>(
       get: { src, dest in dest.text = src.content },
-      set: { src, dest in src.content = dest.text }),
+      set: { src, dest in src.content = dest.text }
+    ),
   ] }
   #endif
 
@@ -343,13 +345,13 @@ struct SharedStateWithBindingView: View {
                     value: viewStore.binding(keyPath: \.count, send: FeatureAction.binding),
                     in: 0...9)
               .font(Font.system(.body).monospacedDigit())
-              .fixedSize()
               .foregroundColor(viewStore.isCountInternal ? .red : .green)
+              .fixedSize()
           }
           Text("\"count\" value is \(viewStore.isCountInternal ? "internal" : "global")")
             .font(.footnote)
-            .frame(maxWidth: .infinity, alignment: .trailing)
             .foregroundColor(viewStore.isCountInternal ? .red : .green)
+            .frame(maxWidth: .infinity, alignment: .trailing)
         }
         .id(viewStore.name)
         .listRowInsets(EdgeInsets(top: 11, leading: 8, bottom: 8, trailing: 8))

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
@@ -159,11 +159,12 @@ struct SharedStateWithBinding: Equatable {
             PropertyBinding(\.count, \.count),
 
             // Explicit declaration, equivalent to
-            // PropertyBinding(\.content, \.text)
-            PropertyBinding<Self, FeatureState>(
-              get: { src, dest in dest.text = src.content },
-              set: { src, dest in src.content = dest.text }
-            )
+            // PropertyBinding(\.content, \.text) or (\.content, \.text)
+            PropertyBinding<Self, FeatureState> { src, dest in
+                dest.text = src.content
+            } set: { src, dest in
+                src.content = dest.text
+            }
         ]
         #endif
     }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState-StateBindings.swift
@@ -159,12 +159,11 @@ struct SharedStateWithBinding: Equatable {
             PropertyBinding(\.count, \.count),
 
             // Explicit declaration, equivalent to
-            // PropertyBinding(\.content, \.text) or (\.content, \.text)
-            PropertyBinding<Self, FeatureState> { src, dest in
-                dest.text = src.content
-            } set: { src, dest in
-                src.content = dest.text
-            }
+            // PropertyBinding(\.content, \.text)
+            PropertyBinding<Self, FeatureState>(
+              get: { src, dest in dest.text = src.content },
+              set: { src, dest in src.content = dest.text }
+            )
         ]
         #endif
     }

--- a/Examples/CaseStudies/SwiftUICaseStudies/Internal/StateBinding.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/Internal/StateBinding.swift
@@ -1,65 +1,3 @@
-
-/// A struct that describe a directional binding between instances of `Source` and `Destination`. It's main
-/// use is to describe a connection between a property of `Source` and a property of `Destination` when
-/// using `BoundState`, `OptionalBoundState`, `ComputedState` or `ComputedOptionalState`
-public struct PropertyBinding<Source, Destination> {
-  let get: (Source, inout Destination) -> Void
-  let set: (inout Source, Destination) -> Void
-  /// Initialize a binding between a `Source` instance and a`Destination` instance.
-  /// - Parameters:
-  ///   - get: A function applied when `Destination` is requested from `Source`. The `Destination`
-  ///   instance can be updated at this point.
-  ///   - set: A function applied when `Destination` is set in `Source`. The `Source` instance can be
-  ///   updated at this point.
-  public init(
-    get: @escaping (Source, inout Destination) -> Void = { _, _ in },
-    set: @escaping (inout Source, Destination) -> Void = { _, _ in }
-  ) {
-    self.get = get
-    self.set = set
-  }
-
-  /// Initialized a `PropertyBinding` using a couble of `KeyPath` describing a similar property in
-  /// `Source` and `Destination`.
-  /// - Parameters:
-  ///   - sourceValue: A `KeyPath` to get and set `Value` in `Source`
-  ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
-  ///   - removeDuplicates: Used when the `Value` is set on `Source`. If this function is implemented
-  ///     and returns `true`, no assignation will occur and `Source` will be kept untouched.
-  public init<Value>(
-    _ sourceValue: WritableKeyPath<Source, Value>,
-    _ destinationValue: WritableKeyPath<Destination, Value>,
-    removeDuplicates: ((Value, Value) -> Bool)? = nil
-  ) {
-    self.get = { source, destination in
-      destination[keyPath: destinationValue] = source[keyPath: sourceValue]
-    }
-
-    self.set = { source, destination in
-      guard removeDuplicates?(source[keyPath: sourceValue], destination[keyPath: destinationValue]) != true
-      else { return }
-      source[keyPath: sourceValue] = destination[keyPath: destinationValue]
-    }
-  }
-
-  /// Initialized a `PropertyBinding` using a couble of `KeyPath` describing a similar property in
-  /// `Source` and `Destination`. This binding is unidirectional (readonly on Source )and the
-  /// `KeyPath<Source, Value` doesn't need to be writable.
-  /// - Parameters:
-  ///   - sourceValue: A `KeyPath` to get `Value` in `Source`
-  ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
-  public init<Value>(
-    readonly sourceValue: KeyPath<Source, Value>,
-    _ destinationValue: WritableKeyPath<Destination, Value>
-  ) {
-    self.get = { source, destination in
-      destination[keyPath: destinationValue] = source[keyPath: sourceValue]
-    }
-    self.set = { _, _ in
-    }
-  }
-}
-
 /// Describe a binding between a parent state `Source` and a child state `Destination`. Several initializer are
 /// provided to handle the following cases:
 /// - Synchronization of a subset of `Destination` properties with `Source`
@@ -101,7 +39,6 @@ public struct StateBinding<Source, Destination> {
   public let set: (_ source: inout Source, _ newValue: Destination) -> Void
 }
 
-#if swift(>=5.4)
 public extension StateBinding {
   /// Initialize a binding between a parent state `Source` and a child state `Destination`.
   /// A private storage for a `Source` is provided so unaffected properties are preserved between accesses.
@@ -111,43 +48,17 @@ public extension StateBinding {
   ///   - storage: A writable (private) keyPath to an instance of `Destination`, used to store
   ///   `Destination`'s internal properties.
   ///   - removeDuplicateStorage: A function used to compare private storage and avoid setting it in `Source` if unnecessary
-  ///   - properties: A function that returns an array of `PropertyBinding<Source, Destination>`
-  init(
-    _ storage: WritableKeyPath<Source, Destination>,
-    removeDuplicateStorage: ((Destination, Destination) -> Bool)? = nil,
-    @PropertyBindingsBuilder <Source, Destination> properties: () -> [PropertyBinding<Source, Destination>]
-  ) {
-    self = .init(_storage: storage, removeDuplicateStorage: removeDuplicateStorage, properties: properties)
-  }
-  
-  /// Initialize a binding between a parent state `Source` and a child state `Destination`.
-  /// A private storage for a `Source` is provided so unaffected properties are preserved between accesses.
-  /// In other words, `Destination` can have private fields and only properties specified in `properties`
-  /// are synchronized with `Source`.
-  /// - Parameters:
-  ///   - storage: A writable (private) keyPath to an instance of `Destination`, used to store
-  ///   `Destination`'s internal properties.
-  ///   - properties: A function that returns an array of `PropertyBinding<Source, Destination>`
-  /// Remark: this function is defined to maintain trailing closure syntax between Swift 5.3 and earlier versions.
-  init(
-    _ storage: WritableKeyPath<Source, Destination>,
-    @PropertyBindingsBuilder <Source, Destination> properties: () -> [PropertyBinding<Source, Destination>]
-  ) {
-    self = .init(storage, removeDuplicateStorage: nil, properties: properties)
-  }
-
-  /// Initialize a  computed binding between a parent state `Source` and a child state `Destination`. These derived states
-  /// are used when all the properties of `Destination` can be individually stored in `Source`.
-  /// - Parameters:
-  ///   - source: The `Source`'s or parent state type
-  ///   - destination: A function that returns an default instance of `Destination` (the child state)
-  ///   - properties: A function that returns an array of `PropertyBinding<Source, Destination>`
-  init(
-    _ source: Source.Type,
-    with destination: @escaping () -> Destination,
-    @PropertyBindingsBuilder <Source, Destination> properties: () -> [PropertyBinding<Source, Destination>]
-  ) {
-    self = .init(_source: source, with: destination, properties: properties)
+  init(_ storage: WritableKeyPath<Source, Destination>,
+       removeDuplicateStorage: ((Destination, Destination) -> Bool)? = nil)
+  {
+    get = { source in
+      source[keyPath: storage]
+    }
+    set = { source, newValue in
+      if removeDuplicateStorage?(source[keyPath: storage], newValue) != true {
+        source[keyPath: storage] = newValue
+      }
+    }
   }
 
   /// Initialize a binding between a parent state `Source` and a child state `Destination`.
@@ -158,29 +69,16 @@ public extension StateBinding {
   ///   - storage: A writable (private) keyPath to an instance of `Destination?`, used to store
   ///   `Destination`'s internal properties. If this instance is nil, the computed property will be also nil.
   ///   - removeDuplicateStorage: A function used to compare private storage and avoid setting it in `Source` if unnecessary
-  ///   - properties: A function that returns an array of `PropertyBinding<Source, Destination>`
   init<UnwrappedDestination>(
     _ storage: WritableKeyPath<Source, Destination>,
-    removeDuplicateStorage: ((Destination, Destination) -> Bool)? = nil,
-    @PropertyBindingsBuilder <Source, UnwrappedDestination> properties: () -> [PropertyBinding<Source, UnwrappedDestination>]
+    removeDuplicateStorage: ((Destination, Destination) -> Bool)? = nil
   ) where Destination == UnwrappedDestination? {
-    self = .init(_storage: storage, removeDuplicateStorage: removeDuplicateStorage, properties: properties)
-  }
-  
-  /// Initialize a binding between a parent state `Source` and a child state `Destination`.
-  /// A private storage for an optional `Source` is provided so unaffected properties are preserved between accesses.
-  /// In other words, `Destination` can have private fields and only properties specified in `properties` are synchronized
-  /// with `Source`. If the child is set to nil, source properties other than the storage property are kept untouched
-  /// - Parameters:
-  ///   - storage: A writable (private) keyPath to an instance of `Destination?`, used to store
-  ///   `Destination`'s internal properties. If this instance is nil, the computed property will be also nil.
-  ///   - removeDuplicateStorage: A function used to compare private storage and avoid setting it in `Source` if unnecessary
-  ///   - properties: A function that returns an array of `PropertyBinding<Source, Destination>`
-  init<UnwrappedDestination>(
-    _ storage: WritableKeyPath<Source, Destination>,
-    @PropertyBindingsBuilder <Source, UnwrappedDestination> properties: () -> [PropertyBinding<Source, UnwrappedDestination>]
-  ) where Destination == UnwrappedDestination? {
-    self = .init(_storage: storage, removeDuplicateStorage: nil, properties: properties)
+    get = { $0[keyPath: storage] }
+    set = { source, newValue in
+      if removeDuplicateStorage?(source[keyPath: storage], newValue) != true {
+        source[keyPath: storage] = newValue
+      }
+    }
   }
 
   /// Initialize a  computed binding between a parent state `Source` and an optional child state `Destination`
@@ -188,203 +86,194 @@ public extension StateBinding {
   /// If the child is set to nil, the source properties are kept untouched
   /// - Parameters:
   ///   - destination: A function that returns an default instance of `Destination`(the child state) or nil.
-  ///   - properties: A function that returns an array of `PropertyBinding<Source, Destination>`
   init<UnwrappedDestination>(
-    with destination: @escaping (Source) -> Destination,
-    @PropertyBindingsBuilder <Source, UnwrappedDestination> properties: () -> [PropertyBinding<Source, UnwrappedDestination>] = { [] }
+    with destination: @escaping (Source) -> Destination
   ) where Destination == UnwrappedDestination? {
-    self = .init(_with: destination, properties: properties)
+    get = destination
+    set = { _, _ in () }
+  }
+
+  /// Initialize a  computed binding between a parent state `Source` and a child state `Destination`. These derived states
+  /// are used when all the properties of `Destination` can be individually stored in `Source`.
+  /// - Parameters:
+  ///   - source: The `Source`'s or parent state type
+  ///   - destination: A function that returns an default instance of `Destination` (the child state)
+  init(
+    _ source: Source.Type,
+    with destination: @escaping () -> Destination
+  ) {
+    get = { _ in destination() }
+    set = { _, _ in () }
   }
 }
 
-@resultBuilder public enum PropertyBindingsBuilder<Source, Destination> {
-  /// Initialize a `PropertyBinding<Source, Destination>` from a couple of `WritableKeyPath`
-  public static func buildExpression<Value>(_ expression: (WritableKeyPath<Source, Value>, WritableKeyPath<Destination, Value>)
-  ) -> [PropertyBinding<Source, Destination>] {
-    [PropertyBinding(expression.0, expression.1)]
-  }
-
-  /// Initialize a readonly `PropertyBinding<Source, Destination>` from a couple`(KeyPath,WritableKeyPath)`.
-  public static func buildExpression<Value>(readonly expression: (KeyPath<Source, Value>, WritableKeyPath<Destination, Value>)
-  ) -> [PropertyBinding<Source, Destination>] {
-    [PropertyBinding(readonly: expression.0, expression.1)]
-  }
-
-  /// Initialize a  deduplicating`PropertyBinding<Source, Destination>` from a couple of `WritableKeyPath<_, Value>`
-  /// and a function `(Value, Value) -> Bool` which returns `true` when both argurments are duplicates.
-  public static func buildExpression<Value>(_ expression: (WritableKeyPath<Source, Value>, WritableKeyPath<Destination, Value>, (Value, Value) -> Bool)
-  ) -> [PropertyBinding<Source, Destination>] {
-    [PropertyBinding(expression.0, expression.1, removeDuplicates: expression.2)]
-  }
-
-  public static func buildExpression(_ expression: PropertyBinding<Source, Destination>) -> [PropertyBinding<Source, Destination>] {
-    [expression]
-  }
-  
-  public static func buildExpression(_ expression: [PropertyBinding<Source, Destination>]) -> [PropertyBinding<Source, Destination>] {
-    expression
-  }
-
-  public static func buildBlock(_ components: [PropertyBinding<Source, Destination>]...) -> [PropertyBinding<Source, Destination>] {
-    components.flatMap { $0 }
-  }
-
-  public static func buildArray(_ components: [[PropertyBinding<Source, Destination>]]) -> [PropertyBinding<Source, Destination>] {
-    components.flatMap { $0 }
-  }
-
-  public static func buildEither(first component: [PropertyBinding<Source, Destination>]) -> [PropertyBinding<Source, Destination>] {
-    component
-  }
-
-  public static func buildEither(second component: [PropertyBinding<Source, Destination>]) -> [PropertyBinding<Source, Destination>] {
-    component
-  }
-
-  public static func buildOptional(_ component: [PropertyBinding<Source, Destination>]?) -> [PropertyBinding<Source, Destination>] {
-    component ?? []
-  }
-}
-
-#else
 public extension StateBinding {
-  /// Initialize a binding between a parent state `Source` and a child state `Destination`.
-  /// A private storage for a `Source` is provided so unaffected properties are preserved between accesses.
-  /// In other words, `Destination` can have private fields and only properties specified in `properties`
-  /// are synchronized with `Source`.
-  /// - Parameters:
-  ///   - storage: A writable (private) keyPath to an instance of `Destination`, used to store
-  ///   `Destination`'s internal properties.
-  ///   - removeDuplicateStorage: A function used to compare private storage and avoid setting it in `Source` if unnecessary
-  ///   - properties: A function that returns an array of `PropertyBinding<Source, Destination>`
-   init(
-    _ storage: WritableKeyPath<Source, Destination>,
-    removeDuplicateStorage: ((Destination, Destination) -> Bool)? = nil,
-    properties: () -> [PropertyBinding<Source, Destination>]
-  ) {
-    self = .init(_storage: storage, removeDuplicateStorage: removeDuplicateStorage, properties: properties)
+  /// Returns a modified `StateBinding`using a couble of `PropertyBinding`  to bind similar
+  /// properties in `Source` and `Destination`.
+  func with(_ propertyBinding: PropertyBinding<Source, Destination>) -> Self {
+    let get: (Source) -> Destination = { source in
+      var destination = self.get(source)
+      propertyBinding.get(source, &destination)
+      return destination
+    }
+    let set: (inout Source, Destination) -> Void = { source, destination in
+      self.set(&source, destination)
+      propertyBinding.set(&source, destination)
+    }
+    return .init(get: get, set: set)
   }
 
-  /// Initialize a  computed binding between a parent state `Source` and a child state `Destination`. These derived states
-  /// are used when all the properties of `Destination` can be individually stored in `Source`.
-  /// - Parameters:
-  ///   - source: The `Source`'s or parent state type
-  ///   - destination: A function that returns an default instance of `Destination` (the child state)
-  ///   - properties: A function that returns an array of `PropertyBinding<Source, Destination>`
-  init(
-    _ source: Source.Type,
-    with destination: @escaping () -> Destination,
-    properties: () -> [PropertyBinding<Source, Destination>]
-  ) {
-    self = .init(_source: source, with: destination, properties: properties)
-  }
-
-  /// Initialize a binding between a parent state `Source` and a child state `Destination`.
-  /// A private storage for an optional `Source` is provided so unaffected properties are preserved between accesses.
-  /// In other words, `Destination` can have private fields and only properties specified in `properties` are synchronized
-  /// with `Source`. If the child is set to nil, source properties other than the storage property are kept untouched
-  /// - Parameters:
-  ///   - storage: A writable (private) keyPath to an instance of `Destination?`, used to store
-  ///   `Destination`'s internal properties. If this instance is nil, the computed property will be also nil.
-  ///   - removeDuplicateStorage: A function used to compare private storage and avoid setting it in `Source` if unnecessary
-  ///   - properties: A function that returns an array of `PropertyBinding<Source, Destination>`
-  init<UnwrappedDestination>(
-    _ storage: WritableKeyPath<Source, Destination>,
-    removeDuplicateStorage: ((Destination, Destination) -> Bool)? = nil,
-    properties: () -> [PropertyBinding<Source, UnwrappedDestination>]
-  ) where Destination == UnwrappedDestination? {
-    self = .init(_storage: storage, removeDuplicateStorage: removeDuplicateStorage, properties: properties)
-  }
-
-  /// Initialize a  computed binding between a parent state `Source` and an optional child state `Destination`
-  /// These derived states are used when all the properties of `Destination` can be individually stored in `Source`.
-  /// If the child is set to nil, the source properties are kept untouched
-  /// - Parameters:
-  ///   - destination: A function that returns an default instance of `Destination`(the child state) or nil.
-  ///   - properties: A function that returns an array of `PropertyBinding<Source, Destination>`
-  init<UnwrappedDestination>(
-    with destination: @escaping (Source) -> Destination,
-    properties: () -> [PropertyBinding<Source, UnwrappedDestination>] = { [] }
-  ) where Destination == UnwrappedDestination? {
-    self = .init(_with: destination, properties: properties)
+  /// Returns a modified `StateBinding`using a couble of `PropertyBinding` to bind similar
+  /// properties in `Source` and `Destination.Wrapped`.
+  func with<UnwrappedDestination>(_ propertyBinding: PropertyBinding<Source, UnwrappedDestination>) -> Self
+    where Destination == UnwrappedDestination?
+  {
+    let get: (Source) -> Destination = { source in
+      guard var destination = self.get(source) else { return nil }
+      propertyBinding.get(source, &destination)
+      return destination
+    }
+    let set: (inout Source, Destination) -> Void = { source, destination in
+      self.set(&source, destination)
+      guard let destination = destination else { return }
+      propertyBinding.set(&source, destination)
+    }
+    return .init(get: get, set: set)
   }
 }
 
-#endif
+public extension StateBinding {
+  /// Returns a modified `StateBinding`using a couble of `KeyPath`  to link in a read-write fashion a similar
+  /// property in `Source` and `Destination`.
+  /// - Parameters:
+  ///   - sourceValue: A `KeyPath` to get and set `Value` in `Source`
+  ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
+  func rw<Value>(_ sourceValue: WritableKeyPath<Source, Value>,
+                 _ destinationValue: WritableKeyPath<Destination, Value>) -> Self
+  {
+    with(.init(sourceValue, destinationValue))
+  }
 
-fileprivate extension StateBinding {
-  // Binding With Storage
-  init(
-    _storage storage: WritableKeyPath<Source, Destination>,
-    removeDuplicateStorage: ((Destination, Destination) -> Bool)? = nil,
-    properties: () -> [PropertyBinding<Source, Destination>]
+  /// Returns a modified `StateBinding`using a couble of `KeyPath`  to link in a read-write fashion a similar
+  /// property in `Source` and `Destination`.
+  /// - Parameters:
+  ///   - sourceValue: A `KeyPath` to get and set `Value` in `Source`
+  ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
+  ///   - removeDuplicates: Used when the `Value` is set on `Source`. If this function is implemented
+  ///     and returns `true`, no assignation will occur and `Source` will be kept untouched.
+  func rw<Value>(_ sourceValue: WritableKeyPath<Source, Value>,
+                 _ destinationValue: WritableKeyPath<Destination, Value>,
+                 removeDuplicates: @escaping (Value, Value) -> Bool) -> Self
+  {
+    with(.init(sourceValue, destinationValue, removeDuplicates: removeDuplicates))
+  }
+
+  /// Returns a modified `StateBinding`using a couble of `KeyPath`  to link in a read-write fashion a similar
+  /// property in `Source` and `Destination.Wrapped`.
+  /// - Parameters:
+  ///   - sourceValue: A `KeyPath` to get and set `Value` in `Source`
+  ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
+  func rw<Value, UnwrappedDestination>(_ sourceValue: WritableKeyPath<Source, Value>,
+                                       _ destinationValue: WritableKeyPath<UnwrappedDestination, Value>) -> Self
+    where Destination == UnwrappedDestination?
+  {
+    with(.init(sourceValue, destinationValue))
+  }
+
+  /// Returns a modified `StateBinding`using a couble of `KeyPath`  to link in a read-write fashion a similar
+  /// property in `Source` and `Destination.Wrapped`.
+  /// - Parameters:
+  ///   - sourceValue: A `KeyPath` to get and set `Value` in `Source`
+  ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
+  ///   - removeDuplicates: Used when the `Value` is set on `Source`. If this function is implemented
+  ///     and returns `true`, no assignation will occur and `Source` will be kept untouched.
+  func rw<Value, UnwrappedDestination>(_ sourceValue: WritableKeyPath<Source, Value>,
+                                       _ destinationValue: WritableKeyPath<UnwrappedDestination, Value>,
+                                       removeDuplicates: @escaping (Value, Value) -> Bool) -> Self
+    where Destination == UnwrappedDestination?
+  {
+    with(.init(sourceValue, destinationValue, removeDuplicates: removeDuplicates))
+  }
+
+  /// Returns a modified `StateBinding`using a couble of `KeyPath`  to link in a read-only fashion a similar
+  /// property in `Source` and `Destination`.
+  /// - Parameters:
+  ///   - sourceValue: A `KeyPath` to get and set `Value` in `Source`
+  ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
+  func ro<Value>(_ sourceValue: KeyPath<Source, Value>,
+                 _ destinationValue: WritableKeyPath<Destination, Value>) -> Self
+  {
+    with(.init(readonly: sourceValue, destinationValue))
+  }
+
+  /// Returns a modified `StateBinding`using a couble of `KeyPath`  to link in a read-only fashion a similar
+  /// property in `Source` and `Destination.Wrapped`.
+  /// - Parameters:
+  ///   - sourceValue: A `KeyPath` to get and set `Value` in `Source`
+  ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
+  func ro<Value, UnwrappedDestination>(_ sourceValue: KeyPath<Source, Value>,
+                                       _ destinationValue: WritableKeyPath<UnwrappedDestination, Value>) -> Self
+    where Destination == UnwrappedDestination?
+  {
+    with(.init(readonly: sourceValue, destinationValue))
+  }
+}
+
+/// A struct that describe a directional binding between instances of `Source` and `Destination`.
+public struct PropertyBinding<Source, Destination> {
+  let get: (Source, inout Destination) -> Void
+  let set: (inout Source, Destination) -> Void
+  /// Initialize a binding between a `Source` instance and a`Destination` instance.
+  /// - Parameters:
+  ///   - get: A function applied when `Destination` is requested from `Source`. The `Destination`
+  ///   instance can be updated at this point.
+  ///   - set: A function applied when `Destination` is set in `Source`. The `Source` instance can be
+  ///   updated at this point.
+  public init(
+    get: @escaping (Source, inout Destination) -> Void = { _, _ in },
+    set: @escaping (inout Source, Destination) -> Void = { _, _ in }
   ) {
-    let properties = properties()
-    get = { source in
-      var stored = source[keyPath: storage]
-      properties.forEach { $0.get(source, &stored) }
-      return stored
-    }
-    set = { source, newValue in
-      if removeDuplicateStorage?(source[keyPath: storage], newValue) != true {
-        source[keyPath: storage] = newValue
-      }
-      properties.forEach { $0.set(&source, newValue) }
-    }
+    self.get = get
+    self.set = set
   }
 
-  // Computed Binding Without Storage
-  init(
-    _source source: Source.Type,
-    with destination: @escaping () -> Destination,
-    properties: () -> [PropertyBinding<Source, Destination>]
+  /// Initialize a `PropertyBinding` using a couble of `KeyPath` describing a similar property in
+  /// `Source` and `Destination`.
+  /// - Parameters:
+  ///   - sourceValue: A `KeyPath` to get and set `Value` in `Source`
+  ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
+  ///   - removeDuplicates: Used when the `Value` is set on `Source`. If this function is implemented
+  ///     and returns `true`, no assignation will occur and `Source` will be kept untouched.
+  public init<Value>(
+    _ sourceValue: WritableKeyPath<Source, Value>,
+    _ destinationValue: WritableKeyPath<Destination, Value>,
+    removeDuplicates: ((Value, Value) -> Bool)? = nil
   ) {
-    let properties = properties()
-    get = { source in
-      var destination = destination()
-      properties.forEach { $0.get(source, &destination) }
-      return destination
+    self.get = { source, destination in
+      destination[keyPath: destinationValue] = source[keyPath: sourceValue]
     }
-    set = { source, newValue in
-      properties.forEach { $0.set(&source, newValue) }
-    }
-  }
-  
-  // Optional Binding With Storage
-  init<UnwrappedDestination>(
-    _storage storage: WritableKeyPath<Source, Destination>,
-    removeDuplicateStorage: ((Destination, Destination) -> Bool)? = nil,
-    properties: () -> [PropertyBinding<Source, UnwrappedDestination>]
-  ) where Destination == UnwrappedDestination? {
-    let properties = properties()
-    get = { source in
-      guard var stored = source[keyPath: storage] else { return nil }
-      properties.forEach { $0.get(source, &stored) }
-      return stored
-    }
-    set = { source, newValue in
-      if removeDuplicateStorage?(source[keyPath: storage], newValue) != true {
-        source[keyPath: storage] = newValue
-      }
-      guard let newValue = newValue else { return }
-      properties.forEach { $0.set(&source, newValue) }
+
+    self.set = { source, destination in
+      guard removeDuplicates?(source[keyPath: sourceValue], destination[keyPath: destinationValue]) != true
+      else { return }
+      source[keyPath: sourceValue] = destination[keyPath: destinationValue]
     }
   }
 
-  // Computed Optional Binding Without Storage
-  init<UnwrappedDestination>(
-    _with destination: @escaping (Source) -> Destination,
-    properties: () -> [PropertyBinding<Source, UnwrappedDestination>] = { [] }
-  ) where Destination == UnwrappedDestination? {
-    let properties = properties()
-    get = { source in
-      guard var destination = destination(source) else { return nil }
-      properties.forEach { $0.get(source, &destination) }
-      return destination
+  /// Initialize a `PropertyBinding` using a couble of `KeyPath` describing a similar property in
+  /// `Source` and `Destination`. This binding is unidirectional (readonly on Source ) and the
+  /// `KeyPath<Source, Value` doesn't need to be writable.
+  /// - Parameters:
+  ///   - sourceValue: A `KeyPath` to get `Value` in `Source`
+  ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
+  public init<Value>(
+    readonly sourceValue: KeyPath<Source, Value>,
+    _ destinationValue: WritableKeyPath<Destination, Value>
+  ) {
+    self.get = { source, destination in
+      destination[keyPath: destinationValue] = source[keyPath: sourceValue]
     }
-    set = { source, newValue in
-      guard let newValue = newValue else { return }
-      properties.forEach { $0.set(&source, newValue) }
+    self.set = { _, _ in
     }
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/Internal/StateBinding.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/Internal/StateBinding.swift
@@ -100,9 +100,9 @@ public extension StateBinding {
   /// - Parameters:
   ///   - destination: A function that returns an default instance of `Destination`(the child state) or nil. `Source` can
   ///   be used to decide if `Destination` is nil or not.
-  init<UnwrappedDestination>(
+  init(
     with destination: @escaping (Source) -> Destination
-  ) where Destination == UnwrappedDestination? {
+  ) {
     get = destination
     set = { _, _ in () }
   }

--- a/Examples/CaseStudies/SwiftUICaseStudies/Internal/StateBinding.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/Internal/StateBinding.swift
@@ -1,4 +1,6 @@
-/// Describe a binding between a parent state `Source` and a child state `Destination`. Several initializer are
+import ComposableArchitecture
+
+/// Describes a binding between a parent state `Source` and a child state `Destination`. Several initializers are
 /// provided to handle the following cases:
 /// - Synchronization of a subset of `Destination` properties with `Source`
 /// - Synchronization of a subset of an optional `Destination` state with `Source`
@@ -43,7 +45,7 @@ public struct StateBinding<Source, Destination> {
 }
 
 public extension StateBinding {
-  /// Initialize a binding between a parent state `Source` and a child state `Destination`.
+  /// Initializes a binding between a parent state `Source` and a child state `Destination`.
   /// A private storage for a `Source` is provided so unaffected properties are preserved between accesses.
   /// In other words, `Destination` can have private fields and only properties specified in `properties`
   /// are synchronized with `Source`.
@@ -52,64 +54,40 @@ public extension StateBinding {
   ///   `Destination`'s internal properties.
   ///   - removeDuplicateStorage: A function used to compare private storage and avoid setting it in `Source` if unnecessary
   init(_ storage: WritableKeyPath<Source, Destination>,
-       removeDuplicateStorage: ((Destination, Destination) -> Bool)? = nil)
+       removeDuplicateStorage: @escaping (Destination, Destination) -> Bool = { _, _ in false })
   {
     get = { $0[keyPath: storage] }
     set = { source, newValue in
-      if removeDuplicateStorage?(source[keyPath: storage], newValue) != true {
+      if !removeDuplicateStorage(source[keyPath: storage], newValue) {
         source[keyPath: storage] = newValue
       }
     }
   }
 
-  /// Initialize a binding between a parent state `Source` and a child state `Destination`.
-  /// A private storage for an optional `Source` is provided so unaffected properties are preserved between accesses.
-  /// In other words, `Destination` can have private fields and only properties specified in `properties` are synchronized
-  /// with `Source`. If the child is set to nil, source properties other than the storage property are kept untouched
-  /// - Parameters:
-  ///   - storage: A writable (private) keyPath to an instance of `Destination?`, used to store
-  ///   `Destination`'s internal properties. If this instance is nil, the computed property will be also nil.
-  ///   - removeDuplicateStorage: A function used to compare private storage and avoid setting it in `Source` if unnecessary
-  init<UnwrappedDestination>(
-    _ storage: WritableKeyPath<Source, Destination>,
-    removeDuplicateStorage: ((Destination, Destination) -> Bool)? = nil
-  ) where Destination == UnwrappedDestination? {
-    get = { $0[keyPath: storage] }
-    set = { source, newValue in
-      if removeDuplicateStorage?(source[keyPath: storage], newValue) != true {
-        source[keyPath: storage] = newValue
-      }
-    }
-  }
-  
-  /// Initialize a computed binding between a parent state `Source` and a child state `Destination`. These derived states
-  /// are used when all the properties of `Destination` can be individually stored in `Source`. Please note that this version
-  /// needs explicit generics on call site as the initializer lacks information to resolve `Source` by itself.
-  /// - Parameters:
-  ///   - destination: A function that returns an default instance of `Destination` (the child state)
-  init(
-    with destination: @escaping () -> Destination
-  ) {
-    get = { _ in destination() }
-    set = { _, _ in () }
-  }
-
-  /// Initialize a computed binding between a parent state `Source` and an optional child state `Destination`
+  /// Initializes a computed binding between a parent state `Source` and an optional child state `Destination`
   /// These derived states are used when all the properties of `Destination` can be individually stored in `Source`.
   /// If the child is set to nil, the source properties are kept untouched
   /// - Parameters:
   ///   - destination: A function that returns an default instance of `Destination`(the child state) or nil. `Source` can
   ///   be used to decide if `Destination` is nil or not.
-  init(
-    with destination: @escaping (Source) -> Destination
-  ) {
+  init(with destination: @escaping (Source) -> Destination) {
     get = destination
     set = { _, _ in () }
   }
+
+  /// Initializes a computed binding between a parent state `Source` and a child state `Destination`. These derived states
+  /// are used when all the properties of `Destination` can be individually stored in `Source`. Please note that this version
+  /// needs explicit generics on call site as the initializer lacks information to resolve `Source` by itself.
+  /// - Parameters:
+  ///   - destination: A function that returns an default instance of `Destination` (the child state).
+  ///     This initializer signature is convenient when `Destination` has a `.init()` initializer without arguments.
+  init(with destination: @escaping () -> Destination) {
+    self.init(with: { _ in destination() })
+  }
 }
 
-fileprivate extension StateBinding {
-  /// Returns a modified `StateBinding`using a couble of `PropertyBinding`  to bind similar
+public extension StateBinding {
+  /// Returns a modified `StateBinding`using a couble of `PropertyBinding` to bind similar
   /// properties in `Source` and `Destination`.
   func with(_ propertyBinding: PropertyBinding<Source, Destination>) -> Self {
     let get: (Source) -> Destination = { source in
@@ -124,26 +102,6 @@ fileprivate extension StateBinding {
     return .init(get: get, set: set)
   }
 
-  /// Returns a modified `StateBinding`using a couble of `PropertyBinding` to bind similar
-  /// properties in `Source` and `Destination.Wrapped`.
-  func with<UnwrappedDestination>(_ propertyBinding: PropertyBinding<Source, UnwrappedDestination>) -> Self
-    where Destination == UnwrappedDestination?
-  {
-    let get: (Source) -> Destination = { source in
-      guard var destination = self.get(source) else { return nil }
-      propertyBinding.get(source, &destination)
-      return destination
-    }
-    let set: (inout Source, Destination) -> Void = { source, destination in
-      self.set(&source, destination)
-      guard let destination = destination else { return }
-      propertyBinding.set(&source, destination)
-    }
-    return .init(get: get, set: set)
-  }
-}
-
-public extension StateBinding {
   /// Returns a modified `StateBinding` binding similar properties between `Source` and `Destination`.
   /// - Parameters:
   ///   - get: A function applied when `Destination` is requested from `Source`. The `Destination`
@@ -151,50 +109,23 @@ public extension StateBinding {
   ///   - set: A function applied when `Destination` is set in `Source`. The `Source` instance can be
   ///   updated at this point.
   func with(get: @escaping (Source, inout Destination) -> Void,
-            set: @escaping (inout Source, Destination) -> Void = { _, _ in () }
-  ) -> Self {
+            set: @escaping (inout Source, Destination) -> Void = { _, _ in () }) -> Self
+  {
     with(PropertyBinding<Source, Destination>(get: get, set: set))
   }
+}
 
-  /// Returns a modified `StateBinding` binding similar properties between `Source` and `Destination.Wrapped`.
-  /// - Parameters:
-  ///   - get: A function applied when `Destination.Wrapped` is requested from `Source`. The `Destination.Wrapped`
-  ///   instance can be updated at this point.
-  ///   - set: A function applied when `Destination.Wrapped` is set in `Source`. The `Source` instance can be
-  ///   updated at this point.
-  func with<UnwrappedDestination>(get: @escaping (Source, inout UnwrappedDestination) -> Void,
-                                  set: @escaping (inout Source, UnwrappedDestination) -> Void = { _, _ in () }
-                        ) -> Self
-    where Destination == UnwrappedDestination?
-  {
-    with(PropertyBinding<Source, UnwrappedDestination>(get: get, set: set))
-  }
-
+public extension StateBinding {
   /// Returns a modified `StateBinding`using a couble of `KeyPath`  to link in a read-write fashion a similar
   /// property in `Source` and `Destination`.
   /// - Parameters:
   ///   - sourceValue: A `KeyPath` to get and set `Value` in `Source`
   ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
-  ///   - removeDuplicates: Used when the `Value` is set on `Source`. If this function is implemented
-  ///     and returns `true`, no assignation will occur and `Source` will be kept untouched.
+  ///   - removeDuplicates: Used when the `Value` is set on `Source`. If this function returns `true`,
+  ///   no assignation will occur and `Source` will be kept untouched.
   func rw<Value>(_ sourceValue: WritableKeyPath<Source, Value>,
                  _ destinationValue: WritableKeyPath<Destination, Value>,
-                 removeDuplicates: ((Value, Value) -> Bool)? = nil) -> Self
-  {
-    with(.init(sourceValue, destinationValue, removeDuplicates: removeDuplicates))
-  }
-
-  /// Returns a modified `StateBinding`using a couble of `KeyPath`  to link in a read-write fashion a similar
-  /// property in `Source` and `Destination.Wrapped`.
-  /// - Parameters:
-  ///   - sourceValue: A `KeyPath` to get and set `Value` in `Source`
-  ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
-  ///   - removeDuplicates: Used when the `Value` is set on `Source`. If this function is implemented
-  ///     and returns `true`, no assignation will occur and `Source` will be kept untouched.
-  func rw<Value, UnwrappedDestination>(_ sourceValue: WritableKeyPath<Source, Value>,
-                                       _ destinationValue: WritableKeyPath<UnwrappedDestination, Value>,
-                                       removeDuplicates: ((Value, Value) -> Bool)? = nil) -> Self
-    where Destination == UnwrappedDestination?
+                 removeDuplicates: @escaping (Value, Value) -> Bool = { _, _ in false }) -> Self
   {
     with(.init(sourceValue, destinationValue, removeDuplicates: removeDuplicates))
   }
@@ -209,31 +140,137 @@ public extension StateBinding {
   {
     with(.init(readonly: sourceValue, destinationValue))
   }
+}
+
+// Mappings of `StateBinding` so they can work in some containers content directly.
+public extension StateBinding {
+  /// Maps a `PropertyBinding<Source, Wrapped>` to a `PropertyBinding<Source, Wrapped?>` and installs
+  /// it into a `StateBinding<Source, Wrapped?>`.
+  /// - Parameters:
+  ///   - binding: A `PropertyBinding<Source, Wrapped>` to be mapped.
+  ///   - getBack: A `(Source, Wrapped?) -> Wrapped?` function to decide how to reinject the
+  ///   `Wrapped` instance's properties into `Source`. If this function returns nil, the binding will be readonly. The returned type
+  ///   should rigorously be  `Wrapped??`, but since both `nil` values would have the same semantic in the setter,
+  ///   we can use only `Wrapped?`.
+  /// - Returns: A `StateBinding<Source, Wrapped?>` state binding.
+  func map<Wrapped>(_ binding: PropertyBinding<Source, Wrapped>,
+                    getBack: @escaping (Source, Destination) -> Wrapped? = { $1 }) -> Self
+    where Destination == Wrapped?
+  {
+    with(binding.map(getBack: getBack))
+  }
+
+  /// Maps a `PropertyBinding<Source, Element>` to a `PropertyBinding<Source, [Element]>` and installs
+  /// it into a `StateBinding<Source, [Element]>`.
+  /// - Parameters:
+  ///   - binding: A `PropertyBinding<Source, Element>` to be mapped.
+  ///   - getBack: A `(Source, [Element]) -> Element?` function to decide how to reinject the
+  ///   `[Element]` instance's properties into `Source`. If this function returns nil, the binding will be readonly.
+  /// - Returns: A `StateBinding<Source, [Element]>` state binding.
+  func map<Element>(_ binding: PropertyBinding<Source, Element>,
+                    getBack: @escaping (Source, Destination) -> Element? = { _, _ in nil }) -> Self
+    where Destination == [Element]
+  {
+    with(binding.map(getBack: getBack))
+  }
+
+  /// Maps a `PropertyBinding<Source, Value>` to a `PropertyBinding<Source, [Key: Value]>` and installs
+  /// it into a `StateBinding<Source, [Key: Value]>`.
+  /// - Parameters:
+  ///   - binding: A `PropertyBinding<Source, Value>` to be mapped.
+  ///   - getBack: A `(Source, [Key: Value]) -> Value?` function to decide how to reinject the
+  ///   `[Key: Value]` instance's properties into `Source`. If this function returns nil, the binding will be readonly.
+  /// - Returns: A `StateBinding<Source, [Key: Value]>` state binding.
+  func map<Key, Value>(_ binding: PropertyBinding<Source, Value>,
+                       getBack: @escaping (Source, Destination) -> Value? = { _, _ in nil }) -> Self
+    where Destination == [Key: Value]
+  {
+    with(binding.map(getBack: getBack))
+  }
+
+  /// Maps a `PropertyBinding<Source, Element>` to a `PropertyBinding<Source, IdentifiedArray<ID, Element>>`
+  /// and installs it into a `StateBinding<Source, IdentifiedArray<ID, Element>>`.
+  /// - Parameters:
+  ///   - binding: A `PropertyBinding<Source, Element>` to be mapped.
+  ///   - getBack: A `(Source, IdentifiedArray<ID, Element>) -> Element?` function to decide how to reinject the
+  ///   `IdentifiedArray<ID, Element>` instance's properties into `Source`. If this function returns nil, the binding will be readonly.
+  /// - Returns: A `StateBinding<Source, IdentifiedArray<ID, Element>>` state binding.
+  func map<ID, Element>(_ binding: PropertyBinding<Source, Element>,
+                        getBack: @escaping (Source, Destination) -> Element? = { _, _ in nil }) -> Self
+    where Destination == IdentifiedArray<ID, Element>
+  {
+    with(binding.map(getBack: getBack))
+  }
+}
+
+// Because a trivial reduction `(Source, Destination?) -> Destination?` exists, and because
+// mapping successively `Optional` has no sensible performance impact, we can implement
+// dedicated overloads when the destination state is optional. This allows the user to
+// directly chain `rw(...`, `ro(...`, etc. without having to call `.map(...` first.
+public extension StateBinding {
+  /// Returns a modified `StateBinding`using a couble of `KeyPath`  to link in a read-write fashion a similar
+  /// property in `Source` and `Destination.Wrapped`.
+  /// - Parameters:
+  ///   - sourceValue: A `KeyPath` to get and set `Value` in `Source`
+  ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
+  ///   - removeDuplicates: Used when the `Value` is set on `Source`. If this function
+  ///     returns `true`, no assignation will occur and `Source` will be kept untouched.
+  func rw<Value, Wrapped>(_ sourceValue: WritableKeyPath<Source, Value>,
+                          _ destinationValue: WritableKeyPath<Wrapped, Value>,
+                          getBack: (Source, Destination) -> Wrapped? = { $1 },
+                          removeDuplicates: @escaping (Value, Value) -> Bool = { _, _ in false }) -> Self
+    where Destination == Wrapped?
+  {
+    with(.rw(sourceValue, destinationValue, removeDuplicates: removeDuplicates))
+  }
 
   /// Returns a modified `StateBinding`using a couble of `KeyPath`  to link in a read-only fashion a similar
   /// property in `Source` and `Destination.Wrapped`.
   /// - Parameters:
   ///   - sourceValue: A `KeyPath` to get and set `Value` in `Source`
   ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
-  func ro<Value, UnwrappedDestination>(_ sourceValue: KeyPath<Source, Value>,
-                                       _ destinationValue: WritableKeyPath<UnwrappedDestination, Value>) -> Self
-    where Destination == UnwrappedDestination?
+  func ro<Value, Wrapped>(_ sourceValue: KeyPath<Source, Value>,
+                          _ destinationValue: WritableKeyPath<Wrapped, Value>) -> Self
+    where Destination == Wrapped?
   {
-    with(.init(readonly: sourceValue, destinationValue))
+    with(.ro(sourceValue, destinationValue))
+  }
+
+  /// Returns a modified `StateBinding`using a couble of `PropertyBinding` to bind similar
+  /// properties in `Source` and `Destination.Wrapped`.
+  func with<Wrapped>(_ propertyBinding: PropertyBinding<Source, Wrapped>,
+                     getBack: @escaping (Source, Destination) -> Wrapped? = { $1 }) -> Self
+    where Destination == Wrapped?
+  {
+    self.map(propertyBinding, getBack: getBack)
+  }
+
+  /// Returns a modified `StateBinding` binding similar properties between `Source` and `Destination.Wrapped`.
+  /// - Parameters:
+  ///   - get: A function applied when `Destination.Wrapped` is requested from `Source`. The `Destination.Wrapped`
+  ///   instance can be updated at this point.
+  ///   - set: A function applied when `Destination.Wrapped` is set in `Source`. The `Source` instance can be
+  ///   updated at this point.
+  func with<Wrapped>(get: @escaping (Source, inout Wrapped) -> Void,
+                     set: @escaping (inout Source, Wrapped) -> Void = { _, _ in () },
+                     getBack: @escaping (Source, Destination) -> Wrapped? = { $1 }) -> Self
+    where Destination == Wrapped?
+  {
+    with(PropertyBinding<Source, Wrapped>(get: get, set: set), getBack: getBack)
   }
 }
 
 /// A utility struct that describe a directional binding between instances of `Source` and `Destination`.
-fileprivate struct PropertyBinding<Source, Destination> {
+public struct PropertyBinding<Source, Destination> {
   let get: (Source, inout Destination) -> Void
   let set: (inout Source, Destination) -> Void
-  /// Initialize a binding between a `Source` instance and a`Destination` instance.
+  /// Initializes a binding between a `Source` instance and a`Destination` instance.
   /// - Parameters:
   ///   - get: A function applied when `Destination` is requested from `Source`. The `Destination`
   ///   instance can be updated at this point.
   ///   - set: A function applied when `Destination` is set in `Source`. The `Source` instance can be
   ///   updated at this point.
-  init(
+  public init(
     get: @escaping (Source, inout Destination) -> Void = { _, _ in },
     set: @escaping (inout Source, Destination) -> Void = { _, _ in }
   ) {
@@ -241,30 +278,32 @@ fileprivate struct PropertyBinding<Source, Destination> {
     self.set = set
   }
 
-  /// Initialize a `PropertyBinding` using a couble of `KeyPath` describing a similar property in
+  /// Initializes a `PropertyBinding` using a couble of `KeyPath` describing a similar property in
   /// `Source` and `Destination`.
   /// - Parameters:
   ///   - sourceValue: A `KeyPath` to get and set `Value` in `Source`
   ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
-  ///   - removeDuplicates: Used when the `Value` is set on `Source`. If this function is implemented
-  ///     and returns `true`, no assignation will occur and `Source` will be kept untouched.
-  init<Value>(
+  ///   - removeDuplicates: Used when the `Value` is set on `Source`. If this function
+  ///    returns `true`, no assignation will occur and `Source` will be kept untouched.
+  public init<Value>(
     _ sourceValue: WritableKeyPath<Source, Value>,
     _ destinationValue: WritableKeyPath<Destination, Value>,
-    removeDuplicates: ((Value, Value) -> Bool)? = nil
+    removeDuplicates: @escaping (Value, Value) -> Bool = { _, _ in false }
   ) {
     self.get = { source, destination in
       destination[keyPath: destinationValue] = source[keyPath: sourceValue]
     }
 
     self.set = { source, destination in
-      guard removeDuplicates?(source[keyPath: sourceValue], destination[keyPath: destinationValue]) != true
-      else { return }
-      source[keyPath: sourceValue] = destination[keyPath: destinationValue]
+      if !removeDuplicates(source[keyPath: sourceValue],
+                           destination[keyPath: destinationValue])
+      {
+        source[keyPath: sourceValue] = destination[keyPath: destinationValue]
+      }
     }
   }
 
-  /// Initialize a `PropertyBinding` using a couble of `KeyPath` describing a similar property in
+  /// Initializes a `PropertyBinding` using a couble of `KeyPath` describing a similar property in
   /// `Source` and `Destination`. This binding is unidirectional (readonly on Source ) and the
   /// `KeyPath<Source, Value` doesn't need to be writable.
   /// - Parameters:
@@ -279,5 +318,161 @@ fileprivate struct PropertyBinding<Source, Destination> {
     }
     self.set = { _, _ in
     }
+  }
+}
+
+// Convenience initializers
+public extension PropertyBinding {
+  /// Initializes a `PropertyBinding` using a couble of `KeyPath` describing a similar property in
+  /// `Source` and `Destination`.
+  /// - Parameters:
+  ///   - sourceValue: A `KeyPath` to get and set `Value` in `Source`
+  ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
+  ///   - removeDuplicates: Used when the `Value` is set on `Source`. If this function returns `true`,
+  ///   no assignation will occur and `Source` will be kept untouched.
+  static func rw<Value>(_ sourceValue: WritableKeyPath<Source, Value>,
+                        _ destinationValue: WritableKeyPath<Destination, Value>,
+                        removeDuplicates: @escaping (Value, Value) -> Bool = { _, _ in false })
+    -> Self { .init(sourceValue, destinationValue, removeDuplicates: removeDuplicates) }
+
+  /// Initializes a `PropertyBinding` using a couble of `KeyPath` describing a similar property in
+  /// `Source` and `Destination`.
+  /// - Parameters:
+  ///   - sourceValue: A `KeyPath` to get and set `Value` in `Source`
+  ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
+  ///   - removeDuplicates: Used when the `Value` is set on `Source`. If this function returns `true`,
+  ///   no assignation will occur and `Source` will be kept untouched.
+  func rw<Value>(_ sourceValue: WritableKeyPath<Source, Value>,
+                 _ destinationValue: WritableKeyPath<Destination, Value>,
+                 removeDuplicates: @escaping (Value, Value) -> Bool = { _, _ in false })
+    -> Self { self.with(Self.rw(sourceValue, destinationValue, removeDuplicates: removeDuplicates)) }
+
+  /// Initializes a `PropertyBinding` using a couble of `KeyPath` describing a similar property in
+  /// `Source` and `Destination`. This binding is unidirectional (readonly on Source ) and the
+  /// `KeyPath<Source, Value` doesn't need to be writable.
+  /// - Parameters:
+  ///   - sourceValue: A `KeyPath` to get `Value` in `Source`
+  ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
+  static func ro<Value>(_ sourceValue: KeyPath<Source, Value>,
+                        _ destinationValue: WritableKeyPath<Destination, Value>)
+    -> Self { .init(readonly: sourceValue, destinationValue) }
+
+  /// Initializes a `PropertyBinding` using a couble of `KeyPath` describing a similar property in
+  /// `Source` and `Destination`. This binding is unidirectional (readonly on Source ) and the
+  /// `KeyPath<Source, Value` doesn't need to be writable.
+  /// - Parameters:
+  ///   - sourceValue: A `KeyPath` to get `Value` in `Source`
+  ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
+  func ro<Value>(_ sourceValue: KeyPath<Source, Value>,
+                 _ destinationValue: WritableKeyPath<Destination, Value>)
+    -> Self { self.with(Self.ro(sourceValue, destinationValue)) }
+
+  /// Combines the current property binding with another one. The appended binding transormations will occur after the
+  /// current binding's transormations.
+  func with(_ propertyBinding: PropertyBinding<Source, Destination>) -> Self {
+    let get: (Source, inout Destination) -> Void = { source, destination in
+      self.get(source, &destination)
+      propertyBinding.get(source, &destination)
+    }
+    let set: (inout Source, Destination) -> Void = { source, destination in
+      self.set(&source, destination)
+      propertyBinding.set(&source, destination)
+    }
+    return .init(get: get, set: set)
+  }
+
+  /// Combines the current property binding with another one. The appended binding transormations will occur after the
+  /// current binding's transormations.
+  func with(get: @escaping (Source, inout Destination) -> Void,
+            set: @escaping (inout Source, Destination) -> Void = { _, _ in () }) -> Self
+  {
+    PropertyBinding<Source, Destination>(get: get, set: set)
+  }
+}
+
+// PropertyBinding Mappings
+public extension PropertyBinding {
+  /// Transform a binding from `Source` to `Destination` into a binding from `Source` to `Destination?`.
+  /// - Parameter getBack: A `(Source, Destination?) -> Destination?` function to decide how to reinject the
+  ///   `Destination` instance's properties into `Source`. If this function returns nil, the binding will be readonly.
+  ///   The returned type should rigorously be  `Destination??`, but since both `nil` values would have the same
+  ///   semantic in the setter, we can use only `Wrapped?`.
+  /// - Returns: A  `PropertyBinding<Source, Destination?>`
+  func map(getBack: @escaping (Source, Destination?) -> Destination? = { $1 })
+    -> PropertyBinding<Source, Destination?>
+  {
+    PropertyBinding<Source, Destination?>(get: { src, container in
+      container = container.map {
+        var value = $0
+        self.get(src, &value)
+        return value
+      }
+    }, set: { src, container in
+      guard let reduced = getBack(src, container) else { return }
+      self.set(&src, reduced)
+    })
+  }
+
+  /// Transform a binding from `Source` to `Destination` into a binding from `Source` to `[Destination]`.
+  /// - Parameter getBack: A `(Source, [Destination]) -> Destination?` function to decide how to reinject the
+  ///   `Destination` instance's properties into `Source`. If this function returns nil, the binding will be readonly.
+  /// - Returns: A  `PropertyBinding<Source, [Destination]>`
+  func map(getBack: @escaping (Source, [Destination]) -> Destination? = { _, _ in nil })
+    -> PropertyBinding<Source, [Destination]>
+  {
+    PropertyBinding<Source, [Destination]>(get: { src, container in
+      container = container.map {
+        var value = $0
+        self.get(src, &value)
+        return value
+      }
+    }, set: { src, container in
+      guard let reduced = getBack(src, container) else { return }
+      self.set(&src, reduced)
+    })
+  }
+
+  /// Transform a binding from `Source` to `Destination` into a binding from `Source` to `[Key: Destination]`.
+  /// - Parameter getBack: A `(Source, [Key: Destination]) -> Destination?` function to decide how to reinject the
+  ///   `Destination` instance's properties into `Source`. If this function returns nil, the binding will be readonly.
+  /// - Returns: A  `PropertyBinding<Source, [Key: Destination]>`
+  func map<Key>(getBack: @escaping (Source, [Key: Destination]) -> Destination? = { _, _ in nil })
+    -> PropertyBinding<Source, [Key: Destination]>
+  {
+    PropertyBinding<Source, [Key: Destination]>(get: { src, container in
+      container = container.mapValues {
+        var value = $0
+        self.get(src, &value)
+        return value
+      }
+    }, set: { src, container in
+      guard let reduced = getBack(src, container) else { return }
+      self.set(&src, reduced)
+    })
+  }
+
+  /// Transform a binding from `Source` to `Destination` into a binding from `Source` to `IdentifiedArray<ID, Destination>`.
+  /// - Parameter getBack: A `(Source, IdentifiedArray<ID, Destination>) -> Destination?` function to decide how
+  ///   to reinject the `Destination` instance's properties into `Source`. If this function returns nil, the binding will be readonly.
+  /// - Returns: A  `PropertyBinding<Source, IdentifiedArray<ID, Destination>>`
+  func map<ID>(getBack: @escaping (Source, IdentifiedArray<ID, Destination>) -> Destination? = { _, _ in nil })
+    -> PropertyBinding<Source, IdentifiedArray<ID, Destination>> where ID: Hashable
+  {
+    PropertyBinding<Source, IdentifiedArray<ID, Destination>>(get: { src, container in
+                                                                container = IdentifiedArray(
+                                                                  container.elements
+                                                                    .map { value -> Destination in
+                                                                      var value = value
+                                                                      self.get(src, &value)
+                                                                      return value
+                                                                    },
+                                                                  id: container.id
+                                                                )
+                                                              },
+                                                              set: { src, container in
+                                                                guard let reduced = getBack(src, container)
+                                                                else { return }
+                                                                self.set(&src, reduced)
+                                                              })
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/Internal/StateBinding.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/Internal/StateBinding.swift
@@ -1,4 +1,4 @@
-
+#if swift(>=5.4)
 /// A struct that describe a directional binding between instances of `Source` and `Destination`. It's main
 /// use is to describe a connection between a property of `Source` and a property of `Destination` when
 /// using `BoundState`, `OptionalBoundState`, `ComputedState` or `ComputedOptionalState`
@@ -246,3 +246,4 @@ public struct StateBinding<Source, Destination> {
     component ?? []
   }
 }
+#endif

--- a/Examples/CaseStudies/SwiftUICaseStudies/Internal/StateBinding.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/Internal/StateBinding.swift
@@ -12,6 +12,7 @@
 /// ```
 /// struct Destination {
 ///   var value: String = ""
+///   var count: Int = 0
 ///   var internalValue: Int = 0
 /// }
 /// ```
@@ -20,17 +21,19 @@
 /// ```
 /// struct Source {
 ///   var title: String = "Hello! world"
+///   var count: Int = 0
 ///
 ///   private var _storage = Feature()
-///   private static let _binding = StateBinding(\Self._storage) {
-///     (\.title, \.value)
-///   }
+///   private static let _binding = StateBinding(\Self._storage)
+///     .rw(\.title, \.value)
+///     .rw(\.count, \.count)
 ///
 ///   var feature: Feature {
 ///     get { Self._binding.get(self) }
 ///     set { Self._binding.set(&self, newValue) }
 ///   }
 /// }
+/// ```
 ///
 public struct StateBinding<Source, Destination> {
   /// Retrieve the storage in `source`, update it and returns the result.

--- a/Examples/CaseStudies/SwiftUICaseStudies/Internal/StateBinding.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/Internal/StateBinding.swift
@@ -108,7 +108,7 @@ public extension StateBinding {
   }
 }
 
-public extension StateBinding {
+fileprivate extension StateBinding {
   /// Returns a modified `StateBinding`using a couble of `PropertyBinding`  to bind similar
   /// properties in `Source` and `Destination`.
   func with(_ propertyBinding: PropertyBinding<Source, Destination>) -> Self {
@@ -144,6 +144,31 @@ public extension StateBinding {
 }
 
 public extension StateBinding {
+  /// Returns a modified `StateBinding` binding similar properties between `Source` and `Destination`.
+  /// - Parameters:
+  ///   - get: A function applied when `Destination` is requested from `Source`. The `Destination`
+  ///   instance can be updated at this point.
+  ///   - set: A function applied when `Destination` is set in `Source`. The `Source` instance can be
+  ///   updated at this point.
+  func with(get: @escaping (Source, inout Destination) -> Void,
+            set: @escaping (inout Source, Destination) -> Void = { _, _ in () }
+  ) -> Self {
+    with(PropertyBinding<Source, Destination>(get: get, set: set))
+  }
+
+  /// Returns a modified `StateBinding` binding similar properties between `Source` and `Destination.Wrapped`.
+  /// - Parameters:
+  ///   - get: A function applied when `Destination.Wrapped` is requested from `Source`. The `Destination.Wrapped`
+  ///   instance can be updated at this point.
+  ///   - set: A function applied when `Destination.Wrapped` is set in `Source`. The `Source` instance can be
+  ///   updated at this point.
+  func with<UnwrappedDestination>(get: @escaping (Source, inout UnwrappedDestination) -> Void,
+                                  set: @escaping (inout Source, UnwrappedDestination) -> Void = { _, _ in () }
+                        ) -> Self
+    where Destination == UnwrappedDestination?
+  {
+    with(PropertyBinding<Source, UnwrappedDestination>(get: get, set: set))
+  }
 
   /// Returns a modified `StateBinding`using a couble of `KeyPath`  to link in a read-write fashion a similar
   /// property in `Source` and `Destination`.
@@ -198,8 +223,8 @@ public extension StateBinding {
   }
 }
 
-/// A struct that describe a directional binding between instances of `Source` and `Destination`.
-public struct PropertyBinding<Source, Destination> {
+/// A utility struct that describe a directional binding between instances of `Source` and `Destination`.
+fileprivate struct PropertyBinding<Source, Destination> {
   let get: (Source, inout Destination) -> Void
   let set: (inout Source, Destination) -> Void
   /// Initialize a binding between a `Source` instance and a`Destination` instance.
@@ -208,7 +233,7 @@ public struct PropertyBinding<Source, Destination> {
   ///   instance can be updated at this point.
   ///   - set: A function applied when `Destination` is set in `Source`. The `Source` instance can be
   ///   updated at this point.
-  public init(
+  init(
     get: @escaping (Source, inout Destination) -> Void = { _, _ in },
     set: @escaping (inout Source, Destination) -> Void = { _, _ in }
   ) {
@@ -223,7 +248,7 @@ public struct PropertyBinding<Source, Destination> {
   ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
   ///   - removeDuplicates: Used when the `Value` is set on `Source`. If this function is implemented
   ///     and returns `true`, no assignation will occur and `Source` will be kept untouched.
-  public init<Value>(
+  init<Value>(
     _ sourceValue: WritableKeyPath<Source, Value>,
     _ destinationValue: WritableKeyPath<Destination, Value>,
     removeDuplicates: ((Value, Value) -> Bool)? = nil
@@ -245,7 +270,7 @@ public struct PropertyBinding<Source, Destination> {
   /// - Parameters:
   ///   - sourceValue: A `KeyPath` to get `Value` in `Source`
   ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
-  public init<Value>(
+  init<Value>(
     readonly sourceValue: KeyPath<Source, Value>,
     _ destinationValue: WritableKeyPath<Destination, Value>
   ) {

--- a/Examples/CaseStudies/SwiftUICaseStudies/Internal/StateBinding.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/Internal/StateBinding.swift
@@ -1,0 +1,248 @@
+
+/// A struct that describe a directional binding between instances of `Source` and `Destination`. It's main
+/// use is to describe a connection between a property of `Source` and a property of `Destination` when
+/// using `BoundState`, `OptionalBoundState`, `ComputedState` or `ComputedOptionalState`
+public struct PropertyBinding<Source, Destination> {
+  let get: (Source, inout Destination) -> Void
+  let set: (inout Source, Destination) -> Void
+  /// Initialize a binding between a `Source` instance and a`Destination` instance.
+  /// - Parameters:
+  ///   - get: A function applied when `Destination` is requested from `Source`. The `Destination`
+  ///   instance can be updated at this point.
+  ///   - set: A function applied when `Destination` is set in `Source`. The `Source` instance can be
+  ///   updated at this point.
+  public init(
+    get: @escaping (Source, inout Destination) -> Void = { _, _ in },
+    set: @escaping (inout Source, Destination) -> Void = { _, _ in }
+  ) {
+    self.get = get
+    self.set = set
+  }
+
+  /// Initialized a `PropertyBinding` using a couble of `KeyPath` describing a similar property in
+  /// `Source` and `Destination`.
+  /// - Parameters:
+  ///   - sourceValue: A `KeyPath` to get and set `Value` in `Source`
+  ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
+  ///   - removeDuplicates: Used when the `Value` is set on `Source`. If this function is implemented
+  ///     and returns `true`, no assignation will occur and `Source` will be kept untouched.
+  public init<Value>(
+    _ sourceValue: WritableKeyPath<Source, Value>,
+    _ destinationValue: WritableKeyPath<Destination, Value>,
+    removeDuplicates: ((Value, Value) -> Bool)? = nil
+  ) {
+    self.get = { source, destination in
+      destination[keyPath: destinationValue] = source[keyPath: sourceValue]
+    }
+
+    self.set = { source, destination in
+      guard removeDuplicates?(source[keyPath: sourceValue], destination[keyPath: destinationValue]) != true
+      else { return }
+      source[keyPath: sourceValue] = destination[keyPath: destinationValue]
+    }
+  }
+
+  /// Initialized a `PropertyBinding` using a couble of `KeyPath` describing a similar property in
+  /// `Source` and `Destination`. This binding is unidirectional (readonly on Source )and the
+  /// `KeyPath<Source, Value` doesn't need to be writable.
+  /// - Parameters:
+  ///   - sourceValue: A `KeyPath` to get `Value` in `Source`
+  ///   - destinationValue: A `KeyPath` to get and set `Value` in `Destination`
+  public init<Value>(
+    readonly sourceValue: KeyPath<Source, Value>,
+    _ destinationValue: WritableKeyPath<Destination, Value>
+  ) {
+    self.get = { source, destination in
+      destination[keyPath: destinationValue] = source[keyPath: sourceValue]
+    }
+    self.set = { _, _ in
+    }
+  }
+}
+
+/// Describe a binding between a parent state `Source` and a child state `Destination`. Several initializer are
+/// provided to handle the following cases:
+/// - Synchronization of a subset of `Destination` properties with `Source`
+/// - Synchronization of a subset of an optional `Destination` state with `Source`
+/// - Synchronization of all the properties of `Destination` with `Source`
+/// - Synchronization of all the properties of an optional `Destination` with `Source`.
+///
+/// This binding can then be used to define public accessors to a `Destination` instance in `Source`, calling
+/// the `get` and `set` function with the `Source` instance and `Destination`'s `newValue`.
+///
+/// Let the child state `Destination` be:
+/// ```
+/// struct Destination {
+///   var value: String = ""
+///   var internalValue: Int = 0
+/// }
+/// ```
+/// We can the use `StateBinding` to generate a `Destination` instance whose `value` will be synchronized
+/// with the `title` value of `Source`:
+/// ```
+/// struct Source {
+///   var title: String = "Hello! world"
+///
+///   private var _storage = Feature()
+///   private static let _binding = StateBinding(\Self._storage) {
+///     (\.title, \.value)
+///   }
+///
+///   var feature: Feature {
+///     get { Self._binding.get(self) }
+///     set { Self._binding.set(&self, newValue) }
+///   }
+/// }
+///
+public struct StateBinding<Source, Destination> {
+  /// Retrieve the storage in `source`, update it and returns the result.
+  public let get: (_ source: Source) -> Destination
+  /// Set the storage in `source` and update `source`.
+  public let set: (_ source: inout Source, _ newValue: Destination) -> Void
+
+  /// Initialize an binding between a parent state `Source` and a child state `Destination`.
+  /// A private storage for a `Source` is provided so unaffected properties are preserved between accesses.
+  /// In other words, `Destination` can have private fields and only properties specified in `properties`
+  /// are synchronized with `Source`.
+  /// - Parameters:
+  ///   - storage: A writable (private) keyPath to an instance of `Destination`, used to store
+  ///   `Destination`'s internal properties.
+  ///   - removeDuplicateStorage: A function used to compare private storage and avoid setting it in `Source` if unnecessary
+  ///   - properties: A function that returns an array of `PropertyBinding<Source, Destination>`
+  public init(
+    _ storage: WritableKeyPath<Source, Destination>,
+    removeDuplicateStorage: ((Destination, Destination) -> Bool)? = nil,
+    @PropertyBindingsBuilder <Source, Destination> properties: () -> [PropertyBinding<Source, Destination>]
+  ) {
+    let properties = properties()
+    get = { source in
+      var stored = source[keyPath: storage]
+      properties.forEach { $0.get(source, &stored) }
+      return stored
+    }
+    set = { source, newValue in
+      if removeDuplicateStorage?(source[keyPath: storage], newValue) != true {
+        source[keyPath: storage] = newValue
+      }
+      properties.forEach { $0.set(&source, newValue) }
+    }
+  }
+
+  /// Initialize a  computed binding between a parent state `Source` and a child state `Destination`. These derived states
+  /// are used when all the properties of `Destination` can be individually stored in `Source`.
+  /// - Parameters:
+  ///   - source: The `Source`'s or parent state type
+  ///   - destination: A function that returns an default instance of `Destination` (the child state)
+  ///   - properties: A function that returns an array of `PropertyBinding<Source, Destination>`
+  public init(
+    _ source: Source.Type,
+    with destination: @escaping () -> Destination,
+    @PropertyBindingsBuilder <Source, Destination> properties: () -> [PropertyBinding<Source, Destination>]
+  ) {
+    let properties = properties()
+    get = { source in
+      var destination = destination()
+      properties.forEach { $0.get(source, &destination) }
+      return destination
+    }
+    set = { source, newValue in
+      properties.forEach { $0.set(&source, newValue) }
+    }
+  }
+
+  /// Initialize an binding between a parent state `Source` and a child state `Destination`.
+  /// A private storage for an optional `Source` is provided so unaffected properties are preserved between accesses.
+  /// In other words, `Destination` can have private fields and only properties specified in `properties` are synchronized
+  /// with `Source`. If the child is set to nil, source properties other than the storage property are kept untouched
+  /// - Parameters:
+  ///   - storage: A writable (private) keyPath to an instance of `Destination?`, used to store
+  ///   `Destination`'s internal properties. If this instance is nil, the computed property will be also nil.
+  ///   - removeDuplicateStorage: A function used to compare private storage and avoid setting it in `Source` if unnecessary
+  ///   - properties: A function that returns an array of `PropertyBinding<Source, Destination>`
+  public init<UnwrappedDestination>(
+    _ storage: WritableKeyPath<Source, Destination>,
+    removeDuplicateStorage: ((Destination, Destination) -> Bool)? = nil,
+    @PropertyBindingsBuilder <Source, UnwrappedDestination> properties: () -> [PropertyBinding<Source, UnwrappedDestination>]
+  ) where Destination == UnwrappedDestination? {
+    let properties = properties()
+    get = { source in
+      guard var stored = source[keyPath: storage] else { return nil }
+      properties.forEach { $0.get(source, &stored) }
+      return stored
+    }
+    set = { source, newValue in
+      if removeDuplicateStorage?(source[keyPath: storage], newValue) != true {
+        source[keyPath: storage] = newValue
+      }
+      guard let newValue = newValue else { return }
+      properties.forEach { $0.set(&source, newValue) }
+    }
+  }
+
+  /// Initialize a  computed binding between a parent state `Source` and an optional child state `Destination`
+  /// These derived states are used when all the properties of `Destination` can be individually stored in `Source`.
+  /// If the child is set to nil, the source properties are kept untouched
+  /// - Parameters:
+  ///   - destination: A function that returns an default instance of `Destination`(the child state) or nil.
+  ///   - properties: A function that returns an array of `PropertyBinding<Source, Destination>`
+  public init<UnwrappedDestination>(
+    with destination: @escaping (Source) -> Destination,
+    @PropertyBindingsBuilder <Source, UnwrappedDestination> properties: () -> [PropertyBinding<Source, UnwrappedDestination>] = { [] }
+  ) where Destination == UnwrappedDestination? {
+    let properties = properties()
+    get = { source in
+      guard var destination = destination(source) else { return nil }
+      properties.forEach { $0.get(source, &destination) }
+      return destination
+    }
+    set = { source, newValue in
+      guard let newValue = newValue else { return }
+      properties.forEach { $0.set(&source, newValue) }
+    }
+  }
+}
+
+@resultBuilder public enum PropertyBindingsBuilder<Source, Destination> {
+  /// Initialize a `PropertyBinding<Source, Destination>` from a couple of `WritableKeyPath`
+  public static func buildExpression<Value>(_ expression: (WritableKeyPath<Source, Value>, WritableKeyPath<Destination, Value>)
+  ) -> [PropertyBinding<Source, Destination>] {
+    [PropertyBinding(expression.0, expression.1)]
+  }
+
+  /// Initialize a readonly `PropertyBinding<Source, Destination>` from a couple`(KeyPath,WritableKeyPath)`.
+  public static func buildExpression<Value>(readonly expression: (KeyPath<Source, Value>, WritableKeyPath<Destination, Value>)
+  ) -> [PropertyBinding<Source, Destination>] {
+    [PropertyBinding(readonly: expression.0, expression.1)]
+  }
+
+  /// Initialize a  deduplicating`PropertyBinding<Source, Destination>` from a couple of `WritableKeyPath<_, Value>`
+  /// and a function `(Value, Value) -> Bool` which returns `true` when both argurments are duplicates.
+  public static func buildExpression<Value>(_ expression: (WritableKeyPath<Source, Value>, WritableKeyPath<Destination, Value>, (Value, Value) -> Bool)
+  ) -> [PropertyBinding<Source, Destination>] {
+    [PropertyBinding(expression.0, expression.1, removeDuplicates: expression.2)]
+  }
+
+  public static func buildExpression(_ expression: PropertyBinding<Source, Destination>) -> [PropertyBinding<Source, Destination>] {
+    [expression]
+  }
+
+  public static func buildBlock(_ components: [PropertyBinding<Source, Destination>]...) -> [PropertyBinding<Source, Destination>] {
+    components.flatMap { $0 }
+  }
+
+  public static func buildArray(_ components: [[PropertyBinding<Source, Destination>]]) -> [PropertyBinding<Source, Destination>] {
+    components.flatMap { $0 }
+  }
+
+  public static func buildEither(first component: [PropertyBinding<Source, Destination>]) -> [PropertyBinding<Source, Destination>] {
+    component
+  }
+
+  public static func buildEither(second component: [PropertyBinding<Source, Destination>]) -> [PropertyBinding<Source, Destination>] {
+    component
+  }
+
+  public static func buildOptional(_ component: [PropertyBinding<Source, Destination>]?) -> [PropertyBinding<Source, Destination>] {
+    component ?? []
+  }
+}

--- a/Examples/CaseStudies/SwiftUICaseStudies/Internal/StateBinding.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/Internal/StateBinding.swift
@@ -100,6 +100,7 @@ public struct StateBinding<Source, Destination> {
   /// Set the storage in `source` and update `source`.
   public let set: (_ source: inout Source, _ newValue: Destination) -> Void
 
+  #if swift(>=5.4)
   /// Initialize an binding between a parent state `Source` and a child state `Destination`.
   /// A private storage for a `Source` is provided so unaffected properties are preserved between accesses.
   /// In other words, `Destination` can have private fields and only properties specified in `properties`
@@ -127,7 +128,37 @@ public struct StateBinding<Source, Destination> {
       properties.forEach { $0.set(&source, newValue) }
     }
   }
+  #else
+  /// Initialize an binding between a parent state `Source` and a child state `Destination`.
+  /// A private storage for a `Source` is provided so unaffected properties are preserved between accesses.
+  /// In other words, `Destination` can have private fields and only properties specified in `properties`
+  /// are synchronized with `Source`.
+  /// - Parameters:
+  ///   - storage: A writable (private) keyPath to an instance of `Destination`, used to store
+  ///   `Destination`'s internal properties.
+  ///   - removeDuplicateStorage: A function used to compare private storage and avoid setting it in `Source` if unnecessary
+  ///   - properties: A function that returns an array of `PropertyBinding<Source, Destination>`
+  public init(
+    _ storage: WritableKeyPath<Source, Destination>,
+    removeDuplicateStorage: ((Destination, Destination) -> Bool)? = nil,
+    properties: () -> [PropertyBinding<Source, Destination>]
+  ) {
+    let properties = properties()
+    get = { source in
+      var stored = source[keyPath: storage]
+      properties.forEach { $0.get(source, &stored) }
+      return stored
+    }
+    set = { source, newValue in
+      if removeDuplicateStorage?(source[keyPath: storage], newValue) != true {
+        source[keyPath: storage] = newValue
+      }
+      properties.forEach { $0.set(&source, newValue) }
+    }
+  }
+  #endif
 
+  #if swift(>=5.4)
   /// Initialize a  computed binding between a parent state `Source` and a child state `Destination`. These derived states
   /// are used when all the properties of `Destination` can be individually stored in `Source`.
   /// - Parameters:
@@ -149,7 +180,31 @@ public struct StateBinding<Source, Destination> {
       properties.forEach { $0.set(&source, newValue) }
     }
   }
+  #else
+  /// Initialize a  computed binding between a parent state `Source` and a child state `Destination`. These derived states
+  /// are used when all the properties of `Destination` can be individually stored in `Source`.
+  /// - Parameters:
+  ///   - source: The `Source`'s or parent state type
+  ///   - destination: A function that returns an default instance of `Destination` (the child state)
+  ///   - properties: A function that returns an array of `PropertyBinding<Source, Destination>`
+  public init(
+    _ source: Source.Type,
+    with destination: @escaping () -> Destination,
+    properties: () -> [PropertyBinding<Source, Destination>]
+  ) {
+    let properties = properties()
+    get = { source in
+      var destination = destination()
+      properties.forEach { $0.get(source, &destination) }
+      return destination
+    }
+    set = { source, newValue in
+      properties.forEach { $0.set(&source, newValue) }
+    }
+  }
+  #endif
 
+  #if swift(>=5.4)
   /// Initialize an binding between a parent state `Source` and a child state `Destination`.
   /// A private storage for an optional `Source` is provided so unaffected properties are preserved between accesses.
   /// In other words, `Destination` can have private fields and only properties specified in `properties` are synchronized
@@ -178,7 +233,38 @@ public struct StateBinding<Source, Destination> {
       properties.forEach { $0.set(&source, newValue) }
     }
   }
+  #else
+  /// Initialize an binding between a parent state `Source` and a child state `Destination`.
+  /// A private storage for an optional `Source` is provided so unaffected properties are preserved between accesses.
+  /// In other words, `Destination` can have private fields and only properties specified in `properties` are synchronized
+  /// with `Source`. If the child is set to nil, source properties other than the storage property are kept untouched
+  /// - Parameters:
+  ///   - storage: A writable (private) keyPath to an instance of `Destination?`, used to store
+  ///   `Destination`'s internal properties. If this instance is nil, the computed property will be also nil.
+  ///   - removeDuplicateStorage: A function used to compare private storage and avoid setting it in `Source` if unnecessary
+  ///   - properties: A function that returns an array of `PropertyBinding<Source, Destination>`
+  public init<UnwrappedDestination>(
+    optional storage: WritableKeyPath<Source, Destination>,
+    removeDuplicateStorage: ((Destination, Destination) -> Bool)? = nil,
+    properties: () -> [PropertyBinding<Source, UnwrappedDestination>]
+  ) where Destination == UnwrappedDestination? {
+    let properties = properties()
+    get = { source in
+      guard var stored = source[keyPath: storage] else { return nil }
+      properties.forEach { $0.get(source, &stored) }
+      return stored
+    }
+    set = { source, newValue in
+      if removeDuplicateStorage?(source[keyPath: storage], newValue) != true {
+        source[keyPath: storage] = newValue
+      }
+      guard let newValue = newValue else { return }
+      properties.forEach { $0.set(&source, newValue) }
+    }
+  }
+  #endif
 
+  #if swift(>=5.4)
   /// Initialize a  computed binding between a parent state `Source` and an optional child state `Destination`
   /// These derived states are used when all the properties of `Destination` can be individually stored in `Source`.
   /// If the child is set to nil, the source properties are kept untouched
@@ -200,8 +286,32 @@ public struct StateBinding<Source, Destination> {
       properties.forEach { $0.set(&source, newValue) }
     }
   }
+  #else
+  /// Initialize a  computed binding between a parent state `Source` and an optional child state `Destination`
+  /// These derived states are used when all the properties of `Destination` can be individually stored in `Source`.
+  /// If the child is set to nil, the source properties are kept untouched
+  /// - Parameters:
+  ///   - destination: A function that returns an default instance of `Destination`(the child state) or nil.
+  ///   - properties: A function that returns an array of `PropertyBinding<Source, Destination>`
+  public init<UnwrappedDestination>(
+    with destination: @escaping (Source) -> Destination,
+    properties: () -> [PropertyBinding<Source, UnwrappedDestination>] = { [] }
+  ) where Destination == UnwrappedDestination? {
+    let properties = properties()
+    get = { source in
+      guard var destination = destination(source) else { return nil }
+      properties.forEach { $0.get(source, &destination) }
+      return destination
+    }
+    set = { source, newValue in
+      guard let newValue = newValue else { return }
+      properties.forEach { $0.set(&source, newValue) }
+    }
+  }
+  #endif
 }
 
+#if swift(>=5.4)
 @resultBuilder public enum PropertyBindingsBuilder<Source, Destination> {
   /// Initialize a `PropertyBinding<Source, Destination>` from a couple of `WritableKeyPath`
   public static func buildExpression<Value>(_ expression: (WritableKeyPath<Source, Value>, WritableKeyPath<Destination, Value>)
@@ -246,3 +356,4 @@ public struct StateBinding<Source, Destination> {
     component ?? []
   }
 }
+#endif

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/Internal/StateBindingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/Internal/StateBindingTests.swift
@@ -11,7 +11,13 @@ class StateBindingTests: XCTestCase {
       var content: String = ""
       var _feature: Feature = .init()
       static var _feature = StateBinding(\Self._feature) {
+        #if swift(>=5.4)
         (\.content, \.external)
+        #else
+        return [
+          PropertyBinding(\.content, \.external),
+        ]
+        #endif
       }
 
       var feature: Feature {
@@ -41,9 +47,15 @@ class StateBindingTests: XCTestCase {
     struct State {
       var content: String = ""
       var _feature: Feature? = nil
+      #if swift(>=5.4)
       static var _feature = StateBinding(\Self._feature) {
         (\.content, \.external)
       }
+      #else
+      static var _feature = StateBinding(optional: \Self._feature) {
+        [PropertyBinding(\.content, \.external)]
+      }
+      #endif
 
       var feature: Feature? {
         get { Self._feature.get(self) }
@@ -81,8 +93,15 @@ class StateBindingTests: XCTestCase {
       var count = 0
             
       static var _feature = StateBinding(Self.self, with: Feature.init) {
+        #if swift(>=5.4)
         (\.content, \.external)
         (\.count, \.internal)
+        #else
+        return [
+          PropertyBinding(\.content, \.external),
+          PropertyBinding(\.count, \.internal),
+        ]
+        #endif
       }
 
       var feature: Feature {
@@ -115,8 +134,15 @@ class StateBindingTests: XCTestCase {
       var count = 0
       var hasFeature = false
       static var _feature = StateBinding<State, Feature?>(with: { $0.hasFeature ? .init() : nil }) {
+        #if swift(>=5.4)
         (\.content, \.external)
         (\.count, \.internal)
+        #else
+        return [
+          PropertyBinding(\.content, \.external),
+          PropertyBinding(\.count, \.internal),
+        ]
+        #endif
       }
 
       var feature: Feature? {
@@ -167,7 +193,13 @@ class StateBindingTests: XCTestCase {
       }
 
       static var _feature = StateBinding(\Self._feature, removeDuplicateStorage: ==) {
+        #if swift(>=5.4)
         (\.content, \.external, removeDuplicates: ==)
+        #else
+        return [
+          PropertyBinding(\.content, \.external, removeDuplicates: ==),
+        ]
+        #endif
       }
 
       var feature: Feature {

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/Internal/StateBindingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/Internal/StateBindingTests.swift
@@ -1,0 +1,184 @@
+@testable import SwiftUICaseStudies
+import XCTest
+
+class StateBindingTests: XCTestCase {
+  func testStateBindingWithStorage() {
+    struct Feature {
+      var external: String = ""
+      var `internal`: Int = 0
+    }
+    struct State {
+      var content: String = ""
+      var _feature: Feature = .init()
+      static var _feature = StateBinding(\Self._feature) {
+        (\.content, \.external)
+      }
+
+      var feature: Feature {
+        get { Self._feature.get(self) }
+        set { Self._feature.set(&self, newValue) }
+      }
+    }
+        
+    var state = State()
+    state.feature.internal = 1
+    state.feature.external = "Hello!"
+        
+    XCTAssertEqual(state.feature.internal, 1)
+    XCTAssertEqual(state.feature.external, "Hello!")
+    XCTAssertEqual(state.content, "Hello!")
+
+    state.content = "World!"
+    XCTAssertEqual(state.feature.internal, 1)
+    XCTAssertEqual(state.feature.external, "World!")
+  }
+    
+  func testOptionalStateBindingWithStorage() {
+    struct Feature {
+      var external: String = ""
+      var `internal`: Int = 0
+    }
+    struct State {
+      var content: String = ""
+      var _feature: Feature? = nil
+      static var _feature = StateBinding(\Self._feature) {
+        (\.content, \.external)
+      }
+
+      var feature: Feature? {
+        get { Self._feature.get(self) }
+        set { Self._feature.set(&self, newValue) }
+      }
+    }
+        
+    var state = State()
+    state.feature = .init()
+        
+    state.feature?.internal = 1
+    state.feature?.external = "Hello!"
+        
+    XCTAssertEqual(state.feature?.internal, 1)
+    XCTAssertEqual(state.feature?.external, "Hello!")
+    XCTAssertEqual(state.content, "Hello!")
+
+    state.content = "World!"
+    XCTAssertEqual(state.feature?.internal, 1)
+    XCTAssertEqual(state.feature?.external, "World!")
+        
+    state._feature = nil
+    state.feature?.external = "Test"
+    // `content` should be unchanged as `feature` is nil.
+    XCTAssertEqual(state.content, "World!")
+  }
+    
+  func testComputedStateBinding() {
+    struct Feature {
+      var external: String = ""
+      var `internal`: Int = 0
+    }
+    struct State {
+      var content: String = ""
+      var count = 0
+            
+      static var _feature = StateBinding(Self.self, with: Feature.init) {
+        (\.content, \.external)
+        (\.count, \.internal)
+      }
+
+      var feature: Feature {
+        get { Self._feature.get(self) }
+        set { Self._feature.set(&self, newValue) }
+      }
+    }
+        
+    var state = State()
+    state.feature.internal = 1
+    state.feature.external = "Hello!"
+        
+    XCTAssertEqual(state.feature.internal, 1)
+    XCTAssertEqual(state.feature.external, "Hello!")
+        
+    state.content = "World!"
+    state.count = 2
+        
+    XCTAssertEqual(state.feature.internal, 2)
+    XCTAssertEqual(state.feature.external, "World!")
+  }
+    
+  func testOptionalComputedStateBinding() {
+    struct Feature {
+      var external: String = ""
+      var `internal`: Int = 0
+    }
+    struct State {
+      var content: String = ""
+      var count = 0
+      var hasFeature = false
+      static var _feature = StateBinding<State, Feature?>(with: { $0.hasFeature ? .init() : nil }) {
+        (\.content, \.external)
+        (\.count, \.internal)
+      }
+
+      var feature: Feature? {
+        get { Self._feature.get(self) }
+        set { Self._feature.set(&self, newValue) }
+      }
+    }
+        
+    var state = State()
+    XCTAssertNil(state.feature)
+        
+    state.content = "World!"
+    state.count = 2
+        
+    state.hasFeature = true
+
+    XCTAssertEqual(state.feature?.internal, 2)
+    XCTAssertEqual(state.feature?.external, "World!")
+        
+    state.feature?.internal = 1
+    state.feature?.external = "Hello!"
+        
+    XCTAssertEqual(state.count, 1)
+    XCTAssertEqual(state.content, "Hello!")
+        
+    state.hasFeature = false
+
+    state.feature?.internal = 3
+    state.feature?.external = "Test"
+        
+    // Should be unchanged as `feature` is nil.
+    XCTAssertEqual(state.count, 1)
+    XCTAssertEqual(state.content, "Hello!")
+  }
+  
+  func testStateBindingDeDuplication() {
+    struct Feature: Equatable {
+      var external: String = ""
+      var `internal`: Int = 0
+    }
+    struct State {
+      var content: String = "" {
+        didSet { XCTFail("`content` value was set") }
+      }
+
+      var _feature: Feature = .init() {
+        didSet { XCTFail("`_feature` value was set") }
+      }
+
+      static var _feature = StateBinding(\Self._feature, removeDuplicateStorage: ==) {
+        (\.content, \.external, removeDuplicates: ==)
+      }
+
+      var feature: Feature {
+        get { Self._feature.get(self) }
+        set { Self._feature.set(&self, newValue) }
+      }
+    }
+        
+    var state = State(content: "Hello!", _feature: .init(external: "Hello!", internal: 1))
+    // This would hit didSet and fail if not deduplicated.
+    state.feature.internal = 1
+    state.feature.external = "Hello!"
+  }
+}

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/Internal/StateBindingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/Internal/StateBindingTests.swift
@@ -11,13 +11,7 @@ class StateBindingTests: XCTestCase {
       var content: String = ""
       var _feature: Feature = .init()
       static var _feature = StateBinding(\Self._feature) {
-        #if swift(>=5.4)
         (\.content, \.external)
-        #else
-        return [
-          PropertyBinding(\.content, \.external),
-        ]
-        #endif
       }
 
       var feature: Feature {
@@ -47,15 +41,9 @@ class StateBindingTests: XCTestCase {
     struct State {
       var content: String = ""
       var _feature: Feature? = nil
-      #if swift(>=5.4)
       static var _feature = StateBinding(\Self._feature) {
         (\.content, \.external)
       }
-      #else
-      static var _feature = StateBinding(optional: \Self._feature) {
-        [PropertyBinding(\.content, \.external)]
-      }
-      #endif
 
       var feature: Feature? {
         get { Self._feature.get(self) }
@@ -93,15 +81,8 @@ class StateBindingTests: XCTestCase {
       var count = 0
             
       static var _feature = StateBinding(Self.self, with: Feature.init) {
-        #if swift(>=5.4)
         (\.content, \.external)
         (\.count, \.internal)
-        #else
-        return [
-          PropertyBinding(\.content, \.external),
-          PropertyBinding(\.count, \.internal),
-        ]
-        #endif
       }
 
       var feature: Feature {
@@ -134,15 +115,8 @@ class StateBindingTests: XCTestCase {
       var count = 0
       var hasFeature = false
       static var _feature = StateBinding<State, Feature?>(with: { $0.hasFeature ? .init() : nil }) {
-        #if swift(>=5.4)
         (\.content, \.external)
         (\.count, \.internal)
-        #else
-        return [
-          PropertyBinding(\.content, \.external),
-          PropertyBinding(\.count, \.internal),
-        ]
-        #endif
       }
 
       var feature: Feature? {
@@ -193,13 +167,7 @@ class StateBindingTests: XCTestCase {
       }
 
       static var _feature = StateBinding(\Self._feature, removeDuplicateStorage: ==) {
-        #if swift(>=5.4)
         (\.content, \.external, removeDuplicates: ==)
-        #else
-        return [
-          PropertyBinding(\.content, \.external, removeDuplicates: ==),
-        ]
-        #endif
       }
 
       var feature: Feature {

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/Internal/StateBindingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/Internal/StateBindingTests.swift
@@ -79,7 +79,7 @@ class StateBindingTests: XCTestCase {
       var content: String = ""
       var count = 0
             
-      static var _feature = StateBinding(Self.self, with: Feature.init)
+      static var _feature = StateBinding<State, Feature>(with: Feature.init)
         .rw(\.content, \.external)
         .rw(\.count, \.internal)
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/Internal/StateBindingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/Internal/StateBindingTests.swift
@@ -318,4 +318,41 @@ class StateBindingTests: XCTestCase {
     XCTAssertEqual(state.content, "World!")
     XCTAssertEqual(state.features[0].external, "World!")
   }
+  
+  func testStatesSynchronization() {
+    let store = TestStore(
+      initialState: SharedStateWithBinding(),
+      reducer: sharedStateWithBindingReducer,
+      environment: ()
+    )
+
+    store.assert(
+      .send(.feature1(.binding(BindingAction<SharedStateWithBinding.FeatureState>.set(\.text, "Hello!")))) {
+        $0.content = "Hello!"
+        $0._feature2.count = 0
+        $0._feature2.text = ""
+        $0._feature2.name = ""
+      },
+      .send(.feature2(.binding(BindingAction<SharedStateWithBinding.FeatureState>.set(\.count, 4)))) {
+        $0._feature2.count = 4
+        $0._feature2.text = "Hello!"
+        $0._feature2.name = $0.feature2Name
+        $0._feature3 = nil
+      },
+      .send(.toggleFeature3) {
+        $0._feature3 = SharedStateWithBinding.FeatureState()
+      },
+      .send(.feature3(.binding(BindingAction<SharedStateWithBinding.FeatureState>.set(\.count, 10)))) {
+        $0._feature3?.count = 10
+        $0._feature3?.text = "Hello!"
+        $0._feature3!.name = $0.feature3Name
+      },
+      .send(.feature3(.binding(BindingAction<SharedStateWithBinding.FeatureState>.set(\.text, "World")))) {
+        $0._feature3?.count = 10
+        $0._feature3?.text = "World"
+        $0.content = "World"
+      }
+    )
+  }
+  
 }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/Internal/StateBindingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/Internal/StateBindingTests.swift
@@ -11,9 +11,8 @@ class StateBindingTests: XCTestCase {
       var content: String = ""
       var _feature: Feature = .init()
       
-      static var _feature = StateBinding(\Self._feature) {[
-        PropertyBinding(\.content, \.external)
-      ]}
+      static var _feature = StateBinding(\Self._feature)
+        .rw(\.content, \.external)
 
       var feature: Feature {
         get { Self._feature.get(self) }
@@ -42,9 +41,8 @@ class StateBindingTests: XCTestCase {
     struct State {
       var content: String = ""
       var _feature: Feature? = nil
-      static var _feature = StateBinding(\Self._feature) {[
-        PropertyBinding(\.content, \.external)
-      ]}
+      static var _feature = StateBinding(\Self._feature)
+        .rw(\.content, \.external)
 
       var feature: Feature? {
         get { Self._feature.get(self) }
@@ -81,10 +79,9 @@ class StateBindingTests: XCTestCase {
       var content: String = ""
       var count = 0
             
-      static var _feature = StateBinding(Self.self, with: Feature.init) {[
-        PropertyBinding(\.content, \.external),
-        PropertyBinding(\.count, \.internal),
-      ]}
+      static var _feature = StateBinding(Self.self, with: Feature.init)
+        .rw(\.content, \.external)
+        .rw(\.count, \.internal)
 
       var feature: Feature {
         get { Self._feature.get(self) }
@@ -115,10 +112,9 @@ class StateBindingTests: XCTestCase {
       var content: String = ""
       var count = 0
       var hasFeature = false
-      static var _feature = StateBinding<State, Feature?>(with: { $0.hasFeature ? .init() : nil }) {[
-        PropertyBinding(\.content, \.external),
-        PropertyBinding(\.count, \.internal),
-      ]}
+      static var _feature = StateBinding<State, Feature?>(with: { $0.hasFeature ? .init() : nil })
+        .rw(\.content, \.external)
+        .rw(\.count, \.internal)
 
       var feature: Feature? {
         get { Self._feature.get(self) }
@@ -167,9 +163,8 @@ class StateBindingTests: XCTestCase {
         didSet { XCTFail("`_feature` value was set") }
       }
 
-      static var _feature = StateBinding(\Self._feature, removeDuplicateStorage: ==) {[
-        PropertyBinding(\.content, \.external, removeDuplicates: ==)
-       ]}
+      static var _feature = StateBinding(\Self._feature, removeDuplicateStorage: ==)
+        .rw(\.content, \.external, removeDuplicates: ==)
 
       var feature: Feature {
         get { Self._feature.get(self) }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/Internal/StateBindingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/Internal/StateBindingTests.swift
@@ -1,4 +1,3 @@
-#if swift(>=5.4)
 @testable import SwiftUICaseStudies
 import XCTest
 
@@ -11,9 +10,10 @@ class StateBindingTests: XCTestCase {
     struct State {
       var content: String = ""
       var _feature: Feature = .init()
-      static var _feature = StateBinding(\Self._feature) {
-        (\.content, \.external)
-      }
+      
+      static var _feature = StateBinding(\Self._feature) {[
+        PropertyBinding(\.content, \.external)
+      ]}
 
       var feature: Feature {
         get { Self._feature.get(self) }
@@ -42,9 +42,9 @@ class StateBindingTests: XCTestCase {
     struct State {
       var content: String = ""
       var _feature: Feature? = nil
-      static var _feature = StateBinding(\Self._feature) {
-        (\.content, \.external)
-      }
+      static var _feature = StateBinding(\Self._feature) {[
+        PropertyBinding(\.content, \.external)
+      ]}
 
       var feature: Feature? {
         get { Self._feature.get(self) }
@@ -81,10 +81,10 @@ class StateBindingTests: XCTestCase {
       var content: String = ""
       var count = 0
             
-      static var _feature = StateBinding(Self.self, with: Feature.init) {
-        (\.content, \.external)
-        (\.count, \.internal)
-      }
+      static var _feature = StateBinding(Self.self, with: Feature.init) {[
+        PropertyBinding(\.content, \.external),
+        PropertyBinding(\.count, \.internal),
+      ]}
 
       var feature: Feature {
         get { Self._feature.get(self) }
@@ -115,10 +115,10 @@ class StateBindingTests: XCTestCase {
       var content: String = ""
       var count = 0
       var hasFeature = false
-      static var _feature = StateBinding<State, Feature?>(with: { $0.hasFeature ? .init() : nil }) {
-        (\.content, \.external)
-        (\.count, \.internal)
-      }
+      static var _feature = StateBinding<State, Feature?>(with: { $0.hasFeature ? .init() : nil }) {[
+        PropertyBinding(\.content, \.external),
+        PropertyBinding(\.count, \.internal),
+      ]}
 
       var feature: Feature? {
         get { Self._feature.get(self) }
@@ -167,9 +167,9 @@ class StateBindingTests: XCTestCase {
         didSet { XCTFail("`_feature` value was set") }
       }
 
-      static var _feature = StateBinding(\Self._feature, removeDuplicateStorage: ==) {
-        (\.content, \.external, removeDuplicates: ==)
-      }
+      static var _feature = StateBinding(\Self._feature, removeDuplicateStorage: ==) {[
+        PropertyBinding(\.content, \.external, removeDuplicates: ==)
+       ]}
 
       var feature: Feature {
         get { Self._feature.get(self) }
@@ -183,4 +183,3 @@ class StateBindingTests: XCTestCase {
     state.feature.external = "Hello!"
   }
 }
-#endif

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/Internal/StateBindingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/Internal/StateBindingTests.swift
@@ -1,3 +1,4 @@
+#if swift(>=5.4)
 @testable import SwiftUICaseStudies
 import XCTest
 
@@ -182,3 +183,4 @@ class StateBindingTests: XCTestCase {
     state.feature.external = "Hello!"
   }
 }
+#endif


### PR DESCRIPTION
Hello!,

Including a substate with shared values in a parent state is currently inconvenient and error-prone:
Each construction is bespoke, and one has to make sure that getters and setters are coherent. Changing the order of the child properties changes the generated initializer, forcing to update the parent's call site. Adding a property to the child state forces to inform all the parents of its existence or to resort to custom strategies.
Furthermore, avoiding deduplication in the setter has to be implemented explicitly each time it's required.

This PR attempts to improve the situation on many points. One has only to describe once the connection between the parent state and its child state, and one can specify if and how values should be deduplicated at this point. 
The description is mainly realized by providing couples of `KeyPaths`.

Two types are added to this end: `PropertyBinding`, which describe a binding between a property `V` of the parent and the child, and `StateBinding` which describe how a list of `PropertyBinding` is applied, such as the parent's properties and the child instance are in sync. From the `StateBinding`, one can generate *bona fide* accessors to a child state instance.

These types were added in the form of a new SwiftUI case-study called `01-GettingStarted-SharedState-StateBindings` (albeit it would work the same in UIKit). The case study present many use-cases: substates with internal properties, optional substates, fine-grained deduplication, etc. It also shows that the syntax is very similar in each configuration.

This is purely additional and only concerns the `State` part of TCA. I've already presented the idea in #409, but this is a much more refined version with only two types and a simplified syntax <del>thanks to a `@resultBuilder`</del>(Edit: [no more builder](https://github.com/pointfreeco/swift-composable-architecture/pull/451#issuecomment-803663539)).

Please tell me what you think.