### PR TITLE
Don't use CasePath in .binding

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -2,34 +2,6 @@ import CasePaths
 import Combine
 import SwiftUI
 
-// NB: Deprecated after 0.21.0:
-
-extension Reducer {
-  @available(*, deprecated, message: "This method no longer takes a CasePath. Pass a case path expression directly, or pass the case path’s `extract(from:)` method.")
-  @_disfavoredOverload
-  public func binding(action toBindingAction: CasePath<Action, BindingAction<State>>) -> Self {
-    Self { state, action, environment in
-      toBindingAction.extract(from: action)?.set(&state)
-      return .none
-    }
-    .combined(with: self)
-  }
-}
-
-
-// NB: Deprecated after 0.17.0:
-
-extension IfLetStore {
-  @available(*, deprecated, message: "'else' now takes a view builder closure")
-  public init<IfContent, ElseContent>(
-    _ store: Store<State?, Action>,
-    @ViewBuilder then ifContent: @escaping (Store<State, Action>) -> IfContent,
-    else elseContent: @escaping @autoclosure () -> ElseContent
-  ) where Content == _ConditionalContent<IfContent, ElseContent> {
-    self.init(store, then: ifContent, else: elseContent)
-  }
-}
-
 // NB: Deprecated after 0.13.0:
 
 @available(*, deprecated, renamed: "BindingAction")
@@ -38,7 +10,7 @@ public typealias FormAction = BindingAction
 extension Reducer {
   @available(*, deprecated, renamed: "binding")
   public func form(action toFormAction: CasePath<Action, BindingAction<State>>) -> Self {
-    self.binding(action: toFormAction)
+    self.binding(action: toFormAction.extract(from:))
   }
 }
 

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -5,7 +5,7 @@ import SwiftUI
 // NB: Deprecated after 0.21.0:
 
 extension Reducer {
-  @available(*, deprecated, message: "This method no longer takes a CasePath. Pass the case path's `extract(from:)` method directly.")
+  @available(*, deprecated, message: "This method no longer takes a CasePath. Pass a case path expression directly, or pass the case path’s `extract(from:)` method.")
   @_disfavoredOverload
   public func binding(action toBindingAction: CasePath<Action, BindingAction<State>>) -> Self {
     Self { state, action, environment in

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -1,5 +1,21 @@
+import CasePaths
 import Combine
 import SwiftUI
+
+// NB: Deprecated after 0.21.0:
+
+extension Reducer {
+  @available(*, deprecated, message: "This method no longer takes a CasePath. Pass the case path's `extract(from:)` method directly.")
+  @_disfavoredOverload
+  public func binding(action toBindingAction: CasePath<Action, BindingAction<State>>) -> Self {
+    Self { state, action, environment in
+      toBindingAction.extract(from: action)?.set(&state)
+      return .none
+    }
+    .combined(with: self)
+  }
+}
+
 
 // NB: Deprecated after 0.17.0:
 

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -223,9 +223,8 @@ extension Reducer {
   public func binding(action toBindingAction: @escaping (Action) -> BindingAction<State>?) -> Self {
     Self { state, action, environment in
       toBindingAction(action)?.set(&state)
-      return .none
+      return self.run(&state, action, environment)
     }
-    .combined(with: self)
   }
 }
 

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -1,4 +1,3 @@
-import CasePaths
 import SwiftUI
 
 /// An action that describes simple mutations to some root state at a writable key path.
@@ -140,7 +139,7 @@ import SwiftUI
 public struct BindingAction<Root>: Equatable {
   public let keyPath: PartialKeyPath<Root>
 
-  fileprivate let set: (inout Root) -> Void
+  let set: (inout Root) -> Void
   private let value: Any
   private let valueIsEqualTo: (Any) -> Bool
 
@@ -216,13 +215,14 @@ extension Reducer {
   /// .binding(action: /SettingsAction.binding)
   /// ```
   ///
-  /// - Parameter toBindingAction: A case path from this reducer's `Action` type to a
-  ///   `BindingAction` over this reducer's `State`.
+  /// - Parameter toBindingAction: A function that extracts a `BindingAction<State>` from an
+  /// `Action`. Typically this is done by using the prefix operator `/` to automatically derive
+  /// an extraction function from any case of any enum.
   /// - Returns: A reducer that applies ``BindingAction`` mutations to `State` before running this
   ///   reducer's logic.
-  public func binding(action toBindingAction: CasePath<Action, BindingAction<State>>) -> Self {
+  public func binding(action toBindingAction: @escaping (Action) -> BindingAction<State>?) -> Self {
     Self { state, action, environment in
-      toBindingAction.extract(from: action)?.set(&state)
+      toBindingAction(action)?.set(&state)
       return .none
     }
     .combined(with: self)


### PR DESCRIPTION
Deprecating the `.binding` helper that takes a `CasePath` directly and adding a new one that only takes an extraction.