### PR TITLE
Fix a redundant conformance constraint warning in ForEachStore

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -82,7 +82,7 @@ where Data: Collection, ID: Hashable, Content: View {
   /// - Parameters:
   ///   - store: A store on an identified array of data and an identified action.
   ///   - content: A function that can generate content given a store of an element.
-  public init<EachContent: View>(
+  public init<EachContent>(
     _ store: Store<IdentifiedArray<ID, EachState>, (ID, EachAction)>,
     @ViewBuilder content: @escaping (Store<EachState, EachAction>) -> EachContent
   )


### PR DESCRIPTION
The warning was:

    Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift:141:28: warning: redundant conformance constraint 'EachContent' : 'View'
      public init<EachContent: View>(
                               ^
    Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift:146:16: note: conformance constraint 'EachContent' : 'View' implied here
        EachContent: View,
                   ^

I fixed the warning by removing the redundant constraint from the type
parameter.