### PR TITLE
Add Stateless

### DIFF
--- a/Sources/ComposableArchitecture/Stateless.swift
+++ b/Sources/ComposableArchitecture/Stateless.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// A helper to using Stateless in IfLetStore
+/// Example case:
+/// struct State {
+///   var childState: Stateless?
+/// }
+///
+/// enum AppAction {
+///   case child(ChildAction)
+/// }
+///
+/// Type of ChildView store is Store<Void, ChildAction>
+///
+///     IfLetStore(
+///       store.scope(state: \.childState, action: AppAction.child),
+///       then: ChildView.init(store:),
+///       else: { Text("No Child") }
+///     )
+///
+public struct Stateless: Equatable {
+  public init() {}
+}


### PR DESCRIPTION
Let said we have a AppState that need an optional stateless Child (`Store<Void, ChildAction>`) , that will shown/hide using `IfLetStore`
```swift
struct AppState: Equatable {
  	var childState: Void?
}
```
We can't make that Void because Void is not `Equatable`.
So This PR is adding a helper `Stateless` struct that contains no property but it is Equatable
```swift
struct AppState: Equatable {
  	var childState: Stateless?
}
```

So you can do this now:
```swift
IfLetStore(
  store.scope(state: \.childState, action: AppAction.child).stateless,
  then: ChildView.init(store:),
  else: { Text("No Child") }
)
```
Update:
I used it in the UIKit world (actually my project is using Texture, which similar api as UIKit)

Open for any input 🙏🏻