### PR TITLE
Update Package.swift: Fix syntax error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "0.4.0"),
-    .package(url: "https://github.com/pointfreeco/swift-case-paths", .branch("performance-2"),
+    .package(url: "https://github.com/pointfreeco/swift-case-paths", .branch("performance-2")),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.1.0"),
   ],
   targets: [


### PR DESCRIPTION
**Describe the bug**

Xcode fails to resolve packages with:
```
invalidManifestFormat("/var/folders/mt/ywrj52cs19d30dw61wt2blyh0000gn/T/TemporaryFile.N1nYD8.swift:23:3: error: expected expression in list of expressions
  ],
  ^
/var/folders/mt/ywrj52cs19d30dw61wt2blyh0000gn/T/TemporaryFile.N1nYD8.swift:40:2: error: expected \']\' in container literal expression
)
 ^
/var/folders/mt/ywrj52cs19d30dw61wt2blyh0000gn/T/TemporaryFile.N1nYD8.swift:19:17: note: to match this opening \'[\'
  dependencies: [
                ^
/var/folders/mt/ywrj52cs19d30dw61wt2blyh0000gn/T/TemporaryFile.N1nYD8.swift:24:12: error: extra argument \'targets\' in call
  targets: [
           ^
/var/folders/mt/ywrj52cs19d30dw61wt2blyh0000gn/T/TemporaryFile.N1nYD8.swift:22:6: error: type \'String?\' has no member \'package\'
    .package(url: \"https://github.com/pointfreeco/xctest-dynamic-overlay\", from: \"0.1.0\"),
    ~^~~~~~~
/var/folders/mt/ywrj52cs19d30dw61wt2blyh0000gn/T/TemporaryFile.N1nYD8.swift:25:6: error: type \'Any\' has no member \'target\'
    .target(
    ~^~~~~~
/var/folders/mt/ywrj52cs19d30dw61wt2blyh0000gn/T/TemporaryFile.N1nYD8.swift:33:6: error: type \'Any\' has no member \'testTarget\'
    .testTarget(
    ~^~~~~~~~~~", diagnosticFile: Optional(<AbsolutePath:"/Users/marius/Library/Developer/Xcode/DerivedData/nlbb-ios-cjeinvyisbftidcqthnsawahefiv/SourcePackages/ManifestLoading/swift-composable-architecture.dia">)) in https://github.com/pointfreeco/swift-composable-architecture.git
```

This happened. Then I had a look at the branch and realized there was indeed a syntax error.

**Expected behavior**
Packages resolution to complete.

**Environment**
 - Xcode 12.5 (did try also 12.4, 12.3)
 - Swift: `Apple Swift version 5.4 (swiftlang-1205.0.26.9 clang-1205.0.19.55)
 Target: x86_64-apple-darwin20.5.0`
- Swift Package Manager - Swift 5.4.0
