### PR TITLE
POC: generic effects

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -9,10 +9,10 @@ private let readMe = """
   inspired by Elm's `subscriptions` API.
   """
 
-extension Reducer {
+extension _Reducer where Effects == Effect<Action, Never> {
   static func subscriptions(
     _ subscriptions: @escaping (State, Environment) -> [AnyHashable: Effect<Action, Never>]
-  ) -> Reducer {
+  ) -> Self {
     var activeSubscriptions: [AnyHashable: Effect<Action, Never>] = [:]
 
     return Reducer { state, _, environment in

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -11,7 +11,7 @@ private let readMe = """
   are sent to the store.
   """
 
-extension Reducer {
+extension _Reducer where Effects == Effect<Action, Never> {
   public func lifecycle(
     onAppear: @escaping (Environment) -> Effect<Action, Never>,
     onDisappear: @escaping (Environment) -> Effect<Never, Never>

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -13,13 +13,13 @@ private let readMe = """
   rows.
   """
 
-extension Reducer {
+extension _Reducer {
   static func recurse(
-    _ reducer: @escaping (Reducer, inout State, Action, Environment) -> Effect<Action, Never>
-  ) -> Reducer {
+    _ reducer: @escaping (_Reducer, inout State, Action, Environment) -> Effects
+  ) -> Self {
 
-    var `self`: Reducer!
-    self = Reducer { state, action, environment in
+    var `self`: Self!
+    self = Self { state, action, environment in
       reducer(self, &state, action, environment)
     }
     return self

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
@@ -47,12 +47,12 @@ struct DownloadComponentEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
 }
 
-extension Reducer {
+extension _Reducer where Effects == Effect<Action, Never> {
   func downloadable<ID: Hashable>(
     state: WritableKeyPath<State, DownloadComponentState<ID>>,
     action: CasePath<Action, DownloadComponentAction>,
     environment: @escaping (Environment) -> DownloadComponentEnvironment
-  ) -> Reducer {
+  ) -> Self {
     .combine(
       Reducer<DownloadComponentState<ID>, DownloadComponentAction, DownloadComponentEnvironment> {
         state, action, environment in

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -50,13 +50,13 @@ struct FavoriteError: Equatable, Error, Identifiable {
   static func == (lhs: Self, rhs: Self) -> Bool { lhs.id == rhs.id }
 }
 
-extension Reducer {
+extension _Reducer where Effects == Effect<Action, Never> {
   /// Enhances a reducer with favoriting logic.
   func favorite<ID>(
     state: WritableKeyPath<State, FavoriteState<ID>>,
     action: CasePath<Action, FavoriteAction>,
     environment: @escaping (Environment) -> FavoriteEnvironment<ID>
-  ) -> Reducer where ID: Hashable {
+  ) -> Self where ID: Hashable {
     .combine(
       self,
       Reducer<FavoriteState<ID>, FavoriteAction, FavoriteEnvironment> {

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-StrictReducers.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-StrictReducers.swift
@@ -21,10 +21,10 @@ private let readMe = """
   Instead, it introduces a new action to feed the random number back into the system.
   """
 
-extension Reducer {
+extension _Reducer where Effects == Effect<Action, Never> {
   static func strict(
     _ reducer: @escaping (inout State, Action) -> (Environment) -> Effect<Action, Never>
-  ) -> Reducer {
+  ) -> Self {
     Self { state, action, environment in
       reducer(&state, action)(environment)
     }

--- a/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
@@ -28,7 +28,7 @@ public enum ActionFormat {
   case prettyPrint
 }
 
-extension Reducer {
+extension _Reducer where Effects == Effect<Action, Never> {
   /// Prints debug messages describing all received actions and state mutations.
   ///
   /// Printing is only done in debug (`#if DEBUG`) builds.
@@ -46,7 +46,7 @@ extension Reducer {
     environment toDebugEnvironment: @escaping (Environment) -> DebugEnvironment = { _ in
       DebugEnvironment()
     }
-  ) -> Reducer {
+  ) -> Self {
     self.debug(
       prefix,
       state: { $0 },
@@ -73,7 +73,7 @@ extension Reducer {
     environment toDebugEnvironment: @escaping (Environment) -> DebugEnvironment = { _ in
       DebugEnvironment()
     }
-  ) -> Reducer {
+  ) -> Self {
     self.debug(
       prefix,
       state: { _ in () },
@@ -104,7 +104,7 @@ extension Reducer {
     environment toDebugEnvironment: @escaping (Environment) -> DebugEnvironment = { _ in
       DebugEnvironment()
     }
-  ) -> Reducer {
+  ) -> Self {
     #if DEBUG
       return .init { state, action, environment in
         let previousState = toLocalState(state)

--- a/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
@@ -1,7 +1,7 @@
 import Combine
 import os.signpost
 
-extension Reducer {
+extension _Reducer where Effects == Effect<Action, Never> {
   /// Instruments the reducer with
   /// [signposts](https://developer.apple.com/documentation/os/logging/recording_performance_data).
   /// Each invocation of the reducer will be measured by an interval, and the lifecycle of its

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -39,7 +39,7 @@ extension AlertState.Button {
 
 // NB: Deprecated after 0.20.0:
 
-extension Reducer {
+extension _Reducer where Effects == Effect<Action, Never> {
   @available(*, deprecated, message: "Use the 'IdentifiedArray'-based version, instead")
   public func forEach<GlobalState, GlobalAction, GlobalEnvironment>(
     state toLocalState: WritableKeyPath<GlobalState, [State]>,
@@ -162,7 +162,7 @@ extension IfLetStore {
 @available(*, deprecated, renamed: "BindingAction")
 public typealias FormAction = BindingAction
 
-extension Reducer {
+extension _Reducer where Effects == Effect<Action, Never> {
   @available(*, deprecated, renamed: "binding")
   public func form(action toFormAction: CasePath<Action, BindingAction<State>>) -> Self {
     self.binding(action: toFormAction.extract(from:))
@@ -278,7 +278,7 @@ extension Store {
 
 // NB: Deprecated after 0.6.0:
 
-extension Reducer {
+extension _Reducer where Effects == Effect<Action, Never> {
   @available(*, deprecated, renamed: "optional()")
   public var optional: Reducer<State?, Action, Environment> {
     self.optional()

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -191,7 +191,7 @@ public struct BindingAction<Root>: Equatable {
   }
 }
 
-extension Reducer {
+extension _Reducer where Effects == Effect<Action, Never> {
   /// Returns a reducer that applies ``BindingAction`` mutations to `State` before running this
   /// reducer's logic.
   ///


### PR DESCRIPTION
Afternoon! This is a very experimental PR that is not at all production ready, and is very possibly not the direction y’all have been envisioning for this project. However, I do think it is interesting, and perhaps it could trigger some interesting discussion! 

This PR re-defines `Reducer` to be generic over its `Effects` type. (Well, in this PR, just to keep this diff small, a new type called `_Reducer` is introduced, and `Reducer` is then redefined as a `typealias` for the previous shape. This is just for convenience of implementing the POC and is probably not the right way to do this “for real”).

Mechanically speaking, the next thing that happens is that reducer operators get floated “upwards” to live in less-constrained extensions. Two new protocols, `HasNone` and `HasMerge` (each given a deliberately bad name 😅) are introduced to support this. Some reducer operators can’t be generalized easily, so they continue to live in an extension where `_Reducer.Effects == Effect<Action, Never>`. (Just to be clear at this point, `Effects` is the new generic parameter introduced as part of this PR, and `Effect` is the existing TCA effect type. The constraint just mentioned recovers existing TCA behavior after the new generic initially breaks it.)

At this point there is some syntactic noise because writing an `extension` on a `typealias` doesn’t work well in Swift for some reason, but after fixing that, we can run the existing tests and they pass!

Now the fun part. We can start supporting generic effects. We’ll introduce this function:
```swift
public extension _Reducer {
  /// interpret a possibly simple `_Reducer` (`self`) in terms of an alternative (possibly more complex) `Environment` and `Effects`. To do this, provide a function (`localEnv`) which shows how to extract `Environment` from any other set of possibly larger dependencies (`GlobalEnvironment`). Also, provide a function which, given those larger dependencies, provides a mapping from this reducer’s `Effects` type into an alternative effects type (`NewEffects`).
  /// - Parameters:
  ///   - localEnv: a function that provides a mapping from some new environment type to this reducer’s `Environment` type
  ///   - effects: a function that uses the expanded environment to convert this reducer’s `Effects` into a new effects type (`NewEffects`)
  /// - Returns: a new reducer of type `_Reducer<State, Action, GlobalEnvironment, NewEffects>`
  func interpret<GlobalEnvironment, NewEffects>(
    localEnv: @escaping (GlobalEnvironment) -> Environment,
    newEffects: @escaping (GlobalEnvironment, Effects) -> NewEffects
  ) -> _Reducer<State, Action, GlobalEnvironment, NewEffects> {
    .init { state, action, env in
      let localEnv = localEnv(env)
      return newEffects(env, self(&state, action, localEnv))
    }
  }
}
```
This function “interprets” a `_Reducer` into a new effects type by providing a two mappings, one a pullback-flavored mapping from some `GlobalEnvironment` into the local `Environment`, and one covariant mapping into a `NewEffects` type. _Very sneakily_, the *global environment* is available during this second mapping. 

Practically speaking, this lets us write reducers where the `Effects` are defunctionalized and can be represented by any value. We can then, at a time of our choosing, `interpret` such reducers into a functionalized or “terminal” effect type (e.g. TCA `Effect`s) and use them in existing stores. 

This opens up some interesting possibilities! I don’t have a ton of case studies, but I tried to add a couple. One is, sometimes a simple `struct` can be used to represent an effect. I updated the Counter example to send “analytics”; while the analytics reducer is layered on to the business logic reducer in a way we are already used to, the core of the analytics reducer doesn’t have to know anything about how to send effects. Its “effect type” is just this:
```swift
private struct CounterAnalyticsEvent {
  var message: String
  var userID: Int
}
```
It’s worth noting again that the defunctionalized `counterAnalyticsReducer` has a `Void` environment now; it no longer needs to know how to actually send the effects. I think this is particularly neato — writing a reducer where the effects are just a simple data type usually means that that reducer needs radically fewer dependencies than before.

I also updated the Effects Basics reducer in a similar way: the main body of the reducer now only knows about an `enum EffectsBasicsEffect` and no longer needs any dependencies. Just before using this reducer, we `interpret` it to rebuild the original TCA `Effect`s.

There’s one other snippet in here that is basically just a sketch: `_Reducer.replaceError` can be used (I think! I have only just started playing with this) to turn a reducer where the `Effect.Failure` is _not_ `Never` into a reducer where it is, by replacing all Combine errors with a provided `action` (e.g. `FooAction.displayError("there was an error")`). So, `replaceError` but at the `Reducer` level.

It’s possible that this technique could be used to support other “terminal” effects types as well. For example, my colleague @srgisme and I use this construction in an in-house library (which is heavily inspired by TCA, in case it wasn’t already obvious!) to support RxSwift for effects as well. (At the store level, there’s nothing fancy to this, we just have two different kinds of `Store`s.)

Thanks for the great library and all the awesome content! I hope this PR at least provides a fun Friday read! 