### PR TITLE
Also run CI on Big Sur

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         xcode:
-          - 13.0
+          - '13.0'
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode ${{ matrix.xcode }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,21 @@ jobs:
         if: ${{ matrix.xcode != 11.3 }}
         run: make benchmark
 
+  library-beta:
+    runs-on: macos-11.0
+    strategy:
+      matrix:
+        xcode:
+          - 13.0
+    steps:
+      - uses: actions/checkout@v2
+      - name: Select Xcode ${{ matrix.xcode }}
+        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+      - name: Run tests
+        run: make test-library
+      - name: Run benchmark
+        run: make benchmark
+
   examples:
     runs-on: macos-10.15
     strategy:
@@ -37,17 +52,3 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Run tests
         run: make test-examples
-
-# NB: GitHub's Big Sur instances are super flaky. We should revisit later.
-#   bigsur-tests:
-#     runs-on: macos-11.0
-#     strategy:
-#       matrix:
-#         xcode:
-#           - 12.4
-#     steps:
-#       - uses: actions/checkout@v2
-#       - name: Select Xcode ${{ matrix.xcode }}
-#         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
-#       - name: Run tests
-#         run: make test

--- a/Tests/ComposableArchitectureTests/ViewStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/ViewStoreTests.swift
@@ -138,7 +138,7 @@ final class ViewStoreTests: XCTestCase {
   }
 
   #if compiler(>=5.5)
-    @available(iOS 15, *)
+    @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
     func testSendWhile() async {
       enum Action {
         case response
@@ -165,7 +165,7 @@ final class ViewStoreTests: XCTestCase {
       XCTAssertEqual(viewStore.state, false)
     }
 
-    @available(iOS 15, *)
+    @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
     func testSuspend() async {
       enum Action {
         case response

--- a/Tests/ComposableArchitectureTests/ViewStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/ViewStoreTests.swift
@@ -138,60 +138,72 @@ final class ViewStoreTests: XCTestCase {
   }
 
   #if compiler(>=5.5)
-    @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
-    func testSendWhile() async {
-      enum Action {
-        case response
-        case tapped
-      }
-      let reducer = Reducer<Bool, Action, Void> { state, action, environment in
-        switch action {
-        case .response:
-          state = false
-          return .none
-        case .tapped:
-          state = true
-          return Effect(value: .response)
-            .receive(on: DispatchQueue.main)
-            .eraseToEffect()
+    func testSendWhile() {
+      guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else { return }
+
+      let expectation = self.expectation(description: "await")
+      Task { @MainActor in
+        enum Action {
+          case response
+          case tapped
         }
+        let reducer = Reducer<Bool, Action, Void> { state, action, environment in
+          switch action {
+          case .response:
+            state = false
+            return .none
+          case .tapped:
+            state = true
+            return Effect(value: .response)
+              .receive(on: DispatchQueue.main)
+              .eraseToEffect()
+          }
+        }
+
+        let store = Store(initialState: false, reducer: reducer, environment: ())
+        let viewStore = ViewStore(store)
+
+        XCTAssertEqual(viewStore.state, false)
+        await viewStore.send(.tapped, while: { $0 })
+        XCTAssertEqual(viewStore.state, false)
+        expectation.fulfill()
       }
-
-      let store = Store(initialState: false, reducer: reducer, environment: ())
-      let viewStore = ViewStore(store)
-
-      XCTAssertEqual(viewStore.state, false)
-      await viewStore.send(.tapped, while: { $0 })
-      XCTAssertEqual(viewStore.state, false)
+      self.wait(for: [expectation], timeout: 1)
     }
 
-    @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
-    func testSuspend() async {
-      enum Action {
-        case response
-        case tapped
-      }
-      let reducer = Reducer<Bool, Action, Void> { state, action, environment in
-        switch action {
-        case .response:
-          state = false
-          return .none
-        case .tapped:
-          state = true
-          return Effect(value: .response)
-            .receive(on: DispatchQueue.main)
-            .eraseToEffect()
+    func testSuspend() {
+      guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else { return }
+
+      let expectation = self.expectation(description: "await")
+      Task { @MainActor in
+        enum Action {
+          case response
+          case tapped
         }
+        let reducer = Reducer<Bool, Action, Void> { state, action, environment in
+          switch action {
+          case .response:
+            state = false
+            return .none
+          case .tapped:
+            state = true
+            return Effect(value: .response)
+              .receive(on: DispatchQueue.main)
+              .eraseToEffect()
+          }
+        }
+
+        let store = Store(initialState: false, reducer: reducer, environment: ())
+        let viewStore = ViewStore(store)
+
+        XCTAssertEqual(viewStore.state, false)
+        viewStore.send(.tapped)
+        XCTAssertEqual(viewStore.state, true)
+        await viewStore.suspend(while: { $0 })
+        XCTAssertEqual(viewStore.state, false)
+        expectation.fulfill()
       }
-
-      let store = Store(initialState: false, reducer: reducer, environment: ())
-      let viewStore = ViewStore(store)
-
-      XCTAssertEqual(viewStore.state, false)
-      viewStore.send(.tapped)
-      XCTAssertEqual(viewStore.state, true)
-      await viewStore.suspend(while: { $0 })
-      XCTAssertEqual(viewStore.state, false)
+      self.wait(for: [expectation], timeout: 1)
     }
   #endif
 }


### PR DESCRIPTION
I think the runners have gotten more reliable (we use it for swift-format), so let's start running CI against macOS 11 and Xcode 13.