### PR TITLE
Add UIKit `DiffableListsOfState` example

### DIFF
--- a/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
+++ b/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0AAA31292644B32A0091B0B1 /* CounterCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAA31262644B3290091B0B1 /* CounterCollectionViewCell.swift */; };
+		0AAA312B2644B32A0091B0B1 /* DiffableListsOfState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAA31282644B3290091B0B1 /* DiffableListsOfState.swift */; };
 		4F5AC11F24ECC7E4009DC50B /* 01-GettingStarted-SharedStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5AC11E24ECC7E4009DC50B /* 01-GettingStarted-SharedStateTests.swift */; };
 		CA0C0C4724B89BEC00CBDD8A /* 04-HigherOrderReducers-LifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C0C4624B89BEC00CBDD8A /* 04-HigherOrderReducers-LifecycleTests.swift */; };
 		CA0C51FB245389CC00A04EAB /* 04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C51FA245389CC00A04EAB /* 04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift */; };
@@ -150,6 +152,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0AAA31262644B3290091B0B1 /* CounterCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CounterCollectionViewCell.swift; sourceTree = "<group>"; };
+		0AAA31282644B3290091B0B1 /* DiffableListsOfState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiffableListsOfState.swift; sourceTree = "<group>"; };
 		4F5AC11E24ECC7E4009DC50B /* 01-GettingStarted-SharedStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-GettingStarted-SharedStateTests.swift"; sourceTree = "<group>"; };
 		CA0C0C4624B89BEC00CBDD8A /* 04-HigherOrderReducers-LifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-LifecycleTests.swift"; sourceTree = "<group>"; };
 		CA0C51FA245389CC00A04EAB /* 04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift"; sourceTree = "<group>"; };
@@ -283,6 +287,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0AAA31252644B3290091B0B1 /* DiffableListsOfState */ = {
+			isa = PBXGroup;
+			children = (
+				0AAA31282644B3290091B0B1 /* DiffableListsOfState.swift */,
+				0AAA31262644B3290091B0B1 /* CounterCollectionViewCell.swift */,
+			);
+			path = DiffableListsOfState;
+			sourceTree = "<group>";
+		};
 		CA6AC25F2451131C00C71CB3 /* 04-HigherOrderReducers-ResuableOfflineDownloads */ = {
 			isa = PBXGroup;
 			children = (
@@ -333,6 +346,7 @@
 				DC630FD92451016B00BAECBA /* ListsOfState.swift */,
 				DC4C6ED92450E6050066A05D /* NavigateAndLoad.swift */,
 				DC25DC602450F2B000082E81 /* LoadThenNavigate.swift */,
+				0AAA31252644B3290091B0B1 /* DiffableListsOfState */,
 				DC25DC622450F2D100082E81 /* Internal */,
 				DC4C6EAF2450DD380066A05D /* Assets.xcassets */,
 				DC4C6EB42450DD380066A05D /* LaunchScreen.storyboard */,
@@ -719,10 +733,12 @@
 				DC4C6ED62450E1050066A05D /* CounterViewController.swift in Sources */,
 				DC4C6EDA2450E6050066A05D /* NavigateAndLoad.swift in Sources */,
 				DC4C6EAC2450DD380066A05D /* SceneDelegate.swift in Sources */,
+				0AAA31292644B32A0091B0B1 /* CounterCollectionViewCell.swift in Sources */,
 				DC25DC612450F2B000082E81 /* LoadThenNavigate.swift in Sources */,
 				DC25DC5F2450F13200082E81 /* IfLetStoreController.swift in Sources */,
 				DC4C6EAE2450DD380066A05D /* RootViewController.swift in Sources */,
 				DC630FDA2451016B00BAECBA /* ListsOfState.swift in Sources */,
+				0AAA312B2644B32A0091B0B1 /* DiffableListsOfState.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
@@ -3,7 +3,8 @@ import ComposableArchitecture
 import SwiftUI
 import UIKit
 
-struct CounterState: Equatable {
+struct CounterState: Equatable, Identifiable {
+  var id: UUID = .init() // used for diffing in `DiffableListsOfState` case study
   var count = 0
 }
 

--- a/Examples/CaseStudies/UIKitCaseStudies/DiffableListsOfState/CounterCollectionViewCell.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/DiffableListsOfState/CounterCollectionViewCell.swift
@@ -1,0 +1,73 @@
+import Combine
+import ComposableArchitecture
+import UIKit
+
+final class CounterCollectionViewCell: UICollectionViewListCell {
+
+  static var identifier: String { "\(type(of: self))" }
+
+  let countLabel = UILabel()
+
+  var viewStore: ViewStore<CounterState, CounterAction>? {
+    didSet { setUpBindings() }
+  }
+
+  private var cancellable: Cancellable?
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    setUpSubviews()
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  private func setUpSubviews() {
+    self.contentView.backgroundColor = .systemBackground
+
+    let decrementButton = UIButton(type: .system)
+    decrementButton.addTarget(self, action: #selector(decrementButtonTapped), for: .touchUpInside)
+    decrementButton.setTitle("−", for: .normal)
+
+    self.countLabel.font = .monospacedDigitSystemFont(ofSize: 17, weight: .regular)
+
+    let incrementButton = UIButton(type: .system)
+    incrementButton.addTarget(self, action: #selector(incrementButtonTapped), for: .touchUpInside)
+    incrementButton.setTitle("+", for: .normal)
+
+    let rootStackView = UIStackView(
+      arrangedSubviews: [decrementButton, self.countLabel, incrementButton]
+    )
+    rootStackView.translatesAutoresizingMaskIntoConstraints = false
+    self.contentView.addSubview(rootStackView)
+
+    NSLayoutConstraint.activate([
+      rootStackView.centerXAnchor.constraint(equalTo: self.contentView.centerXAnchor),
+      rootStackView.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor),
+    ])
+  }
+
+  private func setUpBindings() {
+    self.cancellable = self.viewStore?.publisher
+      .map { "\($0.count)" }
+      .assign(to: \.text, on: countLabel)
+  }
+
+  override func prepareForReuse() {
+    super.prepareForReuse()
+
+    self.cancellable?.cancel()
+    self.viewStore = nil
+  }
+
+
+  @objc func decrementButtonTapped() {
+    self.viewStore?.send(.decrementButtonTapped)
+  }
+
+  @objc func incrementButtonTapped() {
+    self.viewStore?.send(.incrementButtonTapped)
+  }
+}

--- a/Examples/CaseStudies/UIKitCaseStudies/DiffableListsOfState/DiffableListsOfState.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/DiffableListsOfState/DiffableListsOfState.swift
@@ -1,0 +1,232 @@
+import Combine
+import ComposableArchitecture
+import SwiftUI
+import UIKit
+
+struct DiffableCounterListState: Equatable {
+  var counters: IdentifiedArray<UUID, CounterState>
+}
+
+enum DiffableCounterListAction: Equatable {
+  case counter(id: UUID, action: CounterAction)
+  case shuffle
+  case insert
+  case remove(id: UUID)
+}
+
+let diffableCounterListReducer = Reducer<DiffableCounterListState, DiffableCounterListAction, Void>
+  .combine(
+    counterReducer
+      .forEach(
+        state: \DiffableCounterListState.counters,
+        action: /DiffableCounterListAction.counter(id:action:),
+        environment: { _ in .init() }
+      ),
+    Reducer { state, action, _ in
+      switch action {
+      case .shuffle:
+        state.counters.shuffle()
+        return .none
+      case .insert:
+        state.counters.append(.init())
+        return .none
+      case .remove(let id):
+        state.counters.remove(id: id)
+        return .none
+      case .counter:
+        return .none
+      }
+    }
+  )
+
+final class DiffableCountersTableViewController: UIViewController, UICollectionViewDelegate {
+
+  struct DummySection: Hashable {}
+
+  let store: Store<DiffableCounterListState, DiffableCounterListAction>
+  let viewStore: ViewStore<DiffableCounterListState, DiffableCounterListAction>
+  var cancellables: Set<AnyCancellable> = []
+
+  var collectionView: UICollectionView!
+  var dataSource: UICollectionViewDiffableDataSource<DummySection, CounterState.ID>!
+
+  init(store: Store<DiffableCounterListState, DiffableCounterListAction>) {
+    self.store = store
+    self.viewStore = ViewStore(store)
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    self.title = "Diffable Lists"
+
+    setUpCollectionView()
+    setUpSubviews()
+
+    collectionView.delegate = self
+  }
+
+  private func setUpSubviews() {
+    let shuffle = UIButton(type: .roundedRect)
+    shuffle.backgroundColor = .lightGray
+    shuffle.setTitle("Shuffle", for: .normal)
+    shuffle.addTarget(self, action: #selector(shuffleTapped), for: .touchUpInside)
+
+    let insert = UIButton(type: .roundedRect)
+    insert.backgroundColor = .lightGray
+    insert.setTitle("Insert", for: .normal)
+    insert.addTarget(self, action: #selector(insertTapped), for: .touchUpInside)
+
+    let stackView = UIStackView(arrangedSubviews: [shuffle, insert])
+    stackView.distribution = .fillEqually
+
+    view.addSubview(collectionView)
+    view.addSubview(stackView)
+
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(equalTo: view.topAnchor),
+      collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      collectionView.bottomAnchor.constraint(equalTo: stackView.topAnchor),
+      stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      stackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+    ])
+  }
+
+  private func setUpCollectionView() {
+    var listConfiguration = UICollectionLayoutListConfiguration(appearance: .sidebarPlain)
+    listConfiguration.trailingSwipeActionsConfigurationProvider = { indexPath in
+      UISwipeActionsConfiguration(
+        actions: [
+          .init(
+            style: .destructive,
+            title: "Delete",
+            handler: { [weak self] _, _, completion in
+              guard let id = self?.dataSource.itemIdentifier(for: indexPath) else { return }
+              self?.viewStore.send(.remove(id: id))
+              completion(true)
+            }
+          )
+        ]
+      )
+    }
+
+    self.collectionView = UICollectionView(
+      frame: view.frame,
+      collectionViewLayout: UICollectionViewCompositionalLayout.list(using: listConfiguration)
+    )
+
+    self.collectionView.register(
+      CounterCollectionViewCell.self,
+      forCellWithReuseIdentifier: CounterCollectionViewCell.identifier
+    )
+
+    self.dataSource = .init(
+      collectionView: collectionView,
+      cellProvider: { [store] collectionView, indexPath, id in
+        let cell = collectionView.dequeueReusableCell(
+          withReuseIdentifier: CounterCollectionViewCell.identifier,
+          for: indexPath
+        ) as! CounterCollectionViewCell
+
+        let childStore = store.child(
+          id: id,
+          state: \.counters,
+          action: DiffableCounterListAction.counter(id:action:)
+        )
+
+        cell.viewStore = ViewStore(childStore)
+
+        return cell
+      }
+    )
+
+    self.viewStore.publisher.counters
+      .sink(receiveValue: { [weak self] in
+        var snapshot = NSDiffableDataSourceSnapshot<DummySection, CounterState.ID>()
+        snapshot.appendSections([.init()])
+        snapshot.appendItems($0.ids.elements)
+
+        // check the window to prevent `UITableViewAlertForLayoutOutsideViewHierarchy` from firing
+        // when not visible
+        self?.dataSource.apply(
+          snapshot,
+          animatingDifferences: self?.view.window != nil ? true : false
+        )
+      })
+      .store(in: &self.cancellables)
+  }
+
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    guard let id = self.dataSource.itemIdentifier(for: indexPath) else { return }
+
+    self.navigationController?.pushViewController(
+      CounterViewController(
+        store: self.store.child(
+          id: id,
+          state: \.counters,
+          action: DiffableCounterListAction.counter(id:action:)
+        )
+      ),
+      animated: true
+    )
+  }
+
+  @objc func shuffleTapped() {
+    self.viewStore.send(.shuffle)
+  }
+
+  @objc func insertTapped() {
+    self.viewStore.send(.insert)
+  }
+}
+
+extension Store {
+
+  func child<LocalState: Equatable, LocalAction, ID>(
+    id: ID,
+    state toLocalStateContainer: @escaping (State) -> IdentifiedArray<ID, LocalState>,
+    action fromLocalAction: @escaping (ID, LocalAction) -> Action
+  ) -> Store<LocalState, LocalAction> {
+    let scopedStore = scope(state: toLocalStateContainer)
+
+    // NB: We cache current element here to avoid a crash where UIKit may re-evaluate the store
+    //     following item deletion in table/collection views.
+    let element = ViewStore(scopedStore).state[id: id]!
+
+    return scopedStore.scope(
+      state: { $0[id: id] ?? element },
+      action: { fromLocalAction(id, $0) }
+    )
+  }
+}
+
+struct DiffableCountersTableViewController_Previews: PreviewProvider {
+  static var previews: some View {
+    let vc = UINavigationController(
+      rootViewController: DiffableCountersTableViewController(
+        store: Store(
+          initialState: DiffableCounterListState(
+            counters: [
+              CounterState(),
+              CounterState(),
+              CounterState(),
+            ]
+          ),
+          reducer: diffableCounterListReducer,
+          environment: ()
+        )
+      )
+    )
+    return UIViewRepresented(makeUIView: { _ in vc.view })
+  }
+}

--- a/Examples/CaseStudies/UIKitCaseStudies/RootViewController.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/RootViewController.swift
@@ -40,6 +40,22 @@ let dataSource: [CaseStudy] = [
     )
   ),
   CaseStudy(
+    title: "Diffable Lists",
+    viewController: DiffableCountersTableViewController(
+      store: Store(
+        initialState: DiffableCounterListState(
+          counters: [
+            CounterState(),
+            CounterState(),
+            CounterState(),
+          ]
+        ),
+        reducer: diffableCounterListReducer,
+        environment: ()
+      )
+    )
+  ),
+  CaseStudy(
     title: "Navigate and load",
     viewController: EagerNavigationViewController(
       store: Store(


### PR DESCRIPTION
## Motivation

A new `DiffableListsOfState` UIKit example was created to demonstrate the usage of TCA with a list of (collection view) cells that have a store and are backed by a diffable data source.

It uses a `Store.child` helper to return a single scoped store for a particular child (cell), from its identifier. This is useful to
avoid re-scoping all children when only a subset of children needs to be created (e.g. in a diffing set up, only insertion stores need to be created).

## Changes

- Create new `DiffableListsOfState` UIKit example
  + Create new DiffableCounterList TCA "stack" and`DiffableCountersTableViewController` which uses Diffing in a `UICollectionView` via `UICollectionViewDiffableDataSource`.
  + Create new `CounterCollectionViewCell` which wraps a counter, to demonstrate injecting child stores in cells.
  + Enrich `CounterState` with a `id: UUID` property for diffing.

## `DiffableListsOfState` Demo

https://user-images.githubusercontent.com/1391324/116435915-c701ef00-a843-11eb-9a67-b9f3007745fb.mov