### PR TITLE
Add an async/await aware .send method to View Store.

### DIFF
--- a/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
+++ b/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		CAA9ADC824465D950003A984 /* 02-Effects-CancellationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA9ADC724465D950003A984 /* 02-Effects-CancellationTests.swift */; };
 		CAA9ADCA2446605B0003A984 /* 02-Effects-LongLiving.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA9ADC92446605B0003A984 /* 02-Effects-LongLiving.swift */; };
 		CAA9ADCC2446615B0003A984 /* 02-Effects-LongLivingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA9ADCB2446615B0003A984 /* 02-Effects-LongLivingTests.swift */; };
+		CABC4F3926AEE00C00D5FA2C /* 02-Effects-Refreshable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABC4F3826AEE00C00D5FA2C /* 02-Effects-Refreshable.swift */; };
+		CABC4F3B26AEE20200D5FA2C /* 02-Effects-RefreshableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABC4F3A26AEE20200D5FA2C /* 02-Effects-RefreshableTests.swift */; };
 		CAE962FD24A7F7BE00EFC025 /* 01-GettingStarted-AlertsAndActionSheets.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE962FC24A7F7BE00EFC025 /* 01-GettingStarted-AlertsAndActionSheets.swift */; };
 		CAF069D024ACC5AF00A1AAEF /* 00-Core.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF069CF24ACC5AF00A1AAEF /* 00-Core.swift */; };
 		CAF88E7324B8E26D00539345 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF88E7224B8E26D00539345 /* AppDelegate.swift */; };
@@ -170,6 +172,8 @@
 		CAA9ADC724465D950003A984 /* 02-Effects-CancellationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "02-Effects-CancellationTests.swift"; sourceTree = "<group>"; };
 		CAA9ADC92446605B0003A984 /* 02-Effects-LongLiving.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "02-Effects-LongLiving.swift"; sourceTree = "<group>"; };
 		CAA9ADCB2446615B0003A984 /* 02-Effects-LongLivingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "02-Effects-LongLivingTests.swift"; sourceTree = "<group>"; };
+		CABC4F3826AEE00C00D5FA2C /* 02-Effects-Refreshable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "02-Effects-Refreshable.swift"; sourceTree = "<group>"; };
+		CABC4F3A26AEE20200D5FA2C /* 02-Effects-RefreshableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "02-Effects-RefreshableTests.swift"; sourceTree = "<group>"; };
 		CAE962FC24A7F7BE00EFC025 /* 01-GettingStarted-AlertsAndActionSheets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-GettingStarted-AlertsAndActionSheets.swift"; sourceTree = "<group>"; };
 		CAF069CF24ACC5AF00A1AAEF /* 00-Core.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "00-Core.swift"; sourceTree = "<group>"; };
 		CAF88E7024B8E26D00539345 /* tvOSCaseStudies.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = tvOSCaseStudies.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -401,6 +405,7 @@
 				CAA9ADC12446587C0003A984 /* 02-Effects-Basics.swift */,
 				CAA9ADC524465C810003A984 /* 02-Effects-Cancellation.swift */,
 				CAA9ADC92446605B0003A984 /* 02-Effects-LongLiving.swift */,
+				CABC4F3826AEE00C00D5FA2C /* 02-Effects-Refreshable.swift */,
 				DC89C45424465C44006900B9 /* 02-Effects-Timers.swift */,
 				CA410EDF247A15FE00E41798 /* 02-Effects-WebSocket.swift */,
 				CA27C0B6245780CE00CB1E59 /* 03-Effects-SystemEnvironment.swift */,
@@ -434,11 +439,12 @@
 				CAA9ADC324465AB00003A984 /* 02-Effects-BasicsTests.swift */,
 				CAA9ADC724465D950003A984 /* 02-Effects-CancellationTests.swift */,
 				CAA9ADCB2446615B0003A984 /* 02-Effects-LongLivingTests.swift */,
+				CABC4F3A26AEE20200D5FA2C /* 02-Effects-RefreshableTests.swift */,
 				DC07231624465D1E003A8B65 /* 02-Effects-TimersTests.swift */,
 				CA410EE1247C73B400E41798 /* 02-Effects-WebSocketTests.swift */,
