### PR TITLE
Updated TestStore DSL

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndActionSheetsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndActionSheetsTests.swift
@@ -13,23 +13,21 @@ class AlertsAndActionSheetsTests: XCTestCase {
       environment: AlertAndSheetEnvironment()
     )
 
-    store.assert(
-      .send(.alertButtonTapped) {
-        $0.alert = .init(
-          title: .init("Alert!"),
-          message: .init("This is an alert"),
-          primaryButton: .cancel(),
-          secondaryButton: .default(.init("Increment"), send: .incrementButtonTapped)
-        )
-      },
-      .send(.incrementButtonTapped) {
-        $0.alert = .init(title: .init("Incremented!"))
-        $0.count = 1
-      },
-      .send(.alertDismissed) {
-        $0.alert = nil
-      }
-    )
+    store.send(.alertButtonTapped) {
+      $0.alert = .init(
+        title: .init("Alert!"),
+        message: .init("This is an alert"),
+        primaryButton: .cancel(),
+        secondaryButton: .default(.init("Increment"), send: .incrementButtonTapped)
+      )
+    }
+    store.send(.incrementButtonTapped) {
+      $0.alert = .init(title: .init("Incremented!"))
+      $0.count = 1
+    }
+    store.send(.alertDismissed) {
+      $0.alert = nil
+    }
   }
 
   func testActionSheet() {
@@ -39,25 +37,23 @@ class AlertsAndActionSheetsTests: XCTestCase {
       environment: AlertAndSheetEnvironment()
     )
 
-    store.assert(
-      .send(.actionSheetButtonTapped) {
-        $0.actionSheet = .init(
-          title: .init("Action sheet"),
-          message: .init("This is an action sheet."),
-          buttons: [
-            .cancel(),
-            .default(.init("Increment"), send: .incrementButtonTapped),
-            .default(.init("Decrement"), send: .decrementButtonTapped),
-          ]
-        )
-      },
-      .send(.incrementButtonTapped) {
-        $0.alert = .init(title: .init("Incremented!"))
-        $0.count = 1
-      },
-      .send(.actionSheetDismissed) {
-        $0.actionSheet = nil
-      }
-    )
+    store.send(.actionSheetButtonTapped) {
+      $0.actionSheet = .init(
+        title: .init("Action sheet"),
+        message: .init("This is an action sheet."),
+        buttons: [
+          .cancel(),
+          .default(.init("Increment"), send: .incrementButtonTapped),
+          .default(.init("Decrement"), send: .decrementButtonTapped),
+        ]
+      )
+    }
+    store.send(.incrementButtonTapped) {
+      $0.alert = .init(title: .init("Incremented!"))
+      $0.count = 1
+    }
+    store.send(.actionSheetDismissed) {
+      $0.actionSheet = nil
+    }
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
@@ -16,49 +16,47 @@ class AnimationTests: XCTestCase {
       )
     )
 
-    store.assert(
-      .send(.rainbowButtonTapped),
+    store.send(.rainbowButtonTapped)
 
-      .receive(.setColor(.red)) {
-        $0.circleColor = .red
-      },
+    store.receive(.setColor(.red)) {
+      $0.circleColor = .red
+    }
 
-      .do { self.scheduler.advance(by: .seconds(1)) },
-      .receive(.setColor(.blue)) {
-        $0.circleColor = .blue
-      },
+    self.scheduler.advance(by: .seconds(1))
+    store.receive(.setColor(.blue)) {
+      $0.circleColor = .blue
+    }
 
-      .do { self.scheduler.advance(by: .seconds(1)) },
-      .receive(.setColor(.green)) {
-        $0.circleColor = .green
-      },
+    self.scheduler.advance(by: .seconds(1))
+    store.receive(.setColor(.green)) {
+      $0.circleColor = .green
+    }
 
-      .do { self.scheduler.advance(by: .seconds(1)) },
-      .receive(.setColor(.orange)) {
-        $0.circleColor = .orange
-      },
+    self.scheduler.advance(by: .seconds(1))
+    store.receive(.setColor(.orange)) {
+      $0.circleColor = .orange
+    }
 
-      .do { self.scheduler.advance(by: .seconds(1)) },
-      .receive(.setColor(.pink)) {
-        $0.circleColor = .pink
-      },
+    self.scheduler.advance(by: .seconds(1))
+    store.receive(.setColor(.pink)) {
+      $0.circleColor = .pink
+    }
 
-      .do { self.scheduler.advance(by: .seconds(1)) },
-      .receive(.setColor(.purple)) {
-        $0.circleColor = .purple
-      },
+    self.scheduler.advance(by: .seconds(1))
+    store.receive(.setColor(.purple)) {
+      $0.circleColor = .purple
+    }
 
-      .do { self.scheduler.advance(by: .seconds(1)) },
-      .receive(.setColor(.yellow)) {
-        $0.circleColor = .yellow
-      },
+    self.scheduler.advance(by: .seconds(1))
+    store.receive(.setColor(.yellow)) {
+      $0.circleColor = .yellow
+    }
 
-      .do { self.scheduler.advance(by: .seconds(1)) },
-      .receive(.setColor(.white)) {
-        $0.circleColor = .white
-      },
+    self.scheduler.advance(by: .seconds(1))
+    store.receive(.setColor(.white)) {
+      $0.circleColor = .white
+    }
 
-      .do { self.scheduler.run() }
-    )
+    self.scheduler.run()
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-BindingBasicsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-BindingBasicsTests.swift
@@ -12,23 +12,21 @@ class BindingFormTests: XCTestCase {
       environment: BindingFormEnvironment()
     )
 
-    store.assert(
-      .send(.binding(.set(\.sliderValue, 2))) {
-        $0.sliderValue = 2
-      },
-      .send(.binding(.set(\.stepCount, 1))) {
-        $0.sliderValue = 1
-        $0.stepCount = 1
-      },
-      .send(.binding(.set(\.text, "Blob"))) {
-        $0.text = "Blob"
-      },
-      .send(.binding(.set(\.toggleIsOn, true))) {
-        $0.toggleIsOn = true
-      },
-      .send(.resetButtonTapped) {
-        $0 = .init(sliderValue: 5, stepCount: 10, text: "", toggleIsOn: false)
-      }
-    )
+    store.send(.binding(.set(\.sliderValue, 2))) {
+      $0.sliderValue = 2
+    }
+    store.send(.binding(.set(\.stepCount, 1))) {
+      $0.sliderValue = 1
+      $0.stepCount = 1
+    }
+    store.send(.binding(.set(\.text, "Blob"))) {
+      $0.text = "Blob"
+    }
+    store.send(.binding(.set(\.toggleIsOn, true))) {
+      $0.toggleIsOn = true
+    }
+    store.send(.resetButtonTapped) {
+      $0 = .init(sliderValue: 5, stepCount: 10, text: "", toggleIsOn: false)
+    }
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-SharedStateTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-SharedStateTests.swift
@@ -12,17 +12,16 @@ class SharedStateTests: XCTestCase {
       environment: ()
     )
 
