### PR TITLE
Fix websocket case study and FactClient.

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -104,6 +104,7 @@ let webSocketReducer = Reducer<WebSocketState, WebSocketAction, WebSocketEnviron
     state.messageToSend = ""
 
     return environment.webSocket.send(WebSocketId(), .string(messageToSend))
+      .receive(on: environment.mainQueue)
       .eraseToEffect()
       .map(WebSocketAction.sendResponse)
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
@@ -33,7 +33,7 @@ extension FactClient {
 extension FactClient {
   // This is the "unimplemented" fact dependency that is useful to plug into tests that you want
   // to prove do not need the dependency.
-  static let unimplemented = Self(
+  static let failing = Self(
     fetch: { _ in
       XCTFail("\(Self.self).fact is unimplemented.")
       return .none

--- a/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
@@ -29,6 +29,7 @@ extension FactClient {
     })
 }
 
+#if DEBUG
 extension FactClient {
   // This is the "unimplemented" fact dependency that is useful to plug into tests that you want
   // to prove do not need the dependency.
@@ -38,3 +39,4 @@ extension FactClient {
       return .none
     })
 }
+#endif

--- a/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
@@ -31,7 +31,7 @@ extension FactClient {
 
 #if DEBUG
 extension FactClient {
-  // This is the "unimplemented" fact dependency that is useful to plug into tests that you want
+  // This is the "failing" fact dependency that is useful to plug into tests that you want
   // to prove do not need the dependency.
   static let failing = Self(
     fetch: { _ in

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-BasicsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-BasicsTests.swift
@@ -9,7 +9,7 @@ class EffectsBasicsTests: XCTestCase {
       initialState: EffectsBasicsState(),
       reducer: effectsBasicsReducer,
       environment: EffectsBasicsEnvironment(
-        fact: .unimplemented,
+        fact: .failing,
         mainQueue: .immediate
       )
     )


### PR DESCRIPTION
Two small things I found while testing some of the new case path stuff:

* The web socket case study has an effect that needs to a `.recieve(on:)`
* The failing `FactClient` should be wrapped in `#if DEBUG`.