### PR TITLE
Use in-house benchmarking framework instead of swift-benchmark

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/swift-composable-architecture-benchmark.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/swift-composable-architecture-benchmark.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ComposableArchitectureTests"
+               BuildableName = "ComposableArchitectureTests"
+               BlueprintName = "ComposableArchitectureTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,6 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "0.5.0"),
     .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.4.0"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "0.1.0"),
@@ -42,8 +41,7 @@ let package = Package(
     .target(
       name: "swift-composable-architecture-benchmark",
       dependencies: [
-        "ComposableArchitecture",
-        .product(name: "Benchmark", package: "Benchmark"),
+        "ComposableArchitecture"
       ]
     ),
   ]

--- a/Sources/swift-composable-architecture-benchmark/Benchmark/Benchmark+Compat.swift
+++ b/Sources/swift-composable-architecture-benchmark/Benchmark/Benchmark+Compat.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+public func benchmark(_ label: String, block: @escaping () -> Void) {
+  let benchmark = BenchmarkCase(label: label,
+                                block: BenchmarkBlock(block: { _ in block() }))
+  let study = BenchmarkStudy(name: label, baseline: benchmark, cases: [], configuration: .init())
+  defaultBenchmarkSuite.studies.append(study.erased)
+}
+
+public var defaultBenchmarkSuite = BenchmarkSuite(name: "Default Suite", studies: [])
+
+public extension BenchmarkSuite {
+  mutating func benchmark(_ label: String, block: @escaping () -> Void) {
+    let benchmark = BenchmarkCase(label: label,
+                                  block: BenchmarkBlock(block: { _ in block() }))
+    let study = BenchmarkStudy(name: label, baseline: benchmark, cases: [], configuration: .init())
+    studies.append(study.erased)
+  }
+}
+
+public extension BenchmarkSuite {
+  mutating func register(benchmark: AnyBenchmark) {
+    let benchmarkCase = BenchmarkCase(label: benchmark.name, block: .init(block: { measure in
+      benchmark.setUp()
+      var state = BenchmarkState()
+      measure(.start)
+      try! benchmark.run(&state)
+      measure(.stop)
+      benchmark.tearDown()
+
+    }))
+    studies.append(
+      BenchmarkStudy(name: benchmark.name, baseline: benchmarkCase, cases: [], configuration: .init()).erased
+    )
+  }
+}
+
+public struct BenchmarkSetting {}
+public struct BenchmarkState {}
+public protocol AnyBenchmark {
+  var name: String { get }
+  var settings: [BenchmarkSetting] { get }
+  func setUp()
+  func run(_ state: inout BenchmarkState) throws
+  func tearDown()
+}

--- a/Sources/swift-composable-architecture-benchmark/Benchmark/Benchmark.swift
+++ b/Sources/swift-composable-architecture-benchmark/Benchmark/Benchmark.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public enum Benchmark {
+  public static var suites: [BenchmarkSuite] = [defaultBenchmarkSuite]
+  public static func main(_ suites: [BenchmarkSuite] = Self.suites) {
+    var reports = String()
+    for suite in suites {
+      let report = suite.execute()
+      reports.append(report.formattedString() + "\n")
+    }
+    print("Benchmark Results:")
+    print(reports)
+  }
+}

