### PR TITLE
Modernize examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - '*'
 
 jobs:
-  tests:
+  library:
     runs-on: macos-10.15
     strategy:
       matrix:
@@ -22,7 +22,21 @@ jobs:
       - name: Select Xcode ${{ matrix.xcode }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Run tests
-        run: make test
+        run: make test-library
+
+  examples:
+    runs-on: macos-10.15
+    strategy:
+      matrix:
+        xcode:
+          - 11.7
+          - 12.4
+    steps:
+      - uses: actions/checkout@v2
+      - name: Select Xcode ${{ matrix.xcode }}
+        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+      - name: Run tests
+        run: make test-examples
 
 # NB: GitHub's Big Sur instances are super flaky. We should revisit later.
 #   bigsur-tests:

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
@@ -78,7 +78,7 @@ struct RootEnvironment {
     downloadClient: .live,
     favorite: favorite(id:isFavorite:),
     fetchNumber: liveFetchNumber,
-    mainQueue: DispatchQueue.main.eraseToAnyScheduler(),
+    mainQueue: .main,
     numberFact: liveNumberFact(for:),
     userDidTakeScreenshot: liveUserDidTakeScreenshot,
     uuid: UUID.init,

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -14,7 +14,7 @@ struct RootView: View {
               "Basics",
               destination: CounterDemoView(
                 store: self.store.scope(
-                  state: { $0.counter },
+                  state: \.counter,
                   action: RootAction.counter
                 )
               )
@@ -24,7 +24,7 @@ struct RootView: View {
               "Pullback and combine",
               destination: TwoCountersView(
                 store: self.store.scope(
-                  state: { $0.twoCounters },
+                  state: \.twoCounters,
                   action: RootAction.twoCounters
                 )
               )
@@ -34,7 +34,7 @@ struct RootView: View {
               "Bindings",
               destination: BindingBasicsView(
                 store: self.store.scope(
-                  state: { $0.bindingBasics },
+                  state: \.bindingBasics,
                   action: RootAction.bindingBasics
                 )
               )
@@ -44,7 +44,7 @@ struct RootView: View {
               "Form bindings",
               destination: BindingFormView(
                 store: self.store.scope(
-                  state: { $0.bindingForm },
+                  state: \.bindingForm,
                   action: RootAction.bindingForm
                 )
               )
@@ -54,7 +54,7 @@ struct RootView: View {
               "Optional state",
               destination: OptionalBasicsView(
                 store: self.store.scope(
-                  state: { $0.optionalBasics },
+                  state: \.optionalBasics,
                   action: RootAction.optionalBasics
                 )
               )
@@ -64,7 +64,7 @@ struct RootView: View {
               "Shared state",
               destination: SharedStateView(
                 store: self.store.scope(
-                  state: { $0.shared },
+                  state: \.shared,
                   action: RootAction.shared
                 )
               )
@@ -74,7 +74,7 @@ struct RootView: View {
               "Alerts and Action Sheets",
               destination: AlertAndSheetView(
                 store: self.store.scope(
-                  state: { $0.alertAndActionSheet },
+                  state: \.alertAndActionSheet,
                   action: RootAction.alertAndActionSheet
                 )
               )
@@ -84,7 +84,7 @@ struct RootView: View {
               "Animations",
               destination: AnimationsView(
                 store: self.store.scope(
-                  state: { $0.animation },
+                  state: \.animation,
                   action: RootAction.animation
                 )
               )
@@ -96,7 +96,7 @@ struct RootView: View {
               "Basics",
               destination: EffectsBasicsView(
                 store: self.store.scope(
-                  state: { $0.effectsBasics },
+                  state: \.effectsBasics,
                   action: RootAction.effectsBasics
                 )
               )
@@ -106,7 +106,7 @@ struct RootView: View {
               "Cancellation",
               destination: EffectsCancellationView(
                 store: self.store.scope(
-                  state: { $0.effectsCancellation },
+                  state: \.effectsCancellation,
                   action: RootAction.effectsCancellation)
               )
             )
@@ -115,7 +115,7 @@ struct RootView: View {
               "Long-living effects",
               destination: LongLivingEffectsView(
                 store: self.store.scope(
-                  state: { $0.longLivingEffects },
+                  state: \.longLivingEffects,
                   action: RootAction.longLivingEffects
                 )
               )
@@ -125,7 +125,7 @@ struct RootView: View {
               "Timers",
               destination: TimersView(
                 store: self.store.scope(
-                  state: { $0.timers },
+                  state: \.timers,
                   action: RootAction.timers
                 )
               )
@@ -135,7 +135,7 @@ struct RootView: View {
               "System environment",
               destination: MultipleDependenciesView(
                 store: self.store.scope(
-                  state: { $0.multipleDependencies },
+                  state: \.multipleDependencies,
                   action: RootAction.multipleDependencies
                 )
               )
@@ -145,7 +145,7 @@ struct RootView: View {
               "Web socket",
               destination: WebSocketView(
                 store: self.store.scope(
-                  state: { $0.webSocket },
+                  state: \.webSocket,
                   action: RootAction.webSocket
                 )
               )
@@ -157,7 +157,7 @@ struct RootView: View {
               "Navigate and load data",
               destination: NavigateAndLoadView(
                 store: self.store.scope(
-                  state: { $0.navigateAndLoad },
+                  state: \.navigateAndLoad,
                   action: RootAction.navigateAndLoad
                 )
               )
@@ -167,7 +167,7 @@ struct RootView: View {
               "Load data then navigate",
               destination: LoadThenNavigateView(
                 store: self.store.scope(
-                  state: { $0.loadThenNavigate },
+                  state: \.loadThenNavigate,
                   action: RootAction.loadThenNavigate
                 )
               )
@@ -177,7 +177,7 @@ struct RootView: View {
               "Lists: Navigate and load data",
               destination: NavigateAndLoadListView(
                 store: self.store.scope(
-                  state: { $0.navigateAndLoadList },
+                  state: \.navigateAndLoadList,
                   action: RootAction.navigateAndLoadList
                 )
               )
@@ -187,7 +187,7 @@ struct RootView: View {
               "Lists: Load data then navigate",
               destination: LoadThenNavigateListView(
                 store: self.store.scope(
-                  state: { $0.loadThenNavigateList },
+                  state: \.loadThenNavigateList,
                   action: RootAction.loadThenNavigateList
                 )
               )
@@ -197,7 +197,7 @@ struct RootView: View {
               "Sheets: Present and load data",
               destination: PresentAndLoadView(
                 store: self.store.scope(
-                  state: { $0.presentAndLoad },
+                  state: \.presentAndLoad,
                   action: RootAction.presentAndLoad
                 )
               )
@@ -207,7 +207,7 @@ struct RootView: View {
               "Sheets: Load data then present",
               destination: LoadThenPresentView(
                 store: self.store.scope(
-                  state: { $0.loadThenPresent },
+                  state: \.loadThenPresent,
                   action: RootAction.loadThenPresent
                 )
               )
@@ -219,7 +219,7 @@ struct RootView: View {
               "Reusable favoriting component",
               destination: EpisodesView(
                 store: self.store.scope(
-                  state: { $0.episodes },
+                  state: \.episodes,
                   action: RootAction.episodes
                 )
               )
@@ -229,7 +229,7 @@ struct RootView: View {
               "Reusable offline download component",
               destination: CitiesView(
                 store: self.store.scope(
-                  state: { $0.map },
+                  state: \.map,
                   action: RootAction.map
                 )
               )
@@ -239,7 +239,7 @@ struct RootView: View {
               "Lifecycle",
               destination: LifecycleDemoView(
                 store: self.store.scope(
-                  state: { $0.lifecycle },
+                  state: \.lifecycle,
                   action: RootAction.lifecycle
                 )
               )
@@ -249,7 +249,7 @@ struct RootView: View {
               "Strict reducers",
               destination: DieRollView(
                 store: self.store.scope(
-                  state: { $0.dieRoll },
+                  state: \.dieRoll,
                   action: RootAction.dieRoll
                 )
               )
@@ -259,7 +259,7 @@ struct RootView: View {
               "Elm-like subscriptions",
               destination: ClockView(
                 store: self.store.scope(
-                  state: { $0.clock },
+                  state: \.clock,
                   action: RootAction.clock
                 )
               )
@@ -269,7 +269,7 @@ struct RootView: View {
               "Recursive state and actions",
               destination: NestedView(
                 store: self.store.scope(
-                  state: { $0.nested },
+                  state: \.nested,
                   action: RootAction.nested
                 )
               )

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndActionSheets.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndActionSheets.swift
@@ -101,13 +101,13 @@ struct AlertAndSheetView: View {
 
           Button("Alert") { viewStore.send(.alertButtonTapped) }
             .alert(
-              self.store.scope(state: { $0.alert }),
+              self.store.scope(state: \.alert),
               dismiss: .alertDismissed
             )
 
           Button("Action sheet") { viewStore.send(.actionSheetButtonTapped) }
             .actionSheet(
-              self.store.scope(state: { $0.actionSheet }),
+              self.store.scope(state: \.actionSheet),
               dismiss: .actionSheetDismissed
             )
         }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -116,7 +116,7 @@ struct AnimationsView: View {
             "Big mode",
             isOn:
               viewStore
-              .binding(get: { $0.isCircleScaled }, send: AnimationsAction.circleScaleToggleChanged)
+              .binding(get: \.isCircleScaled, send: AnimationsAction.circleScaleToggleChanged)
               .animation(.interactiveSpring(response: 0.25, dampingFraction: 0.1))
           )
           .padding()
@@ -137,7 +137,7 @@ struct AnimationsView_Previews: PreviewProvider {
             initialState: AnimationsState(circleCenter: CGPoint(x: 50, y: 50)),
             reducer: animationsReducer,
             environment: AnimationsEnvironment(
-              mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+              mainQueue: .main
             )
           )
         )
@@ -149,7 +149,7 @@ struct AnimationsView_Previews: PreviewProvider {
             initialState: AnimationsState(circleCenter: CGPoint(x: 50, y: 50)),
             reducer: animationsReducer,
             environment: AnimationsEnvironment(
-              mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+              mainQueue: .main
             )
           )
         )

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -69,7 +69,7 @@ struct BindingBasicsView: View {
           HStack {
             TextField(
               "Type here",
-              text: viewStore.binding(get: { $0.text }, send: BindingBasicsAction.textChange)
+              text: viewStore.binding(get: \.text, send: BindingBasicsAction.textChange)
             )
             .disableAutocorrection(true)
             .foregroundColor(viewStore.toggleIsOn ? .gray : .primary)
@@ -78,14 +78,14 @@ struct BindingBasicsView: View {
           .disabled(viewStore.toggleIsOn)
 
           Toggle(
-            isOn: viewStore.binding(get: { $0.toggleIsOn }, send: BindingBasicsAction.toggleChange)
+            isOn: viewStore.binding(get: \.toggleIsOn, send: BindingBasicsAction.toggleChange)
           ) {
             Text("Disable other controls")
           }
 
           Stepper(
             value: viewStore.binding(
-              get: { $0.stepCount }, send: BindingBasicsAction.stepCountChanged),
+              get: \.stepCount, send: BindingBasicsAction.stepCountChanged),
             in: 0...100
           ) {
             Text("Max slider value: \(viewStore.stepCount)")
@@ -98,7 +98,7 @@ struct BindingBasicsView: View {
               .font(Font.body.monospacedDigit())
             Slider(
               value: viewStore.binding(
-                get: { $0.sliderValue },
+                get: \.sliderValue,
                 send: BindingBasicsAction.sliderValueChanged
               ),
               in: 0...Double(viewStore.stepCount)

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -44,7 +44,7 @@ struct TwoCountersView: View {
           Text("Counter 1")
 
           CounterView(
-            store: self.store.scope(state: { $0.counter1 }, action: TwoCountersAction.counter1)
+            store: self.store.scope(state: \.counter1, action: TwoCountersAction.counter1)
           )
           .buttonStyle(BorderlessButtonStyle())
           .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
@@ -53,7 +53,7 @@ struct TwoCountersView: View {
           Text("Counter 2")
 
           CounterView(
-            store: self.store.scope(state: { $0.counter2 }, action: TwoCountersAction.counter2)
+            store: self.store.scope(state: \.counter2, action: TwoCountersAction.counter2)
           )
           .buttonStyle(BorderlessButtonStyle())
           .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -61,7 +61,9 @@ struct OptionalBasicsView: View {
 
           IfLetStore(
             self.store.scope(
-              state: { $0.optionalCounter }, action: OptionalBasicsAction.optionalCounter),
+              state: \.optionalCounter,
+              action: OptionalBasicsAction.optionalCounter
+            ),
             then: { store in
               VStack(alignment: .leading, spacing: 16) {
                 Text(template: "`CounterState` is non-`nil`", .body)

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
@@ -150,7 +150,7 @@ struct SharedStateView: View {
   let store: Store<SharedState, SharedStateAction>
 
   var body: some View {
-    WithViewStore(self.store.scope(state: { $0.currentTab })) { viewStore in
+    WithViewStore(self.store.scope(state: \.currentTab)) { viewStore in
       VStack {
         Picker(
           "Tab",
@@ -166,12 +166,12 @@ struct SharedStateView: View {
 
         if viewStore.state == .counter {
           SharedStateCounterView(
-            store: self.store.scope(state: { $0.counter }, action: SharedStateAction.counter))
+            store: self.store.scope(state: \.counter, action: SharedStateAction.counter))
         }
 
         if viewStore.state == .profile {
           SharedStateProfileView(
-            store: self.store.scope(state: { $0.profile }, action: SharedStateAction.profile))
+            store: self.store.scope(state: \.profile, action: SharedStateAction.profile))
         }
 
         Spacer()
@@ -205,7 +205,7 @@ struct SharedStateCounterView: View {
       .padding(16)
       .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .top)
       .navigationBarTitle("Shared State Demo")
-      .alert(self.store.scope(state: { $0.alert }), dismiss: .alertDismissed)
+      .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
     }
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -135,7 +135,7 @@ struct EffectsBasicsView_Previews: PreviewProvider {
           initialState: EffectsBasicsState(),
           reducer: effectsBasicsReducer,
           environment: EffectsBasicsEnvironment(
-            mainQueue: DispatchQueue.main.eraseToAnyScheduler(),
+            mainQueue: .main,
             numberFact: liveNumberFact(for:))
         )
       )

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -91,7 +91,7 @@ struct EffectsCancellationView: View {
         ) {
           Stepper(
             value: viewStore.binding(
-              get: { $0.count }, send: EffectsCancellationAction.stepperChanged)
+              get: \.count, send: EffectsCancellationAction.stepperChanged)
           ) {
             Text("\(viewStore.count)")
           }
@@ -127,7 +127,7 @@ struct EffectsCancellation_Previews: PreviewProvider {
           initialState: EffectsCancellationState(),
           reducer: effectsCancellationReducer,
           environment: EffectsCancellationEnvironment(
-            mainQueue: DispatchQueue.main.eraseToAnyScheduler(),
+            mainQueue: .main,
             numberFact: liveNumberFact(for:)
           )
         )

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -131,7 +131,7 @@ struct TimersView_Previews: PreviewProvider {
           initialState: TimersState(),
           reducer: timersReducer,
           environment: TimersEnvironment(
-            mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+            mainQueue: .main
           )
         )
       )

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -147,7 +147,7 @@ struct WebSocketView: View {
           TextField(
             "Message to send",
             text: viewStore.binding(
-              get: { $0.messageToSend }, send: WebSocketAction.messageToSendChanged)
+              get: \.messageToSend, send: WebSocketAction.messageToSendChanged)
           )
 
           Button(
@@ -174,7 +174,7 @@ struct WebSocketView: View {
         Text(viewStore.receivedMessages.joined(separator: "\n"))
       }
       .padding()
-      .alert(self.store.scope(state: { $0.alert }), dismiss: .alertDismissed)
+      .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
       .navigationBarTitle("Web Socket")
     }
   }
@@ -350,7 +350,7 @@ struct WebSocketView_Previews: PreviewProvider {
           initialState: .init(receivedMessages: ["Echo"]),
           reducer: webSocketReducer,
           environment: WebSocketEnvironment(
-            mainQueue: DispatchQueue.main.eraseToAnyScheduler(),
+            mainQueue: .main,
             webSocket: .live
           )
         )

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-SystemEnvironment.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-SystemEnvironment.swift
@@ -106,7 +106,7 @@ struct MultipleDependenciesView: View {
           }
 
           Button("Delayed Alert") { viewStore.send(.alertButtonTapped) }
-            .alert(self.store.scope(state: { $0.alert }), dismiss: .alertDismissed)
+            .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
         }
 
         Section(
@@ -177,7 +177,7 @@ struct SystemEnvironment<Environment> {
     Self(
       date: Date.init,
       environment: environment,
-      mainQueue: { DispatchQueue.main.eraseToAnyScheduler() },
+      mainQueue: { .main },
       uuid: UUID.init
     )
   }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -96,12 +96,14 @@ struct LoadThenNavigateListView: View {
             NavigationLink(
               destination: IfLetStore(
                 self.store.scope(
-                  state: { $0.selection?.value }, action: LoadThenNavigateListAction.counter),
+                  state: \.selection?.value,
+                  action: LoadThenNavigateListAction.counter
+                ),
                 then: CounterView.init(store:)
               ),
               tag: row.id,
               selection: viewStore.binding(
-                get: { $0.selection?.id },
+                get: \.selection?.id,
                 send: LoadThenNavigateListAction.setNavigation(selection:)
               )
             ) {
@@ -135,7 +137,7 @@ struct LoadThenNavigateListView_Previews: PreviewProvider {
           ),
           reducer: loadThenNavigateListReducer,
           environment: LoadThenNavigateListEnvironment(
-            mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+            mainQueue: .main
           )
         )
       )

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -87,13 +87,15 @@ struct NavigateAndLoadListView: View {
             NavigationLink(
               destination: IfLetStore(
                 self.store.scope(
-                  state: { $0.selection?.value }, action: NavigateAndLoadListAction.counter),
+                  state: \.selection?.value,
+                  action: NavigateAndLoadListAction.counter
+                ),
                 then: CounterView.init(store:),
                 else: { ActivityIndicator() }
               ),
               tag: row.id,
               selection: viewStore.binding(
-                get: { $0.selection?.id },
+                get: \.selection?.id,
                 send: NavigateAndLoadListAction.setNavigation(selection:)
               )
             ) {
@@ -121,7 +123,7 @@ struct NavigateAndLoadListView_Previews: PreviewProvider {
           ),
           reducer: navigateAndLoadListReducer,
           environment: NavigateAndLoadListEnvironment(
-            mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+            mainQueue: .main
           )
         )
       )

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -70,11 +70,13 @@ struct LoadThenNavigateView: View {
           NavigationLink(
             destination: IfLetStore(
               self.store.scope(
-                state: { $0.optionalCounter }, action: LoadThenNavigateAction.optionalCounter),
+                state: \.optionalCounter,
+                action: LoadThenNavigateAction.optionalCounter
+              ),
               then: CounterView.init(store:)
             ),
             isActive: viewStore.binding(
-              get: { $0.isNavigationActive },
+              get: \.isNavigationActive,
               send: LoadThenNavigateAction.setNavigation(isActive:)
             )
           ) {
@@ -101,7 +103,7 @@ struct LoadThenNavigateView_Previews: PreviewProvider {
           initialState: LoadThenNavigateState(),
           reducer: loadThenNavigateReducer,
           environment: LoadThenNavigateEnvironment(
-            mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+            mainQueue: .main
           )
         )
       )

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -69,12 +69,14 @@ struct NavigateAndLoadView: View {
           NavigationLink(
             destination: IfLetStore(
               self.store.scope(
-                state: { $0.optionalCounter }, action: NavigateAndLoadAction.optionalCounter),
+                state: \.optionalCounter,
+                action: NavigateAndLoadAction.optionalCounter
+              ),
               then: CounterView.init(store:),
               else: { ActivityIndicator() }
             ),
             isActive: viewStore.binding(
-              get: { $0.isNavigationActive },
+              get: \.isNavigationActive,
               send: NavigateAndLoadAction.setNavigation(isActive:)
             )
           ) {
@@ -97,7 +99,7 @@ struct NavigateAndLoadView_Previews: PreviewProvider {
           initialState: NavigateAndLoadState(),
           reducer: navigateAndLoadReducer,
           environment: NavigateAndLoadEnvironment(
-            mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+            mainQueue: .main
           )
         )
       )

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -80,13 +80,15 @@ struct LoadThenPresentView: View {
       }
       .sheet(
         isPresented: viewStore.binding(
-          get: { $0.isSheetPresented },
+          get: \.isSheetPresented,
           send: LoadThenPresentAction.setSheet(isPresented:)
         )
       ) {
         IfLetStore(
           self.store.scope(
-            state: { $0.optionalCounter }, action: LoadThenPresentAction.optionalCounter),
+            state: \.optionalCounter,
+            action: LoadThenPresentAction.optionalCounter
+          ),
           then: CounterView.init(store:)
         )
       }
@@ -103,7 +105,7 @@ struct LoadThenPresentView_Previews: PreviewProvider {
           initialState: LoadThenPresentState(),
           reducer: loadThenPresentReducer,
           environment: LoadThenPresentEnvironment(
-            mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+            mainQueue: .main
           )
         )
       )

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -71,13 +71,15 @@ struct PresentAndLoadView: View {
       }
       .sheet(
         isPresented: viewStore.binding(
-          get: { $0.isSheetPresented },
+          get: \.isSheetPresented,
           send: PresentAndLoadAction.setSheet(isPresented:)
         )
       ) {
         IfLetStore(
           self.store.scope(
-            state: { $0.optionalCounter }, action: PresentAndLoadAction.optionalCounter),
+            state: \.optionalCounter,
+            action: PresentAndLoadAction.optionalCounter
+          ),
           then: CounterView.init(store:),
           else: { ActivityIndicator() }
         )
@@ -95,7 +97,7 @@ struct PresentAndLoadView_Previews: PreviewProvider {
           initialState: PresentAndLoadState(),
           reducer: presentAndLoadReducer,
           environment: PresentAndLoadEnvironment(
-            mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+            mainQueue: .main
           )
         )
       )

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -154,7 +154,7 @@ struct Subscriptions_Previews: PreviewProvider {
           initialState: ClockState(),
           reducer: clockReducer,
           environment: ClockEnvironment(
-            mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+            mainQueue: .main
           )
         )
       )

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -83,7 +83,7 @@ struct LifecycleDemoView: View {
         Button("Toggle Timer") { viewStore.send(.toggleTimerButtonTapped) }
 
         IfLetStore(
-          self.store.scope(state: { $0.count }, action: LifecycleDemoAction.timer),
+          self.store.scope(state: \.count, action: LifecycleDemoAction.timer),
           then: TimerView.init(store:)
         )
 
@@ -158,7 +158,7 @@ struct Lifecycle_Previews: PreviewProvider {
             initialState: .init(),
             reducer: lifecycleDemoReducer,
             environment: .init(
-              mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+              mainQueue: .main
             )
           )
         )

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -77,18 +77,18 @@ struct NestedView: View {
   let store: Store<NestedState, NestedAction>
 
   var body: some View {
-    WithViewStore(self.store.scope(state: { $0.description })) { viewStore in
+    WithViewStore(self.store.scope(state: \.description)) { viewStore in
       Form {
         Section(header: Text(template: readMe, .caption)) {
 
           ForEachStore(
-            self.store.scope(state: { $0.children }, action: NestedAction.node(index:action:))
+            self.store.scope(state: \.children, action: NestedAction.node(index:action:))
           ) { childStore in
             WithViewStore(childStore) { childViewStore in
               HStack {
                 TextField(
                   "Untitled",
-                  text: childViewStore.binding(get: { $0.description }, send: NestedAction.rename)
+                  text: childViewStore.binding(get: \.description, send: NestedAction.rename)
                 )
 
                 Spacer()

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
@@ -164,7 +164,7 @@ struct DownloadComponent<ID: Equatable>: View {
         }
       }
       .alert(
-        self.store.scope(state: { $0.alert }, action: DownloadComponentAction.alert),
+        self.store.scope(state: \.alert, action: DownloadComponentAction.alert),
         dismiss: .dismiss
       )
     }

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -99,7 +99,7 @@ struct CityMapRowView: View {
 
           DownloadComponent(
             store: self.store.scope(
-              state: { $0.downloadComponent },
+              state: \.downloadComponent,
               action: CityMapAction.downloadComponent
             )
           )
@@ -131,7 +131,7 @@ struct CityMapDetailView: View {
 
           DownloadComponent(
             store: self.store.scope(
-              state: { $0.downloadComponent },
+              state: \.downloadComponent,
               action: CityMapAction.downloadComponent
             )
           )
@@ -178,7 +178,7 @@ struct CitiesView: View {
         header: Text(readMe)
       ) {
         ForEachStore(
-          self.store.scope(state: { $0.cityMaps }, action: MapAppAction.cityMaps(index:action:))
+          self.store.scope(state: \.cityMaps, action: MapAppAction.cityMaps(index:action:))
         ) { cityMapStore in
           CityMapRowView(store: cityMapStore)
             .buttonStyle(BorderlessButtonStyle())
@@ -199,7 +199,7 @@ struct DownloadList_Previews: PreviewProvider {
             reducer: mapAppReducer,
             environment: .init(
               downloadClient: .live,
-              mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+              mainQueue: .main
             )
           )
         )

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -99,7 +99,7 @@ struct FavoriteButton<ID>: View where ID: Hashable {
       Button(action: { viewStore.send(.buttonTapped) }) {
         Image(systemName: viewStore.isFavorite ? "heart.fill" : "heart")
       }
-      .alert(self.store.scope(state: { $0.alert }), dismiss: .alertDismissed)
+      .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
     }
   }
 }
@@ -138,7 +138,7 @@ struct EpisodeView: View {
         Spacer()
 
         FavoriteButton(
-          store: self.store.scope(state: { $0.favorite }, action: EpisodeAction.favorite))
+          store: self.store.scope(state: \.favorite, action: EpisodeAction.favorite))
       }
     }
   }
@@ -179,7 +179,7 @@ struct EpisodesView: View {
     Form {
       Section(header: Text(template: readMe, .caption)) {
         ForEachStore(
-          self.store.scope(state: { $0.episodes }, action: EpisodesAction.episode(index:action:))
+          self.store.scope(state: \.episodes, action: EpisodesAction.episode(index:action:))
         ) { rowStore in
           EpisodeView(store: rowStore)
             .buttonStyle(BorderlessButtonStyle())
@@ -201,7 +201,7 @@ struct EpisodesView_Previews: PreviewProvider {
           reducer: episodesReducer,
           environment: EpisodesEnvironment(
             favorite: favorite(id:isFavorite:),
-            mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+            mainQueue: .main
           )
         )
       )

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-BasicsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-BasicsTests.swift
@@ -9,7 +9,7 @@ class EffectsBasicsTests: XCTestCase {
       initialState: EffectsBasicsState(),
       reducer: effectsBasicsReducer,
       environment: EffectsBasicsEnvironment(
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
+        mainQueue: .immediate.eraseToAnyScheduler(),
         numberFact: { _ in fatalError("Unimplemented") }
       )
     )
@@ -30,7 +30,7 @@ class EffectsBasicsTests: XCTestCase {
       initialState: EffectsBasicsState(),
       reducer: effectsBasicsReducer,
       environment: EffectsBasicsEnvironment(
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
+        mainQueue: .immediate.eraseToAnyScheduler(),
         numberFact: { n in Effect(value: "\(n) is a good number Brent") }
       )
     )

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-BasicsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-BasicsTests.swift
@@ -9,7 +9,7 @@ class EffectsBasicsTests: XCTestCase {
       initialState: EffectsBasicsState(),
       reducer: effectsBasicsReducer,
       environment: EffectsBasicsEnvironment(
-        mainQueue: .immediate.eraseToAnyScheduler(),
+        mainQueue: .immediate,
         numberFact: { _ in fatalError("Unimplemented") }
       )
     )
@@ -30,7 +30,7 @@ class EffectsBasicsTests: XCTestCase {
       initialState: EffectsBasicsState(),
       reducer: effectsBasicsReducer,
       environment: EffectsBasicsEnvironment(
-        mainQueue: .immediate.eraseToAnyScheduler(),
+        mainQueue: .immediate,
         numberFact: { n in Effect(value: "\(n) is a good number Brent") }
       )
     )

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-CancellationTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-CancellationTests.swift
@@ -10,7 +10,7 @@ class EffectsCancellationTests: XCTestCase {
       initialState: .init(),
       reducer: effectsCancellationReducer,
       environment: .init(
-        mainQueue: .immediate.eraseToAnyScheduler(),
+        mainQueue: .immediate,
         numberFact: { n in Effect(value: "\(n) is a good number Brent") }
       )
     )
@@ -35,7 +35,7 @@ class EffectsCancellationTests: XCTestCase {
       initialState: .init(),
       reducer: effectsCancellationReducer,
       environment: .init(
-        mainQueue: .immediate.eraseToAnyScheduler(),
+        mainQueue: .immediate,
         numberFact: { _ in Fail(error: NumbersApiError()).eraseToEffect() }
       )
     )

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-CancellationTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-CancellationTests.swift
@@ -10,7 +10,7 @@ class EffectsCancellationTests: XCTestCase {
       initialState: .init(),
       reducer: effectsCancellationReducer,
       environment: .init(
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
+        mainQueue: .immediate.eraseToAnyScheduler(),
         numberFact: { n in Effect(value: "\(n) is a good number Brent") }
       )
     )
@@ -35,7 +35,7 @@ class EffectsCancellationTests: XCTestCase {
       initialState: .init(),
       reducer: effectsCancellationReducer,
       environment: .init(
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
+        mainQueue: .immediate.eraseToAnyScheduler(),
         numberFact: { _ in Fail(error: NumbersApiError()).eraseToEffect() }
       )
     )

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
@@ -13,7 +13,7 @@ class WebSocketTests: XCTestCase {
       initialState: .init(),
       reducer: webSocketReducer,
       environment: WebSocketEnvironment(
-        mainQueue: .immediate.eraseToAnyScheduler(),
+        mainQueue: .immediate,
         webSocket: .mock(
           open: { _, _, _ in socketSubject.eraseToEffect() },
           receive: { _ in receiveSubject.eraseToEffect() },
@@ -61,7 +61,7 @@ class WebSocketTests: XCTestCase {
       initialState: .init(),
       reducer: webSocketReducer,
       environment: WebSocketEnvironment(
-        mainQueue: .immediate.eraseToAnyScheduler(),
+        mainQueue: .immediate,
         webSocket: .mock(
           open: { _, _, _ in socketSubject.eraseToEffect() },
           receive: { _ in receiveSubject.eraseToEffect() },
@@ -142,7 +142,7 @@ class WebSocketTests: XCTestCase {
       initialState: .init(),
       reducer: webSocketReducer,
       environment: WebSocketEnvironment(
-        mainQueue: .immediate.eraseToAnyScheduler(),
+        mainQueue: .immediate,
         webSocket: .mock(
           cancel: { _, _, _ in .fireAndForget { socketSubject.send(completion: .finished) } },
           open: { _, _, _ in socketSubject.eraseToEffect() },

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
@@ -13,7 +13,7 @@ class WebSocketTests: XCTestCase {
       initialState: .init(),
       reducer: webSocketReducer,
       environment: WebSocketEnvironment(
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
+        mainQueue: .immediate.eraseToAnyScheduler(),
         webSocket: .mock(
           open: { _, _, _ in socketSubject.eraseToEffect() },
           receive: { _ in receiveSubject.eraseToEffect() },
@@ -61,7 +61,7 @@ class WebSocketTests: XCTestCase {
       initialState: .init(),
       reducer: webSocketReducer,
       environment: WebSocketEnvironment(
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
+        mainQueue: .immediate.eraseToAnyScheduler(),
         webSocket: .mock(
           open: { _, _, _ in socketSubject.eraseToEffect() },
           receive: { _ in receiveSubject.eraseToEffect() },
@@ -142,7 +142,7 @@ class WebSocketTests: XCTestCase {
       initialState: .init(),
       reducer: webSocketReducer,
       environment: WebSocketEnvironment(
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
+        mainQueue: .immediate.eraseToAnyScheduler(),
         webSocket: .mock(
           cancel: { _, _, _ in .fireAndForget { socketSubject.send(completion: .finished) } },
           open: { _, _, _ in socketSubject.eraseToEffect() },

--- a/Examples/CaseStudies/UIKitCaseStudies/ListsOfState.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/ListsOfState.swift
@@ -66,7 +66,7 @@ final class CountersTableViewController: UITableViewController {
     self.navigationController?.pushViewController(
       CounterViewController(
         store: self.store.scope(
-          state: { $0.counters[indexPath.row] },
+          state: \.counters[indexPath.row],
           action: { .counter(index: indexPath.row, action: $0) }
         )
       ),

--- a/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
@@ -95,7 +95,7 @@ class LazyNavigationViewController: UIViewController {
       .store(in: &self.cancellables)
 
     self.store
-      .scope(state: { $0.optionalCounter }, action: LazyNavigationAction.optionalCounter)
+      .scope(state: \.optionalCounter, action: LazyNavigationAction.optionalCounter)
       .ifLet(
         then: { [weak self] store in
           self?.navigationController?.pushViewController(
@@ -130,7 +130,7 @@ struct LazyNavigationViewController_Previews: PreviewProvider {
           initialState: LazyNavigationState(),
           reducer: lazyNavigationReducer,
           environment: LazyNavigationEnvironment(
-            mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+            mainQueue: .main
           )
         )
       )

--- a/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
@@ -88,7 +88,7 @@ class EagerNavigationViewController: UIViewController {
         self.navigationController?.pushViewController(
           IfLetStoreController(
             store: self.store
-              .scope(state: { $0.optionalCounter }, action: EagerNavigationAction.optionalCounter),
+              .scope(state: \.optionalCounter, action: EagerNavigationAction.optionalCounter),
             then: CounterViewController.init(store:),
             else: ActivityIndicatorViewController.init
           ),
@@ -122,7 +122,7 @@ struct EagerNavigationViewController_Previews: PreviewProvider {
           initialState: EagerNavigationState(),
           reducer: eagerNavigationReducer,
           environment: EagerNavigationEnvironment(
-            mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+            mainQueue: .main
           )
         )
       )

--- a/Examples/CaseStudies/UIKitCaseStudies/RootViewController.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/RootViewController.swift
@@ -46,7 +46,7 @@ let dataSource: [CaseStudy] = [
         initialState: EagerNavigationState(),
         reducer: eagerNavigationReducer,
         environment: EagerNavigationEnvironment(
-          mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+          mainQueue: .main
         )
       )
     )
@@ -58,7 +58,7 @@ let dataSource: [CaseStudy] = [
         initialState: LazyNavigationState(),
         reducer: lazyNavigationReducer,
         environment: LazyNavigationEnvironment(
-          mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+          mainQueue: .main
         )
       )
     )

--- a/Examples/CaseStudies/tvOSCaseStudies/Core.swift
+++ b/Examples/CaseStudies/tvOSCaseStudies/Core.swift
@@ -16,6 +16,6 @@ let rootReducer = Reducer<RootState, RootAction, RootEnvironment>.combine(
   focusReducer.pullback(
     state: \.focus,
     action: /RootAction.focus,
-    environment: { $0.focus }
+    environment: \.focus
   )
 )

--- a/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
+++ b/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
@@ -20,7 +20,7 @@ struct RootView: View {
         return AnyView(
           NavigationLink(
             destination: FocusView(
-              store: self.store.scope(state: { $0.focus }, action: RootAction.focus)
+              store: self.store.scope(state: \.focus, action: RootAction.focus)
             ),
             label: {
               Text("Focus")

--- a/Examples/Search/Search/SceneDelegate.swift
+++ b/Examples/Search/Search/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
           reducer: searchReducer.debug(),
           environment: SearchEnvironment(
             weatherClient: WeatherClient.live,
-            mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+            mainQueue: .main
           )
         )
       )

--- a/Examples/Search/Search/SearchView.swift
+++ b/Examples/Search/Search/SearchView.swift
@@ -102,7 +102,7 @@ struct SearchView: View {
             TextField(
               "New York, San Francisco, ...",
               text: viewStore.binding(
-                get: { $0.searchQuery }, send: SearchAction.searchQueryChanged)
+                get: \.searchQuery, send: SearchAction.searchQueryChanged)
             )
             .textFieldStyle(RoundedBorderTextFieldStyle())
             .autocapitalization(.none)
@@ -232,7 +232,7 @@ struct SearchView_Previews: PreviewProvider {
                 id: id
               ))
           }),
-        mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+        mainQueue: .main
       )
     )
 

--- a/Examples/SpeechRecognition/SpeechRecognition/SceneDelegate.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         initialState: .init(),
         reducer: appReducer,
         environment: AppEnvironment(
-          mainQueue: DispatchQueue.main.eraseToAnyScheduler(),
+          mainQueue: .main,
           speechClient: .live
         )
       )

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
@@ -148,7 +148,7 @@ struct SpeechRecognitionView: View {
         }
       }
       .padding()
-      .alert(self.store.scope(state: { $0.alert }), dismiss: .dismissAuthorizationStateAlert)
+      .alert(self.store.scope(state: \.alert), dismiss: .dismissAuthorizationStateAlert)
     }
   }
 }
@@ -160,7 +160,7 @@ struct SpeechRecognitionView_Previews: PreviewProvider {
         initialState: .init(transcribedText: "Test test 123"),
         reducer: appReducer,
         environment: AppEnvironment(
-          mainQueue: DispatchQueue.main.eraseToAnyScheduler(),
+          mainQueue: .main,
           speechClient: .live
         )
       )

--- a/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
+++ b/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
@@ -12,7 +12,7 @@ class SpeechRecognitionTests: XCTestCase {
       initialState: .init(),
       reducer: appReducer,
       environment: AppEnvironment(
-        mainQueue: .immediate.eraseToAnyScheduler(),
+        mainQueue: .immediate,
         speechClient: .mock(
           requestAuthorization: { Effect(value: .denied) }
         )
@@ -40,7 +40,7 @@ class SpeechRecognitionTests: XCTestCase {
       initialState: .init(),
       reducer: appReducer,
       environment: AppEnvironment(
-        mainQueue: .immediate.eraseToAnyScheduler(),
+        mainQueue: .immediate,
         speechClient: .mock(
           requestAuthorization: { Effect(value: .restricted) }
         )
@@ -62,7 +62,7 @@ class SpeechRecognitionTests: XCTestCase {
       initialState: .init(),
       reducer: appReducer,
       environment: AppEnvironment(
-        mainQueue: .immediate.eraseToAnyScheduler(),
+        mainQueue: .immediate,
         speechClient: .mock(
           finishTask: { _ in
             .fireAndForget { self.recognitionTaskSubject.send(completion: .finished) }
@@ -111,7 +111,7 @@ class SpeechRecognitionTests: XCTestCase {
       initialState: .init(),
       reducer: appReducer,
       environment: AppEnvironment(
-        mainQueue: .immediate.eraseToAnyScheduler(),
+        mainQueue: .immediate,
         speechClient: .mock(
           recognitionTask: { _, _ in self.recognitionTaskSubject.eraseToEffect() },
           requestAuthorization: { Effect(value: .authorized) }
@@ -140,7 +140,7 @@ class SpeechRecognitionTests: XCTestCase {
       initialState: .init(),
       reducer: appReducer,
       environment: AppEnvironment(
-        mainQueue: .immediate.eraseToAnyScheduler(),
+        mainQueue: .immediate,
         speechClient: .mock(
           recognitionTask: { _, _ in self.recognitionTaskSubject.eraseToEffect() },
           requestAuthorization: { Effect(value: .authorized) }

--- a/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
+++ b/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
@@ -12,7 +12,7 @@ class SpeechRecognitionTests: XCTestCase {
       initialState: .init(),
       reducer: appReducer,
       environment: AppEnvironment(
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
+        mainQueue: .immediate.eraseToAnyScheduler(),
         speechClient: .mock(
           requestAuthorization: { Effect(value: .denied) }
         )
@@ -40,7 +40,7 @@ class SpeechRecognitionTests: XCTestCase {
       initialState: .init(),
       reducer: appReducer,
       environment: AppEnvironment(
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
+        mainQueue: .immediate.eraseToAnyScheduler(),
         speechClient: .mock(
           requestAuthorization: { Effect(value: .restricted) }
         )
@@ -62,7 +62,7 @@ class SpeechRecognitionTests: XCTestCase {
       initialState: .init(),
       reducer: appReducer,
       environment: AppEnvironment(
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
+        mainQueue: .immediate.eraseToAnyScheduler(),
         speechClient: .mock(
           finishTask: { _ in
             .fireAndForget { self.recognitionTaskSubject.send(completion: .finished) }
@@ -111,7 +111,7 @@ class SpeechRecognitionTests: XCTestCase {
       initialState: .init(),
       reducer: appReducer,
       environment: AppEnvironment(
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
+        mainQueue: .immediate.eraseToAnyScheduler(),
         speechClient: .mock(
           recognitionTask: { _, _ in self.recognitionTaskSubject.eraseToEffect() },
           requestAuthorization: { Effect(value: .authorized) }
@@ -140,7 +140,7 @@ class SpeechRecognitionTests: XCTestCase {
       initialState: .init(),
       reducer: appReducer,
       environment: AppEnvironment(
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
+        mainQueue: .immediate.eraseToAnyScheduler(),
         speechClient: .mock(
           recognitionTask: { _, _ in self.recognitionTaskSubject.eraseToEffect() },
           requestAuthorization: { Effect(value: .authorized) }

--- a/Examples/TicTacToe/Sources/Core/NewGameCore.swift
+++ b/Examples/TicTacToe/Sources/Core/NewGameCore.swift
@@ -23,45 +23,45 @@ public struct NewGameEnvironment {
   public init() {}
 }
 
-public let newGameReducer =
+public let newGameReducer = Reducer<NewGameState, NewGameAction, NewGameEnvironment>.combine(
   gameReducer
-  .optional()
-  .pullback(
-    state: \.game,
-    action: /NewGameAction.game,
-    environment: { _ in GameEnvironment() }
-  )
-  .combined(
-    with: Reducer<NewGameState, NewGameAction, NewGameEnvironment> { state, action, _ in
-      switch action {
-      case .game(.quitButtonTapped):
-        state.game = nil
-        return .none
+    .optional()
+    .pullback(
+      state: \.game,
+      action: /NewGameAction.game,
+      environment: { _ in GameEnvironment() }
+    ),
 
-      case .gameDismissed:
-        state.game = nil
-        return .none
+  .init { state, action, _ in
+    switch action {
+    case .game(.quitButtonTapped):
+      state.game = nil
+      return .none
 
-      case .game:
-        return .none
+    case .gameDismissed:
+      state.game = nil
+      return .none
 
-      case .letsPlayButtonTapped:
-        state.game = GameState(
-          oPlayerName: state.oPlayerName,
-          xPlayerName: state.xPlayerName
-        )
-        return .none
+    case .game:
+      return .none
 
-      case .logoutButtonTapped:
-        return .none
+    case .letsPlayButtonTapped:
+      state.game = GameState(
+        oPlayerName: state.oPlayerName,
+        xPlayerName: state.xPlayerName
+      )
+      return .none
 
-      case let .oPlayerNameChanged(name):
-        state.oPlayerName = name
-        return .none
+    case .logoutButtonTapped:
+      return .none
 
-      case let .xPlayerNameChanged(name):
-        state.xPlayerName = name
-        return .none
-      }
+    case let .oPlayerNameChanged(name):
+      state.oPlayerName = name
+      return .none
+
+    case let .xPlayerNameChanged(name):
+      state.xPlayerName = name
+      return .none
     }
-  )
+  }
+)

--- a/Examples/TicTacToe/Sources/RootView.swift
+++ b/Examples/TicTacToe/Sources/RootView.swift
@@ -31,7 +31,7 @@ struct RootView: View {
     reducer: appReducer.debug(),
     environment: AppEnvironment(
       authenticationClient: .live,
-      mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+      mainQueue: .main
     )
   )
 

--- a/Examples/TicTacToe/Sources/Views-SwiftUI/AppSwiftView.swift
+++ b/Examples/TicTacToe/Sources/Views-SwiftUI/AppSwiftView.swift
@@ -13,14 +13,14 @@ public struct AppView: View {
   }
 
   @ViewBuilder public var body: some View {
-    IfLetStore(self.store.scope(state: { $0.login }, action: AppAction.login)) { store in
+    IfLetStore(self.store.scope(state: \.login, action: AppAction.login)) { store in
       NavigationView {
         LoginView(store: store)
       }
       .navigationViewStyle(StackNavigationViewStyle())
     }
 
-    IfLetStore(self.store.scope(state: { $0.newGame }, action: AppAction.newGame)) { store in
+    IfLetStore(self.store.scope(state: \.newGame, action: AppAction.newGame)) { store in
       NavigationView {
         NewGameView(store: store)
       }

--- a/Examples/TicTacToe/Sources/Views-SwiftUI/GameSwiftView.swift
+++ b/Examples/TicTacToe/Sources/Views-SwiftUI/GameSwiftView.swift
@@ -3,14 +3,25 @@ import GameCore
 import SwiftUI
 
 public struct GameView: View {
+  let store: Store<GameState, GameAction>
+
   struct ViewState: Equatable {
     var board: [[String]]
     var isGameDisabled: Bool
     var isPlayAgainButtonVisible: Bool
     var title: String
-  }
 
-  let store: Store<GameState, GameAction>
+    init(state: GameState) {
+      self.board = state.board.map { $0.map { $0?.label ?? "" } }
+      self.isGameDisabled = state.board.hasWinner || state.board.isFilled
+      self.isPlayAgainButtonVisible = state.board.hasWinner || state.board.isFilled
+      self.title = state.board.hasWinner
+        ? "Winner! Congrats \(state.currentPlayerName)!"
+        : state.board.isFilled
+          ? "Tied game!"
+          : "\(state.currentPlayerName), place your \(state.currentPlayer.label)"
+    }
+  }
 
   public init(store: Store<GameState, GameAction>) {
     self.store = store
@@ -18,7 +29,7 @@ public struct GameView: View {
 
   public var body: some View {
     GeometryReader { proxy in
-      WithViewStore(self.store.scope(state: { $0.view })) { viewStore in
+      WithViewStore(self.store.scope(state: ViewState.init)) { viewStore in
         VStack(spacing: 0.0) {
           VStack {
             Text(viewStore.title)
@@ -77,21 +88,6 @@ public struct GameView: View {
             : Color(red: 0.6, green: 0.6, blue: 0.6)
         )
     }
-  }
-}
-
-extension GameState {
-  var view: GameView.ViewState {
-    GameView.ViewState(
-      board: self.board.map { $0.map { $0?.label ?? "" } },
-      isGameDisabled: self.board.hasWinner || self.board.isFilled,
-      isPlayAgainButtonVisible: self.board.hasWinner || self.board.isFilled,
-      title: self.board.hasWinner
-        ? "Winner! Congrats \(self.currentPlayerName)!"
-        : self.board.isFilled
-          ? "Tied game!"
-          : "\(self.currentPlayerName), place your \(self.currentPlayer.label)"
-    )
   }
 }
 

--- a/Examples/TicTacToe/Sources/Views-SwiftUI/LoginSwiftView.swift
+++ b/Examples/TicTacToe/Sources/Views-SwiftUI/LoginSwiftView.swift
@@ -129,7 +129,7 @@ struct LoginView_Previews: PreviewProvider {
               login: { _ in Effect(value: .init(token: "deadbeef", twoFactorRequired: false)) },
               twoFactor: { _ in Effect(value: .init(token: "deadbeef", twoFactorRequired: false)) }
             ),
-            mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+            mainQueue: .main
           )
         )
       )

--- a/Examples/TicTacToe/Sources/Views-SwiftUI/LoginSwiftView.swift
+++ b/Examples/TicTacToe/Sources/Views-SwiftUI/LoginSwiftView.swift
@@ -7,6 +7,8 @@ import TwoFactorCore
 import TwoFactorSwiftUI
 
 public struct LoginView: View {
+  let store: Store<LoginState, LoginAction>
+
   struct ViewState: Equatable {
     var alert: AlertState<LoginAction>?
     var email: String
@@ -15,6 +17,16 @@ public struct LoginView: View {
     var isLoginButtonDisabled: Bool
     var password: String
     var isTwoFactorActive: Bool
+
+    init(state: LoginState) {
+      self.alert = state.alert
+      self.email = state.email
+      self.isActivityIndicatorVisible = state.isLoginRequestInFlight
+      self.isFormDisabled = state.isLoginRequestInFlight
+      self.isLoginButtonDisabled = !state.isFormValid
+      self.password = state.password
+      self.isTwoFactorActive = state.twoFactor != nil
+    }
   }
 
   enum ViewAction {
@@ -25,14 +37,12 @@ public struct LoginView: View {
     case twoFactorDismissed
   }
 
-  let store: Store<LoginState, LoginAction>
-
   public init(store: Store<LoginState, LoginAction>) {
     self.store = store
   }
 
   public var body: some View {
-    WithViewStore(self.store.scope(state: { $0.view }, action: LoginAction.view)) { viewStore in
+    WithViewStore(self.store.scope(state: ViewState.init, action: LoginAction.init)) { viewStore in
       ScrollView {
         VStack(spacing: 16) {
           Text(
@@ -47,7 +57,7 @@ public struct LoginView: View {
             Text("Email")
             TextField(
               "blob@pointfree.co",
-              text: viewStore.binding(get: { $0.email }, send: ViewAction.emailChanged)
+              text: viewStore.binding(get: \.email, send: ViewAction.emailChanged)
             )
             .autocapitalization(.none)
             .keyboardType(.emailAddress)
@@ -59,18 +69,18 @@ public struct LoginView: View {
             Text("Password")
             SecureField(
               "••••••••",
-              text: viewStore.binding(get: { $0.password }, send: ViewAction.passwordChanged)
+              text: viewStore.binding(get: \.password, send: ViewAction.passwordChanged)
             )
             .textFieldStyle(RoundedBorderTextFieldStyle())
           }
 
           NavigationLink(
             destination: IfLetStore(
-              self.store.scope(state: { $0.twoFactor }, action: LoginAction.twoFactor),
+              self.store.scope(state: \.twoFactor, action: LoginAction.twoFactor),
               then: TwoFactorView.init(store:)
             ),
             isActive: viewStore.binding(
-              get: { $0.isTwoFactorActive },
+              get: \.isTwoFactorActive,
               send: { $0 ? .loginButtonTapped : .twoFactorDismissed }
             )
           ) {
@@ -82,7 +92,7 @@ public struct LoginView: View {
           }
           .disabled(viewStore.isLoginButtonDisabled)
         }
-        .alert(self.store.scope(state: { $0.alert }), dismiss: .alertDismissed)
+        .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
         .disabled(viewStore.isFormDisabled)
         .padding(.horizontal)
       }
@@ -93,33 +103,19 @@ public struct LoginView: View {
   }
 }
 
-extension LoginState {
-  var view: LoginView.ViewState {
-    LoginView.ViewState(
-      alert: self.alert,
-      email: self.email,
-      isActivityIndicatorVisible: self.isLoginRequestInFlight,
-      isFormDisabled: self.isLoginRequestInFlight,
-      isLoginButtonDisabled: !self.isFormValid,
-      password: self.password,
-      isTwoFactorActive: self.twoFactor != nil
-    )
-  }
-}
-
 extension LoginAction {
-  static func view(_ localAction: LoginView.ViewAction) -> Self {
-    switch localAction {
+  init(action: LoginView.ViewAction) {
+    switch action {
     case .alertDismissed:
-      return .alertDismissed
+      self = .alertDismissed
     case .twoFactorDismissed:
-      return .twoFactorDismissed
+      self = .twoFactorDismissed
     case let .emailChanged(email):
-      return .emailChanged(email)
+      self = .emailChanged(email)
     case .loginButtonTapped:
-      return .loginButtonTapped
+      self = .loginButtonTapped
     case let .passwordChanged(password):
-      return .passwordChanged(password)
+      self = .passwordChanged(password)
     }
   }
 }

--- a/Examples/TicTacToe/Sources/Views-SwiftUI/LoginSwiftView.swift
+++ b/Examples/TicTacToe/Sources/Views-SwiftUI/LoginSwiftView.swift
@@ -97,10 +97,7 @@ public struct LoginView: View {
         .padding(.horizontal)
       }
     }
-    .navigationBarTitle("Login")
-    // NB: This is necessary to clear the bar items from the game.
-    .navigationBarItems(trailing: EmptyView())
-  }
+    .navigationBarTitle("Login")  }
 }
 
 extension LoginAction {

--- a/Examples/TicTacToe/Sources/Views-SwiftUI/NewGameSwiftView.swift
+++ b/Examples/TicTacToe/Sources/Views-SwiftUI/NewGameSwiftView.swift
@@ -6,11 +6,20 @@ import SwiftUI
 import TicTacToeCommon
 
 public struct NewGameView: View {
+  let store: Store<NewGameState, NewGameAction>
+
   struct ViewState: Equatable {
     var isGameActive: Bool
     var isLetsPlayButtonDisabled: Bool
     var oPlayerName: String
     var xPlayerName: String
+
+    init(state: NewGameState) {
+      self.isGameActive = state.game != nil
+      self.isLetsPlayButtonDisabled = state.oPlayerName.isEmpty || state.xPlayerName.isEmpty
+      self.oPlayerName = state.oPlayerName
+      self.xPlayerName = state.xPlayerName
+    }
   }
 
   enum ViewAction {
@@ -21,14 +30,12 @@ public struct NewGameView: View {
     case xPlayerNameChanged(String)
   }
 
-  let store: Store<NewGameState, NewGameAction>
-
   public init(store: Store<NewGameState, NewGameAction>) {
     self.store = store
   }
 
   public var body: some View {
-    WithViewStore(self.store.scope(state: { $0.view }, action: NewGameAction.view)) { viewStore in
+    WithViewStore(self.store.scope(state: ViewState.init, action: NewGameAction.init)) { viewStore in
       ScrollView {
         VStack(spacing: 16) {
           VStack(alignment: .leading) {
@@ -77,30 +84,19 @@ public struct NewGameView: View {
   }
 }
 
-extension NewGameState {
-  var view: NewGameView.ViewState {
-    NewGameView.ViewState(
-      isGameActive: self.game != nil,
-      isLetsPlayButtonDisabled: self.oPlayerName.isEmpty || self.xPlayerName.isEmpty,
-      oPlayerName: self.oPlayerName,
-      xPlayerName: self.xPlayerName
-    )
-  }
-}
-
 extension NewGameAction {
-  static func view(_ viewAction: NewGameView.ViewAction) -> Self {
-    switch viewAction {
+  init(action: NewGameView.ViewAction) {
+    switch action {
     case .gameDismissed:
-      return .gameDismissed
+      self = .gameDismissed
     case .letsPlayButtonTapped:
-      return .letsPlayButtonTapped
+      self = .letsPlayButtonTapped
     case .logoutButtonTapped:
-      return .logoutButtonTapped
+      self = .logoutButtonTapped
     case let .oPlayerNameChanged(name):
-      return .oPlayerNameChanged(name)
+      self = .oPlayerNameChanged(name)
     case let .xPlayerNameChanged(name):
-      return .xPlayerNameChanged(name)
+      self = .xPlayerNameChanged(name)
     }
   }
 }

--- a/Examples/TicTacToe/Sources/Views-SwiftUI/NewGameSwiftView.swift
+++ b/Examples/TicTacToe/Sources/Views-SwiftUI/NewGameSwiftView.swift
@@ -42,7 +42,7 @@ public struct NewGameView: View {
             Text("X Player Name")
             TextField(
               "Blob Sr.",
-              text: viewStore.binding(get: { $0.xPlayerName }, send: ViewAction.xPlayerNameChanged)
+              text: viewStore.binding(get: \.xPlayerName, send: ViewAction.xPlayerNameChanged)
             )
             .autocapitalization(.words)
             .disableAutocorrection(true)
@@ -54,7 +54,7 @@ public struct NewGameView: View {
             Text("O Player Name")
             TextField(
               "Blob Jr.",
-              text: viewStore.binding(get: { $0.oPlayerName }, send: ViewAction.oPlayerNameChanged)
+              text: viewStore.binding(get: \.oPlayerName, send: ViewAction.oPlayerNameChanged)
             )
             .autocapitalization(.words)
             .disableAutocorrection(true)
@@ -64,11 +64,11 @@ public struct NewGameView: View {
 
           NavigationLink(
             destination: IfLetStore(
-              self.store.scope(state: { $0.game }, action: NewGameAction.game),
+              self.store.scope(state: \.game, action: NewGameAction.game),
               then: GameView.init(store:)
             ),
             isActive: viewStore.binding(
-              get: { $0.isGameActive },
+              get: \.isGameActive,
               send: { $0 ? .letsPlayButtonTapped : .gameDismissed }
             )
           ) {

--- a/Examples/TicTacToe/Sources/Views-SwiftUI/TwoFactorSwiftView.swift
+++ b/Examples/TicTacToe/Sources/Views-SwiftUI/TwoFactorSwiftView.swift
@@ -98,7 +98,7 @@ struct TwoFactorView_Previews: PreviewProvider {
                 Effect(value: .init(token: "deadbeef", twoFactorRequired: false))
               }
             ),
-            mainQueue: DispatchQueue.main.eraseToAnyScheduler()
+            mainQueue: .main
           )
         )
       )

--- a/Examples/TicTacToe/Sources/Views-SwiftUI/TwoFactorSwiftView.swift
+++ b/Examples/TicTacToe/Sources/Views-SwiftUI/TwoFactorSwiftView.swift
@@ -5,12 +5,22 @@ import TicTacToeCommon
 import TwoFactorCore
 
 public struct TwoFactorView: View {
+  let store: Store<TwoFactorState, TwoFactorAction>
+
   struct ViewState: Equatable {
     var alert: AlertState<TwoFactorAction>?
     var code: String
     var isActivityIndicatorVisible: Bool
     var isFormDisabled: Bool
     var isSubmitButtonDisabled: Bool
+
+    init(state: TwoFactorState) {
+      self.alert = state.alert
+      self.code = state.code
+      self.isActivityIndicatorVisible = state.isTwoFactorRequestInFlight
+      self.isFormDisabled = state.isTwoFactorRequestInFlight
+      self.isSubmitButtonDisabled = !state.isFormValid
+    }
   }
 
   enum ViewAction: Equatable {
@@ -19,14 +29,14 @@ public struct TwoFactorView: View {
     case submitButtonTapped
   }
 
-  let store: Store<TwoFactorState, TwoFactorAction>
-
   public init(store: Store<TwoFactorState, TwoFactorAction>) {
     self.store = store
   }
 
   public var body: some View {
-    WithViewStore(self.store.scope(state: { $0.view }, action: TwoFactorAction.view)) { viewStore in
+    WithViewStore(
+      self.store.scope(state: ViewState.init, action: TwoFactorAction.init)
+    ) { viewStore in
       ScrollView {
         VStack(spacing: 16) {
           Text(#"To confirm the second factor enter "1234" into the form."#)
@@ -35,7 +45,7 @@ public struct TwoFactorView: View {
             Text("Code")
             TextField(
               "1234",
-              text: viewStore.binding(get: { $0.code }, send: ViewAction.codeChanged)
+              text: viewStore.binding(get: \.code, send: ViewAction.codeChanged)
             )
             .keyboardType(.numberPad)
             .textFieldStyle(RoundedBorderTextFieldStyle())
@@ -52,7 +62,7 @@ public struct TwoFactorView: View {
             }
           }
         }
-        .alert(self.store.scope(state: { $0.alert }), dismiss: .alertDismissed)
+        .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
         .disabled(viewStore.isFormDisabled)
         .padding(.horizontal)
       }
@@ -61,27 +71,15 @@ public struct TwoFactorView: View {
   }
 }
 
-extension TwoFactorState {
-  var view: TwoFactorView.ViewState {
-    TwoFactorView.ViewState(
-      alert: self.alert,
-      code: self.code,
-      isActivityIndicatorVisible: self.isTwoFactorRequestInFlight,
-      isFormDisabled: self.isTwoFactorRequestInFlight,
-      isSubmitButtonDisabled: !self.isFormValid
-    )
-  }
-}
-
 extension TwoFactorAction {
-  static func view(_ localAction: TwoFactorView.ViewAction) -> Self {
-    switch localAction {
+  init(action: TwoFactorView.ViewAction) {
+    switch action {
     case .alertDismissed:
-      return .alertDismissed
+      self = .alertDismissed
     case let .codeChanged(code):
-      return .codeChanged(code)
+      self = .codeChanged(code)
     case .submitButtonTapped:
-      return .submitButtonTapped
+      self = .submitButtonTapped
     }
   }
 }

--- a/Examples/TicTacToe/Sources/Views-UIKit/AppViewController.swift
+++ b/Examples/TicTacToe/Sources/Views-UIKit/AppViewController.swift
@@ -36,14 +36,14 @@ class AppViewController: UINavigationController {
     super.viewDidLoad()
 
     self.store
-      .scope(state: { $0.login }, action: AppAction.login)
+      .scope(state: \.login, action: AppAction.login)
       .ifLet(then: { [weak self] loginStore in
         self?.setViewControllers([LoginViewController(store: loginStore)], animated: false)
       })
       .store(in: &self.cancellables)
 
     self.store
-      .scope(state: { $0.newGame }, action: AppAction.newGame)
+      .scope(state: \.newGame, action: AppAction.newGame)
       .ifLet(then: { [weak self] newGameStore in
         self?.setViewControllers([NewGameViewController(store: newGameStore)], animated: false)
       })

--- a/Examples/TicTacToe/Sources/Views-UIKit/TwoFactorViewController.swift
+++ b/Examples/TicTacToe/Sources/Views-UIKit/TwoFactorViewController.swift
@@ -5,11 +5,22 @@ import TwoFactorCore
 import UIKit
 
 public final class TwoFactorViewController: UIViewController {
+  let store: Store<TwoFactorState, TwoFactorAction>
+  let viewStore: ViewStore<ViewState, ViewAction>
+  private var cancellables: Set<AnyCancellable> = []
+
   struct ViewState: Equatable {
     let alert: AlertState<TwoFactorAction>?
     let code: String?
     let isActivityIndicatorHidden: Bool
     let isLoginButtonEnabled: Bool
+
+    init(state: TwoFactorState) {
+      self.alert = state.alert
+      self.code = state.code
+      self.isActivityIndicatorHidden = !state.isTwoFactorRequestInFlight
+      self.isLoginButtonEnabled = state.isFormValid && !state.isTwoFactorRequestInFlight
+    }
   }
 
   enum ViewAction {
@@ -18,14 +29,9 @@ public final class TwoFactorViewController: UIViewController {
     case loginButtonTapped
   }
 
-  let store: Store<TwoFactorState, TwoFactorAction>
-  let viewStore: ViewStore<ViewState, ViewAction>
-
-  private var cancellables: Set<AnyCancellable> = []
-
   public init(store: Store<TwoFactorState, TwoFactorAction>) {
     self.store = store
-    self.viewStore = ViewStore(store.scope(state: { $0.view }, action: TwoFactorAction.view))
+    self.viewStore = ViewStore(store.scope(state: ViewState.init, action: TwoFactorAction.init))
     super.init(nibName: nil, bundle: nil)
   }
 
@@ -114,26 +120,15 @@ public final class TwoFactorViewController: UIViewController {
   }
 }
 
-extension TwoFactorState {
-  var view: TwoFactorViewController.ViewState {
-    .init(
-      alert: self.alert,
-      code: self.code,
-      isActivityIndicatorHidden: !self.isTwoFactorRequestInFlight,
-      isLoginButtonEnabled: self.isFormValid && !self.isTwoFactorRequestInFlight
-    )
-  }
-}
-
 extension TwoFactorAction {
-  static func view(_ localAction: TwoFactorViewController.ViewAction) -> Self {
-    switch localAction {
+  init(action: TwoFactorViewController.ViewAction) {
+    switch action {
     case .alertDismissed:
-      return .alertDismissed
+      self = .alertDismissed
     case let .codeChanged(code):
-      return .codeChanged(code ?? "")
+      self = .codeChanged(code ?? "")
     case .loginButtonTapped:
-      return .submitButtonTapped
+      self = .submitButtonTapped
     }
   }
 }

--- a/Examples/TicTacToe/Tests/GameSwiftUITests.swift
+++ b/Examples/TicTacToe/Tests/GameSwiftUITests.swift
@@ -13,7 +13,7 @@ class GameSwiftUITests: XCTestCase {
     reducer: gameReducer,
     environment: GameEnvironment()
   )
-  .scope(state: { $0.view })
+  .scope(state: GameView.ViewState.init)
 
   func testFlow_Winner_Quit() {
     self.store.send(.cellTapped(row: 0, column: 0)) {
@@ -81,7 +81,7 @@ class GameSwiftUITests: XCTestCase {
       $0.title = "Tied game!"
     }
     self.store.send(.playAgainButtonTapped) {
-      $0 = GameState(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr.").view
+      $0 = GameView.ViewState(state: GameState(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr."))
     }
   }
 }

--- a/Examples/TicTacToe/Tests/LoginCoreTests.swift
+++ b/Examples/TicTacToe/Tests/LoginCoreTests.swift
@@ -19,7 +19,7 @@ class LoginCoreTests: XCTestCase {
             Effect(value: .init(token: "deadbeefdeadbeef", twoFactorRequired: false))
           }
         ),
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler()
+        mainQueue: .immediate.eraseToAnyScheduler()
       )
     )
 

--- a/Examples/TicTacToe/Tests/LoginCoreTests.swift
+++ b/Examples/TicTacToe/Tests/LoginCoreTests.swift
@@ -19,7 +19,7 @@ class LoginCoreTests: XCTestCase {
             Effect(value: .init(token: "deadbeefdeadbeef", twoFactorRequired: false))
           }
         ),
-        mainQueue: .immediate.eraseToAnyScheduler()
+        mainQueue: .immediate
       )
     )
 

--- a/Examples/TicTacToe/Tests/LoginSwiftUITests.swift
+++ b/Examples/TicTacToe/Tests/LoginSwiftUITests.swift
@@ -18,10 +18,10 @@ class LoginSwiftUITests: XCTestCase {
             Effect(value: .init(token: "deadbeefdeadbeef", twoFactorRequired: false))
           }
         ),
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler()
+        mainQueue: .immediate
       )
     )
-    .scope(state: { $0.view }, action: LoginAction.view)
+    .scope(state: LoginView.ViewState.init, action: LoginAction.init)
 
     store.send(.emailChanged("blob@pointfree.co")) {
       $0.email = "blob@pointfree.co"
@@ -52,10 +52,10 @@ class LoginSwiftUITests: XCTestCase {
             Effect(value: .init(token: "deadbeefdeadbeef", twoFactorRequired: true))
           }
         ),
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler()
+        mainQueue: .immediate
       )
     )
-    .scope(state: { $0.view }, action: LoginAction.view)
+    .scope(state: LoginView.ViewState.init, action: LoginAction.init)
 
     store.send(.emailChanged("2fa@pointfree.co")) {
       $0.email = "2fa@pointfree.co"
@@ -88,10 +88,10 @@ class LoginSwiftUITests: XCTestCase {
         authenticationClient: .mock(
           login: { _ in Effect(error: .invalidUserPassword) }
         ),
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler()
+        mainQueue: .immediate
       )
     )
-    .scope(state: { $0.view }, action: LoginAction.view)
+    .scope(state: LoginView.ViewState.init, action: LoginAction.init)
 
     store.send(.emailChanged("blob")) {
       $0.email = "blob"

--- a/Examples/TicTacToe/Tests/NewGameSwiftUITests.swift
+++ b/Examples/TicTacToe/Tests/NewGameSwiftUITests.swift
@@ -10,7 +10,7 @@ class NewGameSwiftUITests: XCTestCase {
     reducer: newGameReducer,
     environment: NewGameEnvironment()
   )
-  .scope(state: { $0.view }, action: NewGameAction.view)
+  .scope(state: NewGameView.ViewState.init, action: NewGameAction.init)
 
   func testNewGame() {
     self.store.send(.xPlayerNameChanged("Blob Sr.")) {

--- a/Examples/TicTacToe/Tests/TwoFactorSwiftUITests.swift
+++ b/Examples/TicTacToe/Tests/TwoFactorSwiftUITests.swift
@@ -18,10 +18,10 @@ class TwoFactorSwiftUITests: XCTestCase {
             Effect(value: .init(token: "deadbeefdeadbeef", twoFactorRequired: false))
           }
         ),
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler()
+        mainQueue: .immediate
       )
     )
-    .scope(state: { $0.view }, action: TwoFactorAction.view)
+    .scope(state: TwoFactorView.ViewState.init, action: TwoFactorAction.init)
 
     store.environment.authenticationClient.twoFactor = { _ in
       Effect(value: .init(token: "deadbeefdeadbeef", twoFactorRequired: false))
@@ -61,10 +61,10 @@ class TwoFactorSwiftUITests: XCTestCase {
             Effect(error: .invalidTwoFactor)
           }
         ),
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler()
+        mainQueue: .immediate
       )
     )
-    .scope(state: { $0.view }, action: TwoFactorAction.view)
+    .scope(state: TwoFactorView.ViewState.init, action: TwoFactorAction.init)
 
     store.send(.codeChanged("1234")) {
       $0.code = "1234"

--- a/Examples/Todos/Todos/SceneDelegate.swift
+++ b/Examples/Todos/Todos/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         initialState: AppState(),
         reducer: appReducer,
         environment: AppEnvironment(
-          mainQueue: DispatchQueue.main.eraseToAnyScheduler(),
+          mainQueue: .main,
           uuid: UUID.init
         )
       )

--- a/Examples/Todos/Todos/Todo.swift
+++ b/Examples/Todos/Todos/Todo.swift
@@ -40,7 +40,7 @@ struct TodoView: View {
 
         TextField(
           "Untitled Todo",
-          text: viewStore.binding(get: { $0.description }, send: TodoAction.textFieldChanged)
+          text: viewStore.binding(get: \.description, send: TodoAction.textFieldChanged)
         )
       }
       .foregroundColor(viewStore.isComplete ? .gray : nil)

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -121,7 +121,7 @@ struct AppView: View {
           }
         }
         .pickerStyle(SegmentedPickerStyle())
-        .padding([.leading, .trailing])
+        .padding(.horizontal)
 
         List {
           ForEachStore(

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -90,11 +90,13 @@ let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
 
 struct AppView: View {
   struct ViewState: Equatable {
-    var editMode: EditMode
-    var isClearCompletedButtonDisabled: Bool
+    let editMode: EditMode
+    let filter: Filter
+    let isClearCompletedButtonDisabled: Bool
 
     init(state: AppState) {
       self.editMode = state.editMode
+      self.filter = state.filter
       self.isClearCompletedButtonDisabled = !state.todos.contains(where: \.isComplete)
     }
   }
@@ -105,17 +107,15 @@ struct AppView: View {
     WithViewStore(self.store.scope(state: ViewState.init)) { viewStore in
       NavigationView {
         VStack(alignment: .leading) {
-          WithViewStore(self.store.scope(state: \.filter, action: AppAction.filterPicked)) {
-            filterViewStore in
-            Picker(
-              "Filter", selection: filterViewStore.binding(send: { $0 }).animation()
-            ) {
-              ForEach(Filter.allCases, id: \.self) { filter in
-                Text(filter.rawValue).tag(filter)
-              }
+          Picker(
+            "Filter",
+            selection: viewStore.binding(get: \.filter, send: AppAction.filterPicked).animation()
+          ) {
+            ForEach(Filter.allCases, id: \.self) { filter in
+              Text(filter.rawValue).tag(filter)
             }
-            .pickerStyle(SegmentedPickerStyle())
           }
+          .pickerStyle(SegmentedPickerStyle())
           .padding([.leading, .trailing])
 
           List {

--- a/Examples/VoiceMemos/VoiceMemos/SceneDelegate.swift
+++ b/Examples/VoiceMemos/VoiceMemos/SceneDelegate.swift
@@ -20,7 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             audioPlayerClient: .live,
             audioRecorderClient: .live,
             date: Date.init,
-            mainQueue: DispatchQueue.main.eraseToAnyScheduler(),
+            mainQueue: .main,
             openSettings: .fireAndForget {
               UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
             },

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
@@ -129,7 +129,7 @@ struct VoiceMemoView: View {
           TextField(
             "Untitled, \(dateFormatter.string(from: self.viewStore.date))",
             text: self.viewStore.binding(
-              get: { $0.title }, send: VoiceMemoAction.titleTextFieldChanged)
+              get: \.title, send: VoiceMemoAction.titleTextFieldChanged)
           )
 
           Spacer()

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -193,7 +193,7 @@ struct VoiceMemosView: View {
           List {
             ForEachStore(
               self.store.scope(
-                state: { $0.voiceMemos }, action: VoiceMemosAction.voiceMemo(index:action:)
+                state: \.voiceMemos, action: VoiceMemosAction.voiceMemo(index:action:)
               ),
               id: \.url,
               content: VoiceMemoView.init(store:)
@@ -241,7 +241,7 @@ struct VoiceMemosView: View {
           .padding()
         }
         .alert(
-          self.store.scope(state: { $0.alert }),
+          self.store.scope(state: \.alert),
           dismiss: .alertDismissed
         )
         .navigationBarTitle("Voice memos")
@@ -284,7 +284,7 @@ struct VoiceMemos_Previews: PreviewProvider {
             stopRecording: { _ in .none }
           ),
           date: Date.init,
-          mainQueue: DispatchQueue.main.eraseToAnyScheduler(),
+          mainQueue: .main,
           openSettings: .none,
           temporaryDirectory: { URL(fileURLWithPath: NSTemporaryDirectory()) },
           uuid: UUID.init

--- a/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
+++ b/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
@@ -85,7 +85,7 @@ class VoiceMemosTests: XCTestCase {
         audioRecorderClient: .mock(
           requestRecordPermission: { Effect(value: false) }
         ),
-        mainQueue: .immediate.eraseToAnyScheduler(),
+        mainQueue: .immediate,
         openSettings: .fireAndForget { didOpenSettings = true }
       )
     )
@@ -117,7 +117,7 @@ class VoiceMemosTests: XCTestCase {
           startRecording: { _, _ in audioRecorderSubject.eraseToEffect() }
         ),
         date: { Date(timeIntervalSinceReferenceDate: 0) },
-        mainQueue: .immediate.eraseToAnyScheduler(),
+        mainQueue: .immediate,
         temporaryDirectory: { URL(fileURLWithPath: "/tmp") },
         uuid: { UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF")! }
       )
@@ -313,7 +313,7 @@ extension VoiceMemosEnvironment {
     audioRecorderClient: AudioRecorderClient = .mock(),
     date: @escaping () -> Date = { fatalError() },
     mainQueue: AnySchedulerOf<DispatchQueue> =
-      .immediate.eraseToAnyScheduler(),
+      .immediate,
     openSettings: Effect<Never, Never> = .fireAndForget { fatalError() },
     temporaryDirectory: @escaping () -> URL = { fatalError() },
     uuid: @escaping () -> UUID = { fatalError() }

--- a/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
+++ b/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
@@ -85,7 +85,7 @@ class VoiceMemosTests: XCTestCase {
         audioRecorderClient: .mock(
           requestRecordPermission: { Effect(value: false) }
         ),
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
+        mainQueue: .immediate.eraseToAnyScheduler(),
         openSettings: .fireAndForget { didOpenSettings = true }
       )
     )
@@ -117,7 +117,7 @@ class VoiceMemosTests: XCTestCase {
           startRecording: { _, _ in audioRecorderSubject.eraseToEffect() }
         ),
         date: { Date(timeIntervalSinceReferenceDate: 0) },
-        mainQueue: DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
+        mainQueue: .immediate.eraseToAnyScheduler(),
         temporaryDirectory: { URL(fileURLWithPath: "/tmp") },
         uuid: { UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF")! }
       )
@@ -313,7 +313,7 @@ extension VoiceMemosEnvironment {
     audioRecorderClient: AudioRecorderClient = .mock(),
     date: @escaping () -> Date = { fatalError() },
     mainQueue: AnySchedulerOf<DispatchQueue> =
-      DispatchQueue.immediateScheduler.eraseToAnyScheduler(),
+      .immediate.eraseToAnyScheduler(),
     openSettings: Effect<Never, Never> = .fireAndForget { fatalError() },
     temporaryDirectory: @escaping () -> URL = { fatalError() },
     uuid: @escaping () -> UUID = { fatalError() }

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ PLATFORM_WATCHOS = watchOS Simulator,name=Apple Watch Series 4 - 44mm
 
 default: test
 
-test:
+test-all: test-library test-examples
+
+test-library:
 	xcodebuild test \
 		-scheme ComposableArchitecture \
 		-destination platform="$(PLATFORM_IOS)"
@@ -18,6 +20,8 @@ test:
 	xcodebuild \
 		-scheme ComposableArchitecture_watchOS \
 		-destination platform="$(PLATFORM_WATCHOS)"
+
+test-examples:
 	xcodebuild test \
 		-scheme "CaseStudies (SwiftUI)" \
 		-destination platform="$(PLATFORM_IOS)"

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ let appView = AppView(
     initialState: AppState(),
     reducer: appReducer,
     environment: AppEnvironment(
-      mainQueue: DispatchQueue.main.eraseToAnyScheduler(),
+      mainQueue: .main,
       numberFact: { number in Effect(value: "\(number) is a good number Brent") }
     )
   )

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -10,7 +10,7 @@ class TestStoreTests: XCTestCase {
       case a, b1, b2, b3, c1, c2, c3, d
     }
 
-    let testScheduler = DispatchQueue.test
+    let mainQueue = DispatchQueue.test
 
     let reducer = Reducer<State, Action, AnySchedulerOf<DispatchQueue>> { _, action, scheduler in
       switch action {
@@ -42,12 +42,12 @@ class TestStoreTests: XCTestCase {
     let store = TestStore(
       initialState: State(),
       reducer: reducer,
-      environment: testScheduler.eraseToAnyScheduler()
+      environment: mainQueue.eraseToAnyScheduler()
     )
 
     store.send(.a)
 
-    testScheduler.advance(by: 1)
+    mainQueue.advance(by: 1)
 
     store.receive(.b1)
     store.receive(.b2)


### PR DESCRIPTION
Some of the example code was looking a little old, so updating everything with our more modern practices, e.g. key paths for functions, `ViewState.init` and `.main`/`.test`/`.immediate` scheduler helpers.