### PR TITLE
Fixes #434 by only using the newly-scoped state in case it returned a non-nil value.

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -139,8 +139,8 @@ where Data: Collection, ID: Hashable, Content: View {
       WithViewStore(store.scope(state: { $0.ids })) { viewStore in
         ForEach(viewStore.state, id: \.self) { id in
           content(
-            store.scope(
-              state: { $0[id: id] ?? data[id: id]! },
+            store.optionalScope(
+              state: { $0[id: id] ?? data[id: id] },
               action: { (id, $0) }
             )
           )


### PR DESCRIPTION
`ForEachStore` has issues with first inserting and afterwards updates I think, which is shown in https://gist.github.com/fabstu/17ecfff9f327654eb69fb1ae92b2a0fb, I think #434 is similar. What deletion and the Todos-example have in common is, that the scoping does not have a value it can obtain through `$0[id: id]`. This fix simply ignores the parent-state change and waits for a real value to pass on the state change to the scoped store.

I do not know whether this design is sane, but it avoids crashes with the Todos example in #434 and for my example too. Is this testable?