### PR TITLE
Convert #file to #fileID for debug purposes

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -46,7 +46,7 @@ extension Reducer {
     action toLocalAction: CasePath<GlobalAction, (Int, Action)>,
     environment toLocalEnvironment: @escaping (GlobalEnvironment) -> Environment,
     breakpointOnNil: Bool = true,
-    _ file: StaticString = #file,
+    _ file: StaticString = #fileID,
     _ line: UInt = #line
   ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
     .init { globalState, globalAction, globalEnvironment in

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -463,7 +463,7 @@ public struct Reducer<State, Action, Environment> {
     action toLocalAction: CasePath<GlobalAction, Action>,
     environment toLocalEnvironment: @escaping (GlobalEnvironment) -> Environment,
     breakpointOnNil: Bool = true,
-    _ file: StaticString = #file,
+    _ file: StaticString = #fileID,
     _ line: UInt = #line
   ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
     .init { globalState, globalAction, globalEnvironment in
@@ -672,7 +672,7 @@ public struct Reducer<State, Action, Environment> {
   /// - Returns: A reducer that works on optional state.
   public func optional(
     breakpointOnNil: Bool = true,
-    _ file: StaticString = #file,
+    _ file: StaticString = #fileID,
     _ line: UInt = #line
   ) -> Reducer<
     State?, Action, Environment
@@ -757,7 +757,7 @@ public struct Reducer<State, Action, Environment> {
     action toLocalAction: CasePath<GlobalAction, (ID, Action)>,
     environment toLocalEnvironment: @escaping (GlobalEnvironment) -> Environment,
     breakpointOnNil: Bool = true,
-    _ file: StaticString = #file,
+    _ file: StaticString = #fileID,
     _ line: UInt = #line
   ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
     .init { globalState, globalAction, globalEnvironment in
@@ -828,7 +828,7 @@ public struct Reducer<State, Action, Environment> {
     action toLocalAction: CasePath<GlobalAction, (Key, Action)>,
     environment toLocalEnvironment: @escaping (GlobalEnvironment) -> Environment,
     breakpointOnNil: Bool = true,
-    _ file: StaticString = #file,
+    _ file: StaticString = #fileID,
     _ line: UInt = #line
   ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
     .init { globalState, globalAction, globalEnvironment in

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -162,7 +162,7 @@ extension SwitchStore {
 
   public init<State1, Action1, Content1>(
     _ store: Store<State, Action>,
-    file: StaticString = #file,
+    file: StaticString = #fileID,
     line: UInt = #line,
     @ViewBuilder content: @escaping () -> CaseLet<State, Action, State1, Action1, Content1>
   )
@@ -221,7 +221,7 @@ extension SwitchStore {
 
   public init<State1, Action1, Content1, State2, Action2, Content2>(
     _ store: Store<State, Action>,
-    file: StaticString = #file,
+    file: StaticString = #fileID,
     line: UInt = #line,
     @ViewBuilder content: @escaping () -> TupleView<
       (
@@ -301,7 +301,7 @@ extension SwitchStore {
 
   public init<State1, Action1, Content1, State2, Action2, Content2, State3, Action3, Content3>(
     _ store: Store<State, Action>,
-    file: StaticString = #file,
+    file: StaticString = #fileID,
     line: UInt = #line,
     @ViewBuilder content: @escaping () -> TupleView<
       (
@@ -398,7 +398,7 @@ extension SwitchStore {
     State4, Action4, Content4
   >(
     _ store: Store<State, Action>,
-    file: StaticString = #file,
+    file: StaticString = #fileID,
     line: UInt = #line,
     @ViewBuilder content: @escaping () -> TupleView<
       (
@@ -508,7 +508,7 @@ extension SwitchStore {
     State5, Action5, Content5
   >(
     _ store: Store<State, Action>,
-    file: StaticString = #file,
+    file: StaticString = #fileID,
     line: UInt = #line,
     @ViewBuilder content: @escaping () -> TupleView<
       (
@@ -631,7 +631,7 @@ extension SwitchStore {
     State6, Action6, Content6
   >(
     _ store: Store<State, Action>,
-    file: StaticString = #file,
+    file: StaticString = #fileID,
     line: UInt = #line,
     @ViewBuilder content: @escaping () -> TupleView<
       (
@@ -767,7 +767,7 @@ extension SwitchStore {
     State7, Action7, Content7
   >(
     _ store: Store<State, Action>,
-    file: StaticString = #file,
+    file: StaticString = #fileID,
     line: UInt = #line,
     @ViewBuilder content: @escaping () -> TupleView<
       (
@@ -916,7 +916,7 @@ extension SwitchStore {
     State8, Action8, Content8
   >(
     _ store: Store<State, Action>,
-    file: StaticString = #file,
+    file: StaticString = #fileID,
     line: UInt = #line,
     @ViewBuilder content: @escaping () -> TupleView<
       (
@@ -1078,7 +1078,7 @@ extension SwitchStore {
     State9, Action9, Content9
   >(
     _ store: Store<State, Action>,
-    file: StaticString = #file,
+    file: StaticString = #fileID,
     line: UInt = #line,
     @ViewBuilder content: @escaping () -> TupleView<
       (


### PR DESCRIPTION
I think we only support Xcode 12+ these days, which means we can use `#fileID` in our debug helpers.