-    store.assert(
-      .send(.selectTab(.profile)) {
-        $0.currentTab = .profile
-        $0.profile = .init(
-          currentTab: .profile, count: 0, maxCount: 0, minCount: 0, numberOfCounts: 0)
-      },
-      .send(.profile(.resetCounterButtonTapped)) {
-        $0.currentTab = .counter
-        $0.profile = .init(
-          currentTab: .counter, count: 0, maxCount: 0, minCount: 0, numberOfCounts: 0)
-      })
+    store.send(.selectTab(.profile)) {
+      $0.currentTab = .profile
+      $0.profile = .init(
+        currentTab: .profile, count: 0, maxCount: 0, minCount: 0, numberOfCounts: 0)
+    }
+    store.send(.profile(.resetCounterButtonTapped)) {
+      $0.currentTab = .counter
+      $0.profile = .init(
+        currentTab: .counter, count: 0, maxCount: 0, minCount: 0, numberOfCounts: 0)
+    }
   }
 
   func testTabSelection() {
@@ -32,17 +31,16 @@ class SharedStateTests: XCTestCase {
       environment: ()
     )
 
-    store.assert(
-      .send(.selectTab(.profile)) {
-        $0.currentTab = .profile
-        $0.profile = .init(
-          currentTab: .profile, count: 0, maxCount: 0, minCount: 0, numberOfCounts: 0)
-      },
-      .send(.selectTab(.counter)) {
-        $0.currentTab = .counter
-        $0.profile = .init(
-          currentTab: .counter, count: 0, maxCount: 0, minCount: 0, numberOfCounts: 0)
-      })
+    store.send(.selectTab(.profile)) {
+      $0.currentTab = .profile
+      $0.profile = .init(
+        currentTab: .profile, count: 0, maxCount: 0, minCount: 0, numberOfCounts: 0)
+    }
+    store.send(.selectTab(.counter)) {
+      $0.currentTab = .counter
+      $0.profile = .init(
+        currentTab: .counter, count: 0, maxCount: 0, minCount: 0, numberOfCounts: 0)
+    }
   }
 
   func testSharedCounts() {
@@ -52,21 +50,20 @@ class SharedStateTests: XCTestCase {
       environment: ()
     )
 
-    store.assert(
-      .send(.counter(.incrementButtonTapped)) {
-        $0.counter.count = 1
-        $0.counter.maxCount = 1
-        $0.counter.numberOfCounts = 1
-      },
-      .send(.counter(.decrementButtonTapped)) {
-        $0.counter.count = 0
-        $0.counter.numberOfCounts = 2
-      },
-      .send(.counter(.decrementButtonTapped)) {
-        $0.counter.count = -1
-        $0.counter.minCount = -1
-        $0.counter.numberOfCounts = 3
-      })
+    store.send(.counter(.incrementButtonTapped)) {
+      $0.counter.count = 1
+      $0.counter.maxCount = 1
+      $0.counter.numberOfCounts = 1
+    }
+    store.send(.counter(.decrementButtonTapped)) {
+      $0.counter.count = 0
+      $0.counter.numberOfCounts = 2
+    }
+    store.send(.counter(.decrementButtonTapped)) {
+      $0.counter.count = -1
+      $0.counter.minCount = -1
+      $0.counter.numberOfCounts = 3
+    }
   }
 
   func testIsPrimeWhenPrime() {
@@ -77,16 +74,14 @@ class SharedStateTests: XCTestCase {
       environment: ()
     )
 
-    store.assert(
-      .send(.isPrimeButtonTapped) {
-        $0.alert = .init(
-          title: .init("👍 The number \($0.count) is prime!")
-        )
-      },
-      .send(.alertDismissed) {
-        $0.alert = nil
-      }
-    )
+    store.send(.isPrimeButtonTapped) {
+      $0.alert = .init(
+        title: .init("👍 The number \($0.count) is prime!")
+      )
+    }
+    store.send(.alertDismissed) {
+      $0.alert = nil
+    }
   }
 
   func testIsPrimeWhenNotPrime() {
@@ -97,15 +92,13 @@ class SharedStateTests: XCTestCase {
       environment: ()
     )
 
-    store.assert(
-      .send(.isPrimeButtonTapped) {
-        $0.alert = .init(
-          title: .init("👎 The number \($0.count) is not prime :(")
-        )
-      },
-      .send(.alertDismissed) {
-        $0.alert = nil
-      }
-    )
+    store.send(.isPrimeButtonTapped) {
+      $0.alert = .init(
+        title: .init("👎 The number \($0.count) is not prime :(")
+      )
+    }
+    store.send(.alertDismissed) {
+      $0.alert = nil
+    }
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-BasicsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-BasicsTests.swift
@@ -4,30 +4,25 @@ import XCTest
 @testable import SwiftUICaseStudies
 
 class EffectsBasicsTests: XCTestCase {
-  let scheduler = DispatchQueue.testScheduler
-
   func testCountDown() {
     let store = TestStore(
       initialState: EffectsBasicsState(),
       reducer: effectsBasicsReducer,
       environment: EffectsBasicsEnvironment(
-        mainQueue: self.scheduler.eraseToAnyScheduler(),
+        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
         numberFact: { _ in fatalError("Unimplemented") }
       )
     )
 
-    store.assert(
-      .send(.incrementButtonTapped) {
-        $0.count = 1
-      },
-      .send(.decrementButtonTapped) {
-        $0.count = 0
-      },
-      .do { self.scheduler.advance(by: 1) },
-      .receive(.incrementButtonTapped) {
-        $0.count = 1
-      }
-    )
+    store.send(.incrementButtonTapped) {
+      $0.count = 1
+    }
+    store.send(.decrementButtonTapped) {
+      $0.count = 0
+    }
+    store.receive(.incrementButtonTapped) {
+      $0.count = 1
+    }
   }
 
   func testNumberFact() {
@@ -35,23 +30,20 @@ class EffectsBasicsTests: XCTestCase {
       initialState: EffectsBasicsState(),
       reducer: effectsBasicsReducer,
       environment: EffectsBasicsEnvironment(
-        mainQueue: self.scheduler.eraseToAnyScheduler(),
+        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
         numberFact: { n in Effect(value: "\(n) is a good number Brent") }
       )
     )
 
-    store.assert(
-      .send(.incrementButtonTapped) {
-        $0.count = 1
-      },
-      .send(.numberFactButtonTapped) {
-        $0.isNumberFactRequestInFlight = true
-      },
-      .do { self.scheduler.advance() },
-      .receive(.numberFactResponse(.success("1 is a good number Brent"))) {
-        $0.isNumberFactRequestInFlight = false
-        $0.numberFact = "1 is a good number Brent"
-      }
-    )
+    store.send(.incrementButtonTapped) {
+      $0.count = 1
+    }
+    store.send(.numberFactButtonTapped) {
+      $0.isNumberFactRequestInFlight = true
+    }
+    store.receive(.numberFactResponse(.success("1 is a good number Brent"))) {
+      $0.isNumberFactRequestInFlight = false
+      $0.numberFact = "1 is a good number Brent"
+    }
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-CancellationTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-CancellationTests.swift
@@ -5,111 +5,93 @@ import XCTest
 @testable import SwiftUICaseStudies
 
 class EffectsCancellationTests: XCTestCase {
-  let scheduler = DispatchQueue.testScheduler
-
-  func testTrivia_SuccessfulRequest() throws {
+  func testTrivia_SuccessfulRequest() {
     let store = TestStore(
       initialState: .init(),
       reducer: effectsCancellationReducer,
       environment: .init(
-        mainQueue: self.scheduler.eraseToAnyScheduler(),
+        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
         numberFact: { n in Effect(value: "\(n) is a good number Brent") }
       )
     )
-
-    store.assert(
-      .send(.stepperChanged(1)) {
-        $0.count = 1
-      },
-      .send(.stepperChanged(0)) {
-        $0.count = 0
-      },
-      .send(.triviaButtonTapped) {
-        $0.isTriviaRequestInFlight = true
-      },
-      .do {
-        self.scheduler.advance()
-      },
-      .receive(.triviaResponse(.success("0 is a good number Brent"))) {
-        $0.currentTrivia = "0 is a good number Brent"
-        $0.isTriviaRequestInFlight = false
-      }
-    )
+    
+    store.send(.stepperChanged(1)) {
+      $0.count = 1
+    }
+    store.send(.stepperChanged(0)) {
+      $0.count = 0
+    }
+    store.send(.triviaButtonTapped) {
+      $0.isTriviaRequestInFlight = true
+    }
+    store.receive(.triviaResponse(.success("0 is a good number Brent"))) {
+      $0.currentTrivia = "0 is a good number Brent"
+      $0.isTriviaRequestInFlight = false
+    }
   }
-
-  func testTrivia_FailedRequest() throws {
+  
+  func testTrivia_FailedRequest() {
     let store = TestStore(
       initialState: .init(),
       reducer: effectsCancellationReducer,
       environment: .init(
-        mainQueue: self.scheduler.eraseToAnyScheduler(),
+        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
         numberFact: { _ in Fail(error: NumbersApiError()).eraseToEffect() }
       )
     )
-
-    store.assert(
-      .send(.triviaButtonTapped) {
-        $0.isTriviaRequestInFlight = true
-      },
-      .do {
-        self.scheduler.advance()
-      },
-      .receive(.triviaResponse(.failure(NumbersApiError()))) {
-        $0.isTriviaRequestInFlight = false
-      }
-    )
+    
+    store.send(.triviaButtonTapped) {
+      $0.isTriviaRequestInFlight = true
+    }
+    store.receive(.triviaResponse(.failure(NumbersApiError()))) {
+      $0.isTriviaRequestInFlight = false
+    }
   }
-
+  
   // NB: This tests that the cancel button really does cancel the in-flight API request.
   //
   // To see the real power of this test, try replacing the `.cancel` effect with a `.none` effect
   // in the `.cancelButtonTapped` action of the `effectsCancellationReducer`. This will cause the
   // test to fail, showing that we are exhaustively asserting that the effect truly is canceled and
   // will never emit.
-  func testTrivia_CancelButtonCancelsRequest() throws {
+  func testTrivia_CancelButtonCancelsRequest() {
+    let scheduler = DispatchQueue.testScheduler
     let store = TestStore(
       initialState: .init(),
       reducer: effectsCancellationReducer,
       environment: .init(
-        mainQueue: self.scheduler.eraseToAnyScheduler(),
+        mainQueue: scheduler.eraseToAnyScheduler(),
         numberFact: { n in Effect(value: "\(n) is a good number Brent") }
       )
     )
-
-    store.assert(
-      .send(.triviaButtonTapped) {
-        $0.isTriviaRequestInFlight = true
-      },
-      .send(.cancelButtonTapped) {
-        $0.isTriviaRequestInFlight = false
-      },
-      .do {
-        self.scheduler.run()
-      }
-    )
+    
+    store.send(.triviaButtonTapped) {
+      $0.isTriviaRequestInFlight = true
+    }
+    store.send(.cancelButtonTapped) {
+      $0.isTriviaRequestInFlight = false
+    }
+    scheduler.run()
   }
-
-  func testTrivia_PlusMinusButtonsCancelsRequest() throws {
+  
+  func testTrivia_PlusMinusButtonsCancelsRequest() {
+    let scheduler = DispatchQueue.testScheduler
     let store = TestStore(
       initialState: .init(),
       reducer: effectsCancellationReducer,
       environment: .init(
-        mainQueue: self.scheduler.eraseToAnyScheduler(),
+        mainQueue: scheduler.eraseToAnyScheduler(),
         numberFact: { n in Effect(value: "\(n) is a good number Brent") }
       )
     )
-
-    store.assert(
-      .send(.triviaButtonTapped) {
-        $0.isTriviaRequestInFlight = true
-      },
-      .send(.stepperChanged(1)) {
-        $0.count = 1
-        $0.isTriviaRequestInFlight = false
-      },
-      .do {
-        self.scheduler.advance()
-      }
-    )
+    
+    store.send(.triviaButtonTapped) {
+      $0.isTriviaRequestInFlight = true
+    }
+    store.send(.stepperChanged(1)) {
+      $0.count = 1
+      $0.isTriviaRequestInFlight = false
+    }
+    scheduler.advance()
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
@@ -17,20 +17,18 @@ class LongLivingEffectsTests: XCTestCase {
       )
     )
 
-    store.assert(
-      .send(.onAppear),
+    store.send(.onAppear)
 
-      // Simulate a screenshot being taken
-      .do { screenshotTaken.send() },
-      .receive(.userDidTakeScreenshotNotification) {
-        $0.screenshotCount = 1
-      },
+    // Simulate a screenshot being taken
+    screenshotTaken.send()
+    store.receive(.userDidTakeScreenshotNotification) {
+      $0.screenshotCount = 1
+    }
 
-      .send(.onDisappear),
+    store.send(.onDisappear)
 
-      // Simulate a screenshot being taken to show no effects
-      // are executed.
-      .do { screenshotTaken.send() }
-    )
+    // Simulate a screenshot being taken to show no effects
+    // are executed.
+    screenshotTaken.send()
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-TimersTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-TimersTests.swift
@@ -15,33 +15,31 @@ class TimersTests: XCTestCase {
       )
     )
 
-    store.assert(
-      .send(.toggleTimerButtonTapped) {
-        $0.isTimerActive = true
-      },
-      .do { self.scheduler.advance(by: 1) },
-      .receive(.timerTicked) {
-        $0.secondsElapsed = 1
-      },
-      .do { self.scheduler.advance(by: 5) },
-      .receive(.timerTicked) {
-        $0.secondsElapsed = 2
-      },
-      .receive(.timerTicked) {
-        $0.secondsElapsed = 3
-      },
-      .receive(.timerTicked) {
-        $0.secondsElapsed = 4
-      },
-      .receive(.timerTicked) {
-        $0.secondsElapsed = 5
-      },
-      .receive(.timerTicked) {
-        $0.secondsElapsed = 6
-      },
-      .send(.toggleTimerButtonTapped) {
-        $0.isTimerActive = false
-      }
-    )
+    store.send(.toggleTimerButtonTapped) {
+      $0.isTimerActive = true
+    }
+    self.scheduler.advance(by: 1)
+    store.receive(.timerTicked) {
+      $0.secondsElapsed = 1
+    }
+    self.scheduler.advance(by: 5)
+    store.receive(.timerTicked) {
+      $0.secondsElapsed = 2
+    }
+    store.receive(.timerTicked) {
+      $0.secondsElapsed = 3
+    }
+    store.receive(.timerTicked) {
+      $0.secondsElapsed = 4
+    }
+    store.receive(.timerTicked) {
+      $0.secondsElapsed = 5
+    }
+    store.receive(.timerTicked) {
+      $0.secondsElapsed = 6
+    }
+    store.send(.toggleTimerButtonTapped) {
+      $0.isTimerActive = false
+    }
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-LifecycleTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-LifecycleTests.swift
@@ -16,36 +16,34 @@ class LifecycleTests: XCTestCase {
       )
     )
 
-    store.assert(
-      .send(.toggleTimerButtonTapped) {
+      store.send(.toggleTimerButtonTapped) {
         $0.count = 0
-      },
+      }
 
-      .send(.timer(.onAppear)),
+      store.send(.timer(.onAppear))
 
-      .do { scheduler.advance(by: .seconds(1)) },
-      .receive(.timer(.action(.tick))) {
+      scheduler.advance(by: .seconds(1))
+      store.receive(.timer(.action(.tick))) {
         $0.count = 1
-      },
+      }
 
-      .do { scheduler.advance(by: .seconds(1)) },
-      .receive(.timer(.action(.tick))) {
+      scheduler.advance(by: .seconds(1))
+      store.receive(.timer(.action(.tick))) {
         $0.count = 2
-      },
+      }
 
-      .send(.timer(.action(.incrementButtonTapped))) {
+      store.send(.timer(.action(.incrementButtonTapped))) {
         $0.count = 3
-      },
+      }
 
-      .send(.timer(.action(.decrementButtonTapped))) {
+      store.send(.timer(.action(.decrementButtonTapped))) {
         $0.count = 2
-      },
+      }
 
-      .send(.toggleTimerButtonTapped) {
+      store.send(.toggleTimerButtonTapped) {
         $0.count = nil
-      },
+      }
 
-      .send(.timer(.onDisappear))
-    )
+      store.send(.timer(.onDisappear))
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
@@ -5,6 +5,8 @@ import XCTest
 @testable import SwiftUICaseStudies
 
 class ReusableComponentsFavoritingTests: XCTestCase {
+  let scheduler = DispatchQueue.testScheduler
+
   func testFavoriteButton() {
     let store = TestStore(
       initialState: EpisodesState(
@@ -29,7 +31,7 @@ class ReusableComponentsFavoritingTests: XCTestCase {
       reducer: episodesReducer,
       environment: EpisodesEnvironment(
         favorite: { _, isFavorite in Effect.future { $0(.success(isFavorite)) } },
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler()
+        mainQueue: self.scheduler.eraseToAnyScheduler()
       )
     )
 
@@ -38,6 +40,7 @@ class ReusableComponentsFavoritingTests: XCTestCase {
       $0.episodes[0].isFavorite = true
     }
 
+    self.scheduler.advance()
     store.receive(.episode(index: 0, action: .favorite(.response(.success(true)))))
 
     store.send(.episode(index: 1, action: .favorite(.buttonTapped))) {
@@ -47,6 +50,7 @@ class ReusableComponentsFavoritingTests: XCTestCase {
       $0.episodes[1].isFavorite = false
     }
 
+    self.scheduler.advance()
     store.receive(.episode(index: 1, action: .favorite(.response(.success(false)))))
 
     store.environment.favorite = { _, _ in .future { $0(.failure(error)) } }
@@ -54,6 +58,7 @@ class ReusableComponentsFavoritingTests: XCTestCase {
       $0.episodes[2].isFavorite = true
     }
 
+    self.scheduler.advance()
     store.receive(
       .episode(index: 2, action: .favorite(.response(.failure(FavoriteError(error: error)))))
     ) {

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
@@ -29,7 +29,7 @@ class ReusableComponentsFavoritingTests: XCTestCase {
       reducer: episodesReducer,
       environment: EpisodesEnvironment(
         favorite: { _, isFavorite in Effect.future { $0(.success(isFavorite)) } },
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
+        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler()
       )
     )
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
@@ -33,24 +33,22 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
       )
     )
 
-    store.assert(
-      .send(.buttonTapped) {
-        $0.mode = .startingToDownload
-      },
+    store.send(.buttonTapped) {
+      $0.mode = .startingToDownload
+    }
 
-      .do { self.downloadSubject.send(.updateProgress(0.2)) },
-      .do { self.scheduler.advance() },
-      .receive(.downloadClient(.success(.updateProgress(0.2)))) {
-        $0.mode = .downloading(progress: 0.2)
-      },
+    self.downloadSubject.send(.updateProgress(0.2))
+    self.scheduler.advance()
+    store.receive(.downloadClient(.success(.updateProgress(0.2)))) {
+      $0.mode = .downloading(progress: 0.2)
+    }
 
-      .do { self.downloadSubject.send(.response(Data())) },
-      .do { self.downloadSubject.send(completion: .finished) },
-      .do { self.scheduler.advance(by: 1) },
-      .receive(.downloadClient(.success(.response(Data())))) {
-        $0.mode = .downloaded
-      }
-    )
+    self.downloadSubject.send(.response(Data()))
+    self.downloadSubject.send(completion: .finished)
+    self.scheduler.advance(by: 1)
+    store.receive(.downloadClient(.success(.response(Data())))) {
+      $0.mode = .downloaded
+    }
   }
 
   func testDownloadThrottling() {
@@ -69,29 +67,27 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
       )
     )
 
-    store.assert(
-      .send(.buttonTapped) {
-        $0.mode = .startingToDownload
-      },
+    store.send(.buttonTapped) {
+      $0.mode = .startingToDownload
+    }
 
-      .do { self.downloadSubject.send(.updateProgress(0.5)) },
-      .do { self.scheduler.advance() },
-      .receive(.downloadClient(.success(.updateProgress(0.5)))) {
-        $0.mode = .downloading(progress: 0.5)
-      },
+    self.downloadSubject.send(.updateProgress(0.5))
+    self.scheduler.advance()
+    store.receive(.downloadClient(.success(.updateProgress(0.5)))) {
+      $0.mode = .downloading(progress: 0.5)
+    }
 
-      .do { self.downloadSubject.send(.updateProgress(0.6)) },
-      .do { self.scheduler.advance(by: 0.5) },
+    self.downloadSubject.send(.updateProgress(0.6))
+    self.scheduler.advance(by: 0.5)
 
-      .do { self.downloadSubject.send(.updateProgress(0.7)) },
-      .do { self.scheduler.advance(by: 0.5) },
-      .receive(.downloadClient(.success(.updateProgress(0.7)))) {
-        $0.mode = .downloading(progress: 0.7)
-      },
+    self.downloadSubject.send(.updateProgress(0.7))
+    self.scheduler.advance(by: 0.5)
+    store.receive(.downloadClient(.success(.updateProgress(0.7)))) {
+      $0.mode = .downloading(progress: 0.7)
+    }
 
-      .do { self.downloadSubject.send(completion: .finished) },
-      .do { self.scheduler.run() }
-    )
+    self.downloadSubject.send(completion: .finished)
+    self.scheduler.run()
   }
 
   func testCancelDownloadFlow() {
@@ -111,26 +107,24 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
       )
     )
 
-    store.assert(
-      .send(.buttonTapped) {
-        $0.mode = .startingToDownload
-      },
+    store.send(.buttonTapped) {
+      $0.mode = .startingToDownload
+    }
 
-      .send(.buttonTapped) {
-        $0.alert = .init(
-          title: .init("Do you want to cancel downloading this map?"),
-          primaryButton: .destructive(.init("Cancel"), send: .cancelButtonTapped),
-          secondaryButton: .default(.init("Nevermind"), send: .nevermindButtonTapped)
-        )
-      },
+    store.send(.buttonTapped) {
+      $0.alert = .init(
+        title: .init("Do you want to cancel downloading this map?"),
+        primaryButton: .destructive(.init("Cancel"), send: .cancelButtonTapped),
+        secondaryButton: .default(.init("Nevermind"), send: .nevermindButtonTapped)
+      )
+    }
 
-      .send(.alert(.cancelButtonTapped)) {
-        $0.alert = nil
-        $0.mode = .notDownloaded
-      },
+    store.send(.alert(.cancelButtonTapped)) {
+      $0.alert = nil
+      $0.mode = .notDownloaded
+    }
 
-      .do { self.scheduler.run() }
-    )
+    self.scheduler.run()
   }
 
   func testDownloadFinishesWhileTryingToCancel() {
@@ -150,27 +144,25 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
       )
     )
 
-    store.assert(
-      .send(.buttonTapped) {
-        $0.mode = .startingToDownload
-      },
+    store.send(.buttonTapped) {
+      $0.mode = .startingToDownload
+    }
 
-      .send(.buttonTapped) {
-        $0.alert = .init(
-          title: .init("Do you want to cancel downloading this map?"),
-          primaryButton: .destructive(.init("Cancel"), send: .cancelButtonTapped),
-          secondaryButton: .default(.init("Nevermind"), send: .nevermindButtonTapped)
-        )
-      },
+    store.send(.buttonTapped) {
+      $0.alert = .init(
+        title: .init("Do you want to cancel downloading this map?"),
+        primaryButton: .destructive(.init("Cancel"), send: .cancelButtonTapped),
+        secondaryButton: .default(.init("Nevermind"), send: .nevermindButtonTapped)
+      )
+    }
 
-      .do { self.downloadSubject.send(.response(Data())) },
-      .do { self.downloadSubject.send(completion: .finished) },
-      .do { self.scheduler.advance(by: 1) },
-      .receive(.downloadClient(.success(.response(Data())))) {
-        $0.alert = nil
-        $0.mode = .downloaded
-      }
-    )
+    self.downloadSubject.send(.response(Data()))
+    self.downloadSubject.send(completion: .finished)
+    self.scheduler.advance(by: 1)
+    store.receive(.downloadClient(.success(.response(Data())))) {
+      $0.alert = nil
+      $0.mode = .downloaded
+    }
   }
 
   func testDeleteDownloadFlow() {
@@ -190,20 +182,18 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
       )
     )
 
-    store.assert(
-      .send(.buttonTapped) {
-        $0.alert = .init(
-          title: .init("Do you want to delete this map from your offline storage?"),
-          primaryButton: .destructive(.init("Delete"), send: .deleteButtonTapped),
-          secondaryButton: .default(.init("Nevermind"), send: .nevermindButtonTapped)
-        )
-      },
+    store.send(.buttonTapped) {
+      $0.alert = .init(
+        title: .init("Do you want to delete this map from your offline storage?"),
+        primaryButton: .destructive(.init("Delete"), send: .deleteButtonTapped),
+        secondaryButton: .default(.init("Nevermind"), send: .nevermindButtonTapped)
+      )
+    }
 
-      .send(.alert(.deleteButtonTapped)) {
-        $0.alert = nil
-        $0.mode = .notDownloaded
-      }
-    )
+    store.send(.alert(.deleteButtonTapped)) {
+      $0.alert = nil
+      $0.mode = .notDownloaded
+    }
   }
 }
 

