### PR TITLE
Update swift-format for Swift 5.5

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,7 +3,7 @@ name: Format
 on:
   push:
     branches:
-      - '*'
+      - main
 
 jobs:
   swift_format:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Tap
         run: brew tap pointfreeco/formulae
       - name: Install
-        run: brew install Formulae/swift-format@latest
+        run: brew install Formulae/swift-format
       - name: Format
         run: make format
       - uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,18 +3,20 @@ name: Format
 on:
   push:
     branches:
-      - main
+      - '*'
 
 jobs:
   swift_format:
     name: swift-format
-    runs-on: macOS-latest
+    runs-on: macOS-11
     steps:
       - uses: actions/checkout@v2
+      - name: Xcode Select
+        run: sudo xcode-select -s /Applications/Xcode_13.0.app
       - name: Tap
         run: brew tap pointfreeco/formulae
       - name: Install
-        run: brew install Formulae/swift-format@5.3
+        run: brew install Formulae/swift-format@latest
       - name: Format
         run: make format
       - uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Tap
         run: brew tap pointfreeco/formulae
       - name: Install
-        run: brew install Formulae/swift-format
+        run: brew install Formulae/swift-format@5.5
       - name: Format
         run: make format
       - uses: stefanzweifel/git-auto-commit-action@v4

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -99,8 +99,7 @@ let refreshableReducer = Reducer<
           }
         }
         .refreshable {
-          await
-          viewStore.send(.refresh, while: \.isLoading)
+          await viewStore.send(.refresh, while: \.isLoading)
         }
       }
     }


### PR DESCRIPTION
Ha looks like @allevato was preparing a branch at the same time we were looking at this yesterday: https://forums.swift.org/t/support-for-swift-format-on-xcode-beta-13-0b1/50205/3

The GitHub action on the previous commit was successful (other than the final commit to the `main` branch), so this should be good to merge!