### PR TITLE
Add `catchToEffect()` with mapping function

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -340,6 +340,34 @@ extension Publisher {
       .eraseToEffect()
   }
 
+  /// Turns any publisher into an ``Effect`` that cannot fail by wrapping its output and failure into
+  /// result and then applying passed in function to it.
+  ///
+  /// This is a convenience operator for writing `catchToEffect()` followed by a `map()` .
+  ///
+  /// ```swift
+  /// case .buttonTapped:
+  ///   return fetchUser(id: 1)
+  ///     .catchToEffect {
+  ///       switch $0 {
+  ///       case let .success(response):
+  ///         return ProfileAction.updatedUser(response)
+  ///       case let .failure(error):
+  ///         return ProfileAction.failedUserUpdate(error)
+  ///       }
+  ///     }
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - f: A mapping function that converts `Result<Output,Failure>` to another type.
+  /// - Returns: An effect that wraps `self`.
+  public func catchToEffect<T>(_ f: @escaping (Result<Output,Failure>) -> T) -> Effect<T,Never> {
+    self
+      .catchToEffect()
+      .map(f)
+      .eraseToEffect()
+  }
+
   /// Turns any publisher into an ``Effect`` for any output and failure type by ignoring all output
   /// and any failure.
   ///

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -24,6 +24,30 @@ final class EffectTests: XCTestCase {
       .eraseToEffect()
       .sink { XCTAssertEqual($0, 42) }
       .store(in: &self.cancellables)
+
+    Future<Int, Error> { $0(.success(42)) }
+        .catchToEffect {
+            switch $0 {
+            case let .success(val):
+                return val
+            case .failure:
+                return -1
+            }
+        }
+        .sink { XCTAssertEqual($0, 42) }
+        .store(in: &self.cancellables)
+
+    Future<Int, Error> { $0(.failure(Error())) }
+        .catchToEffect {
+            switch $0 {
+            case let .success(val):
+                return val
+            case .failure:
+                return -1
+            }
+        }
+        .sink { XCTAssertEqual($0, -1) }
+        .store(in: &self.cancellables)
   }
 
   func testConcatenate() {


### PR DESCRIPTION
This PR adds a `catchToEffect<T>(_ f: @escaping (Result<Output,Failure>) -> T)` which basically is a `catchToEffect` followed by a map function:

given:

```swift
enum StateAction {
  case opSuccess(OpValue)
  case opFailure(Error)
}
```

then you can do this:

```swift
case .doSomething:
  return env.doingSomething()
    .catchToEffect {
      switch $0 {
      case let .success(value):
        return .opSuccess(value)
      case let .failure(error):
        return .opFailure(error)
      }
    }
```

Since `catchToEffect()` with map is (usually?) used to map result to state actions, there is a place for a shorter operator that accepts action enum cases with associated values that map directly to `Output` and `Failure` types:

```swift
...
case .doSomething:
  return env.doingSomething()
    .catchToEffect(StateAction.opSuccess, StateAction.opFailure)
```

But this is not included in this PR. Given the need - new one can be created.