--- a/Examples/Search/SearchTests/SearchTests.swift
+++ b/Examples/Search/SearchTests/SearchTests.swift
@@ -17,22 +17,18 @@ class SearchTests: XCTestCase {
       )
     )
 
-    store.assert(
-      .environment {
-        $0.weatherClient.searchLocation = { _ in Effect(value: mockLocations) }
-      },
-      .send(.searchQueryChanged("S")) {
-        $0.searchQuery = "S"
-      },
-      .do { self.scheduler.advance(by: 0.3) },
-      .receive(.locationsResponse(.success(mockLocations))) {
-        $0.locations = mockLocations
-      },
-      .send(.searchQueryChanged("")) {
-        $0.locations = []
-        $0.searchQuery = ""
-      }
-    )
+    store.environment.weatherClient.searchLocation = { _ in Effect(value: mockLocations) }
+    store.send(.searchQueryChanged("S")) {
+      $0.searchQuery = "S"
+    }
+    self.scheduler.advance(by: 0.3)
+    store.receive(.locationsResponse(.success(mockLocations))) {
+      $0.locations = mockLocations
+    }
+    store.send(.searchQueryChanged("")) {
+      $0.locations = []
+      $0.searchQuery = ""
+    }
   }
 
   func testSearchFailure() {
@@ -45,16 +41,12 @@ class SearchTests: XCTestCase {
       )
     )
 
-    store.assert(
-      .environment {
-        $0.weatherClient.searchLocation = { _ in Effect(error: .init()) }
-      },
-      .send(.searchQueryChanged("S")) {
-        $0.searchQuery = "S"
-      },
-      .do { self.scheduler.advance(by: 0.3) },
-      .receive(.locationsResponse(.failure(.init())))
-    )
+    store.environment.weatherClient.searchLocation = { _ in Effect(error: .init()) }
+    store.send(.searchQueryChanged("S")) {
+      $0.searchQuery = "S"
+    }
+    self.scheduler.advance(by: 0.3)
+    store.receive(.locationsResponse(.failure(.init())))
   }
 
   func testClearQueryCancelsInFlightSearchRequest() {
@@ -67,16 +59,14 @@ class SearchTests: XCTestCase {
       )
     )
 
-    store.assert(
-      .send(.searchQueryChanged("S")) {
-        $0.searchQuery = "S"
-      },
-      .do { self.scheduler.advance(by: 0.2) },
-      .send(.searchQueryChanged("")) {
-        $0.searchQuery = ""
-      },
-      .do { self.scheduler.run() }
-    )
+    store.send(.searchQueryChanged("S")) {
+      $0.searchQuery = "S"
+    }
+    self.scheduler.advance(by: 0.2)
+    store.send(.searchQueryChanged("")) {
+      $0.searchQuery = ""
+    }
+    self.scheduler.run()
   }
 
   func testTapOnLocation() {
@@ -95,16 +85,14 @@ class SearchTests: XCTestCase {
       )
     )
 
-    store.assert(
-      .send(.locationTapped(specialLocation)) {
-        $0.locationWeatherRequestInFlight = specialLocation
-      },
-      .do { self.scheduler.advance() },
-      .receive(.locationWeatherResponse(.success(specialLocationWeather))) {
-        $0.locationWeatherRequestInFlight = nil
-        $0.locationWeather = specialLocationWeather
-      }
-    )
+    store.send(.locationTapped(specialLocation)) {
+      $0.locationWeatherRequestInFlight = specialLocation
+    }
+    self.scheduler.advance()
+    store.receive(.locationWeatherResponse(.success(specialLocationWeather))) {
+      $0.locationWeatherRequestInFlight = nil
+      $0.locationWeather = specialLocationWeather
+    }
   }
 
   func testTapOnLocationCancelsInFlightRequest() {
@@ -123,19 +111,17 @@ class SearchTests: XCTestCase {
       )
     )
 
-    store.assert(
-      .send(.locationTapped(mockLocations.first!)) {
-        $0.locationWeatherRequestInFlight = mockLocations.first!
-      },
-      .send(.locationTapped(specialLocation)) {
-        $0.locationWeatherRequestInFlight = specialLocation
-      },
-      .do { self.scheduler.advance() },
-      .receive(.locationWeatherResponse(.success(specialLocationWeather))) {
-        $0.locationWeatherRequestInFlight = nil
-        $0.locationWeather = specialLocationWeather
-      }
-    )
+    store.send(.locationTapped(mockLocations.first!)) {
+      $0.locationWeatherRequestInFlight = mockLocations.first!
+    }
+    store.send(.locationTapped(specialLocation)) {
+      $0.locationWeatherRequestInFlight = specialLocation
+    }
+    self.scheduler.advance()
+    store.receive(.locationWeatherResponse(.success(specialLocationWeather))) {
+      $0.locationWeatherRequestInFlight = nil
+      $0.locationWeather = specialLocationWeather
+    }
   }
 
   func testTapOnLocationFailure() {
@@ -148,15 +134,13 @@ class SearchTests: XCTestCase {
       )
     )
 
-    store.assert(
-      .send(.locationTapped(mockLocations.first!)) {
-        $0.locationWeatherRequestInFlight = mockLocations.first!
-      },
-      .do { self.scheduler.advance() },
-      .receive(.locationWeatherResponse(.failure(.init()))) {
-        $0.locationWeatherRequestInFlight = nil
-      }
-    )
+    store.send(.locationTapped(mockLocations.first!)) {
+      $0.locationWeatherRequestInFlight = mockLocations.first!
+    }
+    self.scheduler.advance()
+    store.receive(.locationWeatherResponse(.failure(.init()))) {
+      $0.locationWeatherRequestInFlight = nil
+    }
   }
 }
 

