### PR TITLE
Cancel in flight timers with the same id

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Timer.swift
+++ b/Sources/ComposableArchitecture/Effects/Timer.swift
@@ -103,6 +103,6 @@ extension Effect where Failure == Never {
       .autoconnect()
       .setFailureType(to: Failure.self)
       .eraseToEffect()
-      .cancellable(id: id)
+      .cancellable(id: id, cancelInFlight: true)
   }
 }


### PR DESCRIPTION
As discussed in [an issue](https://github.com/pointfreeco/swift-composable-architecture/discussions/532#discussioncomment-711916) *not* cancelling in flight timer with an existing ID is fairly unusual/unexpected behavior. This PR just sets the cancelInFlight parameter to true for the underlying timer effect.