### PR TITLE
Alternate `ViewStore.binding` helper

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -56,7 +56,7 @@ struct BindingFormView: View {
           HStack {
             TextField(
               "Type here",
-              text: viewStore.binding(keyPath: \.text, send: BindingFormAction.binding)
+              text: viewStore.binding(BindingFormAction.binding).text
             )
             .disableAutocorrection(true)
             .foregroundColor(viewStore.toggleIsOn ? .gray : .primary)
@@ -64,12 +64,12 @@ struct BindingFormView: View {
           }
           .disabled(viewStore.toggleIsOn)
 
-          Toggle(isOn: viewStore.binding(keyPath: \.toggleIsOn, send: BindingFormAction.binding)) {
+          Toggle(isOn: viewStore.binding(BindingFormAction.binding).toggleIsOn) {
             Text("Disable other controls")
           }
 
           Stepper(
-            value: viewStore.binding(keyPath: \.stepCount, send: BindingFormAction.binding),
+            value: viewStore.binding(BindingFormAction.binding).stepCount,
             in: 0...100
           ) {
             Text("Max slider value: \(viewStore.stepCount)")
@@ -81,7 +81,7 @@ struct BindingFormView: View {
             Text("Slider value: \(Int(viewStore.sliderValue))")
               .font(Font.body.monospacedDigit())
             Slider(
-              value: viewStore.binding(keyPath: \.sliderValue, send: BindingFormAction.binding),
+              value: viewStore.binding(BindingFormAction.binding).sliderValue,
               in: 0...Double(viewStore.stepCount)
             )
           }

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -356,8 +356,7 @@ public final class Store<State, Action> {
   ///
   /// - Parameter toLocalState: A function that transforms a publisher of `State` into a publisher
   ///   of `LocalState`.
-  /// - Returns: A publisher of stores with its domain (state and action)
-  ///   transformed.
+  /// - Returns: A publisher of stores with its domain (state and action) transformed.
   public func publisherScope<P: Publisher, LocalState>(
     state toLocalState: @escaping (AnyPublisher<State, Never>) -> P
   ) -> AnyPublisher<Store<LocalState, Action>, Never>

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -258,4 +258,29 @@ extension ViewStore {
       send: { action(.set(keyPath, $0)) }
     )
   }
+
+  /// Derives a binding from the store that mutates state by wrapping a ``BindingAction`` with the
+  /// store's action type.
+  ///
+  /// For example, a text field binding can be created like this:
+  ///
+  /// ```swift
+  /// struct State { var text = "" }
+  /// enum Action { case binding(BindingAction<State>) }
+  ///
+  /// TextField(
+  ///   "Enter text",
+  ///   text: viewStore.binding(Action.binding).text
+  /// )
+  /// ```
+  ///
+  /// - Parameter action: A function that wraps a binding action in the view store's action type.
+  /// - Returns: A binding.
+  public func binding(_ action: @escaping (BindingAction<State>) -> Action) -> Binding<State>
+  where State: Equatable {
+    self.binding(
+      get: { $0 },
+      send: { action(.set(\.self, $0)) }
+    )
+  }
 }


### PR DESCRIPTION
It occurred to me we could just leverage dynamic member lookup and derive view store bindings given simply a binding action...there's a caveat, though.