### PR TITLE
Remove equatable constraint from TestStore.Action

### DIFF
--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -354,12 +354,44 @@
       }
     }
 
+    private func expectedStateShouldMatch(
+      expected: LocalState,
+      actual: LocalState,
+      file: StaticString,
+      line: UInt
+    ) {
+      if expected != actual {
+        let diff =
+          debugDiff(expected, actual)
+          .map { "\($0.indent(by: 4))\n\n(Expected: −, Actual: +)" }
+          ?? """
+          Expected:
+          \(String(describing: expected).indent(by: 2))
+
+          Actual:
+          \(String(describing: actual).indent(by: 2))
+          """
+
+        XCTFail(
+          """
+          State change does not match expectation: …
+
+          \(diff)
+          """,
+          file: file,
+          line: line
+        )
+      }
+    }
+  }
+
+  extension TestStore where LocalState: Equatable, Action: Equatable {
     public func receive(
       _ expectedAction: Action,
       file: StaticString = #file,
       line: UInt = #line,
       _ update: @escaping (inout LocalState) throws -> Void = { _ in }
-    ) where Action: Equatable {
+    ) {
       guard !self.receivedActions.isEmpty else {
         XCTFail(
           """
@@ -414,7 +446,7 @@
       _ steps: Step...,
       file: StaticString = #file,
       line: UInt = #line
-    ) where Action: Equatable {
+    ) {
       assert(steps, file: file, line: line)
     }
 
@@ -423,7 +455,7 @@
       _ steps: [Step],
       file: StaticString = #file,
       line: UInt = #line
-    ) where Action: Equatable {
+    ) {
 
       func assert(step: Step) {
         switch step.type {
@@ -477,36 +509,6 @@
       steps.forEach(assert(step:))
 
       self.completed()
-    }
-
-    private func expectedStateShouldMatch(
-      expected: LocalState,
-      actual: LocalState,
-      file: StaticString,
-      line: UInt
-    ) {
-      if expected != actual {
-        let diff =
-          debugDiff(expected, actual)
-          .map { "\($0.indent(by: 4))\n\n(Expected: −, Actual: +)" }
-          ?? """
-          Expected:
-          \(String(describing: expected).indent(by: 2))
-
-          Actual:
-          \(String(describing: actual).indent(by: 2))
-          """
-
-        XCTFail(
-          """
-          State change does not match expectation: …
-
-          \(diff)
-          """,
-          file: file,
-          line: line
-        )
-      }
     }
   }
 

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -167,7 +167,7 @@
   /// wait longer than the 0.5 seconds, because if it wasn't and it delivered an action when we did
   /// not expect it would cause a test failure.
   ///
-  public final class TestStore<State, LocalState, Action: Equatable, LocalAction, Environment> {
+  public final class TestStore<State, LocalState, Action, LocalAction, Environment> {
     public var environment: Environment
 
     private let file: StaticString
@@ -359,7 +359,7 @@
       file: StaticString = #file,
       line: UInt = #line,
       _ update: @escaping (inout LocalState) throws -> Void = { _ in }
-    ) {
+    ) where Action: Equatable {
       guard !self.receivedActions.isEmpty else {
         XCTFail(
           """
@@ -414,7 +414,7 @@
       _ steps: Step...,
       file: StaticString = #file,
       line: UInt = #line
-    ) {
+    ) where Action: Equatable {
       assert(steps, file: file, line: line)
     }
 
@@ -423,7 +423,7 @@
       _ steps: [Step],
       file: StaticString = #file,
       line: UInt = #line
-    ) {
+    ) where Action: Equatable {
 
       func assert(step: Step) {
         switch step.type {


### PR DESCRIPTION
It occurred to me that this is only there for testing actions received by the store, and now that we have our simpler DSL steps for testing, we can test simple features without ever having to worry about conforming the action type to be equatable, or at the very least delay this requirement a bit longer.