### PR TITLE
WithViewStore debug state diffs

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -160,71 +160,69 @@ extension WithViewStore: DynamicViewContent where State: Collection, Content: Dy
   }
 }
 
-#if compiler(>=5.3)
-  @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
-  extension WithViewStore: Scene where Content: Scene {
-    /// Initializes a structure that transforms a store into an observable view store in order to
-    /// compute views from store state.
-    ///
-    /// - Parameters:
-    ///   - store: A store.
-    ///   - isDuplicate: A function to determine when two `State` values are equal. When values are
-    ///     equal, repeat view computations are removed,
-    ///   - content: A function that can generate content from a view store.
-    public init(
-      _ store: Store<State, Action>,
-      removeDuplicates isDuplicate: @escaping (State, State) -> Bool,
-      file: StaticString = #fileID,
-      line: UInt = #line,
-      @SceneBuilder content: @escaping (ViewStore<State, Action>) -> Content
-    ) {
-      self.init(
-        store: store,
-        removeDuplicates: isDuplicate,
-        file: file,
-        line: line,
-        content: content
-      )
-    }
-
-    public var body: Content {
-      self._body
-    }
+@available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
+extension WithViewStore: Scene where Content: Scene {
+  /// Initializes a structure that transforms a store into an observable view store in order to
+  /// compute views from store state.
+  ///
+  /// - Parameters:
+  ///   - store: A store.
+  ///   - isDuplicate: A function to determine when two `State` values are equal. When values are
+  ///     equal, repeat view computations are removed,
+  ///   - content: A function that can generate content from a view store.
+  public init(
+    _ store: Store<State, Action>,
+    removeDuplicates isDuplicate: @escaping (State, State) -> Bool,
+    file: StaticString = #fileID,
+    line: UInt = #line,
+    @SceneBuilder content: @escaping (ViewStore<State, Action>) -> Content
+  ) {
+    self.init(
+      store: store,
+      removeDuplicates: isDuplicate,
+      file: file,
+      line: line,
+      content: content
+    )
   }
 
-  @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
-  extension WithViewStore where State: Equatable, Content: Scene {
-    /// Initializes a structure that transforms a store into an observable view store in order to
-    /// compute scenes from equatable store state.
-    ///
-    /// - Parameters:
-    ///   - store: A store of equatable state.
-    ///   - content: A function that can generate content from a view store.
-    public init(
-      _ store: Store<State, Action>,
-      file: StaticString = #fileID,
-      line: UInt = #line,
-      @SceneBuilder content: @escaping (ViewStore<State, Action>) -> Content
-    ) {
-      self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
-    }
+  public var body: Content {
+    self._body
   }
+}
 
-  @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
-  extension WithViewStore where State == Void, Content: Scene {
-    /// Initializes a structure that transforms a store into an observable view store in order to
-    /// compute scenes from equatable store state.
-    ///
-    /// - Parameters:
-    ///   - store: A store of equatable state.
-    ///   - content: A function that can generate content from a view store.
-    public init(
-      _ store: Store<State, Action>,
-      file: StaticString = #fileID,
-      line: UInt = #line,
-      @SceneBuilder content: @escaping (ViewStore<State, Action>) -> Content
-    ) {
-      self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
-    }
+@available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
+extension WithViewStore where State: Equatable, Content: Scene {
+  /// Initializes a structure that transforms a store into an observable view store in order to
+  /// compute scenes from equatable store state.
+  ///
+  /// - Parameters:
+  ///   - store: A store of equatable state.
+  ///   - content: A function that can generate content from a view store.
+  public init(
+    _ store: Store<State, Action>,
+    file: StaticString = #fileID,
+    line: UInt = #line,
+    @SceneBuilder content: @escaping (ViewStore<State, Action>) -> Content
+  ) {
+    self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
   }
-#endif
+}
+
+@available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
+extension WithViewStore where State == Void, Content: Scene {
+  /// Initializes a structure that transforms a store into an observable view store in order to
+  /// compute scenes from equatable store state.
+  ///
+  /// - Parameters:
+  ///   - store: A store of equatable state.
+  ///   - content: A function that can generate content from a view store.
+  public init(
+    _ store: Store<State, Action>,
+    file: StaticString = #fileID,
+    line: UInt = #line,
+    @SceneBuilder content: @escaping (ViewStore<State, Action>) -> Content
+  ) {
+    self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
+  }
+}

--- a/Tests/ComposableArchitectureTests/WithViewStoreAppTest.swift
+++ b/Tests/ComposableArchitectureTests/WithViewStoreAppTest.swift
@@ -3,38 +3,36 @@
 import ComposableArchitecture
 import SwiftUI
 
-#if compiler(>=5.3)
-  @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
-  struct TestApp: App {
-    let store = Store(
-      initialState: 0,
-      reducer: Reducer<Int, Void, Void> { state, _, _ in
-        state += 1
-        return .none
-      },
-      environment: ()
-    )
-
-    var body: some Scene {
-      WithViewStore(self.store) { viewStore in
-        #if os(iOS) || os(macOS)
-          WindowGroup {
-            EmptyView()
-          }
-          .commands {
-            CommandMenu("Commands") {
-              Button("Increment") {
-                viewStore.send(())
-              }
-              .keyboardShortcut("+")
-            }
-          }
-        #else
-          WindowGroup {
-            EmptyView()
-          }
-        #endif
+@available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
+struct TestApp: App {
+  let store = Store(
+    initialState: 0,
+    reducer: Reducer<Int, Void, Void> { state, _, _ in
+      state += 1
+      return .none
+    },
+    environment: ()
+  )
+  
+  var body: some Scene {
+    WithViewStore(self.store) { viewStore in
+#if os(iOS) || os(macOS)
+      WindowGroup {
+        EmptyView()
       }
+      .commands {
+        CommandMenu("Commands") {
+          Button("Increment") {
+            viewStore.send(())
+          }
+          .keyboardShortcut("+")
+        }
+      }
+#else
+      WindowGroup {
+        EmptyView()
+      }
+#endif
     }
   }
-#endif
+}


### PR DESCRIPTION
This makes a few improvements to `WithViewStore.debug()`:

- Shows a state diff alongside the existing console emission. The diff should hopefully help folks see when a view is observing too much state.
- Improves the formatting of the `State` and `Action` generics to include any types they may be nested in.
- Adds `file`/`line` number for additional context.

As an example, when added to Tic-Tac-Toe's `LoginView`:

```
WithViewStore<LoginView.ViewState, LoginView.ViewAction, _>@LoginSwiftUI/LoginView.swift:44 (Initial state)
  ViewState(
    alert: nil,
    email: "",
    isActivityIndicatorVisible: false,
    isFormDisabled: false,
    isLoginButtonDisabled: true,
    password: "",
    isTwoFactorActive: false
  )
WithViewStore<LoginView.ViewState, LoginView.ViewAction, _>@LoginSwiftUI/LoginView.swift:44 (Changed state)
  ViewState(
    alert: nil,
−   email: "",
+   email: "b",
    isActivityIndicatorVisible: false,
    isFormDisabled: false,
    isLoginButtonDisabled: true,
    password: "",
    isTwoFactorActive: false
  )
```