--- a/Sources/swift-composable-architecture-benchmark/Benchmark/BenchmarkBlock.swift
+++ b/Sources/swift-composable-architecture-benchmark/Benchmark/BenchmarkBlock.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+public enum MeasureDelimiter {
+  case start
+  case stop
+}
+
+public struct ParametricBenchmarkBlock<Parameter> {
+  public init(block: @escaping (_ measure: (MeasureDelimiter) -> Void,
+                                _ parameter: Parameter) -> Void)
+  {
+    self.block = block
+  }
+
+  let block: (_ measure: (MeasureDelimiter) -> Void, _ parameter: Parameter) -> Void
+
+  func execute(parameter: Parameter) -> TimeInterval {
+    var explicitStartTime: UInt64?
+    var explicitEndTime: UInt64?
+    let measure: (MeasureDelimiter) -> Void = {
+      switch $0 {
+      case .start:
+        guard explicitStartTime == nil else {
+          fatalError("`measure(.start)` was called more than once.")
+        }
+        explicitStartTime = timestampInNanoseconds()
+      case .stop:
+        guard explicitEndTime == nil else {
+          fatalError("`measure(.stop)` was called more than once.")
+        }
+        explicitEndTime = timestampInNanoseconds()
+      }
+    }
+    let implicitStartTime = timestampInNanoseconds()
+    block(measure, parameter)
+    let implicitEndTime = timestampInNanoseconds()
+
+    let startTime = explicitStartTime ?? implicitStartTime
+    let endTime = explicitEndTime ?? implicitEndTime
+
+    return seconds(t1: startTime, t2: endTime)
+  }
+}
+
+public typealias BenchmarkBlock = ParametricBenchmarkBlock<Void>
+public extension BenchmarkBlock {
+  init(block: @escaping (_ measure: (MeasureDelimiter) -> Void) -> Void) {
+    self.block = { mesure, _ in block(mesure) }
+  }
+}

--- a/Sources/swift-composable-architecture-benchmark/Benchmark/BenchmarkCase.swift
+++ b/Sources/swift-composable-architecture-benchmark/Benchmark/BenchmarkCase.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+public struct ParametricBenchmarkCase<Parameter> {
+  init(label: String, block: ParametricBenchmarkBlock<Parameter>) {
+    self.label = label
+    self.block = block
+  }
+
+  let label: String
+  let block: ParametricBenchmarkBlock<Parameter>
+
+  func execute(with configuration: BenchmarkConfiguration = .init(), parameter: Parameter) -> Report {
+    var durations = [TimeInterval]()
+    let start = timestampInNanoseconds()
+    var iterations = -configuration.warmupIterations
+    while iterations < configuration.maxIterations {
+      let measure = block.execute(parameter: parameter)
+      if iterations >= 0 {
+        durations.append(measure)
+      }
+      iterations += 1
+
+      if seconds(t1: start, t2: timestampInNanoseconds()) > configuration.maxDuration,
+         iterations >= configuration.minIterations
+      {
+        break
+      }
+    }
+
+    return Report(label: label, parameter: parameter, configuration: configuration, durations: durations)
+  }
+}
+
+public typealias BenchmarkCase = ParametricBenchmarkCase<Void>
+
+extension ParametricBenchmarkCase where Parameter == Void {
+  init(label: String, block: BenchmarkBlock) {
+    self.label = label
+    self.block = block
+  }
+}
+
+extension ParametricBenchmarkCase {
+  struct Report {
+    init(
+      label: String,
+      parameter: Parameter,
+      configuration: BenchmarkConfiguration,
+      durations: [TimeInterval]
+    ) {
+      self.label = label
+      self.parameter = parameter
+      self.configuration = configuration
+      self.durations = durations
+      iterations = durations.count
+      let (mean, stdDev) = durations.meanAndStandardDeviation ?? (0, 0)
+      self.mean = mean
+      std = stdDev / sqrt(Double(iterations))
+    }
+
+    let label: String
+    let parameter: Parameter
+    let configuration: BenchmarkConfiguration
+    let durations: [TimeInterval]
+
+    let iterations: Int
+    let mean: Double
+    let std: Double
+  }
+}

