### PR TITLE
Clarify view store thread safety

### DIFF
--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -47,9 +47,9 @@ import SwiftUI
 ///
 /// ### Thread safety
 ///
-/// The ``ViewStore`` class is not thread-safe, and all interactions with it must happen on the main
-/// thread. See the documentation of the ``Store`` class for more information why this decision was
-/// made.
+/// The ``ViewStore`` class is not thread-safe, and all interactions with it must happen on the same
+/// thread its store runs on, which is typically the main thread for UI-based applications. See the
+/// documentation of the ``Store`` class for more information why this decision was made.
 @dynamicMemberLookup
 public final class ViewStore<State, Action>: ObservableObject {
   // N.B. `ViewStore` does not use a `@Published` property, so `objectWillChange`

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -49,7 +49,7 @@ import SwiftUI
 ///
 /// The ``ViewStore`` class is not thread-safe, and all interactions with it must happen on the same
 /// thread its store runs on, which is typically the main thread for UI-based applications. See the
-/// documentation of the ``Store`` class for more information why this decision was made.
+/// documentation of the ``Store`` class for more information as to why this decision was made.
 @dynamicMemberLookup
 public final class ViewStore<State, Action>: ObservableObject {
   // N.B. `ViewStore` does not use a `@Published` property, so `objectWillChange`

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -47,9 +47,10 @@ import SwiftUI
 ///
 /// ### Thread safety
 ///
-/// The ``ViewStore`` class is not thread-safe, and all interactions with it must happen on the same
-/// thread its store runs on, which is typically the main thread for UI-based applications. See the
-/// documentation of the ``Store`` class for more information as to why this decision was made.
+/// The ``ViewStore`` class is not thread-safe, and all interactions with it (and the store it was
+/// derived from) must happen on the same thread. Further, for SwiftUI applications, all
+/// interactions must happen on _main_ thread. See the documentation of the ``Store`` class for more
+/// information as to why this decision was made.
 @dynamicMemberLookup
 public final class ViewStore<State, Action>: ObservableObject {
   // N.B. `ViewStore` does not use a `@Published` property, so `objectWillChange`

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -49,8 +49,8 @@ import SwiftUI
 ///
 /// The ``ViewStore`` class is not thread-safe, and all interactions with it (and the store it was
 /// derived from) must happen on the same thread. Further, for SwiftUI applications, all
-/// interactions must happen on _main_ thread. See the documentation of the ``Store`` class for more
-/// information as to why this decision was made.
+/// interactions must happen on the _main_ thread. See the documentation of the ``Store`` class for
+/// more information as to why this decision was made.
 @dynamicMemberLookup
 public final class ViewStore<State, Action>: ObservableObject {
   // N.B. `ViewStore` does not use a `@Published` property, so `objectWillChange`


### PR DESCRIPTION
In #689 @p4checo brings up the fact that the view store documentation says it should only be interacted with on the main thread, when this isn't _quite_ the full story. Here's an idea for clarifying that.