### PR TITLE
Only breakpoint when debugger is attached

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Breakpoint.swift
+++ b/Sources/ComposableArchitecture/Internal/Breakpoint.swift
@@ -13,6 +13,13 @@
   }
 
   if isDebuggerAttached {
+    fputs(
+      """
+      Caught internal breakpoint. Type "continue" ("c") to resume execution.
+
+      """,
+      stderr
+    )
     raise(SIGTRAP)
   }
   #endif

--- a/Sources/ComposableArchitecture/Internal/Breakpoint.swift
+++ b/Sources/ComposableArchitecture/Internal/Breakpoint.swift
@@ -15,7 +15,7 @@
   if isDebuggerAttached {
     fputs(
       """
-      Caught internal breakpoint. Type "continue" ("c") to resume execution.
+      Caught debug breakpoint. Type "continue" ("c") to resume execution.
 
       """,
       stderr

--- a/Sources/ComposableArchitecture/Internal/Breakpoint.swift
+++ b/Sources/ComposableArchitecture/Internal/Breakpoint.swift
@@ -1,6 +1,7 @@
 /// Raises a debug breakpoint iff a debugger is attached.
 @inline(__always) func breakpoint() {
   #if DEBUG
+  // https://github.com/bitstadium/HockeySDK-iOS/blob/c6e8d1e940299bec0c0585b1f7b86baf3b17fc82/Classes/BITHockeyHelper.m#L346-L370
   var name: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
   var info: kinfo_proc = kinfo_proc()
   var info_size = MemoryLayout<kinfo_proc>.size

--- a/Sources/ComposableArchitecture/Internal/Breakpoint.swift
+++ b/Sources/ComposableArchitecture/Internal/Breakpoint.swift
@@ -1,0 +1,18 @@
+/// Raises a debug breakpoint iff a debugger is attached.
+@inline(__always) func breakpoint() {
+  #if DEBUG
+  var name: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
+  var info: kinfo_proc = kinfo_proc()
+  var info_size = MemoryLayout<kinfo_proc>.size
+
+  let isDebuggerAttached = name.withUnsafeMutableBytes {
+    $0.bindMemory(to: Int32.self).baseAddress
+      .map { sysctl($0, 4, &info, &info_size, nil, 0) != -1 && info.kp_proc.p_flag & P_TRACED != 0 }
+      ?? false
+  }
+
+  if isDebuggerAttached {
+    raise(SIGTRAP)
+  }
+  #endif
+}

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -443,7 +443,7 @@ public struct Reducer<State, Action, Environment> {
               """,
               stderr
             )
-            raise(SIGTRAP)
+            breakpoint()
           }
         #endif
         return .none
@@ -532,7 +532,7 @@ public struct Reducer<State, Action, Environment> {
               """,
               stderr
             )
-            raise(SIGTRAP)
+            breakpoint()
           }
         #endif
         return .none
@@ -626,7 +626,7 @@ public struct Reducer<State, Action, Environment> {
               """,
               stderr
             )
-            raise(SIGTRAP)
+            breakpoint()
           }
         #endif
         return .none
@@ -700,7 +700,7 @@ public struct Reducer<State, Action, Environment> {
               """,
               stderr
             )
-            raise(SIGTRAP)
+            breakpoint()
           }
         #endif
         return .none


### PR DESCRIPTION
Currently, debug builds will crash when the breakpoint signal is raised. Since we consider these breakpoints to be non-fatal (and skip them in release mode), let's simply ignore them when a debugger isn't attached.