--- a/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
+++ b/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
@@ -6,37 +6,33 @@ import XCTest
 
 class SpeechRecognitionTests: XCTestCase {
   let recognitionTaskSubject = PassthroughSubject<SpeechClient.Action, SpeechClient.Error>()
-  let scheduler = DispatchQueue.testScheduler
 
   func testDenyAuthorization() {
     let store = TestStore(
       initialState: .init(),
       reducer: appReducer,
       environment: AppEnvironment(
-        mainQueue: scheduler.eraseToAnyScheduler(),
+        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
         speechClient: .mock(
           requestAuthorization: { Effect(value: .denied) }
         )
       )
     )
 
-    store.assert(
-      .send(.recordButtonTapped) {
-        $0.isRecording = true
-      },
-      .do { self.scheduler.advance() },
-      .receive(.speechRecognizerAuthorizationStatusResponse(.denied)) {
-        $0.alert = .init(
-          title: .init(
-            """
+    store.send(.recordButtonTapped) {
+      $0.isRecording = true
+    }
+    store.receive(.speechRecognizerAuthorizationStatusResponse(.denied)) {
+      $0.alert = .init(
+        title: .init(
+          """
             You denied access to speech recognition. This app needs access to transcribe your speech.
             """
-          )
         )
-        $0.isRecording = false
-        $0.speechRecognizerAuthorizationStatus = .denied
-      }
-    )
+      )
+      $0.isRecording = false
+      $0.speechRecognizerAuthorizationStatus = .denied
+    }
   }
 
   func testRestrictedAuthorization() {
@@ -44,24 +40,21 @@ class SpeechRecognitionTests: XCTestCase {
       initialState: .init(),
       reducer: appReducer,
       environment: AppEnvironment(
-        mainQueue: scheduler.eraseToAnyScheduler(),
+        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
         speechClient: .mock(
           requestAuthorization: { Effect(value: .restricted) }
         )
       )
     )
 
-    store.assert(
-      .send(.recordButtonTapped) {
-        $0.isRecording = true
-      },
-      .do { self.scheduler.advance() },
-      .receive(.speechRecognizerAuthorizationStatusResponse(.restricted)) {
-        $0.alert = .init(title: .init("Your device does not allow speech recognition."))
-        $0.isRecording = false
-        $0.speechRecognizerAuthorizationStatus = .restricted
-      }
-    )
+    store.send(.recordButtonTapped) {
+      $0.isRecording = true
+    }
+    store.receive(.speechRecognizerAuthorizationStatusResponse(.restricted)) {
+      $0.alert = .init(title: .init("Your device does not allow speech recognition."))
+      $0.isRecording = false
+      $0.speechRecognizerAuthorizationStatus = .restricted
+    }
   }
 
   func testAllowAndRecord() {
@@ -69,7 +62,7 @@ class SpeechRecognitionTests: XCTestCase {
       initialState: .init(),
       reducer: appReducer,
       environment: AppEnvironment(
-        mainQueue: scheduler.eraseToAnyScheduler(),
+        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
         speechClient: .mock(
           finishTask: { _ in
             .fireAndForget { self.recognitionTaskSubject.send(completion: .finished) }
@@ -94,26 +87,23 @@ class SpeechRecognitionTests: XCTestCase {
     finalResult.bestTranscription.formattedString = "Hello world"
     finalResult.isFinal = true
 
-    store.assert(
-      .send(.recordButtonTapped) {
-        $0.isRecording = true
-      },
+    store.send(.recordButtonTapped) {
+      $0.isRecording = true
+    }
 
-      .do { self.scheduler.advance() },
-      .receive(.speechRecognizerAuthorizationStatusResponse(.authorized)) {
-        $0.speechRecognizerAuthorizationStatus = .authorized
-      },
+    store.receive(.speechRecognizerAuthorizationStatusResponse(.authorized)) {
+      $0.speechRecognizerAuthorizationStatus = .authorized
+    }
 
-      .do { self.recognitionTaskSubject.send(.taskResult(result)) },
-      .receive(.speech(.success(.taskResult(result)))) {
-        $0.transcribedText = "Hello"
-      },
+    self.recognitionTaskSubject.send(.taskResult(result))
+    store.receive(.speech(.success(.taskResult(result)))) {
+      $0.transcribedText = "Hello"
+    }
 
-      .do { self.recognitionTaskSubject.send(.taskResult(finalResult)) },
-      .receive(.speech(.success(.taskResult(finalResult)))) {
-        $0.transcribedText = "Hello world"
-      }
-    )
+    self.recognitionTaskSubject.send(.taskResult(finalResult))
+    store.receive(.speech(.success(.taskResult(finalResult)))) {
+      $0.transcribedText = "Hello world"
+    }
   }
 
   func testAudioSessionFailure() {
@@ -121,7 +111,7 @@ class SpeechRecognitionTests: XCTestCase {
       initialState: .init(),
       reducer: appReducer,
       environment: AppEnvironment(
-        mainQueue: scheduler.eraseToAnyScheduler(),
+        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
         speechClient: .mock(
           recognitionTask: { _, _ in self.recognitionTaskSubject.eraseToEffect() },
           requestAuthorization: { Effect(value: .authorized) }
@@ -129,31 +119,28 @@ class SpeechRecognitionTests: XCTestCase {
       )
     )
 
-    store.assert(
-      .send(.recordButtonTapped) {
-        $0.isRecording = true
-      },
+    store.send(.recordButtonTapped) {
+      $0.isRecording = true
+    }
 
-      .do { self.scheduler.advance() },
-      .receive(.speechRecognizerAuthorizationStatusResponse(.authorized)) {
-        $0.speechRecognizerAuthorizationStatus = .authorized
-      },
+    store.receive(.speechRecognizerAuthorizationStatusResponse(.authorized)) {
+      $0.speechRecognizerAuthorizationStatus = .authorized
+    }
 
-      .do { self.recognitionTaskSubject.send(completion: .failure(.couldntConfigureAudioSession)) },
-      .receive(.speech(.failure(.couldntConfigureAudioSession))) {
-        $0.alert = .init(title: .init("Problem with audio device. Please try again."))
-      },
+    self.recognitionTaskSubject.send(completion: .failure(.couldntConfigureAudioSession))
+    store.receive(.speech(.failure(.couldntConfigureAudioSession))) {
+      $0.alert = .init(title: .init("Problem with audio device. Please try again."))
+    }
 
-      .do { self.recognitionTaskSubject.send(completion: .finished) }
-    )
+    self.recognitionTaskSubject.send(completion: .finished)
   }
-
+  
   func testAudioEngineFailure() {
     let store = TestStore(
       initialState: .init(),
       reducer: appReducer,
       environment: AppEnvironment(
-        mainQueue: scheduler.eraseToAnyScheduler(),
+        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
         speechClient: .mock(
           recognitionTask: { _, _ in self.recognitionTaskSubject.eraseToEffect() },
           requestAuthorization: { Effect(value: .authorized) }
@@ -161,22 +148,19 @@ class SpeechRecognitionTests: XCTestCase {
       )
     )
 
-    store.assert(
-      .send(.recordButtonTapped) {
-        $0.isRecording = true
-      },
+    store.send(.recordButtonTapped) {
+      $0.isRecording = true
+    }
 
-      .do { self.scheduler.advance() },
-      .receive(.speechRecognizerAuthorizationStatusResponse(.authorized)) {
-        $0.speechRecognizerAuthorizationStatus = .authorized
-      },
+    store.receive(.speechRecognizerAuthorizationStatusResponse(.authorized)) {
+      $0.speechRecognizerAuthorizationStatus = .authorized
+    }
 
-      .do { self.recognitionTaskSubject.send(completion: .failure(.couldntStartAudioEngine)) },
-      .receive(.speech(.failure(.couldntStartAudioEngine))) {
-        $0.alert = .init(title: .init("Problem with audio device. Please try again."))
-      },
+    self.recognitionTaskSubject.send(completion: .failure(.couldntStartAudioEngine))
+    store.receive(.speech(.failure(.couldntStartAudioEngine))) {
+      $0.alert = .init(title: .init("Problem with audio device. Please try again."))
+    }
 
-      .do { self.recognitionTaskSubject.send(completion: .finished) }
-    )
+    self.recognitionTaskSubject.send(completion: .finished)
   }
 }

--- a/Examples/TicTacToe/Tests/GameCoreTests.swift
+++ b/Examples/TicTacToe/Tests/GameCoreTests.swift
@@ -13,71 +13,67 @@ class GameSwiftUITests: XCTestCase {
   )
 
   func testFlow_Winner_Quit() {
-    self.store.assert(
-      .send(.cellTapped(row: 0, column: 0)) {
-        $0.board[0][0] = .x
-        $0.currentPlayer = .o
-      },
-      .send(.cellTapped(row: 2, column: 1)) {
-        $0.board[2][1] = .o
-        $0.currentPlayer = .x
-      },
-      .send(.cellTapped(row: 1, column: 0)) {
-        $0.board[1][0] = .x
-        $0.currentPlayer = .o
-      },
-      .send(.cellTapped(row: 1, column: 1)) {
-        $0.board[1][1] = .o
-        $0.currentPlayer = .x
-      },
-      .send(.cellTapped(row: 2, column: 0)) {
-        $0.board[2][0] = .x
-      },
-      .send(.quitButtonTapped)
-    )
+    self.store.send(.cellTapped(row: 0, column: 0)) {
+      $0.board[0][0] = .x
+      $0.currentPlayer = .o
+    }
+    self.store.send(.cellTapped(row: 2, column: 1)) {
+      $0.board[2][1] = .o
+      $0.currentPlayer = .x
+    }
+    self.store.send(.cellTapped(row: 1, column: 0)) {
+      $0.board[1][0] = .x
+      $0.currentPlayer = .o
+    }
+    self.store.send(.cellTapped(row: 1, column: 1)) {
+      $0.board[1][1] = .o
+      $0.currentPlayer = .x
+    }
+    self.store.send(.cellTapped(row: 2, column: 0)) {
+      $0.board[2][0] = .x
+    }
+    self.store.send(.quitButtonTapped)
   }
 
   func testFlow_Tie() {
-    self.store.assert(
-      .send(.cellTapped(row: 0, column: 0)) {
-        $0.board[0][0] = .x
-        $0.currentPlayer = .o
-      },
-      .send(.cellTapped(row: 2, column: 2)) {
-        $0.board[2][2] = .o
-        $0.currentPlayer = .x
-      },
-      .send(.cellTapped(row: 1, column: 0)) {
-        $0.board[1][0] = .x
-        $0.currentPlayer = .o
-      },
-      .send(.cellTapped(row: 2, column: 0)) {
-        $0.board[2][0] = .o
-        $0.currentPlayer = .x
-      },
-      .send(.cellTapped(row: 2, column: 1)) {
-        $0.board[2][1] = .x
-        $0.currentPlayer = .o
-      },
-      .send(.cellTapped(row: 1, column: 2)) {
-        $0.board[1][2] = .o
-        $0.currentPlayer = .x
-      },
-      .send(.cellTapped(row: 0, column: 2)) {
-        $0.board[0][2] = .x
-        $0.currentPlayer = .o
-      },
-      .send(.cellTapped(row: 0, column: 1)) {
-        $0.board[0][1] = .o
-        $0.currentPlayer = .x
-      },
-      .send(.cellTapped(row: 1, column: 1)) {
-        $0.board[1][1] = .x
-        $0.currentPlayer = .o
-      },
-      .send(.playAgainButtonTapped) {
-        $0 = GameState(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr.")
-      }
-    )
+    self.store.send(.cellTapped(row: 0, column: 0)) {
+      $0.board[0][0] = .x
+      $0.currentPlayer = .o
+    }
+    self.store.send(.cellTapped(row: 2, column: 2)) {
+      $0.board[2][2] = .o
+      $0.currentPlayer = .x
+    }
+    self.store.send(.cellTapped(row: 1, column: 0)) {
+      $0.board[1][0] = .x
+      $0.currentPlayer = .o
+    }
+    self.store.send(.cellTapped(row: 2, column: 0)) {
+      $0.board[2][0] = .o
+      $0.currentPlayer = .x
+    }
+    self.store.send(.cellTapped(row: 2, column: 1)) {
+      $0.board[2][1] = .x
+      $0.currentPlayer = .o
+    }
+    self.store.send(.cellTapped(row: 1, column: 2)) {
+      $0.board[1][2] = .o
+      $0.currentPlayer = .x
+    }
+    self.store.send(.cellTapped(row: 0, column: 2)) {
+      $0.board[0][2] = .x
+      $0.currentPlayer = .o
+    }
+    self.store.send(.cellTapped(row: 0, column: 1)) {
+      $0.board[0][1] = .o
+      $0.currentPlayer = .x
+    }
+    self.store.send(.cellTapped(row: 1, column: 1)) {
+      $0.board[1][1] = .x
+      $0.currentPlayer = .o
+    }
+    self.store.send(.playAgainButtonTapped) {
+      $0 = GameState(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr.")
+    }
   }
 }

--- a/Examples/TicTacToe/Tests/GameSwiftUITests.swift
+++ b/Examples/TicTacToe/Tests/GameSwiftUITests.swift
@@ -14,78 +14,74 @@ class GameSwiftUITests: XCTestCase {
     environment: GameEnvironment()
   )
   .scope(state: { $0.view })
-
+  
   func testFlow_Winner_Quit() {
-    self.store.assert(
-      .send(.cellTapped(row: 0, column: 0)) {
-        $0.board[0][0] = "❌"
-        $0.title = "Blob Jr., place your ⭕️"
-      },
-      .send(.cellTapped(row: 2, column: 1)) {
-        $0.board[2][1] = "⭕️"
-        $0.title = "Blob Sr., place your ❌"
-      },
-      .send(.cellTapped(row: 1, column: 0)) {
-        $0.board[1][0] = "❌"
-        $0.title = "Blob Jr., place your ⭕️"
-      },
-      .send(.cellTapped(row: 1, column: 1)) {
-        $0.board[1][1] = "⭕️"
-        $0.title = "Blob Sr., place your ❌"
-      },
-      .send(.cellTapped(row: 2, column: 0)) {
-        $0.board[2][0] = "❌"
-        $0.isGameDisabled = true
-        $0.isPlayAgainButtonVisible = true
-        $0.title = "Winner! Congrats Blob Sr.!"
-      },
-      .send(.quitButtonTapped)
-    )
+    self.store.send(.cellTapped(row: 0, column: 0)) {
+      $0.board[0][0] = "❌"
+      $0.title = "Blob Jr., place your ⭕️"
+    }
+    self.store.send(.cellTapped(row: 2, column: 1)) {
+      $0.board[2][1] = "⭕️"
+      $0.title = "Blob Sr., place your ❌"
+    }
+    self.store.send(.cellTapped(row: 1, column: 0)) {
+      $0.board[1][0] = "❌"
+      $0.title = "Blob Jr., place your ⭕️"
+    }
+    self.store.send(.cellTapped(row: 1, column: 1)) {
+      $0.board[1][1] = "⭕️"
+      $0.title = "Blob Sr., place your ❌"
+    }
+    self.store.send(.cellTapped(row: 2, column: 0)) {
+      $0.board[2][0] = "❌"
+      $0.isGameDisabled = true
+      $0.isPlayAgainButtonVisible = true
+      $0.title = "Winner! Congrats Blob Sr.!"
+    }
+    self.store.send(.quitButtonTapped)
   }
-
+  
   func testFlow_Tie() {
-    self.store.assert(
-      .send(.cellTapped(row: 0, column: 0)) {
-        $0.board[0][0] = "❌"
-        $0.title = "Blob Jr., place your ⭕️"
-      },
-      .send(.cellTapped(row: 2, column: 2)) {
-        $0.board[2][2] = "⭕️"
-        $0.title = "Blob Sr., place your ❌"
-      },
-      .send(.cellTapped(row: 1, column: 0)) {
-        $0.board[1][0] = "❌"
-        $0.title = "Blob Jr., place your ⭕️"
-      },
-      .send(.cellTapped(row: 2, column: 0)) {
-        $0.board[2][0] = "⭕️"
-        $0.title = "Blob Sr., place your ❌"
-      },
-      .send(.cellTapped(row: 2, column: 1)) {
-        $0.board[2][1] = "❌"
-        $0.title = "Blob Jr., place your ⭕️"
-      },
-      .send(.cellTapped(row: 1, column: 2)) {
-        $0.board[1][2] = "⭕️"
-        $0.title = "Blob Sr., place your ❌"
-      },
-      .send(.cellTapped(row: 0, column: 2)) {
-        $0.board[0][2] = "❌"
-        $0.title = "Blob Jr., place your ⭕️"
-      },
-      .send(.cellTapped(row: 0, column: 1)) {
-        $0.board[0][1] = "⭕️"
-        $0.title = "Blob Sr., place your ❌"
-      },
-      .send(.cellTapped(row: 1, column: 1)) {
-        $0.board[1][1] = "❌"
-        $0.isGameDisabled = true
-        $0.isPlayAgainButtonVisible = true
-        $0.title = "Tied game!"
-      },
-      .send(.playAgainButtonTapped) {
-        $0 = GameState(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr.").view
-      }
-    )
+    self.store.send(.cellTapped(row: 0, column: 0)) {
+      $0.board[0][0] = "❌"
+      $0.title = "Blob Jr., place your ⭕️"
+    }
+    self.store.send(.cellTapped(row: 2, column: 2)) {
+      $0.board[2][2] = "⭕️"
+      $0.title = "Blob Sr., place your ❌"
+    }
+    self.store.send(.cellTapped(row: 1, column: 0)) {
+      $0.board[1][0] = "❌"
+      $0.title = "Blob Jr., place your ⭕️"
+    }
+    self.store.send(.cellTapped(row: 2, column: 0)) {
+      $0.board[2][0] = "⭕️"
+      $0.title = "Blob Sr., place your ❌"
+    }
+    self.store.send(.cellTapped(row: 2, column: 1)) {
+      $0.board[2][1] = "❌"
+      $0.title = "Blob Jr., place your ⭕️"
+    }
+    self.store.send(.cellTapped(row: 1, column: 2)) {
+      $0.board[1][2] = "⭕️"
+      $0.title = "Blob Sr., place your ❌"
+    }
+    self.store.send(.cellTapped(row: 0, column: 2)) {
+      $0.board[0][2] = "❌"
+      $0.title = "Blob Jr., place your ⭕️"
+    }
+    self.store.send(.cellTapped(row: 0, column: 1)) {
+      $0.board[0][1] = "⭕️"
+      $0.title = "Blob Sr., place your ❌"
+    }
+    self.store.send(.cellTapped(row: 1, column: 1)) {
+      $0.board[1][1] = "❌"
+      $0.isGameDisabled = true
+      $0.isPlayAgainButtonVisible = true
+      $0.title = "Tied game!"
+    }
+    self.store.send(.playAgainButtonTapped) {
+      $0 = GameState(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr.").view
+    }
   }
 }

--- a/Examples/TicTacToe/Tests/LoginCoreTests.swift
+++ b/Examples/TicTacToe/Tests/LoginCoreTests.swift
@@ -6,8 +6,6 @@ import TwoFactorCore
 import XCTest
 
 class LoginCoreTests: XCTestCase {
-  let scheduler = DispatchQueue.testScheduler
-
   func testFlow_Success_TwoFactor_Integration() {
     let store = TestStore(
       initialState: LoginState(),
@@ -21,47 +19,45 @@ class LoginCoreTests: XCTestCase {
             Effect(value: .init(token: "deadbeefdeadbeef", twoFactorRequired: false))
           }
         ),
-        mainQueue: AnyScheduler(self.scheduler)
+        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler()
       )
     )
 
-    store.assert(
-      .send(.emailChanged("2fa@pointfree.co")) {
-        $0.email = "2fa@pointfree.co"
-      },
-      .send(.passwordChanged("password")) {
-        $0.password = "password"
-        $0.isFormValid = true
-      },
-      .send(.loginButtonTapped) {
-        $0.isLoginRequestInFlight = true
-      },
-      .do { self.scheduler.advance() },
-      .receive(.loginResponse(.success(.init(token: "deadbeefdeadbeef", twoFactorRequired: true))))
-      {
-        $0.isLoginRequestInFlight = false
-        $0.twoFactor = TwoFactorState(token: "deadbeefdeadbeef")
-      },
-      .send(.twoFactor(.codeChanged("1234"))) {
-        $0.twoFactor?.code = "1234"
-        $0.twoFactor?.isFormValid = true
-      },
-      .send(.twoFactor(.submitButtonTapped)) {
-        $0.twoFactor?.isTwoFactorRequestInFlight = true
-      },
-      .do {
-        self.scheduler.advance()
-      },
-      .receive(
-        .twoFactor(
-          .twoFactorResponse(.success(.init(token: "deadbeefdeadbeef", twoFactorRequired: false))))
-      ) {
-        $0.twoFactor?.isTwoFactorRequestInFlight = false
-      }
-    )
+    store.send(.emailChanged("2fa@pointfree.co")) {
+      $0.email = "2fa@pointfree.co"
+    }
+    store.send(.passwordChanged("password")) {
+      $0.password = "password"
+      $0.isFormValid = true
+    }
+    store.send(.loginButtonTapped) {
+      $0.isLoginRequestInFlight = true
+    }
+    store.receive(
+      .loginResponse(.success(.init(token: "deadbeefdeadbeef", twoFactorRequired: true)))
+    ) {
+      $0.isLoginRequestInFlight = false
+      $0.twoFactor = TwoFactorState(token: "deadbeefdeadbeef")
+    }
+    store.send(.twoFactor(.codeChanged("1234"))) {
+      $0.twoFactor?.code = "1234"
+      $0.twoFactor?.isFormValid = true
+    }
+    store.send(.twoFactor(.submitButtonTapped)) {
+      $0.twoFactor?.isTwoFactorRequestInFlight = true
+    }
+    store.receive(
+      .twoFactor(
+        .twoFactorResponse(.success(.init(token: "deadbeefdeadbeef", twoFactorRequired: false)))
+      )
+    ) {
+      $0.twoFactor?.isTwoFactorRequestInFlight = false
+    }
   }
 
   func testFlow_DismissEarly_TwoFactor_Integration() {
+    let scheduler = DispatchQueue.testScheduler
+
     let store = TestStore(
       initialState: LoginState(),
       reducer: loginReducer,
@@ -74,37 +70,36 @@ class LoginCoreTests: XCTestCase {
             Effect(value: .init(token: "deadbeefdeadbeef", twoFactorRequired: false))
           }
         ),
-        mainQueue: AnyScheduler(self.scheduler)
+        mainQueue: scheduler.eraseToAnyScheduler()
       )
     )
 
-    store.assert(
-      .send(.emailChanged("2fa@pointfree.co")) {
-        $0.email = "2fa@pointfree.co"
-      },
-      .send(.passwordChanged("password")) {
-        $0.password = "password"
-        $0.isFormValid = true
-      },
-      .send(.loginButtonTapped) {
-        $0.isLoginRequestInFlight = true
-      },
-      .do { self.scheduler.advance() },
-      .receive(.loginResponse(.success(.init(token: "deadbeefdeadbeef", twoFactorRequired: true))))
-      {
-        $0.isLoginRequestInFlight = false
-        $0.twoFactor = TwoFactorState(token: "deadbeefdeadbeef")
-      },
-      .send(.twoFactor(.codeChanged("1234"))) {
-        $0.twoFactor?.code = "1234"
-        $0.twoFactor?.isFormValid = true
-      },
-      .send(.twoFactor(.submitButtonTapped)) {
-        $0.twoFactor?.isTwoFactorRequestInFlight = true
-      },
-      .send(.twoFactorDismissed) {
-        $0.twoFactor = nil
-      }
-    )
+    store.send(.emailChanged("2fa@pointfree.co")) {
+      $0.email = "2fa@pointfree.co"
+    }
+    store.send(.passwordChanged("password")) {
+      $0.password = "password"
+      $0.isFormValid = true
+    }
+    store.send(.loginButtonTapped) {
+      $0.isLoginRequestInFlight = true
+    }
+    scheduler.advance()
+    store.receive(
+      .loginResponse(.success(.init(token: "deadbeefdeadbeef", twoFactorRequired: true)))
+    ) {
+      $0.isLoginRequestInFlight = false
+      $0.twoFactor = TwoFactorState(token: "deadbeefdeadbeef")
+    }
+    store.send(.twoFactor(.codeChanged("1234"))) {
+      $0.twoFactor?.code = "1234"
+      $0.twoFactor?.isFormValid = true
+    }
+    store.send(.twoFactor(.submitButtonTapped)) {
+      $0.twoFactor?.isTwoFactorRequestInFlight = true
+    }
+    store.send(.twoFactorDismissed) {
+      $0.twoFactor = nil
+    }
   }
 }

--- a/Examples/TicTacToe/Tests/NewGameCoreTests.swift
+++ b/Examples/TicTacToe/Tests/NewGameCoreTests.swift
@@ -11,30 +11,28 @@ class NewGameCoreTests: XCTestCase {
   )
 
   func testFlow_NewGame_Integration() {
-    self.store.assert(
-      .send(.oPlayerNameChanged("Blob Sr.")) {
-        $0.oPlayerName = "Blob Sr."
-      },
-      .send(.xPlayerNameChanged("Blob Jr.")) {
-        $0.xPlayerName = "Blob Jr."
-      },
-      .send(.letsPlayButtonTapped) {
-        $0.game = GameState(oPlayerName: "Blob Sr.", xPlayerName: "Blob Jr.")
-      },
-      .send(.game(.cellTapped(row: 0, column: 0))) {
-        $0.game!.board[0][0] = .x
-        $0.game!.currentPlayer = .o
-      },
-      .send(.game(.quitButtonTapped)) {
-        $0.game = nil
-      },
-      .send(.letsPlayButtonTapped) {
-        $0.game = GameState(oPlayerName: "Blob Sr.", xPlayerName: "Blob Jr.")
-      },
-      .send(.gameDismissed) {
-        $0.game = nil
-      },
-      .send(.logoutButtonTapped)
-    )
+    self.store.send(.oPlayerNameChanged("Blob Sr.")) {
+      $0.oPlayerName = "Blob Sr."
+    }
+    self.store.send(.xPlayerNameChanged("Blob Jr.")) {
+      $0.xPlayerName = "Blob Jr."
+    }
+    self.store.send(.letsPlayButtonTapped) {
+      $0.game = GameState(oPlayerName: "Blob Sr.", xPlayerName: "Blob Jr.")
+    }
+    self.store.send(.game(.cellTapped(row: 0, column: 0))) {
+      $0.game!.board[0][0] = .x
+      $0.game!.currentPlayer = .o
+    }
+    self.store.send(.game(.quitButtonTapped)) {
+      $0.game = nil
+    }
+    self.store.send(.letsPlayButtonTapped) {
+      $0.game = GameState(oPlayerName: "Blob Sr.", xPlayerName: "Blob Jr.")
+    }
+    self.store.send(.gameDismissed) {
+      $0.game = nil
+    }
+    self.store.send(.logoutButtonTapped)
   }
 }

--- a/Examples/TicTacToe/Tests/NewGameSwiftUITests.swift
+++ b/Examples/TicTacToe/Tests/NewGameSwiftUITests.swift
@@ -11,23 +11,21 @@ class NewGameSwiftUITests: XCTestCase {
     environment: NewGameEnvironment()
   )
   .scope(state: { $0.view }, action: NewGameAction.view)
-
+  
   func testNewGame() {
-    self.store.assert(
-      .send(.xPlayerNameChanged("Blob Sr.")) {
-        $0.xPlayerName = "Blob Sr."
-      },
-      .send(.oPlayerNameChanged("Blob Jr.")) {
-        $0.oPlayerName = "Blob Jr."
-        $0.isLetsPlayButtonDisabled = false
-      },
-      .send(.letsPlayButtonTapped) {
-        $0.isGameActive = true
-      },
-      .send(.gameDismissed) {
-        $0.isGameActive = false
-      },
-      .send(.logoutButtonTapped)
-    )
+    self.store.send(.xPlayerNameChanged("Blob Sr.")) {
+      $0.xPlayerName = "Blob Sr."
+    }
+    self.store.send(.oPlayerNameChanged("Blob Jr.")) {
+      $0.oPlayerName = "Blob Jr."
+      $0.isLetsPlayButtonDisabled = false
+    }
+    self.store.send(.letsPlayButtonTapped) {
+      $0.isGameActive = true
+    }
+    self.store.send(.gameDismissed) {
+      $0.isGameActive = false
+    }
+    self.store.send(.logoutButtonTapped)
   }
 }

--- a/Examples/TicTacToe/Tests/TwoFactorSwiftUITests.swift
+++ b/Examples/TicTacToe/Tests/TwoFactorSwiftUITests.swift
@@ -8,8 +8,6 @@ import XCTest
 @testable import TwoFactorSwiftUI
 
 class TwoFactorSwiftUITests: XCTestCase {
-  let scheduler = DispatchQueue.testScheduler
-
   func testFlow_Success() {
     let store = TestStore(
       initialState: TwoFactorState(token: "deadbeefdeadbeef"),
@@ -20,44 +18,37 @@ class TwoFactorSwiftUITests: XCTestCase {
             Effect(value: .init(token: "deadbeefdeadbeef", twoFactorRequired: false))
           }
         ),
-        mainQueue: AnyScheduler(self.scheduler)
+        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler()
       )
     )
     .scope(state: { $0.view }, action: TwoFactorAction.view)
 
-    store.assert(
-      .environment {
-        $0.authenticationClient.twoFactor = { _ in
-          Effect(value: .init(token: "deadbeefdeadbeef", twoFactorRequired: false))
-        }
-      },
-      .send(.codeChanged("1")) {
-        $0.code = "1"
-      },
-      .send(.codeChanged("12")) {
-        $0.code = "12"
-      },
-      .send(.codeChanged("123")) {
-        $0.code = "123"
-      },
-      .send(.codeChanged("1234")) {
-        $0.code = "1234"
-        $0.isSubmitButtonDisabled = false
-      },
-      .send(.submitButtonTapped) {
-        $0.isActivityIndicatorVisible = true
-        $0.isFormDisabled = true
-      },
-      .do {
-        self.scheduler.advance()
-      },
-      .receive(
-        .twoFactorResponse(.success(.init(token: "deadbeefdeadbeef", twoFactorRequired: false)))
-      ) {
-        $0.isActivityIndicatorVisible = false
-        $0.isFormDisabled = false
-      }
-    )
+    store.environment.authenticationClient.twoFactor = { _ in
+      Effect(value: .init(token: "deadbeefdeadbeef", twoFactorRequired: false))
+    }
+    store.send(.codeChanged("1")) {
+      $0.code = "1"
+    }
+    store.send(.codeChanged("12")) {
+      $0.code = "12"
+    }
+    store.send(.codeChanged("123")) {
+      $0.code = "123"
+    }
+    store.send(.codeChanged("1234")) {
+      $0.code = "1234"
+      $0.isSubmitButtonDisabled = false
+    }
+    store.send(.submitButtonTapped) {
+      $0.isActivityIndicatorVisible = true
+      $0.isFormDisabled = true
+    }
+    store.receive(
+      .twoFactorResponse(.success(.init(token: "deadbeefdeadbeef", twoFactorRequired: false)))
+    ) {
+      $0.isActivityIndicatorVisible = false
+      $0.isFormDisabled = false
+    }
   }
 
   func testFlow_Failure() {
@@ -70,33 +61,28 @@ class TwoFactorSwiftUITests: XCTestCase {
             Effect(error: .invalidTwoFactor)
           }
         ),
-        mainQueue: AnyScheduler(self.scheduler)
+        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler()
       )
     )
     .scope(state: { $0.view }, action: TwoFactorAction.view)
-
-    store.assert(
-      .send(.codeChanged("1234")) {
-        $0.code = "1234"
-        $0.isSubmitButtonDisabled = false
-      },
-      .send(.submitButtonTapped) {
-        $0.isActivityIndicatorVisible = true
-        $0.isFormDisabled = true
-      },
-      .do {
-        self.scheduler.advance()
-      },
-      .receive(.twoFactorResponse(.failure(.invalidTwoFactor))) {
-        $0.alert = .init(
-          title: TextState(AuthenticationError.invalidTwoFactor.localizedDescription)
-        )
-        $0.isActivityIndicatorVisible = false
-        $0.isFormDisabled = false
-      },
-      .send(.alertDismissed) {
-        $0.alert = nil
-      }
-    )
+    
+    store.send(.codeChanged("1234")) {
+      $0.code = "1234"
+      $0.isSubmitButtonDisabled = false
+    }
+    store.send(.submitButtonTapped) {
+      $0.isActivityIndicatorVisible = true
+      $0.isFormDisabled = true
+    }
+    store.receive(.twoFactorResponse(.failure(.invalidTwoFactor))) {
+      $0.alert = .init(
+        title: TextState(AuthenticationError.invalidTwoFactor.localizedDescription)
+      )
+      $0.isActivityIndicatorVisible = false
+      $0.isFormDisabled = false
+    }
+    store.send(.alertDismissed) {
+      $0.alert = nil
+    }
   }
 }

--- a/Examples/Todos/TodosTests/TodosTests.swift
+++ b/Examples/Todos/TodosTests/TodosTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 class TodosTests: XCTestCase {
   let scheduler = DispatchQueue.testScheduler
-
+  
   func testAddTodo() {
     let store = TestStore(
       initialState: AppState(),
@@ -15,21 +15,19 @@ class TodosTests: XCTestCase {
         uuid: UUID.incrementing
       )
     )
-
-    store.assert(
-      .send(.addTodoButtonTapped) {
-        $0.todos.insert(
-          Todo(
-            description: "",
-            id: UUID(uuidString: "00000000-0000-0000-0000-000000000000")!,
-            isComplete: false
-          ),
-          at: 0
-        )
-      }
-    )
+    
+    store.send(.addTodoButtonTapped) {
+      $0.todos.insert(
+        Todo(
+          description: "",
+          id: UUID(uuidString: "00000000-0000-0000-0000-000000000000")!,
+          isComplete: false
+        ),
+        at: 0
+      )
+    }
   }
-
+  
   func testEditTodo() {
     let state = AppState(
       todos: [
@@ -48,16 +46,14 @@ class TodosTests: XCTestCase {
         uuid: UUID.incrementing
       )
     )
-
-    store.assert(
-      .send(
-        .todo(id: state.todos[0].id, action: .textFieldChanged("Learn Composable Architecture"))
-      ) {
-        $0.todos[0].description = "Learn Composable Architecture"
-      }
-    )
+    
+    store.send(
+      .todo(id: state.todos[0].id, action: .textFieldChanged("Learn Composable Architecture"))
+    ) {
+      $0.todos[0].description = "Learn Composable Architecture"
+    }
   }
-
+  
   func testCompleteTodo() {
     let state = AppState(
       todos: [
@@ -81,21 +77,19 @@ class TodosTests: XCTestCase {
         uuid: UUID.incrementing
       )
     )
-
-    store.assert(
-      .send(.todo(id: state.todos[0].id, action: .checkBoxToggled)) {
-        $0.todos[0].isComplete = true
-      },
-      .do { self.scheduler.advance(by: 1) },
-      .receive(.sortCompletedTodos) {
-        $0.todos = [
-          $0.todos[1],
-          $0.todos[0],
-        ]
-      }
-    )
+    
+    store.send(.todo(id: state.todos[0].id, action: .checkBoxToggled)) {
+      $0.todos[0].isComplete = true
+    }
+    self.scheduler.advance(by: 1)
+    store.receive(.sortCompletedTodos) {
+      $0.todos = [
+        $0.todos[1],
+        $0.todos[0],
+      ]
+    }
   }
-
+  
   func testCompleteTodoDebounces() {
     let state = AppState(
       todos: [
@@ -119,20 +113,18 @@ class TodosTests: XCTestCase {
         uuid: UUID.incrementing
       )
     )
-
-    store.assert(
-      .send(.todo(id: state.todos[0].id, action: .checkBoxToggled)) {
-        $0.todos[0].isComplete = true
-      },
-      .do { self.scheduler.advance(by: 0.5) },
-      .send(.todo(id: state.todos[0].id, action: .checkBoxToggled)) {
-        $0.todos[0].isComplete = false
-      },
-      .do { self.scheduler.advance(by: 1) },
-      .receive(.sortCompletedTodos)
-    )
+    
+    store.send(.todo(id: state.todos[0].id, action: .checkBoxToggled)) {
+      $0.todos[0].isComplete = true
+    }
+    self.scheduler.advance(by: 0.5)
+    store.send(.todo(id: state.todos[0].id, action: .checkBoxToggled)) {
+      $0.todos[0].isComplete = false
+    }
+    self.scheduler.advance(by: 1)
+    store.receive(.sortCompletedTodos)
   }
-
+  
   func testClearCompleted() {
     let state = AppState(
       todos: [
@@ -156,16 +148,14 @@ class TodosTests: XCTestCase {
         uuid: UUID.incrementing
       )
     )
-
-    store.assert(
-      .send(.clearCompletedButtonTapped) {
-        $0.todos = [
-          $0.todos[0]
-        ]
-      }
-    )
+    
+    store.send(.clearCompletedButtonTapped) {
+      $0.todos = [
+        $0.todos[0]
+      ]
+    }
   }
-
+  
   func testDelete() {
     let state = AppState(
       todos: [
@@ -194,17 +184,15 @@ class TodosTests: XCTestCase {
         uuid: UUID.incrementing
       )
     )
-
-    store.assert(
-      .send(.delete([1])) {
-        $0.todos = [
-          $0.todos[0],
-          $0.todos[2],
-        ]
-      }
-    )
+    
+    store.send(.delete([1])) {
+      $0.todos = [
+        $0.todos[0],
+        $0.todos[2],
+      ]
+    }
   }
-
+  
   func testEditModeMoving() {
     let state = AppState(
       todos: [
@@ -233,23 +221,21 @@ class TodosTests: XCTestCase {
         uuid: UUID.incrementing
       )
     )
-
-    store.assert(
-      .send(.editModeChanged(.active)) {
-        $0.editMode = .active
-      },
-      .send(.move([0], 2)) {
-        $0.todos = [
-          $0.todos[1],
-          $0.todos[0],
-          $0.todos[2],
-        ]
-      },
-      .do { self.scheduler.advance(by: .milliseconds(100)) },
-      .receive(.sortCompletedTodos)
-    )
+    
+    store.send(.editModeChanged(.active)) {
+      $0.editMode = .active
+    }
+    store.send(.move([0], 2)) {
+      $0.todos = [
+        $0.todos[1],
+        $0.todos[0],
+        $0.todos[2],
+      ]
+    }
+    self.scheduler.advance(by: .milliseconds(100))
+    store.receive(.sortCompletedTodos)
   }
-
+  
   func testFilteredEdit() {
     let state = AppState(
       todos: [
@@ -273,15 +259,13 @@ class TodosTests: XCTestCase {
         uuid: UUID.incrementing
       )
     )
-
-    store.assert(
-      .send(.filterPicked(.completed)) {
-        $0.filter = .completed
-      },
-      .send(.todo(id: state.todos[1].id, action: .textFieldChanged("Did this already"))) {
-        $0.todos[1].description = "Did this already"
-      }
-    )
+    
+    store.send(.filterPicked(.completed)) {
+      $0.filter = .completed
+    }
+    store.send(.todo(id: state.todos[1].id, action: .textFieldChanged("Did this already"))) {
+      $0.todos[1].description = "Did this already"
+    }
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ store.send(.incrementButtonTapped) {
 }
 store.send(.decrementButtonTapped) {
   $0.count = 0
-},
+}
 
 // Test that tapping the fact button causes us to receive a response from the effect. Note
 // that we have to advance the scheduler because we used `.receive(on:)` in the reducer.

--- a/README.md
+++ b/README.md
@@ -287,28 +287,27 @@ Once the test store is created we can use it to make an assertion of an entire u
 The test below has the user increment and decrement the count, then they ask for a number fact, and the response of that effect triggers an alert to be shown, and then dismissing the alert causes the alert to go away.
 
 ```swift
-store.assert(
-  // Test that tapping on the increment/decrement buttons changes the count
-  .send(.incrementButtonTapped) {
-    $0.count = 1
-  },
-  .send(.decrementButtonTapped) {
-    $0.count = 0
-  },
+// Test that tapping on the increment/decrement buttons changes the count
+store.send(.incrementButtonTapped) {
+  $0.count = 1
+}
+store.send(.decrementButtonTapped) {
+  $0.count = 0
+},
 
-  // Test that tapping the fact button causes us to receive a response from the effect. Note
-  // that we have to advance the scheduler because we used `.receive(on:)` in the reducer.
-  .send(.numberFactButtonTapped),
-  .do { scheduler.advance() },
-  .receive(.numberFactResponse(.success("0 is a good number Brent"))) {
-    $0.numberFactAlert = "0 is a good number Brent"
-  },
+// Test that tapping the fact button causes us to receive a response from the effect. Note
+// that we have to advance the scheduler because we used `.receive(on:)` in the reducer.
+store.send(.numberFactButtonTapped)
 
-  // And finally dismiss the alert
-  .send(.factAlertDismissed) {
-    $0.numberFactAlert = nil
-  }
-)
+scheduler.advance()
+store.receive(.numberFactResponse(.success("0 is a good number Brent"))) {
+  $0.numberFactAlert = "0 is a good number Brent"
+}
+
+// And finally dismiss the alert
+store.send(.factAlertDismissed) {
+  $0.numberFactAlert = nil
+}
 ```
 
 That is the basics of building and testing a feature in the Composable Architecture. There are _a lot_ more things to be explored, such as composition, modularity, adaptability, and complex effects. The [Examples](./Examples) directory has a bunch of projects to explore to see more advanced usages.

--- a/Sources/ComposableArchitecture/Effects/Timer.swift
+++ b/Sources/ComposableArchitecture/Effects/Timer.swift
@@ -63,21 +63,19 @@ extension Effect where Failure == Never {
   ///       )
   ///     )
   ///
-  ///     store.assert(
-  ///       .send(.startButtonTapped),
+  ///     store.send(.startButtonTapped)
   ///
-  ///       .do { scheduler.advance(by: .seconds(1)) },
-  ///       .receive(.timerTicked) { $0.count = 1 },
+  ///     scheduler.advance(by: .seconds(1))
+  ///     store.receive(.timerTicked) { $0.count = 1 }
   ///
-  ///       .do { scheduler.advance(by: .seconds(5)) },
-  ///       .receive(.timerTicked) { $0.count = 2 },
-  ///       .receive(.timerTicked) { $0.count = 3 },
-  ///       .receive(.timerTicked) { $0.count = 4 },
-  ///       .receive(.timerTicked) { $0.count = 5 },
-  ///       .receive(.timerTicked) { $0.count = 6 },
+  ///     scheduler.advance(by: .seconds(5))
+  ///     store.receive(.timerTicked) { $0.count = 2 }
+  ///     store.receive(.timerTicked) { $0.count = 3 }
+  ///     store.receive(.timerTicked) { $0.count = 4 }
+  ///     store.receive(.timerTicked) { $0.count = 5 }
+  ///     store.receive(.timerTicked) { $0.count = 6 }
   ///
-  ///       .send(.stopButtonTapped)
-  ///     )
+  ///     store.send(.stopButtonTapped)
   ///   }
   ///
   /// - Note: This effect is only meant to be used with features built in the Composable

--- a/Sources/ComposableArchitecture/SwiftUI/ActionSheet.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ActionSheet.swift
@@ -82,22 +82,20 @@ import SwiftUI
 ///       environment: .mock
 ///     )
 ///
-///     store.assert(
-///       .send(.infoTapped) {
-///         $0.actionSheet = .init(
-///           title: "What would you like to do?",
-///           buttons: [
-///             .default(TextState("Favorite"), send: .favoriteTapped),
-///             .destructive(TextState("Delete"), send: .deleteTapped),
-///             .cancel(),
-///           ]
-///         )
-///       },
-///       .send(.favoriteTapped) {
-///         $0.actionSheet = nil
-///         // Also verify that favoriting logic executed correctly
-///       }
-///     )
+///     store.send(.infoTapped) {
+///       $0.actionSheet = .init(
+///         title: "What would you like to do?",
+///         buttons: [
+///           .default(TextState("Favorite"), send: .favoriteTapped),
+///           .destructive(TextState("Delete"), send: .deleteTapped),
+///           .cancel(),
+///         ]
+///       )
+///     }
+///     store.send(.favoriteTapped) {
+///       $0.actionSheet = nil
+///       // Also verify that favoriting logic executed correctly
+///     }
 ///
 @available(iOS 13, *)
 @available(macCatalyst 13, *)

--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -75,20 +75,18 @@ import SwiftUI
 ///       environment: .mock
 ///     )
 ///
-///     store.assert(
-///       .send(.deleteTapped) {
-///         $0.alert = .init(
-///           title: TextState("Delete"),
-///           message: TextState("Are you sure you want to delete this? It cannot be undone."),
-///           primaryButton: .default(TextState("Confirm"), send: .confirmTapped),
-///           secondaryButton: .cancel(send: .cancelTapped)
-///         )
-///       },
-///       .send(.deleteTapped) {
-///         $0.alert = nil
-///         // Also verify that delete logic executed correctly
-///       }
-///     )
+///     store.send(.deleteTapped) {
+///       $0.alert = .init(
+///         title: TextState("Delete"),
+///         message: TextState("Are you sure you want to delete this? It cannot be undone."),
+///         primaryButton: .default(TextState("Confirm"), send: .confirmTapped),
+///         secondaryButton: .cancel(send: .cancelTapped)
+///       )
+///     }
+///     store.send(.deleteTapped) {
+///       $0.alert = nil
+///       // Also verify that delete logic executed correctly
+///     }
 ///
 public struct AlertState<Action> {
   public let id = UUID()

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -114,13 +114,11 @@ import SwiftUI
 ///       environment: SettingsEnvironment(...)
 ///     )
 ///
-///     store.assert(
-///       .send(.binding(.set(\.displayName, "Blob"))) {
-///         $0.displayName = "Blob"
-///       },
-///       .send(.binding(.set(\.protectMyPosts, true))) {
-///         $0.protectMyPosts = true
-///       )
+///     store.send(.binding(.set(\.displayName, "Blob"))) {
+///       $0.displayName = "Blob"
+///     }
+///     store.send(.binding(.set(\.protectMyPosts, true))) {
+///       $0.protectMyPosts = true
 ///     )
 ///
 public struct BindingAction<Root>: Equatable {

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -162,253 +162,88 @@
   /// not expect it would cause a test failure.
   ///
   public final class TestStore<State, LocalState, Action: Equatable, LocalAction, Environment> {
-    private var environment: Environment
+    public var environment: Environment
+
+    private let file: StaticString
     private let fromLocalAction: (LocalAction) -> Action
+    private var line: UInt
+    private var longLivingEffects: Set<LongLivingEffect> = []
+    private var receivedActions: [(action: Action, state: State)] = []
     private let reducer: Reducer<State, Action, Environment>
-    private var state: State
+    private var snapshotState: State
+    private var store: Store<State, TestAction>!
     private let toLocalState: (State) -> LocalState
 
     private init(
       environment: Environment,
+      file: StaticString,
       fromLocalAction: @escaping (LocalAction) -> Action,
       initialState: State,
+      line: UInt,
       reducer: Reducer<State, Action, Environment>,
       toLocalState: @escaping (State) -> LocalState
     ) {
       self.environment = environment
+      self.file = file
       self.fromLocalAction = fromLocalAction
-      self.state = initialState
+      self.line = line
       self.reducer = reducer
+      self.snapshotState = initialState
       self.toLocalState = toLocalState
-    }
-  }
 
-  extension TestStore where State == LocalState, Action == LocalAction {
-    /// Initializes a test store from an initial state, a reducer, and an initial environment.
-    ///
-    /// - Parameters:
-    ///   - initialState: The state to start the test from.
-    ///   - reducer: A reducer.
-    ///   - environment: The environment to start the test from.
-    public convenience init(
-      initialState: State,
-      reducer: Reducer<State, Action, Environment>,
-      environment: Environment
-    ) {
-      self.init(
-        environment: environment,
-        fromLocalAction: { $0 },
+      self.store = Store(
         initialState: initialState,
-        reducer: reducer,
-        toLocalState: { $0 }
-      )
-    }
-  }
-
-  extension TestStore where LocalState: Equatable {
-    /// Asserts against a script of actions.
-    public func assert(
-      _ steps: Step...,
-      file: StaticString = #file,
-      line: UInt = #line
-    ) {
-      assert(steps, file: file, line: line)
-    }
-
-    /// Asserts against an array of actions.
-    public func assert(
-      _ steps: [Step],
-      file: StaticString = #file,
-      line: UInt = #line
-    ) {
-      var receivedActions: [(action: Action, state: State)] = []
-      var longLivingEffects: Set<LongLivingEffect> = []
-      var snapshotState = self.state
-
-      let store = Store(
-        initialState: self.state,
-        reducer: Reducer<State, TestAction, Void> { state, action, _ in
+        reducer: Reducer<State, TestAction, Void> { [unowned self] state, action, _ in
           let effects: Effect<Action, Never>
           switch action.origin {
           case let .send(localAction):
             effects = self.reducer.run(&state, self.fromLocalAction(localAction), self.environment)
-            snapshotState = state
+            self.snapshotState = state
 
           case let .receive(action):
             effects = self.reducer.run(&state, action, self.environment)
-            receivedActions.append((action, state))
+            self.receivedActions.append((action, state))
           }
 
           let effect = LongLivingEffect(file: action.file, line: action.line)
           return
             effects
             .handleEvents(
-              receiveSubscription: { _ in longLivingEffects.insert(effect) },
-              receiveCompletion: { _ in longLivingEffects.remove(effect) },
-              receiveCancel: { longLivingEffects.remove(effect) }
+              receiveSubscription: { [weak self] _ in
+                self?.longLivingEffects.insert(effect)
+              },
+              receiveCompletion: { [weak self] _ in self?.longLivingEffects.remove(effect) },
+              receiveCancel: { [weak self] in self?.longLivingEffects.remove(effect) }
             )
             .map { .init(origin: .receive($0), file: action.file, line: action.line) }
             .eraseToEffect()
+
         },
         environment: ()
       )
-      defer { self.state = store.state.value }
+    }
 
-      func assert(step: Step) {
-        var expectedState = toLocalState(snapshotState)
+    deinit {
+      self.completed()
+    }
 
-        func expectedStateShouldMatch(actualState: LocalState) {
-          if expectedState != actualState {
-            let diff =
-              debugDiff(expectedState, actualState)
-              .map { "\($0.indent(by: 4))\n\n(Expected: −, Actual: +)" }
-              ?? """
-              Expected:
-              \(String(describing: expectedState).indent(by: 2))
-
-              Actual:
-              \(String(describing: actualState).indent(by: 2))
-              """
-
-            _XCTFail(
-              """
-              State change does not match expectation: …
-
-              \(diff)
-              """,
-              file: step.file,
-              line: step.line
-            )
-          }
-        }
-
-        switch step.type {
-        case let .send(action, update):
-          if !receivedActions.isEmpty {
-            _XCTFail(
-              """
-              Must handle \(receivedActions.count) received \
-              action\(receivedActions.count == 1 ? "" : "s") before sending an action: …
-
-              Unhandled actions: \(debugOutput(receivedActions.map { $0.action }))
-              """,
-              file: step.file, line: step.line
-            )
-          }
-          ViewStore(
-            store.scope(
-              state: self.toLocalState,
-              action: { .init(origin: .send($0), file: step.file, line: step.line) }
-            )
-          )
-          .send(action)
-          do {
-            try update(&expectedState)
-          } catch {
-            _XCTFail("Threw error: \(error)", file: step.file, line: step.line)
-          }
-          expectedStateShouldMatch(actualState: toLocalState(snapshotState))
-
-        case let .receive(expectedAction, update):
-          guard !receivedActions.isEmpty else {
-            _XCTFail(
-              """
-              Expected to receive an action, but received none.
-              """,
-              file: step.file, line: step.line
-            )
-            break
-          }
-          let (receivedAction, state) = receivedActions.removeFirst()
-          if expectedAction != receivedAction {
-            let diff =
-              debugDiff(expectedAction, receivedAction)
-              .map { "\($0.indent(by: 4))\n\n(Expected: −, Received: +)" }
-              ?? """
-              Expected:
-              \(String(describing: expectedAction).indent(by: 2))
-
-              Received:
-              \(String(describing: receivedAction).indent(by: 2))
-              """
-
-            _XCTFail(
-              """
-              Received unexpected action: …
-
-              \(diff)
-              """,
-              file: step.file, line: step.line
-            )
-          }
-          do {
-            try update(&expectedState)
-          } catch {
-            _XCTFail("Threw error: \(error)", file: step.file, line: step.line)
-          }
-          expectedStateShouldMatch(actualState: toLocalState(state))
-          snapshotState = state
-
-        case let .environment(work):
-          if !receivedActions.isEmpty {
-            _XCTFail(
-              """
-              Must handle \(receivedActions.count) received \
-              action\(receivedActions.count == 1 ? "" : "s") before performing this work: …
-
-              Unhandled actions: \(debugOutput(receivedActions.map { $0.action }))
-              """,
-              file: step.file, line: step.line
-            )
-          }
-          do {
-            try work(&self.environment)
-          } catch {
-            _XCTFail("Threw error: \(error)", file: step.file, line: step.line)
-          }
-
-        case let .do(work):
-          if !receivedActions.isEmpty {
-            _XCTFail(
-              """
-              Must handle \(receivedActions.count) received \
-              action\(receivedActions.count == 1 ? "" : "s") before performing this work: …
-
-              Unhandled actions: \(debugOutput(receivedActions.map { $0.action }))
-              """,
-              file: step.file, line: step.line
-            )
-          }
-          do {
-            try work()
-          } catch {
-            _XCTFail("Threw error: \(error)", file: step.file, line: step.line)
-          }
-
-        case let .sequence(subSteps):
-          subSteps.forEach(assert(step:))
-        }
-      }
-
-      steps.forEach(assert(step:))
-
-      if !receivedActions.isEmpty {
+    private func completed() {
+      if !self.receivedActions.isEmpty {
         _XCTFail(
           """
-          Received \(receivedActions.count) unexpected \
-          action\(receivedActions.count == 1 ? "" : "s"): …
+          The store received \(self.receivedActions.count) unexpected \
+          action\(self.receivedActions.count == 1 ? "" : "s") after this one: …
 
-          Unhandled actions: \(debugOutput(receivedActions.map { $0.action }))
+          Unhandled actions: \(debugOutput(self.receivedActions.map { $0.action }))
           """,
-          file: file, line: line
+          file: self.file, line: self.line
         )
       }
-
-      for effect in longLivingEffects {
+      for effect in self.longLivingEffects {
         _XCTFail(
           """
           An effect returned for this action is still running. It must complete before the end of \
-          the assertion. …
+          the test. …
 
           To fix, inspect any effects the reducer returns for this action and ensure that all of \
           them complete by the end of the test. There are a few reasons why an effect may not have \
@@ -445,6 +280,230 @@
     }
   }
 
+  extension TestStore where State == LocalState, Action == LocalAction {
+    /// Initializes a test store from an initial state, a reducer, and an initial environment.
+    ///
+    /// - Parameters:
+    ///   - initialState: The state to start the test from.
+    ///   - reducer: A reducer.
+    ///   - environment: The environment to start the test from.
+    public convenience init(
+      initialState: State,
+      reducer: Reducer<State, Action, Environment>,
+      environment: Environment,
+      file: StaticString = #file,
+      line: UInt = #line
+    ) {
+      self.init(
+        environment: environment,
+        file: file,
+        fromLocalAction: { $0 },
+        initialState: initialState,
+        line: line,
+        reducer: reducer,
+        toLocalState: { $0 }
+      )
+    }
+  }
+
+  extension TestStore where LocalState: Equatable {
+    public func send(
+      _ action: LocalAction,
+      _ update: @escaping (inout LocalState) throws -> Void = { _ in },
+      file: StaticString = #file,
+      line: UInt = #line
+    ) {
+      if !self.receivedActions.isEmpty {
+        _XCTFail(
+          """
+          Must handle \(self.receivedActions.count) received \
+          action\(self.receivedActions.count == 1 ? "" : "s") before sending an action: …
+
+          Unhandled actions: \(debugOutput(self.receivedActions.map { $0.action }))
+          """,
+          file: file, line: line
+        )
+      }
+      var expectedState = self.toLocalState(self.snapshotState)
+      ViewStore(
+        self.store.scope(
+          state: self.toLocalState,
+          action: { .init(origin: .send($0), file: file, line: line) }
+        )
+      )
+      .send(action)
+      do {
+        try update(&expectedState)
+      } catch {
+        _XCTFail("Threw error: \(error)", file: file, line: line)
+      }
+      self.expectedStateShouldMatch(
+        expected: expectedState,
+        actual: self.toLocalState(self.snapshotState),
+        file: file,
+        line: line
+      )
+      if "\(self.file)" == "\(file)" {
+        self.line = line
+      }
+    }
+
+    public func receive(
+      _ expectedAction: Action,
+      _ update: @escaping (inout LocalState) throws -> Void = { _ in },
+      file: StaticString = #file,
+      line: UInt = #line
+    ) {
+      guard !self.receivedActions.isEmpty else {
+        _XCTFail(
+          """
+          Expected to receive an action, but received none.
+          """,
+          file: file, line: line
+        )
+        return
+      }
+      let (receivedAction, state) = self.receivedActions.removeFirst()
+      if expectedAction != receivedAction {
+        let diff =
+          debugDiff(expectedAction, receivedAction)
+          .map { "\($0.indent(by: 4))\n\n(Expected: −, Received: +)" }
+          ?? """
+          Expected:
+          \(String(describing: expectedAction).indent(by: 2))
+
+          Received:
+          \(String(describing: receivedAction).indent(by: 2))
+          """
+
+        _XCTFail(
+          """
+          Received unexpected action: …
+
+          \(diff)
+          """,
+          file: file, line: line
+        )
+      }
+      var expectedState = self.toLocalState(self.snapshotState)
+      do {
+        try update(&expectedState)
+      } catch {
+        _XCTFail("Threw error: \(error)", file: file, line: line)
+      }
+      expectedStateShouldMatch(
+        expected: expectedState,
+        actual: self.toLocalState(state),
+        file: file,
+        line: line
+      )
+      snapshotState = state
+      if "\(self.file)" == "\(file)" {
+        self.line = line
+      }
+    }
+
+    /// Asserts against a script of actions.
+    public func assert(
+      _ steps: Step...,
+      file: StaticString = #file,
+      line: UInt = #line
+    ) {
+      assert(steps, file: file, line: line)
+    }
+
+    /// Asserts against an array of actions.
+    public func assert(
+      _ steps: [Step],
+      file: StaticString = #file,
+      line: UInt = #line
+    ) {
+
+      func assert(step: Step) {
+        switch step.type {
+        case let .send(action, update):
+          self.send(action, update, file: step.file, line: step.line)
+
+        case let .receive(expectedAction, update):
+          self.receive(expectedAction, update, file: step.file, line: step.line)
+
+        case let .environment(work):
+          if !self.receivedActions.isEmpty {
+            _XCTFail(
+              """
+              Must handle \(self.receivedActions.count) received \
+              action\(self.receivedActions.count == 1 ? "" : "s") before performing this work: …
+
+              Unhandled actions: \(debugOutput(self.receivedActions.map { $0.action }))
+              """,
+              file: step.file, line: step.line
+            )
+          }
+          do {
+            try work(&self.environment)
+          } catch {
+            _XCTFail("Threw error: \(error)", file: step.file, line: step.line)
+          }
+
+        case let .do(work):
+          if !receivedActions.isEmpty {
+            _XCTFail(
+              """
+              Must handle \(self.receivedActions.count) received \
+              action\(self.receivedActions.count == 1 ? "" : "s") before performing this work: …
+
+              Unhandled actions: \(debugOutput(self.receivedActions.map { $0.action }))
+              """,
+              file: step.file, line: step.line
+            )
+          }
+          do {
+            try work()
+          } catch {
+            _XCTFail("Threw error: \(error)", file: step.file, line: step.line)
+          }
+
+        case let .sequence(subSteps):
+          subSteps.forEach(assert(step:))
+        }
+      }
+
+      steps.forEach(assert(step:))
+
+      self.completed()
+    }
+
+    private func expectedStateShouldMatch(
+      expected: LocalState,
+      actual: LocalState,
+      file: StaticString,
+      line: UInt
+    ) {
+      if expected != actual {
+        let diff =
+          debugDiff(expected, actual)
+          .map { "\($0.indent(by: 4))\n\n(Expected: −, Actual: +)" }
+          ?? """
+          Expected:
+          \(String(describing: expected).indent(by: 2))
+
+          Actual:
+          \(String(describing: actual).indent(by: 2))
+          """
+
+        _XCTFail(
+          """
+          State change does not match expectation: …
+
+          \(diff)
+          """,
+          file: file,
+          line: line
+        )
+      }
+    }
+  }
+
   extension TestStore {
     /// Scopes a store to assert against more local state and actions.
     ///
@@ -463,8 +522,10 @@
     ) -> TestStore<State, S, Action, A, Environment> {
       .init(
         environment: self.environment,
+        file: self.file,
         fromLocalAction: { self.fromLocalAction(fromLocalAction($0)) },
-        initialState: self.state,
+        initialState: self.store.state.value,
+        line: self.line,
         reducer: self.reducer,
         toLocalState: { toLocalState(self.toLocalState($0)) }
       )
@@ -618,7 +679,6 @@
       )
       return
     }
-
     _XCTFailureHandler(_XCTCurrentTestCase(), true, "\(file)", line, message, nil)
   }
 
@@ -629,16 +689,16 @@
 
   private let _XCTest = NSClassFromString("XCTest")
     .flatMap(Bundle.init(for:))
-    .flatMap({ $0.executablePath })
-    .flatMap({ dlopen($0, RTLD_NOW) })
+    .flatMap { $0.executablePath }
+    .flatMap { dlopen($0, RTLD_NOW) }
 
   private let _XCTFailureHandler =
     _XCTest
     .flatMap { dlsym($0, "_XCTFailureHandler") }
-    .map({ unsafeBitCast($0, to: XCTFailureHandler.self) })
+    .map { unsafeBitCast($0, to: XCTFailureHandler.self) }
 
   private let _XCTCurrentTestCase =
     _XCTest
     .flatMap { dlsym($0, "_XCTCurrentTestCase") }
-    .map({ unsafeBitCast($0, to: XCTCurrentTestCase.self) })
+    .map { unsafeBitCast($0, to: XCTCurrentTestCase.self) }
 #endif

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -305,9 +305,9 @@
   extension TestStore where LocalState: Equatable {
     public func send(
       _ action: LocalAction,
-      _ update: @escaping (inout LocalState) throws -> Void = { _ in },
       file: StaticString = #file,
-      line: UInt = #line
+      line: UInt = #line,
+      _ update: @escaping (inout LocalState) throws -> Void = { _ in }
     ) {
       if !self.receivedActions.isEmpty {
         _XCTFail(
@@ -346,9 +346,9 @@
 
     public func receive(
       _ expectedAction: Action,
-      _ update: @escaping (inout LocalState) throws -> Void = { _ in },
       file: StaticString = #file,
-      line: UInt = #line
+      line: UInt = #line,
+      _ update: @escaping (inout LocalState) throws -> Void = { _ in }
     ) {
       guard !self.receivedActions.isEmpty else {
         _XCTFail(
@@ -418,10 +418,10 @@
       func assert(step: Step) {
         switch step.type {
         case let .send(action, update):
-          self.send(action, update, file: step.file, line: step.line)
+          self.send(action, file: step.file, line: step.line, update)
 
         case let .receive(expectedAction, update):
-          self.receive(expectedAction, update, file: step.file, line: step.line)
+          self.receive(expectedAction, file: step.file, line: step.line, update)
 
         case let .environment(work):
           if !self.receivedActions.isEmpty {

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -63,16 +63,13 @@
   ///     class CounterTests: XCTestCase {
   ///       func testCounter() {
   ///         let store = TestStore(
-  ///           initialState: .init(count: 0),  // GIVEN counter state of 0
+  ///           initialState: .init(count: 0),     // GIVEN counter state of 0
   ///           reducer: counterReducer,
   ///           environment: ()
   ///         )
-  ///
-  ///         store.assert(
-  ///           .send(.incrementButtonTapped) { // WHEN the increment button is tapped
-  ///             $0.count = 1                  // THEN the count should be 1
-  ///           }
-  ///         )
+  ///         store.send(.incrementButtonTapped) { // WHEN the increment button is tapped
+  ///           $0.count = 1                       // THEN the count should be 1
+  ///         }
   ///       }
   ///     }
   ///
@@ -130,32 +127,31 @@
   ///         request: { _ in Effect(value: ["Composable Architecture"]) }
   ///       )
   ///     )
-  ///     store.assert(
-  ///       // Change the query
-  ///       .send(.searchFieldChanged("c") {
-  ///         // Assert that state updates accordingly
-  ///         $0.query = "c"
-  ///       },
   ///
-  ///       // Advance the scheduler by a period shorter than the debounce
-  ///       .do { scheduler.advance(by: 0.25) },
+  ///     // Change the query
+  ///     store.send(.searchFieldChanged("c") {
+  ///       // Assert that state updates accordingly
+  ///       $0.query = "c"
+  ///     }
   ///
-  ///       // Change the query again
-  ///       .send(.searchFieldChanged("co") {
-  ///         $0.query = "co"
-  ///       },
+  ///     // Advance the scheduler by a period shorter than the debounce
+  ///     scheduler.advance(by: 0.25)
   ///
-  ///       // Advance the scheduler by a period shorter than the debounce
-  ///       .do { scheduler.advance(by: 0.25) },
-  ///       // Advance the scheduler to the debounce
-  ///       .do { scheduler.advance(by: 0.25) },
+  ///     // Change the query again
+  ///     store.send(.searchFieldChanged("co") {
+  ///       $0.query = "co"
+  ///     }
   ///
-  ///       // Assert that the expected response is received
-  ///       .receive(.response(["Composable Architecture"])) {
-  ///         // Assert that state updates accordingly
-  ///         $0.results = ["Composable Architecture"]
-  ///       }
-  ///     )
+  ///     // Advance the scheduler by a period shorter than the debounce
+  ///     scheduler.advance(by: 0.25)
+  ///     // Advance the scheduler to the debounce
+  ///     scheduler.advance(by: 0.25)
+  ///
+  ///     // Assert that the expected response is received
+  ///     store.receive(.response(["Composable Architecture"])) {
+  ///       // Assert that state updates accordingly
+  ///       $0.results = ["Composable Architecture"]
+  ///     }
   ///
   /// This test is proving that the debounced network requests are correctly canceled when we do not
   /// wait longer than the 0.5 seconds, because if it wasn't and it delivered an action when we did

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -45,22 +45,18 @@ final class ComposableArchitectureTests: XCTestCase {
       environment: scheduler.eraseToAnyScheduler()
     )
 
-    store.assert(
-      .send(.incrAndSquareLater),
-      .do { scheduler.advance(by: 1) },
-      .receive(.squareNow) { $0 = 4 },
-      .do { scheduler.advance(by: 1) },
-      .receive(.incrNow) { $0 = 5 },
-      .receive(.squareNow) { $0 = 25 }
-    )
+    store.send(.incrAndSquareLater)
+    scheduler.advance(by: 1)
+    store.receive(.squareNow) { $0 = 4 }
+    scheduler.advance(by: 1)
+    store.receive(.incrNow) { $0 = 5 }
+    store.receive(.squareNow) { $0 = 25
 
-    store.assert(
-      .send(.incrAndSquareLater),
-      .do { scheduler.advance(by: 2) },
-      .receive(.squareNow) { $0 = 625 },
-      .receive(.incrNow) { $0 = 626 },
-      .receive(.squareNow) { $0 = 391876 }
-    )
+    store.send(.incrAndSquareLater)
+    scheduler.advance(by: 2)
+    store.receive(.squareNow) { $0 = 625 }
+    store.receive(.incrNow) { $0 = 626 }
+    store.receive(.squareNow) { $0 = 391876 }
   }
 
   func testSimultaneousWorkOrdering() {
@@ -114,13 +110,11 @@ final class ComposableArchitectureTests: XCTestCase {
       )
     )
 
-    store.assert(
-      .send(.start),
-      .send(.incr) { $0 = 1 },
-      .do(subject.send),
-      .receive(.incr) { $0 = 2 },
-      .send(.end)
-    )
+    store.send(.start)
+    store.send(.incr) { $0 = 1 }
+    subject.send()
+    store.receive(.incr) { $0 = 2 }
+    store.send(.end)
   }
 
   func testCancellation() {
@@ -167,16 +161,12 @@ final class ComposableArchitectureTests: XCTestCase {
       )
     )
 
-    store.assert(
-      .send(.incr) { $0 = 1 },
-      .do { scheduler.advance() },
-      .receive(.response(1)) { $0 = 1 }
-    )
+    store.send(.incr) { $0 = 1 }
+    scheduler.advance()
+    store.receive(.response(1)) { $0 = 1 }
 
-    store.assert(
-      .send(.incr) { $0 = 2 },
-      .send(.cancel),
-      .do { scheduler.run() }
-    )
+    store.send(.incr) { $0 = 2 }
+    store.send(.cancel)
+    scheduler.run()
   }
 }

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -50,7 +50,7 @@ final class ComposableArchitectureTests: XCTestCase {
     store.receive(.squareNow) { $0 = 4 }
     scheduler.advance(by: 1)
     store.receive(.incrNow) { $0 = 5 }
-    store.receive(.squareNow) { $0 = 25
+    store.receive(.squareNow) { $0 = 25 }
 
     store.send(.incrAndSquareLater)
     scheduler.advance(by: 2)

--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -47,18 +47,16 @@ final class ReducerTests: XCTestCase {
       environment: scheduler.eraseToAnyScheduler()
     )
 
-    store.assert(
-      .send(.increment) {
-        $0 = 2
-      },
-      // Waiting a second causes the fast effect to fire.
-      .do { scheduler.advance(by: 1) },
-      .do { XCTAssertEqual(fastValue, 42) },
-      // Waiting one more second causes the slow effect to fire. This proves that the effects
-      // are merged together, as opposed to concatenated.
-      .do { scheduler.advance(by: 1) },
-      .do { XCTAssertEqual(slowValue, 1729) }
-    )
+    store.send(.increment) {
+      $0 = 2
+    }
+    // Waiting a second causes the fast effect to fire.
+    scheduler.advance(by: 1)
+    XCTAssertEqual(fastValue, 42)
+    // Waiting one more second causes the slow effect to fire. This proves that the effects
+    // are merged together, as opposed to concatenated.
+    scheduler.advance(by: 1)
+    XCTAssertEqual(slowValue, 1729)
   }
 
   func testCombine() {
@@ -87,11 +85,9 @@ final class ReducerTests: XCTestCase {
       environment: ()
     )
 
-    store.assert(
-      .send(.increment) {
-        $0 = 2
-      }
-    )
+    store.send(.increment) {
+      $0 = 2
+    }
 
     XCTAssertTrue(childEffectExecuted)
     XCTAssertTrue(mainEffectExecuted)
@@ -128,10 +124,8 @@ final class ReducerTests: XCTestCase {
       reducer: reducer,
       environment: ()
     )
-    store.assert(
-      .send(.incr) { $0.count = 1 },
-      .send(.noop)
-    )
+    store.send(.incr) { $0.count = 1 }
+    store.send(.noop)
 
     self.wait(for: [logsExpectation], timeout: 2)
 

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -375,17 +375,15 @@ final class StoreTests: XCTestCase {
       environment: ()
     )
 
-    store.assert(
-      .send(.`init`),
-      .send(.incrementTapped),
-      .receive(.doIncrement) {
-        $0 = 1
-      },
-      .send(.incrementTapped),
-      .receive(.doIncrement) {
-        $0 = 2
-      },
-      .do { subject.send(completion: .finished) }
-    )
+    store.send(.`init`)
+    store.send(.incrementTapped)
+    store.receive(.doIncrement) {
+      $0 = 1
+    }
+    store.send(.incrementTapped)
+    store.receive(.doIncrement) {
+      $0 = 2
+    }
+    subject.send(completion: .finished)
   }
 }

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -45,22 +45,18 @@ class TestStoreTests: XCTestCase {
       environment: testScheduler.eraseToAnyScheduler()
     )
 
-    store.assert(
-      .send(.a),
+    store.send(.a)
 
-      .do { testScheduler.advance(by: 1) },
+    testScheduler.advance(by: 1)
 
-      .receive(.b1),
-      .receive(.b2),
-      .receive(.b3),
+    store.receive(.b1)
+    store.receive(.b2)
+    store.receive(.b3)
 
-      .sequence([
-        .receive(.c1),
-        .receive(.c2),
-        .receive(.c3),
-      ]),
+    store.receive(.c1)
+    store.receive(.c2)
+    store.receive(.c3)
 
-      .send(.d)
-    )
+    store.send(.d)
   }
 }


### PR DESCRIPTION
This PR introduces a newer, flatter way of asserting with the test store. Instead of calling `store.assert(...)` with a series of steps, one can now invoke `store.send` and `store.received` directly, improving how/where XCTest failures are surfaced.