### PR TITLE
Introduce `compactScope` operation for IfLetStore

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
@@ -52,7 +52,7 @@ public struct IfLetStore<State, Action, Content>: View where Content: View {
     self.store = store
     self.content = { viewStore in
       if let state = viewStore.state {
-        return ViewBuilder.buildEither(first: ifContent(store.scope(state: { $0 ?? state })))
+        return ViewBuilder.buildEither(first: ifContent(store.compactScope(initialLocalState: state, state: { $0 })))
       } else {
         return ViewBuilder.buildEither(second: elseContent())
       }
@@ -73,7 +73,7 @@ public struct IfLetStore<State, Action, Content>: View where Content: View {
     self.store = store
     self.content = { viewStore in
       viewStore.state.map { state in
-        ifContent(store.scope(state: { $0 ?? state }))
+        ifContent(store.compactScope(initialLocalState: state, state: { $0 }))
       }
     }
   }


### PR DESCRIPTION
As discussed in #496, when using `IfLetStore`, an action from scoped child store to nil out local state might result in local state being replayed back to earlier value right before the view is removed. The issue can be seen in 

https://github.com/pointfreeco/swift-composable-architecture/blob/ba2b9e08e2776bbb02f27ab7123dae767f106fad/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift#L50-L54

where initial state is copied and used later when the scope transformation returns nil.

A `compactScope` operation to avoids this by not forwarding non-nil values to the child store. 

It's a bit awkward solution, because the implementation is nearly the same as regular `scope`. I did not want to sacrifice performance of regular `scope` by having it call `compactScope` internally.  Maybe a better implementation could be found that could combine both scoping methods.