### PR TITLE
Fix background colors in UIKit demos to work in light and dark mode

### DIFF
--- a/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
@@ -41,7 +41,7 @@ final class CounterViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    self.view.backgroundColor = .white
+    self.view.backgroundColor = .systemBackground
 
     let decrementButton = UIButton(type: .system)
     decrementButton.addTarget(self, action: #selector(decrementButtonTapped), for: .touchUpInside)

--- a/Examples/CaseStudies/UIKitCaseStudies/Internal/ActivityIndicatorViewController.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/Internal/ActivityIndicatorViewController.swift
@@ -4,7 +4,7 @@ final class ActivityIndicatorViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    self.view.backgroundColor = .white
+    self.view.backgroundColor = .systemBackground
 
     let activityIndicator = UIActivityIndicatorView()
     activityIndicator.startAnimating()

--- a/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
@@ -69,7 +69,7 @@ class LazyNavigationViewController: UIViewController {
 
     self.title = "Load then navigate"
 
-    self.view.backgroundColor = .white
+    self.view.backgroundColor = .systemBackground
 
     let button = UIButton(type: .system)
     button.addTarget(self, action: #selector(loadOptionalCounterTapped), for: .touchUpInside)

--- a/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
@@ -69,7 +69,7 @@ class EagerNavigationViewController: UIViewController {
 
     self.title = "Navigate and load"
 
-    self.view.backgroundColor = .white
+    self.view.backgroundColor = .systemBackground
 
     let button = UIButton(type: .system)
     button.addTarget(self, action: #selector(loadOptionalCounterTapped), for: .touchUpInside)

--- a/Examples/TicTacToe/Sources/Views-UIKit/GameViewController.swift
+++ b/Examples/TicTacToe/Sources/Views-UIKit/GameViewController.swift
@@ -30,7 +30,7 @@ public final class GameViewController: UIViewController {
     super.viewDidLoad()
 
     self.navigationItem.title = "Tic-Tac-Toe"
-    self.view.backgroundColor = .white
+    self.view.backgroundColor = .systemBackground
 
     self.navigationItem.leftBarButtonItem = UIBarButtonItem(
       title: "Quit",

--- a/Examples/TicTacToe/Sources/Views-UIKit/LoginViewController.swift
+++ b/Examples/TicTacToe/Sources/Views-UIKit/LoginViewController.swift
@@ -43,7 +43,7 @@ class LoginViewController: UIViewController {
     super.viewDidLoad()
 
     self.navigationItem.title = "Login"
-    self.view.backgroundColor = .white
+    self.view.backgroundColor = .systemBackground
 
     let disclaimerLabel = UILabel()
     disclaimerLabel.text = """

--- a/Examples/TicTacToe/Sources/Views-UIKit/TwoFactorViewController.swift
+++ b/Examples/TicTacToe/Sources/Views-UIKit/TwoFactorViewController.swift
@@ -36,7 +36,7 @@ public final class TwoFactorViewController: UIViewController {
   public override func viewDidLoad() {
     super.viewDidLoad()
 
-    self.view.backgroundColor = .white
+    self.view.backgroundColor = .systemBackground
 
     let titleLabel = UILabel()
     titleLabel.text = "Enter the one time code to continue"


### PR DESCRIPTION
I noticed while playing around with the demos that the UIKit demos are setting the background color to `white`, which breaks some of the views in dark mode (the counter label ends up being white on a white background). Setting them to `systemBackground` fixes this.

I tested all of the views that I changed manually and they work in both light and dark mode now. #teamdarkmode