### PR TITLE
Fix build error when minimum target is macOS 11.0

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -362,7 +362,7 @@ extension Publisher {
   ) -> Effect<NewOutput, NewFailure> {
     return
       self
-      .flatMap { _ in Empty() }
+      .flatMap { _ in Empty<NewOutput, Failure>() }
       .catch { _ in Empty() }
       .eraseToEffect()
   }


### PR DESCRIPTION
macOS 11.0 introduced an overload of Publisher.flatMap(maxPublishers:_:)
for when the failure type is Never, documented here:
https://developer.apple.com/documentation/combine/publisher/flatmap(maxpublishers:_:)-qxf

This causes a compiler error in Effect.fireAndForget when the minimum
deployment target is 11.0 or later:

    Sources/ComposableArchitecture/Effect.swift:364:7: error: ambiguous use of 'flatMap(maxPublishers:_:)'
          self
          ^
    Combine.Publisher:3:17: note: found this candidate
        public func flatMap<T, P>(maxPublishers: Subscribers.Demand = .unlimited, _ transform: @escaping (Self.Output) -> P) -> Publishers.FlatMap<P, Self> where T == P.Output, P : Publisher, Self.Failure == P.Failure
                    ^
    Combine.Publisher:3:17: note: found this candidate
        public func flatMap<P>(maxPublishers: Subscribers.Demand = .unlimited, _ transform: @escaping (Self.Output) -> P) -> Publishers.FlatMap<Publishers.SetFailureType<P, Self.Failure>, Self> where P : Publisher, P.Failure == Never
                    ^

We can fix this by adding explicit type parameters to the Empty
publisher used in the flatMap().