### PR TITLE
Expose `Store`'s current state snapshot

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -121,6 +121,9 @@ public final class Store<State, Action> {
   private let reducer: (inout State, Action) -> Effect<Action, Never>
   private var bufferedActions: [Action] = []
 
+  /// The current state.
+  public var currentState: State { state.value }
+
   /// Initializes a store from an initial state, a reducer, and an environment.
   ///
   /// - Parameters:

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -6,6 +6,15 @@ import XCTest
 final class StoreTests: XCTestCase {
   var cancellables: Set<AnyCancellable> = []
 
+  func testCurrentStateEqualsState() {
+    let reducer = Reducer<Double, Void, Void> { _, _, _ in .none }
+    let store = Store(initialState: .pi, reducer: reducer, environment: ())
+
+    XCTAssertEqual(store.currentState, store.state.value)
+    store.state.value = 2 * .pi
+    XCTAssertEqual(store.currentState, store.state.value)
+  }
+
   func testCancellableIsRemovedOnImmediatelyCompletingEffect() {
     let reducer = Reducer<Void, Void, Void> { _, _, _ in .none }
     let store = Store(initialState: (), reducer: reducer, environment: ())


### PR DESCRIPTION
## Motivation

Unlike `Reducer.run` which allows deriving custom third party reducers from existing ones, `Store` doesn't give as much flexibility to create custom third party operators based on `scope` that often require access to the current (initial/snapshot) state.

This is caused by `Store` not exposing its current state publicly as a read-only property. To work around this, devs resort to wrapping the store in a `ViewStore` to have access to its current (initial/snapshot) state first, to then build upon `scope` and use it as needed. This is obviously not ideal.

By creating a `Store.currentState` read-only computed property that wraps `Store.state`, this restriction is lifted. This way, wrapping `ViewStore` is no longer necessary, which makes creating third party scoping operators more straightforward and ergonomic. In terms of `Store.state` encapsulation, I think it should be essentially equivalent to `ViewStore(self).state`, so I don't foresee any concerning differences unless I'm missing something.

**PS:**

For consistency's sake, I think that the `Store`'s public state property should be `state`, and it's `private`/`internal` one `_state`. I didn't make that change because I wanted the "idea" to be reviewed first before increasing changes. Will gladly make that change if you agree with this addition (and the rename).

## Examples

This change will reduce friction when creating custom scoping operators, which is especially frequent for those of us still using TCA with UIKit 😭. Furthermore, it avoids having to increase API surface in TCA, which understandably you want to be very careful with.

Such examples include:

`Store.child` (from #533)
```swift
public func child<LocalState, LocalAction, ID>(
  id: ID,
  state toLocalStateContainer: @escaping (State) -> IdentifiedArray<ID, LocalState>,
  action fromLocalAction: @escaping (ID, LocalAction) -> Action
) -> Store<LocalState, LocalAction> {
  let scopedStore = scope(state: toLocalStateContainer)

  // NB: We cache current element here to avoid a crash where UIKit may re-evaluate the store
  //     following item deletion in table/collection views.
  let element = scopedStore.state.value[id: id]! // <-- can now use `scopedStore.currentState`
  
  return scopedStore.scope(
    state: { $0[id: id] ?? element },
    action: { fromLocalAction(id, $0) }
  )
}
```

`Store.forEach` (from this [comment](https://github.com/pointfreeco/swift-composable-architecture/discussions/351#discussioncomment-312688) in #351)
```swift
public func forEach<LocalState: Equatable, LocalAction>(
  state: @escaping (State) -> [LocalState],
  action: @escaping ((Int, LocalAction)) -> Action
) -> [Store<LocalState, LocalAction>] {
  let scopedStore = scope(state: state)
  let viewStore = ViewStore(scopedStore) // <-- can now use `scopedStore.currentState`
  let localStores = zip(viewStore.indices, viewStore.state).map { index, element in
    scopedStore.scope(
      state: { index < $0.endIndex ? $0[index] : element },
      action: { action((index, $0)) }
    )
  }
  return localStores
}
```

Unfortunately, a similar scenario happens almost every time when trying to implement custom scoping operators, because initial state is often required. 

## Changes

- Add new `Store.currentState` computed property that wraps `Store.state`.