--- a/Sources/swift-composable-architecture-benchmark/Benchmark/BenchmarkStudy.swift
+++ b/Sources/swift-composable-architecture-benchmark/Benchmark/BenchmarkStudy.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+struct BenchmarkStudyConfiguration<Parameter> {
+  init(cases: BenchmarkConfiguration = .init(), parameters: @escaping () -> [Parameter]) {
+    self.cases = cases
+    self.parameters = parameters
+  }
+
+  var cases: BenchmarkConfiguration = .init()
+  var parameters: () -> [Parameter]
+}
+
+extension BenchmarkStudyConfiguration where Parameter == Void {
+  init(_ cases: BenchmarkConfiguration = .init()) {
+    self.cases = cases
+    parameters = { [()] } // Nice!
+  }
+}
+
+public struct BenchmarkConfiguration {
+  public init(
+    iterationsCount: ClosedRange<UInt> = 10 ... 1_000_000,
+    maxDuration: TimeInterval = 5,
+    warmupIterations: Int = 0
+  ) {
+    self.iterationsCount = iterationsCount
+    self.maxDuration = maxDuration
+    self.warmupIterations = warmupIterations
+  }
+
+  public var iterationsCount: ClosedRange<UInt>
+  public var maxDuration: TimeInterval
+  public var warmupIterations: Int
+
+  var minIterations: Int { Int(iterationsCount.lowerBound) }
+  var maxIterations: Int { Int(iterationsCount.upperBound) }
+}
+
+public struct ParametricBenchmarkStudy<Parameter> {
+  var name: String
+
+  var baseline: ParametricBenchmarkCase<Parameter>? = nil
+  var cases: [ParametricBenchmarkCase<Parameter>] = []
+  var configuration: BenchmarkStudyConfiguration<Parameter>
+
+  func execute() -> Report {
+    var baselineReports = [ParametricBenchmarkCase<Parameter>.Report]()
+    var caseReports = [String: [ParametricBenchmarkCase<Parameter>.Report]]()
+    for parameter in configuration.parameters() {
+      if let baseline = baseline {
+        let timestamp = timestampInNanoseconds()
+        print("    Running \(baseline.label)…")
+        let baselineReport = baseline.execute(with: configuration.cases, parameter: parameter)
+        baselineReports.append(baselineReport)
+        print("    Done! (\(TimeUnit.format(seconds(t1: timestamp, t2: timestampInNanoseconds()))))")
+      }
+
+      for benchmark in cases {
+        let timestamp = timestampInNanoseconds()
+        print("    Running \(benchmark.label)…")
+        caseReports[benchmark.label, default: []]
+          .append(benchmark.execute(with: configuration.cases, parameter: parameter))
+        print("    Done! (\(TimeUnit.format(seconds(t1: timestamp, t2: timestampInNanoseconds()))))")
+      }
+    }
+
+    return Report(name: name, baselines: baselineReports, cases: caseReports)
+  }
+}
+
+public typealias BenchmarkStudy = ParametricBenchmarkStudy<Void>
+public extension ParametricBenchmarkStudy where Parameter == Void {
+  mutating func setBaseline(_ label: String = "Baseline", block: @escaping (_ measure: (MeasureDelimiter) -> Void) -> Void) {
+    baseline = BenchmarkCase(label: label, block: .init(block: block))
+  }
+
+  mutating func addCase(_ label: String, block: @escaping (_ measure: (MeasureDelimiter) -> Void) -> Void) {
+    cases.append(BenchmarkCase(label: label, block: .init(block: block)))
+  }
+}
+
+extension ParametricBenchmarkStudy {
+  struct Report {
+    let name: String
+    let baselines: [ParametricBenchmarkCase<Parameter>.Report]
+    let cases: [String: [ParametricBenchmarkCase<Parameter>.Report]]
+
+    func lines() -> [[Columns: String]] {
+      let values = baselines.map(\.mean) + cases.values.flatMap { $0.map(\.mean) }
+      guard let minValue = values.min() else { return [] }
+      let timeUnit = TimeUnit.bestUnit(minValue)
+
+      var lines: [[Columns: String]] = []
+      let numberOfCases = 1 + cases.count
+      var bestMean: TimeInterval = 0
+      // TODO: Handle parametric case
+      if let baseline = baselines.first {
+        bestMean = baseline.mean
+        for report in cases {
+          bestMean = min(bestMean, report.value.first!.mean)
+        }
+        let componentsForBaseline: [Columns: String] = [
+          .label: baseline.label,
+          .best: formatIsBest(bestMean: bestMean, mean: baseline.mean, numberOfCases: numberOfCases),
+          .mean: formatMeanTime(baseline.mean, unit: timeUnit),
+          .delta: "",
+          .variation: "",
+          .performance: "",
+          .standardError: formatStandardError(mean: baseline.mean, std: baseline.std),
+          .iterations: formatIterations(baseline.iterations),
+        ]
+        lines.append(componentsForBaseline)
+      }
+
+      for (_, reports) in cases.sorted(by: { $0.key < $1.key }) {
+        // TODO: Handle parametric case
+        guard let report = reports.first else { continue }
+        if let baseline = baselines.first {
+          let delta = report.mean - baseline.mean
+          let components: [Columns: String] = [
+            .label: report.label,
+            .best: formatIsBest(bestMean: bestMean, mean: report.mean, numberOfCases: numberOfCases),
+            .mean: formatMeanTime(report.mean, unit: timeUnit),
+            .delta: formatDeltaTime(delta, unit: timeUnit),
+            .variation: formatVariation(baseline.mean, delta: delta),
+            .performance: formatPerformance(baseline.mean, reportMean: report.mean),
+            .standardError: formatStandardError(mean: report.mean, std: report.std),
+            .iterations: formatIterations(report.iterations),
+          ]
+          lines.append(components)
+        } else {
+          // No baseline
+          let components: [Columns: String] = [
+            .label: report.label,
+            .best: formatIsBest(bestMean: bestMean, mean: report.mean, numberOfCases: numberOfCases),
+            .mean: formatMeanTime(report.mean, unit: timeUnit),
+            .delta: "",
+            .variation: "",
+            .performance: "",
+            .standardError: formatStandardError(mean: report.mean, std: report.std),
+            .iterations: formatIterations(report.iterations),
+          ]
+          lines.append(components)
+        }
+      }
+      return lines
+    }
+
+    func formatIterations(_ iterations: Int) -> String {
+      String(format: "%d", iterations)
+    }
+
+    func formatMeanTime(_ mean: TimeInterval, unit: TimeUnit) -> String {
+      unit.format(mean)
+    }
+
+    func formatDeltaTime(_ delta: TimeInterval, unit: TimeUnit) -> String {
+      unit.format(delta, signed: true)
+    }
+
+    func formatVariation(_ baselineMean: TimeInterval, delta: TimeInterval) -> String {
+      String(format: "%+.2f %%", 100 * delta / baselineMean)
+    }
+
+    func formatPerformance(_ baselineMean: TimeInterval, reportMean: TimeInterval) -> String {
+      String(format: "x%.2f", baselineMean / reportMean)
+    }
+
+    func formatStandardError(mean: TimeInterval, std: TimeInterval) -> String {
+      String(format: "±%.2f %%", 100 * std / mean)
+    }
+
+    func formatIsBest(bestMean: TimeInterval, mean: TimeInterval, numberOfCases: Int) -> String {
+      if bestMean == mean, numberOfCases > 1 { return "(*)" }
+      return ""
+    }
+  }
+}
+
+// MARK: - AnyBenchmarkStudy
+
+struct AnyBenchmarkStudy {
+  let name: String
+  let execute: () -> [[Columns: String]]
+  init<Parameter>(_ study: ParametricBenchmarkStudy<Parameter>) {
+    name = study.name
+    execute = {
+      study
+        .execute()
+        .lines()
+    }
+  }
+}
+
+extension ParametricBenchmarkStudy {
+  var erased: AnyBenchmarkStudy { AnyBenchmarkStudy(self) }
+}

