### PR TITLE
Update Tic-Tac-Toe to use enum state

### DIFF
--- a/Examples/TicTacToe/Sources/Views-SwiftUI/AppSwiftView.swift
+++ b/Examples/TicTacToe/Sources/Views-SwiftUI/AppSwiftView.swift
@@ -12,7 +12,7 @@ public struct AppView: View {
     self.store = store
   }
 
-  @ViewBuilder public var body: some View {
+  public var body: some View {
     SwitchStore(self.store) {
       CaseLet(state: /AppState.login, action: AppAction.login) { store in
         NavigationView {

--- a/Examples/TicTacToe/Sources/Views-SwiftUI/AppSwiftView.swift
+++ b/Examples/TicTacToe/Sources/Views-SwiftUI/AppSwiftView.swift
@@ -13,18 +13,19 @@ public struct AppView: View {
   }
 
   @ViewBuilder public var body: some View {
-    IfLetStore(self.store.scope(state: \.login, action: AppAction.login)) { store in
-      NavigationView {
-        LoginView(store: store)
+    SwitchStore(self.store) {
+      CaseLet(state: /AppState.login, action: AppAction.login) { store in
+        NavigationView {
+          LoginView(store: store)
+        }
+        .navigationViewStyle(StackNavigationViewStyle())
       }
-      .navigationViewStyle(StackNavigationViewStyle())
-    }
-
-    IfLetStore(self.store.scope(state: \.newGame, action: AppAction.newGame)) { store in
-      NavigationView {
-        NewGameView(store: store)
+      CaseLet(state: /AppState.newGame, action: AppAction.newGame) { store in
+        NavigationView {
+          NewGameView(store: store)
+        }
+        .navigationViewStyle(StackNavigationViewStyle())
       }
-      .navigationViewStyle(StackNavigationViewStyle())
     }
   }
 }

--- a/Examples/TicTacToe/Sources/Views-UIKit/AppViewController.swift
+++ b/Examples/TicTacToe/Sources/Views-UIKit/AppViewController.swift
@@ -36,14 +36,14 @@ class AppViewController: UINavigationController {
     super.viewDidLoad()
 
     self.store
-      .scope(state: \.login, action: AppAction.login)
+      .scope(state: /AppState.login, action: AppAction.login)
       .ifLet(then: { [weak self] loginStore in
         self?.setViewControllers([LoginViewController(store: loginStore)], animated: false)
       })
       .store(in: &self.cancellables)
 
     self.store
-      .scope(state: \.newGame, action: AppAction.newGame)
+      .scope(state: /AppState.newGame, action: AppAction.newGame)
       .ifLet(then: { [weak self] newGameStore in
         self?.setViewControllers([NewGameViewController(store: newGameStore)], animated: false)
       })

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -66,9 +66,9 @@ public struct SwitchStore<State, Action, Content>: View where Content: View {
 public struct CaseLet<GlobalState, GlobalAction, LocalState, LocalAction, Content>: View
 where Content: View {
   @EnvironmentObject private var store: StoreObservableObject<GlobalState, GlobalAction>
-  let toLocalState: (GlobalState) -> LocalState?
-  let fromLocalAction: (LocalAction) -> GlobalAction
-  let content: (Store<LocalState, LocalAction>) -> Content
+  public let toLocalState: (GlobalState) -> LocalState?
+  public let fromLocalAction: (LocalAction) -> GlobalAction
+  public let content: (Store<LocalState, LocalAction>) -> Content
 
   /// Initializes a `CaseLet` view that computes content depending on if a store of enum state
   /// matches a particular case.
@@ -155,10 +155,9 @@ extension SwitchStore {
 
   public init<State1, Action1, Content1>(
     _ store: Store<State, Action>,
-    @ViewBuilder content: @escaping ()
-      -> CaseLet<State, Action, State1, Action1, Content1>,
     file: StaticString = #file,
-    line: UInt = #line
+    line: UInt = #line,
+    @ViewBuilder content: @escaping () -> CaseLet<State, Action, State1, Action1, Content1>
   )
   where
     Content == WithViewStore<
@@ -215,14 +214,14 @@ extension SwitchStore {
 
   public init<State1, Action1, Content1, State2, Action2, Content2>(
     _ store: Store<State, Action>,
+    file: StaticString = #file,
+    line: UInt = #line,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
         CaseLet<State, Action, State2, Action2, Content2>
       )
-    >,
-    file: StaticString = #file,
-    line: UInt = #line
+    >
   )
   where
     Content == WithViewStore<
@@ -295,15 +294,15 @@ extension SwitchStore {
 
   public init<State1, Action1, Content1, State2, Action2, Content2, State3, Action3, Content3>(
     _ store: Store<State, Action>,
+    file: StaticString = #file,
+    line: UInt = #line,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
         CaseLet<State, Action, State2, Action2, Content2>,
         CaseLet<State, Action, State3, Action3, Content3>
       )
-    >,
-    file: StaticString = #file,
-    line: UInt = #line
+    >
   )
   where
     Content == WithViewStore<
@@ -392,6 +391,8 @@ extension SwitchStore {
     State4, Action4, Content4
   >(
     _ store: Store<State, Action>,
+    file: StaticString = #file,
+    line: UInt = #line,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
@@ -399,9 +400,7 @@ extension SwitchStore {
         CaseLet<State, Action, State3, Action3, Content3>,
         CaseLet<State, Action, State4, Action4, Content4>
       )
-    >,
-    file: StaticString = #file,
-    line: UInt = #line
+    >
   )
   where
     Content == WithViewStore<
@@ -502,6 +501,8 @@ extension SwitchStore {
     State5, Action5, Content5
   >(
     _ store: Store<State, Action>,
+    file: StaticString = #file,
+    line: UInt = #line,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
@@ -510,9 +511,7 @@ extension SwitchStore {
         CaseLet<State, Action, State4, Action4, Content4>,
         CaseLet<State, Action, State5, Action5, Content5>
       )
-    >,
-    file: StaticString = #file,
-    line: UInt = #line
+    >
   )
   where
     Content == WithViewStore<


### PR DESCRIPTION
Uses the new `Reducer.pullback` that works with state case paths, and the new `SwitchStore` view.