### PR TITLE
Safely unwrap ForEachStore rows

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -131,18 +131,17 @@ where Data: Collection, ID: Hashable, Content: View {
   where
     EachContent: View,
     Data == IdentifiedArray<ID, EachState>,
-    Content == WithViewStore<[ID], (ID, EachAction), ForEach<[ID], ID, EachContent>>
+    Content == WithViewStore<[ID], (ID, EachAction), ForEach<[ID], ID, IfLetStore<EachState, EachAction, EachContent?>>>
   {
-    let data = store.state.value
-    self.data = data
+    self.data = store.state.value
     self.content = {
       WithViewStore(store.scope(state: { $0.ids })) { viewStore in
         ForEach(viewStore.state, id: \.self) { id in
-          content(
-            store.scope(
-              state: { $0[id: id] ?? data[id: id]! },
-              action: { (id, $0) }
-            )
+          // NB: We safely unwrap state here to avoid a potential crash where SwiftUI may
+          //     re-evaluate views for elements no longer in the collection.
+          IfLetStore(
+            store.scope(state: { $0[id: id] }, action: { (id, $0) }),
+            then: content
           )
         }
       }

--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -139,6 +139,8 @@ where Data: Collection, ID: Hashable, Content: View {
         ForEach(viewStore.state, id: \.self) { id in
           // NB: We safely unwrap state here to avoid a potential crash where SwiftUI may
           //     re-evaluate views for elements no longer in the collection.
+          //
+          // Feedback filed: https://gist.github.com/stephencelis/cdf85ae8dab437adc998fb0204ed9a6b
           IfLetStore(
             store.scope(state: { $0[id: id] }, action: { (id, $0) }),
             then: content


### PR DESCRIPTION
Alternative fix for #469, #434.