### PR TITLE
Coalesce synchronous effectful mutations to state

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -119,7 +119,6 @@ public final class Store<State, Action> {
   private var isSending = false
   private var parentCancellable: AnyCancellable?
   private let reducer: (inout State, Action) -> Effect<Action, Never>
-  private var synchronousActionsToSend: [Action] = []
   private var bufferedActions: [Action] = []
 
   /// Initializes a store from an initial state, a reducer, and an environment.
@@ -360,41 +359,31 @@ public final class Store<State, Action> {
   }
 
   func send(_ action: Action) {
-    if !self.isSending {
-      self.synchronousActionsToSend.append(action)
-    } else {
-      self.bufferedActions.append(action)
-      return
+    self.bufferedActions.append(action)
+    guard !self.isSending else { return }
+
+    self.isSending = true
+    var currentState = self.state.value
+    defer {
+      self.state.value = currentState
+      self.isSending = false
     }
 
-    while !self.synchronousActionsToSend.isEmpty || !self.bufferedActions.isEmpty {
-      let action =
-        !self.synchronousActionsToSend.isEmpty
-        ? self.synchronousActionsToSend.removeFirst()
-        : self.bufferedActions.removeFirst()
-
-      self.isSending = true
-      let effect = self.reducer(&self.state.value, action)
-      self.isSending = false
+    while !self.bufferedActions.isEmpty {
+      let action = self.bufferedActions.removeFirst()
+      let effect = self.reducer(&currentState, action)
 
       var didComplete = false
       let uuid = UUID()
-
-      var isProcessingEffects = true
       let effectCancellable = effect.sink(
         receiveCompletion: { [weak self] _ in
           didComplete = true
           self?.effectCancellables[uuid] = nil
         },
         receiveValue: { [weak self] action in
-          if isProcessingEffects {
-            self?.synchronousActionsToSend.append(action)
-          } else {
-            self?.send(action)
-          }
+          self?.send(action)
         }
       )
-      isProcessingEffects = false
 
       if !didComplete {
         self.effectCancellables[uuid] = effectCancellable

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -434,6 +434,6 @@ final class StoreTests: XCTestCase {
 
     viewStore.send(0)
 
-    XCTAssertEqual(emissions, [0, 1, 2, 3])
+    XCTAssertEqual(emissions, [0, 3])
   }
 }


### PR DESCRIPTION
We directly mutate store state when `send` is called, and additionally for each synchronous effect that may feed back into the reducer. This PR collapses all those mutations into a single one so that each `send` results in a single mutation. For SwiftUI this should result in identical behavior. For UIKit and any other manual subscription to a store, it should result in fewer emissions to contend with.