### PR TITLE
Fix recursive case study

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -27,14 +27,14 @@ extension Reducer {
 }
 
 struct NestedState: Equatable, Identifiable {
-  var children: [NestedState] = []
+  var children: IdentifiedArrayOf<NestedState> = []
   let id: UUID
   var description: String = ""
 }
 
 indirect enum NestedAction: Equatable {
   case append
-  case node(index: Int, action: NestedAction)
+  case node(id: UUID, action: NestedAction)
   case remove(IndexSet)
   case rename(String)
 }
@@ -51,9 +51,11 @@ let nestedReducer = Reducer<
     state.children.append(NestedState(id: environment.uuid()))
     return .none
 
-  case let .node(index, action):
-    return self.run(&state.children[index], action, environment)
-      .map { .node(index: index, action: $0) }
+  case let .node(id, action):
+    guard var child = state.children[id: id] else { return .none }
+    defer { state.children[id: id] = child }
+    return self.run(&child, action, environment)
+      .map { .node(id: id, action: $0) }
 
   case let .remove(indexSet):
     state.children.remove(atOffsets: indexSet)
@@ -74,7 +76,7 @@ struct NestedView: View {
         Section(header: Text(template: readMe, .caption)) {
 
           ForEachStore(
-            self.store.scope(state: \.children, action: NestedAction.node(index:action:))
+            self.store.scope(state: \.children, action: NestedAction.node(id:action:))
           ) { childStore in
             WithViewStore(childStore) { childViewStore in
               HStack {


### PR DESCRIPTION
Relying on the array-based `ForEachStore` means potential crashes when SwiftUI evaluates views that it shouldn't. We always prefer using `IdentifiedArray`, so let's update this example accordingly.