--- a/Sources/swift-composable-architecture-benchmark/Benchmark/BenchmarkSuite.swift
+++ b/Sources/swift-composable-architecture-benchmark/Benchmark/BenchmarkSuite.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+public struct BenchmarkSuite {
+  public let name: String
+  var studies: [AnyBenchmarkStudy] = []
+
+  internal init(name: String, studies: [AnyBenchmarkStudy] = []) {
+    self.name = name
+    self.studies = studies
+  }
+
+  public init(_ name: String, block: (inout BenchmarkSuite) -> Void) {
+    var suite = BenchmarkSuite(name: name)
+    block(&suite)
+    self = suite
+  }
+
+  public mutating func addStudy(_ name: String,
+                                configuration: BenchmarkConfiguration = .init(),
+                                block: (inout BenchmarkStudy) -> Void)
+  {
+    var study = BenchmarkStudy(name: name, configuration: .init(configuration))
+    block(&study)
+    studies.append(study.erased)
+  }
+
+  func execute() -> Report {
+    var reports = [String: [[Columns: String]]]()
+    print("Running \(name)…")
+    for study in studies {
+      let timestamp = timestampInNanoseconds()
+      print("  Running \(study.name)…")
+      reports[study.name] = study.execute()
+      print("  Done! (\(TimeUnit.format(seconds(t1: timestamp, t2: timestampInNanoseconds()))))")
+    }
+    print("Done!")
+    return Report(name: name, studiesReports: reports)
+  }
+}
+
+extension BenchmarkSuite {
+  struct Report {
+    let name: String
+    let studiesReports: [String: [[Columns: String]]]
+
+    func formattedString() -> String {
+      guard !studiesReports.isEmpty else { return "" }
+      let header = Dictionary(uniqueKeysWithValues:
+        Columns.allCases.map { ($0, $0.title) })
+
+      let maxWidthPerColumns = studiesReports
+        .values
+        .flatMap { $0 }
+        .reduce(header.mapValues(\.count)) {
+          $0.merging($1.mapValues(\.count), uniquingKeysWith: max)
+        }
+
+      let length = maxWidthPerColumns.values.reduce(0, +) + (maxWidthPerColumns.count - 1)
+
+      var output = [String]()
+
+      func write(label: String, indent: Int, char: String) {
+        let prefix = String(repeating: char, count: indent)
+        let suffixLength = max(0, length - label.count - indent)
+        let suffix = String(repeating: char, count: suffixLength)
+        output.append("\(prefix)\(label)\(suffix)")
+      }
+
+      func write(line: [Columns: String]) {
+        var lineComponents: [String] = []
+        for column in Columns.allCases {
+          lineComponents.append(
+            align(string: line[column, default: ""],
+                  length: maxWidthPerColumns[column],
+                  alignment: column == .label ? .left : .right)
+          )
+        }
+        output.append(lineComponents.joined(separator: " "))
+      }
+
+      write(label: " \(name) ", indent: 2, char: "=")
+      write(line: header)
+
+      var previousHadMultipleCases: Bool = false
+      for (reportName, report) in studiesReports.sorted(by: { $0.key < $1.key }) {
+        if report.count > 1 {
+          write(label: " \(reportName) ", indent: 2, char: "-")
+        } else if previousHadMultipleCases {
+          write(label: "", indent: 0, char: "-")
+        }
+        report.forEach(write(line:))
+        previousHadMultipleCases = report.count > 1
+      }
+      output.append(String(repeating: "=", count: length))
+
+      return output.joined(separator: "\n") + "\n"
+    }
+
+    enum Alignment {
+      case left
+      case right
+      case center
+    }
+
+    func align(string: String, length: Int?, alignment: Alignment = .right) -> String {
+      guard let length = length else { return string }
+      guard string.count <= length else { return String(string.prefix(length)) }
+      let padding = String(repeating: " ", count: length - string.count)
+      switch alignment {
+      case .left:
+        return string + padding
+      case .right:
+        return padding + string
+      case .center:
+        let padding = String(repeating: " ", count: (length - string.count) / 2)
+        return padding + string + padding + ((length - string.count).isMultiple(of: 2) ? "" : " ")
+      }
+    }
+  }
+}
+
+@discardableResult
+public func benchmarkSuite(_ name: String, block: (inout BenchmarkSuite) -> Void) -> BenchmarkSuite {
+  let suite = BenchmarkSuite(name, block: block)
+  Benchmark.suites.append(suite)
+  return suite
+}

