### PR TITLE
Change ViewStore state update behavior

### DIFF
--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -72,17 +72,17 @@ public final class ViewStore<State, Action>: ObservableObject {
     removeDuplicates isDuplicate: @escaping (State, State) -> Bool
   ) {
     self.publisher = StorePublisher(store.state, removeDuplicates: isDuplicate)
-    self._state =  { store.state.value }
+    self._state = { store.state.value }
     self._send = store.send
     self.viewCancellable = store.state
       .dropFirst()
       .removeDuplicates(by: isDuplicate)
       .sink { [weak self] _ in self?.objectWillChange.send() }
   }
-  
+
   let _state: () -> State
   let _send: (Action) -> Void
-  
+
   /// The current state.
   public var state: State { _state() }
 

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -72,22 +72,19 @@ public final class ViewStore<State, Action>: ObservableObject {
     removeDuplicates isDuplicate: @escaping (State, State) -> Bool
   ) {
     self.publisher = StorePublisher(store.state, removeDuplicates: isDuplicate)
-    self.state = store.state.value
+    self._state =  { store.state.value }
     self._send = store.send
     self.viewCancellable = store.state
       .dropFirst()
       .removeDuplicates(by: isDuplicate)
-      .sink { [weak self] in self?.state = $0 }
+      .sink { [weak self] _ in self?.objectWillChange.send() }
   }
-
-  /// The current state.
-  public private(set) var state: State {
-    willSet {
-      self.objectWillChange.send()
-    }
-  }
-
+  
+  let _state: () -> State
   let _send: (Action) -> Void
+  
+  /// The current state.
+  public var state: State { _state() }
 
   /// Returns the resulting value of a given key path.
   public subscript<LocalState>(dynamicMember keyPath: KeyPath<State, LocalState>) -> LocalState {


### PR DESCRIPTION
I had an issue with a ComposableCollectionView, so that fix resolves the issue.
- `ComposableCollectionView` is a dataSource of self and it returns `store.items.count` from `numberOfItemsInSection` method
- `ComposableCollectionView` subscribes to `state.items.count` changes and updates itself
- After loading data, published `state.items.count` is equal to 10, but `viewStore.items.count` is 0
- So state update is received before the `ViewStore.state` acually changed

The fix is that `ViewStore.state` is taken directly from the `Store` now, so we don't even have to assign a new `Store.state` to the `ViewStore.state` anymore, but instead of this we should send `ViewStore.objectWillChange` event from the subscription