+				CA0C0C4624B89BEC00CBDD8A /* 04-HigherOrderReducers-LifecycleTests.swift */,
 				DC634B242448D15B00DAA016 /* 04-HigherOrderReducers-ReusableFavoritingTests.swift */,
 				CA0C51FA245389CC00A04EAB /* 04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift */,
-				CA0C0C4624B89BEC00CBDD8A /* 04-HigherOrderReducers-LifecycleTests.swift */,
 			);
 			path = SwiftUICaseStudiesTests;
 			sourceTree = "<group>";
@@ -763,6 +769,7 @@
 				CAA9ADC22446587C0003A984 /* 02-Effects-Basics.swift in Sources */,
 				DC89C41B24460F95006900B9 /* 00-RootView.swift in Sources */,
 				DCC68EDD2447A5B00037F998 /* 01-GettingStarted-OptionalState.swift in Sources */,
+				CABC4F3926AEE00C00D5FA2C /* 02-Effects-Refreshable.swift in Sources */,
 				DCC68EAB244666AF0037F998 /* 03-Navigation-Sheet-PresentAndLoad.swift in Sources */,
 				CAE962FD24A7F7BE00EFC025 /* 01-GettingStarted-AlertsAndActionSheets.swift in Sources */,
 				CA25E5D224463AD700DA666A /* 01-GettingStarted-Bindings-Basics.swift in Sources */,
@@ -788,6 +795,7 @@
 				DC634B252448D15B00DAA016 /* 04-HigherOrderReducers-ReusableFavoritingTests.swift in Sources */,
 				CAA9ADC824465D950003A984 /* 02-Effects-CancellationTests.swift in Sources */,
 				CA410EE2247C73B400E41798 /* 02-Effects-WebSocketTests.swift in Sources */,