--- a/Sources/swift-composable-architecture-benchmark/Benchmark/Columns.swift
+++ b/Sources/swift-composable-architecture-benchmark/Benchmark/Columns.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+enum Columns: String, Hashable, CaseIterable {
+  case label
+  case best
+  case mean
+  case delta
+  case variation
+  case performance
+  case standardError
+  case iterations
+
+  var title: String {
+    switch self {
+    case .label: return ""
+    case .best: return ""
+    case .mean: return "Duration"
+    case .delta: return "Difference"
+    case .variation: return "Variation"
+    case .performance: return "Performance"
+    case .standardError: return "Std.Error"
+    case .iterations: return "Iterations"
+    }
+  }
+}

--- a/Sources/swift-composable-architecture-benchmark/Benchmark/TimeUnit.swift
+++ b/Sources/swift-composable-architecture-benchmark/Benchmark/TimeUnit.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+enum TimeUnit: Int {
+  case s = 1
+  case ms = 1000
+  case µs = 1_000_000
+  case ns = 1_000_000_000
+
+  var suffix: String {
+    switch self {
+    case .s: return "s"
+    case .ms: return "ms"
+    case .µs: return "µs"
+    case .ns: return "ns"
+    }
+  }
+
+  func format(_ seconds: TimeInterval, signed: Bool = false) -> String {
+    let decimal = self == .ns ? ".0f" : ".3f"
+    let format = signed ? "%+\(decimal) %@" : "%\(decimal) %@"
+    return String(format: format, seconds * Double(rawValue), suffix)
+  }
+
+  static func bestUnit(_ duration: TimeInterval) -> TimeUnit {
+    if duration > 1 {
+      return .s
+    } else if duration > 1e-3 {
+      return .ms
+    } else if duration > 1e-6 {
+      return .µs
+    } else {
+      return .ns
+    }
+  }
+
+  static func format(_ duration: TimeInterval) -> String {
+    bestUnit(duration).format(duration)
+  }
+}

