### PR TITLE
Keep the StoreObservableObject instance in SwitchStore

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -48,7 +48,7 @@ public struct SwitchStore<State, Action, Content>: View where Content: View {
   public let store: Store<State, Action>
   public let content: () -> Content
   private let storeObservableObject: StoreObservableObject<State, Action>
-  public init(
+  init(
     store: Store<State, Action>,
     @ViewBuilder content: @escaping () -> Content
   ) {

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -47,18 +47,19 @@ import SwiftUI
 public struct SwitchStore<State, Action, Content>: View where Content: View {
   public let store: Store<State, Action>
   public let content: () -> Content
-
-  init(
+  private let storeObservableObject: StoreObservableObject<State, Action>
+  public init(
     store: Store<State, Action>,
     @ViewBuilder content: @escaping () -> Content
   ) {
     self.store = store
     self.content = content
+    self.storeObservableObject = StoreObservableObject(store: store)
   }
 
   public var body: some View {
     self.content()
-      .environmentObject(StoreObservableObject(store: self.store))
+      .environmentObject(self.storeObservableObject)
   }
 }
 


### PR DESCRIPTION
The `StoreObservableObject` instance is now the same for the lifecycle of the view. This should avoid unwanted side-effects when vending a new `ObservableObject` instance each time `body` is evaluated.