### PR TITLE
Keep last non-nil value around for ForEachStore

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -101,10 +101,13 @@ where Data: Collection, ID: Hashable, Content: View {
           //     views for elements no longer in the collection.
           //
           // Feedback filed: https://gist.github.com/stephencelis/cdf85ae8dab437adc998fb0204ed9a6b
-          let element = store.state.value[id: id]!
+          var element = store.state.value[id: id]!
           return content(
             store.scope(
-              state: { $0[id: id] ?? element },
+              state: {
+                element = $0[id: id] ?? element
+                return element
+              },
               action: { (id, $0) }
             )
           )


### PR DESCRIPTION
This eliminates a helper introduced in #667 by inlining the state, and it fixes `ForEachStore` using the same logic.