--- a/Sources/swift-composable-architecture-benchmark/Benchmark/Utilities.swift
+++ b/Sources/swift-composable-architecture-benchmark/Benchmark/Utilities.swift
@@ -1,0 +1,31 @@
+import Foundation
+#if canImport(Accelerate)
+  import Accelerate
+#endif
+
+extension Array where Element == Double {
+  var meanAndStandardDeviation: (mean: Double, stdDev: Double)? {
+    guard !isEmpty else { return nil }
+    guard count > 1 else { return (first!, 0) }
+
+    var mean = 0.0
+    var stdDev = 0.0
+
+    #if canImport(Accelerate)
+      vDSP_normalizeD(self, 1, nil, 1, &mean, &stdDev, vDSP_Length(count))
+      stdDev *= sqrt(Double(count) / Double(count - 1))
+    #else
+      mean = reduce(0, +) / Double(count)
+      stdDev = sqrt(reduce(0) { $0 + ($1 - mean) * ($1 - mean) } / Double(count - 1))
+    #endif
+    return (mean, stdDev)
+  }
+}
+
+func timestampInNanoseconds() -> UInt64 {
+  clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+}
+
+func seconds(t1: UInt64, t2: UInt64) -> TimeInterval {
+  Double(t2 - t1) * 1e-9
+}