+				CABC4F3B26AEE20200D5FA2C /* 02-Effects-RefreshableTests.swift in Sources */,
 				CA34170824A4E89500FAF950 /* 01-GettingStarted-AnimationsTests.swift in Sources */,
 				CA0C0C4724B89BEC00CBDD8A /* 04-HigherOrderReducers-LifecycleTests.swift in Sources */,
 				DC07231724465D1E003A8B65 /* 02-Effects-TimersTests.swift in Sources */,

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
@@ -27,6 +27,7 @@ struct RootState {
   var nested = NestedState.mock
   var optionalBasics = OptionalBasicsState()
   var presentAndLoad = PresentAndLoadState()
+  var refreshable = RefreshableState()
   var shared = SharedState()
   var timers = TimersState()
   var twoCounters = TwoCountersState()
@@ -57,6 +58,7 @@ enum RootAction {
   case optionalBasics(OptionalBasicsAction)
   case onAppear
   case presentAndLoad(PresentAndLoadAction)
+  case refreshable(RefreshableAction)
   case shared(SharedStateAction)
   case timers(TimersAction)
   case twoCounters(TwoCountersAction)
@@ -236,6 +238,14 @@ let rootReducer = Reducer<RootState, RootAction, RootEnvironment>.combine(
       state: \.presentAndLoad,
       action: /RootAction.presentAndLoad,
       environment: { .init(mainQueue: $0.mainQueue) }
+    ),
+  refreshableReducer
+    .pullback(
+      state: \.refreshable,
+      action: /RootAction.refreshable,
+      environment: {
+        .init(fact: $0.fact, mainQueue: $0.mainQueue)
+      }
     ),
   sharedStateReducer
     .pullback(

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -122,6 +122,16 @@ struct RootView: View {
             )
 
             NavigationLink(
+              "Refreshable",
+              destination: RefreshableView(
+                store: self.store.scope(
+                  state: \.refreshable,
+                  action: RootAction.refreshable
+                )
+              )
+            )
+
+            NavigationLink(
               "Timers",
               destination: TimersView(
                 store: self.store.scope(

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -121,6 +121,7 @@ struct RootView: View {
               )
             )
 
+            #if compiler(>=5.5)
             NavigationLink(
               "Refreshable",
               destination: RefreshableView(
@@ -130,6 +131,7 @@ struct RootView: View {
                 )
               )
             )
+            #endif
 
             NavigationLink(
               "Timers",

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -6,8 +6,8 @@ private var readMe = """
   Architecture. Use the "-" and "+" buttons to count up and down, and then pull down to request \
   a fact about that number.
 
-  There is an overload of the `.send` method that allows you to suspend and await until a piece \
-  of state changes to true. You can use this method to communicate to SwiftUI that you are \
+  There is an overload of the `.send` method that allows you to suspend and await while a piece \
+  of state is true. You can use this method to communicate to SwiftUI that you are \
   currently fetching data so that it knows to continue showing the loading indicator.
   """
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -104,7 +104,6 @@ struct RefreshableView: View {
     }
   }
 }
-#endif
 
 struct Refreshable_Previews: PreviewProvider {
   static var previews: some View {
@@ -120,3 +119,4 @@ struct Refreshable_Previews: PreviewProvider {
     )
   }
 }
+#endif

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -72,6 +72,7 @@ let refreshableReducer = Reducer<
   }
 }
 
+#if compiler(>=5.5)
 struct RefreshableView: View {
   let store: Store<RefreshableState, RefreshableAction>
 
@@ -103,6 +104,7 @@ struct RefreshableView: View {
     }
   }
 }
+#endif
 
 struct Refreshable_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -1,0 +1,120 @@
+import ComposableArchitecture
+import SwiftUI
+
+private var readMe = """
+  This application demonstrates how to make use of SwiftUI's `refreshable` API in the Composable \
+  Architecture. Use the "-" and "+" buttons to count up and down, and then pull down to request \
+  a fact about that number.
+
+  There is an overload of the `.send` method that allows you to suspend and await until a piece \
+  of state changes to true. You can use this method to communicate to SwiftUI that you are \
+  currently fetching data so that it knows to continue showing the loading indicator.
+  """
+
+struct RefreshableState: Equatable {
+  var count = 0
+  var fact: String?
+  var isLoading = false
+}
+
+enum RefreshableAction: Equatable {
+  case cancelButtonTapped
+  case decrementButtonTapped
+  case factResponse(Result<String, FactClient.Error>)
+  case incrementButtonTapped
+  case refresh
+}
+
+struct RefreshableEnvironment {
+  var fact: FactClient
+  var mainQueue: AnySchedulerOf<DispatchQueue>
+}
+
+let refreshableReducer = Reducer<
+  RefreshableState,
+  RefreshableAction,
+  RefreshableEnvironment
+> { state, action, environment in
+
+  struct CancelId: Hashable {}
+
+  switch action {
+  case .cancelButtonTapped:
+    state.isLoading = false
+    return .cancel(id: CancelId())
+
+  case .decrementButtonTapped:
+    state.count -= 1
+    return .none
+
+  case let .factResponse(.success(fact)):
+    state.isLoading = false
+    state.fact = fact
+    return .none
+
+  case .factResponse(.failure):
+    state.isLoading = false
+    // TODO: do some error handling
+    return .none
+
+  case .incrementButtonTapped:
+    state.count += 1
+    return .none
+
+  case .refresh:
+    state.fact = nil
+    state.isLoading = true
+    return environment.fact.fetch(state.count)
+      .delay(for: .seconds(2), scheduler: environment.mainQueue.animation())
+      .catchToEffect()
+      .map(RefreshableAction.factResponse)
+      .cancellable(id: CancelId())
+  }
+}
+
+struct RefreshableView: View {
+  let store: Store<RefreshableState, RefreshableAction>
+
+  var body: some View {
+    WithViewStore(self.store) { viewStore in
+      List {
+        Text(template: readMe, .body)
+
+        HStack {
+          Button("-") { viewStore.send(.decrementButtonTapped) }
+          Text("\(viewStore.count)")
+          Button("+") { viewStore.send(.incrementButtonTapped) }
+        }
+        .buttonStyle(.plain)
+
+        if let fact = viewStore.fact {
+          Text(fact)
+            .bold()
+        }
+        if viewStore.isLoading {
+          Button("Cancel") {
+            viewStore.send(.cancelButtonTapped, animation: .default)
+          }
+        }
+      }
+      .refreshable {
+        await viewStore.send(.refresh, while: \.isLoading)
+      }
+    }
+  }
+}
+
+struct Refreshable_Previews: PreviewProvider {
+  static var previews: some View {
+    RefreshableView(
+      store: .init(
+        initialState: .init(),
+        reducer: refreshableReducer,
+        environment: .init(
+          fact: .live,
+          mainQueue: .main
+        )
+      )
+    )
+  }
+}

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-RefreshableTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-RefreshableTests.swift
@@ -1,0 +1,72 @@
+import ComposableArchitecture
+import XCTest
+
+@testable import SwiftUICaseStudies
+
+class RefreshableTests: XCTestCase {
+  func testHappyPath() {
+    let store = TestStore(
+      initialState: .init(),
+      reducer: refreshableReducer,
+      environment: .init(
+        fact: .init { .init(value: "\($0) is a good number.") },
+        mainQueue: .immediate
+      )
+    )
+
+    store.send(.incrementButtonTapped) {
+      $0.count = 1
+    }
+    store.send(.refresh) {
+      $0.isLoading = true
+    }
+    store.receive(.factResponse(.success("1 is a good number."))) {
+      $0.isLoading = false
+      $0.fact = "1 is a good number."
+    }
+  }
+
+  func testUnhappyPath() {
+    let store = TestStore(
+      initialState: .init(),
+      reducer: refreshableReducer,
+      environment: .init(
+        fact: .init { _ in .init(error: .init()) },
+        mainQueue: .immediate
+      )
+    )
+
+    store.send(.incrementButtonTapped) {
+      $0.count = 1
+    }
+    store.send(.refresh) {
+      $0.isLoading = true
+    }
+    store.receive(.factResponse(.failure(.init()))) {
+      $0.isLoading = false
+    }
+  }
+
+  func testCancellation() {
+    let mainQueue = DispatchQueue.test
+
+    let store = TestStore(
+      initialState: .init(),
+      reducer: refreshableReducer,
+      environment: .init(
+        fact: .init { .init(value: "\($0) is a good number.") },
+        mainQueue: mainQueue.eraseToAnyScheduler()
+      )
+    )
+
+    store.send(.incrementButtonTapped) {
+      $0.count = 1
+    }
+    store.send(.refresh) {
+      $0.isLoading = true
+    }
+    store.send(.cancelButtonTapped) {
+      $0.isLoading = false
+    }
+  }
+}

--- a/Sources/ComposableArchitecture/Beta/Concurrency.swift
+++ b/Sources/ComposableArchitecture/Beta/Concurrency.swift
@@ -108,7 +108,8 @@ extension ViewStore {
 
   /// Suspends while a predicate on state is `true`.
   ///
-  ///   - predicate: A predicate on `State` that determines for how long this method should suspend.
+  /// - Parameter predicate: A predicate on `State` that determines for how long this method should
+  /// suspend.
   public func suspend(while predicate: @escaping (State) -> Bool) async {
     var cancellable: Cancellable?
     try? await withTaskCancellationHandler(

--- a/Sources/ComposableArchitecture/Experimental/Concurrency.swift
+++ b/Sources/ComposableArchitecture/Experimental/Concurrency.swift
@@ -1,0 +1,47 @@
+import Combine
+import SwiftUI
+
+#if compiler(>=5.5)
+  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+  extension ViewStore {
+    public func send(
+      _ action: Action,
+      while predicate: @escaping (State) -> Bool
+    ) async {
+      self.send(action)
+      await self.suspend(while: predicate)
+    }
+
+    public func send(
+      _ action: Action,
+      animation: Animation?,
+      while predicate: @escaping (State) -> Bool
+    ) async {
+      withAnimation(animation) { self.send(action) }
+      await self.suspend(while: predicate)
+    }
+
+    public func suspend(while predicate: @escaping (State) -> Bool) async {
+      var cancellable: Cancellable?
+      try? await withTaskCancellationHandler(
+        handler: { [cancellable] in cancellable?.cancel() },
+        operation: {
+          try Task.checkCancellation()
+          try await withUnsafeThrowingContinuation { (continuation: UnsafeContinuation<Void, Error>) in
+            guard !Task.isCancelled else {
+              continuation.resume(throwing: CancellationError())
+              return
+            }
+            cancellable = self.publisher
+              .filter { !predicate($0) }
+              .prefix(1)
+              .sink { _ in
+                continuation.resume()
+                _ = cancellable
+              }
+          }
+        }
+      )
+    }
+  }
+#endif

--- a/Sources/ComposableArchitecture/Experimental/Concurrency.swift
+++ b/Sources/ComposableArchitecture/Experimental/Concurrency.swift
@@ -4,10 +4,83 @@ import SwiftUI
 #if compiler(>=5.5)
 @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
 extension ViewStore {
-  /// <#Description#>
+  /// Sends an action into the store and then suspends while a piece of state is `true`.
+  ///
+  /// This method can be used to interact with async/await code, allowing you to suspend while work
+  /// is being performed in an effect. One common example of this is using SwiftUI's `.refreshable`
+  /// method, which shows a loading indicator on the screen while work is being performed.
+  ///
+  /// For example, suppose we wanted to load some data from the network when a pull-to-refresh
+  /// gesture is performed on a list. The domain and logic for this feature can be modeled like so:
+  ///
+  /// ```swift
+  /// struct State: Equatable {
+  ///   var isLoading = false
+  ///   var response: String?
+  /// }
+  ///
+  /// enum Action {
+  ///   case pulledToRefresh
+  ///   case receivedResponse(String?)
+  /// }
+  ///
+  /// struct Environment {
+  ///   var fetch: () -> Effect<String?, Never>
+  /// }
+  ///
+  /// let reducer = Reducer<State, Action, Environment> { state, action, environment in
+  ///   switch action {
+  ///   case .pulledToRefresh:
+  ///     state.isLoading = true
+  ///     return environment.fetch()
+  ///       .map(Action.receivedResponse)
+  ///
+  ///   case let .receivedResponse(responsne):
+  ///     state.isLoading = false
+  ///     state.response = response
+  ///     return .none
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Note that we keep track of an `isLoading` boolean in our state so that we know exactly when
+  /// the network response is being performed.
+  ///
+  /// The view can show the fact in a `List`, if it's present, and we can use the `.refreshable`
+  /// view modifier to enhance the list with pull-to-refresh capabilities:
+  ///
+  /// ```swift
+  /// struct MyView: View {
+  ///   let store: Store<State, Action>
+  ///
+  ///   var body: some View {
+  ///     WithViewStore(self.store) { viewStore in
+  ///       List {
+  ///         if let response = viewStore.response {
+  ///           Text(response)
+  ///         }
+  ///       }
+  ///       .refreshable {
+  ///         await viewStore.send(.pulledToRefresh, while: \.isLoading)
+  ///       }
+  ///     }
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Here we've used the ``send(_:while:)`` method to suspend while the `isLoading` state is
+  /// `true`. Once that piece of state flips back to `false` the method will resume, signaling to
+  /// `.refreshable` that the work has finished which will cause the loading indicator to disappear.
+  ///
+  /// **Note:** ``ViewStore`` is not thread safe and you should only send actions to it from the
+  /// main thread. If you are wanting to send actions on background threads due to the fact that the
+  /// reducer is performing computationally expensive work, then a better way to handle this is to
+  /// wrap that work in an ``Effect`` that is performed on a background thread so that the result
+  /// can be fed back into the store.
+  ///
   /// - Parameters:
-  ///   - action: <#action description#>
-  ///   - predicate: <#predicate description#>
+  ///   - action: An action.
+  ///   - predicate: A predicate on `State` that determines for how long this method should suspend.
   public func send(
     _ action: Action,
     while predicate: @escaping (State) -> Bool
@@ -16,6 +89,14 @@ extension ViewStore {
     await self.suspend(while: predicate)
   }
 
+  /// Sends an action into the store and then suspends while a piece of state is `true`.
+  ///
+  /// See the documentation of ``send(_:while:)`` for more information.
+  ///
+  /// - Parameters:
+  ///   - action: An action.
+  ///   - animation: The animation to perform when the action is sent.
+  ///   - predicate: A predicate on `State` that determines for how long this method should suspend.
   public func send(
     _ action: Action,
     animation: Animation?,
@@ -25,6 +106,9 @@ extension ViewStore {
     await self.suspend(while: predicate)
   }
 
+  /// Suspends while a predicate on state is `true`.
+  ///
+  ///   - predicate: A predicate on `State` that determines for how long this method should suspend.
   public func suspend(while predicate: @escaping (State) -> Bool) async {
     var cancellable: Cancellable?
     try? await withTaskCancellationHandler(

--- a/Sources/ComposableArchitecture/Experimental/Concurrency.swift
+++ b/Sources/ComposableArchitecture/Experimental/Concurrency.swift
@@ -2,46 +2,50 @@ import Combine
 import SwiftUI
 
 #if compiler(>=5.5)
-  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
-  extension ViewStore {
-    public func send(
-      _ action: Action,
-      while predicate: @escaping (State) -> Bool
-    ) async {
-      self.send(action)
-      await self.suspend(while: predicate)
-    }
-
-    public func send(
-      _ action: Action,
-      animation: Animation?,
-      while predicate: @escaping (State) -> Bool
-    ) async {
-      withAnimation(animation) { self.send(action) }
-      await self.suspend(while: predicate)
-    }
-
-    public func suspend(while predicate: @escaping (State) -> Bool) async {
-      var cancellable: Cancellable?
-      try? await withTaskCancellationHandler(
-        handler: { [cancellable] in cancellable?.cancel() },
-        operation: {
-          try Task.checkCancellation()
-          try await withUnsafeThrowingContinuation { (continuation: UnsafeContinuation<Void, Error>) in
-            guard !Task.isCancelled else {
-              continuation.resume(throwing: CancellationError())
-              return
-            }
-            cancellable = self.publisher
-              .filter { !predicate($0) }
-              .prefix(1)
-              .sink { _ in
-                continuation.resume()
-                _ = cancellable
-              }
-          }
-        }
-      )
-    }
+@available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+extension ViewStore {
+  /// <#Description#>
+  /// - Parameters:
+  ///   - action: <#action description#>
+  ///   - predicate: <#predicate description#>
+  public func send(
+    _ action: Action,
+    while predicate: @escaping (State) -> Bool
+  ) async {
+    self.send(action)
+    await self.suspend(while: predicate)
   }
+
+  public func send(
+    _ action: Action,
+    animation: Animation?,
+    while predicate: @escaping (State) -> Bool
+  ) async {
+    withAnimation(animation) { self.send(action) }
+    await self.suspend(while: predicate)
+  }
+
+  public func suspend(while predicate: @escaping (State) -> Bool) async {
+    var cancellable: Cancellable?
+    try? await withTaskCancellationHandler(
+      handler: { [cancellable] in cancellable?.cancel() },
+      operation: {
+        try Task.checkCancellation()
+        try await withUnsafeThrowingContinuation { (continuation: UnsafeContinuation<Void, Error>) in
+          guard !Task.isCancelled else {
+            continuation.resume(throwing: CancellationError())
+            return
+          }
+          cancellable = self.publisher
+            .filter { !predicate($0) }
+            .prefix(1)
+            .sink { _ in
+              continuation.resume()
+              _ = cancellable
+            }
+        }
+      }
+    )
+  }
+}
 #endif


### PR DESCRIPTION
Based on the work in the [most recent](https://www.pointfree.co/episodes/ep154-async-refreshable-composable-architecture) Point-Free episode, we are introducing _beta_ support for an async/await aware `.send` method. This API could change in the future with future Xcode betas, so use with caution 🙂.

This method allows you to send an action into the store and the suspend while some piece of boolean state is `true`. This can be particularly handy for interfacing with SwiftUI's new `.refreshable` API:

```swift
.refreshable { 
  await viewStore.send(.pulledToRefresh, while: \.isLoading)
}
```