### PR TITLE
Don't run testNestedDump on beta.

### DIFF
--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -248,6 +248,7 @@ final class DebugTests: XCTestCase {
     )
   }
 
+  #if compiler(<5.5)
   func testNestedDump() {
     struct User {
       var id: UUID
@@ -328,6 +329,7 @@ final class DebugTests: XCTestCase {
       """
     )
   }
+  #endif
 
   func testRecursiveOutput() {
     class Foo {


### PR DESCRIPTION
We can delete this once we release the new stuff.