--- a/Sources/swift-composable-architecture-benchmark/main.swift
+++ b/Sources/swift-composable-architecture-benchmark/main.swift
@@ -1,4 +1,3 @@
-import Benchmark
 import ComposableArchitecture
 
 let counterReducer = Reducer<Int, Bool, Void> { state, action, _ in
@@ -10,33 +9,47 @@ let counterReducer = Reducer<Int, Bool, Void> { state, action, _ in
   return .none
 }
 
-let store1 = Store(initialState: 0, reducer: counterReducer, environment: ())
-let store2 = store1.scope { $0 }
-let store3 = store2.scope { $0 }
-let store4 = store3.scope { $0 }
+benchmarkSuite("Scoping") { suite in
+  
+  suite.addStudy("Deep scoping") { study in
+    
+    study.setBaseline("No scope") { measure in
+      let store1 = Store(initialState: 0, reducer: counterReducer, environment: ())
+      let viewStore = ViewStore(store1)
+      measure(.start)
+      viewStore.send(true)
+    }
+    
+    study.addCase("Scope (1)") { measure in
+      let store1 = Store(initialState: 0, reducer: counterReducer, environment: ())
+      let store2 = store1.scope { $0 }
 
-let viewStore1 = ViewStore(store1)
-let viewStore2 = ViewStore(store2)
-let viewStore3 = ViewStore(store3)
-let viewStore4 = ViewStore(store4)
+      let viewStore = ViewStore(store2)
+      measure(.start)
+      viewStore.send(true)
+    }
+    
+    study.addCase("Scope (2)") { measure in
+      let store1 = Store(initialState: 0, reducer: counterReducer, environment: ())
+      let store2 = store1.scope { $0 }
+      let store3 = store2.scope { $0 }
 
-benchmark("Scoping (1)") {
-  viewStore1.send(true)
-}
-viewStore1.send(false)
+      let viewStore = ViewStore(store3)
+      measure(.start)
+      viewStore.send(true)
+    }
+    
+    study.addCase("Scope (3)") { measure in
+      let store1 = Store(initialState: 0, reducer: counterReducer, environment: ())
+      let store2 = store1.scope { $0 }
+      let store3 = store2.scope { $0 }
+      let store4 = store3.scope { $0 }
 
-benchmark("Scoping (2)") {
-  viewStore2.send(true)
-}
-viewStore1.send(false)
-
-benchmark("Scoping (3)") {
-  viewStore3.send(true)
-}
-viewStore1.send(false)
-
-benchmark("Scoping (4)") {
-  viewStore4.send(true)
+      let viewStore = ViewStore(store4)
+      measure(.start)
+      viewStore.send(true)
+    }
+  }
 }
 
 Benchmark.main()


### PR DESCRIPTION
Hello!

I was unhappy with the the Google's `swift-benchmark` library:
- It doesn't allow automatic comparison of benchmarks, and the results are not exposed within the benchmark app.
- It uses `DispatchTime.now` to timestamp events, which can be unreliable according to Stack Overflow.
- It looks semi-archived, with a lonely PR sitting for more than 6 months without any acknowledgement from the maintainers.

I've drafted this library today to try to fix these issues.
Firstly, this library is source compatible with `swift-benchmark`. In `swift-parsing`, one can remove the `swift-benchmark` dependency and create a `Benchmark` target with this code and it "just works" (there is only one change to make: annotate one of the internal function helper as `mutating` as `BenchmarkSuite` is a now a struct)

The library introduces an intermediate group called `BenchmarkStudy` which compares some alternative cases to a baseline one. The hierarchy is `Suite`>`Study`>`Case`. Each study is independent from another. 

Each case is instantiated with a block receiving a `(MeasureDelimiter) -> Void` argument. You can use this function with `MeasureDelimiter`'s cases `.start` or `.stop` to optionally delimit the portion of code that is measured. There is no setup or tear-down as the delimiters allow to execute setup, benchmarks and tear-down in the same block. The use of the delimiters is optional and the library uses the block boundaries if they're absent.

As an example, the updated code that take advantage of the studies for TCA is:
```swift
benchmarkSuite("Scoping") { suite in
  
  suite.addStudy("Deep scoping") { study in
    
    study.setBaseline("No scope") { measure in
      let store1 = Store(initialState: 0, reducer: counterReducer, environment: ())
      let viewStore = ViewStore(store1)
      measure(.start)
      viewStore.send(true)
    }
    
    study.addCase("Scope (1)") { measure in
      let store1 = Store(initialState: 0, reducer: counterReducer, environment: ())
      let store2 = store1.scope { $0 }

      let viewStore = ViewStore(store2)
      measure(.start)
      viewStore.send(true)
    }
    
    study.addCase("Scope (2)") { measure in
      let store1 = Store(initialState: 0, reducer: counterReducer, environment: ())
      let store2 = store1.scope { $0 }
      let store3 = store2.scope { $0 }

      let viewStore = ViewStore(store3)
      measure(.start)
      viewStore.send(true)
    }
    
    study.addCase("Scope (3)") { measure in
      let store1 = Store(initialState: 0, reducer: counterReducer, environment: ())
      let store2 = store1.scope { $0 }
      let store3 = store2.scope { $0 }
      let store4 = store3.scope { $0 }

      let viewStore = ViewStore(store4)
      measure(.start)
      viewStore.send(true)
    }
  }
}
```
Each benchmark case is run by default 1,000,000 times or during 5s, whichever comes first. Parameters are always shared in a study.

The library runs all the cases of all the studies of all the suites and present the results in a human friendly way. As an example, the current benchmark for TCA shows:
```
== Scoping ==================================================================
               Duration Difference Variation Performance Std.Error Iterations
-- Deep scoping -------------------------------------------------------------
No scope  (*) 12.738 µs                                    ±0.12 %     276000
Scope (1)     22.478 µs  +9.740 µs  +76.46 %       x0.57   ±0.11 %     159270
Scope (2)     31.876 µs +19.138 µs +150.24 %       x0.40   ±0.13 %     113743
Scope (3)     42.199 µs +29.461 µs +231.29 %       x0.30   ±0.15 %      86687
=============================================================================
```
The asterisk `(*)` denotes the fastest performer. The first row is empty for Difference, Variation (in %), and Performance (in "times faster") because it's the baseline. The time unit is automatically determined according to the data to be displayed (it is the same for all the cases of a study).

On the technical side, the library uses `clock_gettime_nsec_np` to retrieve a timestamp, which is the Apple's recommendation. It also uses `Accelerate` if available to compute the mean and standard deviation of the results.

More importantly, the library is already set to execute `transversal` benchmarks in the spirit `swift-collections-benchmark`. You can parametrize the execution block with a generic parameter (let say the number of pullbacks), and the library will execute the same sequence described above, but also varying the parameter according to your prescription. This is not really exposed right now as I don't now how to present the results in ASCII, but I guess it should be possible to draw graph images at some point. The currently exposed non-parametric API is hiding the generic parameter behind a typealias.

I guess this module should be extracted as an independent library (it also misses `@inlinable` annotations for now). If there is some interest, I can update `swift-parsing` benchmarks to take advantage of the studies. I've tested it at home and it gives similar results as `swift-benchmark`. In source compatibility mode, it runs all the benchmarks as baseline-only studies, but it can be way nicer if some proper studies are defined. For example, here is a partial result running `Comma separated` benchmarks in the `Numeric` suite, both as a proper study and in source compatibility:

```
== Numerics ============================================================================================
                                          Duration Difference Variation Performance Std.Error Iterations
-- Comma separated -------------------------------------------------------------------------------------
Double.parser                       (*)  13.772 ms                                    ±1.37 %        360
Scanner.scanDouble                      111.553 ms +97.781 ms +710.02 %       x0.12   ±0.71 %         45
String.split                             36.388 ms +22.616 ms +164.22 %       x0.38   ±0.92 %        137
--------------------------------------------------------------------------------------------------------
Comma separated: Double.parser           13.898 ms                                    ±1.39 %        357
Comma separated: Scanner.scanDouble     113.646 ms                                    ±0.57 %         44
Comma separated: String.split            36.877 ms                                    ±0.89 %        136
========================================================================================================
```
and running using `swift-benchmark`:
```
name                                         time             std        iterations
-----------------------------------------------------------------------------------
Numerics.Comma separated: Double.parser       12137402.000 ns ±  30.29 %        107
Numerics.Comma separated: Scanner.scanDouble 113536294.000 ns ±   4.45 %         13
Numerics.Comma separated: String.split        36109335.000 ns ±  10.55 %         39
```

Most importantly, I guess this library will provide a more flexible base to benchmark TCA. I have no issue with @mbrandonw  and @stephencelis taking ownership of the code. This is a very rough draft and I'm sure there is many ways to improve it.

Please let me know what you think!
