### PR TITLE
Update tests to use `XCTAssertNoDifference`

### DIFF
--- a/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
+++ b/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
@@ -269,7 +269,7 @@ class VoiceMemosTests: XCTestCase {
 
     store.send(.voiceMemo(id: url, action: .delete)) {
       $0.voiceMemos = []
-      XCTAssertEqual(didStopAudioPlayerClient, true)
+      XCTAssertNoDifference(didStopAudioPlayerClient, true)
     }
   }
 

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -72,11 +72,11 @@ final class ComposableArchitectureTests: XCTestCase {
     testScheduler.schedule(after: testScheduler.now, interval: 2) { values.append(42) }
       .store(in: &self.cancellables)
 
-    XCTAssertEqual(values, [])
+    XCTAssertNoDifference(values, [])
     testScheduler.advance()
-    XCTAssertEqual(values, [1, 42])
+    XCTAssertNoDifference(values, [1, 42])
     testScheduler.advance(by: 2)
-    XCTAssertEqual(values, [1, 42, 1, 1, 42])
+    XCTAssertNoDifference(values, [1, 42, 1, 1, 42])
   }
 
   func testLongLivingEffects() {

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -8,7 +8,7 @@ final class DebugTests: XCTestCase {
   func testTextState() {
     var dump = ""
     customDump(TextState("Hello, world!"), to: &dump)
-    XCTAssertEqual(
+    XCTAssertNoDifference(
       dump,
       """
       "Hello, world!"
@@ -22,7 +22,7 @@ final class DebugTests: XCTestCase {
       + TextState("!"),
       to: &dump
     )
-    XCTAssertEqual(
+    XCTAssertNoDifference(
       dump,
       """
       "Hello, _**world**_!"
@@ -49,7 +49,7 @@ final class DebugTests: XCTestCase {
         + TextState("\n") + TextState("Not underlined purple").underline(false, color: .pink),
       to: &dump
     )
-    XCTAssertEqual(
+    XCTAssertNoDifference(
       dump,
       #"""
       """
@@ -90,22 +90,22 @@ final class DebugTests: XCTestCase {
       }
     }
 
-    XCTAssertEqual(
+    XCTAssertNoDifference(
       debugCaseOutput(Action.action1(true, label: "Blob")),
       "Action.action1(_:, label:)"
     )
 
-    XCTAssertEqual(
+    XCTAssertNoDifference(
       debugCaseOutput(Action.action2(true, 1, "Blob")),
       "Action.action2(_:, _:, _:)"
     )
 
-    XCTAssertEqual(
+    XCTAssertNoDifference(
       debugCaseOutput(Action.screenA(.row(index: 1, action: .tapped))),
       "Action.screenA(.row(index:, action: .tapped))"
     )
 
-    XCTAssertEqual(
+    XCTAssertNoDifference(
       debugCaseOutput(Action.screenA(.row(index: 1, action: .textChanged(query: "Hi")))),
       "Action.screenA(.row(index:, action: .textChanged(query:)))"
     )

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -23,18 +23,18 @@ final class EffectCancellationTests: XCTestCase {
       .sink { values.append($0) }
       .store(in: &self.cancellables)
 
-    XCTAssertEqual(values, [])
+    XCTAssertNoDifference(values, [])
     subject.send(1)
-    XCTAssertEqual(values, [1])
+    XCTAssertNoDifference(values, [1])
     subject.send(2)
-    XCTAssertEqual(values, [1, 2])
+    XCTAssertNoDifference(values, [1, 2])
 
     Effect<Never, Never>.cancel(id: CancelToken())
       .sink { _ in }
       .store(in: &self.cancellables)
 
     subject.send(3)
-    XCTAssertEqual(values, [1, 2])
+    XCTAssertNoDifference(values, [1, 2])
   }
 
   func testCancelInFlight() {
@@ -46,11 +46,11 @@ final class EffectCancellationTests: XCTestCase {
       .sink { values.append($0) }
       .store(in: &self.cancellables)
 
-    XCTAssertEqual(values, [])
+    XCTAssertNoDifference(values, [])
     subject.send(1)
-    XCTAssertEqual(values, [1])
+    XCTAssertNoDifference(values, [1])
     subject.send(2)
-    XCTAssertEqual(values, [1, 2])
+    XCTAssertNoDifference(values, [1, 2])
 
     Effect(subject)
       .cancellable(id: CancelToken(), cancelInFlight: true)
@@ -58,9 +58,9 @@ final class EffectCancellationTests: XCTestCase {
       .store(in: &self.cancellables)
 
     subject.send(3)
-    XCTAssertEqual(values, [1, 2, 3])
+    XCTAssertNoDifference(values, [1, 2, 3])
     subject.send(4)
-    XCTAssertEqual(values, [1, 2, 3, 4])
+    XCTAssertNoDifference(values, [1, 2, 3, 4])
   }
 
   func testCancellationAfterDelay() {
@@ -73,7 +73,7 @@ final class EffectCancellationTests: XCTestCase {
       .sink { value = $0 }
       .store(in: &self.cancellables)
 
-    XCTAssertEqual(value, nil)
+    XCTAssertNoDifference(value, nil)
 
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
       Effect<Never, Never>.cancel(id: CancelToken())
@@ -83,7 +83,7 @@ final class EffectCancellationTests: XCTestCase {
 
     _ = XCTWaiter.wait(for: [self.expectation(description: "")], timeout: 0.3)
 
-    XCTAssertEqual(value, nil)
+    XCTAssertNoDifference(value, nil)
   }
 
   func testCancellationAfterDelay_WithTestScheduler() {
@@ -97,7 +97,7 @@ final class EffectCancellationTests: XCTestCase {
       .sink { value = $0 }
       .store(in: &self.cancellables)
 
-    XCTAssertEqual(value, nil)
+    XCTAssertNoDifference(value, nil)
 
     scheduler.advance(by: 1)
     Effect<Never, Never>.cancel(id: CancelToken())
@@ -106,7 +106,7 @@ final class EffectCancellationTests: XCTestCase {
 
     scheduler.run()
 
-    XCTAssertEqual(value, nil)
+    XCTAssertNoDifference(value, nil)
   }
 
   func testCancellablesCleanUp_OnComplete() {
@@ -116,7 +116,7 @@ final class EffectCancellationTests: XCTestCase {
       .sink(receiveValue: { _ in })
       .store(in: &self.cancellables)
 
-    XCTAssertEqual([:], cancellationCancellables)
+    XCTAssertNoDifference([:], cancellationCancellables)
   }
 
   func testCancellablesCleanUp_OnCancel() {
@@ -132,7 +132,7 @@ final class EffectCancellationTests: XCTestCase {
       .sink(receiveValue: { _ in })
       .store(in: &self.cancellables)
 
-    XCTAssertEqual([:], cancellationCancellables)
+    XCTAssertNoDifference([:], cancellationCancellables)
   }
 
   func testDoubleCancellation() {
@@ -147,16 +147,16 @@ final class EffectCancellationTests: XCTestCase {
       .sink { values.append($0) }
       .store(in: &self.cancellables)
 
-    XCTAssertEqual(values, [])
+    XCTAssertNoDifference(values, [])
     subject.send(1)
-    XCTAssertEqual(values, [1])
+    XCTAssertNoDifference(values, [1])
 
     Effect<Never, Never>.cancel(id: CancelToken())
       .sink { _ in }
       .store(in: &self.cancellables)
 
     subject.send(2)
-    XCTAssertEqual(values, [1])
+    XCTAssertNoDifference(values, [1])
   }
 
   func testCompleteBeforeCancellation() {
@@ -171,16 +171,16 @@ final class EffectCancellationTests: XCTestCase {
       .store(in: &self.cancellables)
 
     subject.send(1)
-    XCTAssertEqual(values, [1])
+    XCTAssertNoDifference(values, [1])
 
     subject.send(completion: .finished)
-    XCTAssertEqual(values, [1])
+    XCTAssertNoDifference(values, [1])
 
     Effect<Never, Never>.cancel(id: CancelToken())
       .sink { _ in }
       .store(in: &self.cancellables)
 
-    XCTAssertEqual(values, [1])
+    XCTAssertNoDifference(values, [1])
   }
 
   func testConcurrentCancels() {
@@ -240,7 +240,7 @@ final class EffectCancellationTests: XCTestCase {
 
     cancellables.removeAll()
 
-    XCTAssertEqual([:], cancellationCancellables)
+    XCTAssertNoDifference([:], cancellationCancellables)
   }
 
   func testSharedId() {
@@ -264,11 +264,11 @@ final class EffectCancellationTests: XCTestCase {
       .sink { expectedOutput.append($0) }
       .store(in: &cancellables)
 
-    XCTAssertEqual(expectedOutput, [])
+    XCTAssertNoDifference(expectedOutput, [])
     scheduler.advance(by: 1)
-    XCTAssertEqual(expectedOutput, [1])
+    XCTAssertNoDifference(expectedOutput, [1])
     scheduler.advance(by: 1)
-    XCTAssertEqual(expectedOutput, [1, 2])
+    XCTAssertNoDifference(expectedOutput, [1, 2])
   }
 
   func testImmediateCancellation() {
@@ -282,8 +282,8 @@ final class EffectCancellationTests: XCTestCase {
       .cancellable(id: "id")
       .sink { expectedOutput.append($0) }
 
-    XCTAssertEqual(expectedOutput, [])
+    XCTAssertNoDifference(expectedOutput, [])
     scheduler.advance(by: 1)
-    XCTAssertEqual(expectedOutput, [])
+    XCTAssertNoDifference(expectedOutput, [])
   }
 }

--- a/Tests/ComposableArchitectureTests/EffectDebounceTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectDebounceTests.swift
@@ -21,33 +21,33 @@ final class EffectDebounceTests: XCTestCase {
     runDebouncedEffect(value: 1)
 
     // Nothing emits right away.
-    XCTAssertEqual(values, [])
+    XCTAssertNoDifference(values, [])
 
     // Waiting half the time also emits nothing
     scheduler.advance(by: 0.5)
-    XCTAssertEqual(values, [])
+    XCTAssertNoDifference(values, [])
 
     // Run another debounced effect.
     runDebouncedEffect(value: 2)
 
     // Waiting half the time emits nothing because the first debounced effect has been canceled.
     scheduler.advance(by: 0.5)
-    XCTAssertEqual(values, [])
+    XCTAssertNoDifference(values, [])
 
     // Run another debounced effect.
     runDebouncedEffect(value: 3)
 
     // Waiting half the time emits nothing because the second debounced effect has been canceled.
     scheduler.advance(by: 0.5)
-    XCTAssertEqual(values, [])
+    XCTAssertNoDifference(values, [])
 
     // Waiting the rest of the time emits the final effect value.
     scheduler.advance(by: 0.5)
-    XCTAssertEqual(values, [3])
+    XCTAssertNoDifference(values, [3])
 
     // Running out the scheduler
     scheduler.run()
-    XCTAssertEqual(values, [3])
+    XCTAssertNoDifference(values, [3])
   }
 
   func testDebounceIsLazy() {
@@ -70,17 +70,17 @@ final class EffectDebounceTests: XCTestCase {
 
     runDebouncedEffect(value: 1)
 
-    XCTAssertEqual(values, [])
-    XCTAssertEqual(effectRuns, 0)
+    XCTAssertNoDifference(values, [])
+    XCTAssertNoDifference(effectRuns, 0)
 
     scheduler.advance(by: 0.5)
 
-    XCTAssertEqual(values, [])
-    XCTAssertEqual(effectRuns, 0)
+    XCTAssertNoDifference(values, [])
+    XCTAssertNoDifference(effectRuns, 0)
 
     scheduler.advance(by: 0.5)
 
-    XCTAssertEqual(values, [1])
-    XCTAssertEqual(effectRuns, 1)
+    XCTAssertNoDifference(values, [1])
+    XCTAssertNoDifference(effectRuns, 1)
   }
 }

--- a/Tests/ComposableArchitectureTests/EffectDeferredTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectDeferredTests.swift
@@ -20,33 +20,33 @@ final class EffectDeferredTests: XCTestCase {
     runDeferredEffect(value: 1)
 
     // Nothing emits right away.
-    XCTAssertEqual(values, [])
+    XCTAssertNoDifference(values, [])
 
     // Waiting half the time also emits nothing
     scheduler.advance(by: 0.5)
-    XCTAssertEqual(values, [])
+    XCTAssertNoDifference(values, [])
 
     // Run another deferred effect.
     runDeferredEffect(value: 2)
 
     // Waiting half the time emits first deferred effect received.
     scheduler.advance(by: 0.5)
-    XCTAssertEqual(values, [1])
+    XCTAssertNoDifference(values, [1])
 
     // Run another deferred effect.
     runDeferredEffect(value: 3)
 
     // Waiting half the time emits second deferred effect received.
     scheduler.advance(by: 0.5)
-    XCTAssertEqual(values, [1, 2])
+    XCTAssertNoDifference(values, [1, 2])
 
     // Waiting the rest of the time emits the final effect value.
     scheduler.advance(by: 0.5)
-    XCTAssertEqual(values, [1, 2, 3])
+    XCTAssertNoDifference(values, [1, 2, 3])
 
     // Running out the scheduler
     scheduler.run()
-    XCTAssertEqual(values, [1, 2, 3])
+    XCTAssertNoDifference(values, [1, 2, 3])
   }
 
   func testDeferredIsLazy() {
@@ -67,17 +67,17 @@ final class EffectDeferredTests: XCTestCase {
 
     runDeferredEffect(value: 1)
 
-    XCTAssertEqual(values, [])
-    XCTAssertEqual(effectRuns, 0)
+    XCTAssertNoDifference(values, [])
+    XCTAssertNoDifference(effectRuns, 0)
 
     scheduler.advance(by: 0.5)
 
-    XCTAssertEqual(values, [])
-    XCTAssertEqual(effectRuns, 0)
+    XCTAssertNoDifference(values, [])
+    XCTAssertNoDifference(effectRuns, 0)
 
     scheduler.advance(by: 0.5)
 
-    XCTAssertEqual(values, [1])
-    XCTAssertEqual(effectRuns, 1)
+    XCTAssertNoDifference(values, [1])
+    XCTAssertNoDifference(effectRuns, 1)
   }
 }

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -12,17 +12,17 @@ final class EffectTests: XCTestCase {
 
     Future<Int, Error> { $0(.success(42)) }
       .catchToEffect()
-      .sink { XCTAssertEqual($0, .success(42)) }
+      .sink { XCTAssertNoDifference($0, .success(42)) }
       .store(in: &self.cancellables)
 
     Future<Int, Error> { $0(.failure(Error())) }
       .catchToEffect()
-      .sink { XCTAssertEqual($0, .failure(Error())) }
+      .sink { XCTAssertNoDifference($0, .failure(Error())) }
       .store(in: &self.cancellables)
 
     Future<Int, Never> { $0(.success(42)) }
       .eraseToEffect()
-      .sink { XCTAssertEqual($0, 42) }
+      .sink { XCTAssertNoDifference($0, 42) }
       .store(in: &self.cancellables)
 
     Future<Int, Error> { $0(.success(42)) }
@@ -34,7 +34,7 @@ final class EffectTests: XCTestCase {
           return -1
         }
       }
-      .sink { XCTAssertEqual($0, 42) }
+      .sink { XCTAssertNoDifference($0, 42) }
       .store(in: &self.cancellables)
 
     Future<Int, Error> { $0(.failure(Error())) }
@@ -46,7 +46,7 @@ final class EffectTests: XCTestCase {
           return -1
         }
       }
-      .sink { XCTAssertEqual($0, -1) }
+      .sink { XCTAssertNoDifference($0, -1) }
       .store(in: &self.cancellables)
   }
 
@@ -61,19 +61,19 @@ final class EffectTests: XCTestCase {
 
     effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
 
-    XCTAssertEqual(values, [])
+    XCTAssertNoDifference(values, [])
 
     self.scheduler.advance(by: 1)
-    XCTAssertEqual(values, [1])
+    XCTAssertNoDifference(values, [1])
 
     self.scheduler.advance(by: 2)
-    XCTAssertEqual(values, [1, 2])
+    XCTAssertNoDifference(values, [1, 2])
 
     self.scheduler.advance(by: 3)
-    XCTAssertEqual(values, [1, 2, 3])
+    XCTAssertNoDifference(values, [1, 2, 3])
 
     self.scheduler.run()
-    XCTAssertEqual(values, [1, 2, 3])
+    XCTAssertNoDifference(values, [1, 2, 3])
   }
 
   func testConcatenateOneEffect() {
@@ -85,13 +85,13 @@ final class EffectTests: XCTestCase {
 
     effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
 
-    XCTAssertEqual(values, [])
+    XCTAssertNoDifference(values, [])
 
     self.scheduler.advance(by: 1)
-    XCTAssertEqual(values, [1])
+    XCTAssertNoDifference(values, [1])
 
     self.scheduler.run()
-    XCTAssertEqual(values, [1])
+    XCTAssertNoDifference(values, [1])
   }
 
   func testMerge() {
@@ -104,16 +104,16 @@ final class EffectTests: XCTestCase {
     var values: [Int] = []
     effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
 
-    XCTAssertEqual(values, [])
+    XCTAssertNoDifference(values, [])
 
     self.scheduler.advance(by: 1)
-    XCTAssertEqual(values, [1])
+    XCTAssertNoDifference(values, [1])
 
     self.scheduler.advance(by: 1)
-    XCTAssertEqual(values, [1, 2])
+    XCTAssertNoDifference(values, [1, 2])
 
     self.scheduler.advance(by: 1)
-    XCTAssertEqual(values, [1, 2, 3])
+    XCTAssertNoDifference(values, [1, 2, 3])
   }
 
   func testEffectSubscriberInitializer() {
@@ -137,18 +137,18 @@ final class EffectTests: XCTestCase {
       .sink(receiveCompletion: { _ in isComplete = true }, receiveValue: { values.append($0) })
       .store(in: &self.cancellables)
 
-    XCTAssertEqual(values, [1, 2])
-    XCTAssertEqual(isComplete, false)
+    XCTAssertNoDifference(values, [1, 2])
+    XCTAssertNoDifference(isComplete, false)
 
     self.scheduler.advance(by: 1)
 
-    XCTAssertEqual(values, [1, 2, 3])
-    XCTAssertEqual(isComplete, false)
+    XCTAssertNoDifference(values, [1, 2, 3])
+    XCTAssertNoDifference(isComplete, false)
 
     self.scheduler.advance(by: 1)
 
-    XCTAssertEqual(values, [1, 2, 3, 4])
-    XCTAssertEqual(isComplete, true)
+    XCTAssertNoDifference(values, [1, 2, 3, 4])
+    XCTAssertNoDifference(isComplete, true)
   }
 
   func testEffectSubscriberInitializer_WithCancellation() {
@@ -170,8 +170,8 @@ final class EffectTests: XCTestCase {
       .sink(receiveCompletion: { _ in isComplete = true }, receiveValue: { values.append($0) })
       .store(in: &self.cancellables)
 
-    XCTAssertEqual(values, [1])
-    XCTAssertEqual(isComplete, false)
+    XCTAssertNoDifference(values, [1])
+    XCTAssertNoDifference(isComplete, false)
 
     Effect<Void, Never>.cancel(id: CancelId())
       .sink(receiveValue: { _ in })
@@ -179,8 +179,8 @@ final class EffectTests: XCTestCase {
 
     self.scheduler.advance(by: 1)
 
-    XCTAssertEqual(values, [1])
-    XCTAssertEqual(isComplete, true)
+    XCTAssertNoDifference(values, [1])
+    XCTAssertNoDifference(isComplete, true)
   }
 
   func testEffectErrorCrash() {
@@ -223,7 +223,7 @@ final class EffectTests: XCTestCase {
       .sink(receiveValue: { result = $0 })
       .store(in: &self.cancellables)
       self.wait(for: [expectation], timeout: 0)
-      XCTAssertEqual(result, 42)
+      XCTAssertNoDifference(result, 42)
     }
 
   func testThrowingTask() {

--- a/Tests/ComposableArchitectureTests/EffectThrottleTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectThrottleTests.swift
@@ -29,14 +29,14 @@ final class EffectThrottleTests: XCTestCase {
     scheduler.advance()
 
     // A value emits right away.
-    XCTAssertEqual(values, [1])
+    XCTAssertNoDifference(values, [1])
 
     runThrottledEffect(value: 2)
 
     scheduler.advance()
 
     // A second value is throttled.
-    XCTAssertEqual(values, [1])
+    XCTAssertNoDifference(values, [1])
 
     scheduler.advance(by: 0.25)
 
@@ -51,12 +51,12 @@ final class EffectThrottleTests: XCTestCase {
     runThrottledEffect(value: 5)
 
     // A third value is throttled.
-    XCTAssertEqual(values, [1])
+    XCTAssertNoDifference(values, [1])
 
     scheduler.advance(by: 0.25)
 
     // The latest value emits.
-    XCTAssertEqual(values, [1, 5])
+    XCTAssertNoDifference(values, [1, 5])
   }
 
   func testThrottleFirst() {
@@ -83,14 +83,14 @@ final class EffectThrottleTests: XCTestCase {
     scheduler.advance()
 
     // A value emits right away.
-    XCTAssertEqual(values, [1])
+    XCTAssertNoDifference(values, [1])
 
     runThrottledEffect(value: 2)
 
     scheduler.advance()
 
     // A second value is throttled.
-    XCTAssertEqual(values, [1])
+    XCTAssertNoDifference(values, [1])
 
     scheduler.advance(by: 0.25)
 
@@ -107,7 +107,7 @@ final class EffectThrottleTests: XCTestCase {
     scheduler.advance(by: 0.25)
 
     // The second (throttled) value emits.
-    XCTAssertEqual(values, [1, 2])
+    XCTAssertNoDifference(values, [1, 2])
 
     scheduler.advance(by: 0.25)
 
@@ -116,14 +116,14 @@ final class EffectThrottleTests: XCTestCase {
     scheduler.advance(by: 0.50)
 
     // A third value is throttled.
-    XCTAssertEqual(values, [1, 2])
+    XCTAssertNoDifference(values, [1, 2])
 
     runThrottledEffect(value: 7)
 
     scheduler.advance(by: 0.25)
 
     // The third (throttled) value emits.
-    XCTAssertEqual(values, [1, 2, 6])
+    XCTAssertNoDifference(values, [1, 2, 6])
   }
 
   func testThrottleAfterInterval() {
@@ -148,7 +148,7 @@ final class EffectThrottleTests: XCTestCase {
     scheduler.advance()
 
     // A value emits right away.
-    XCTAssertEqual(values, [1])
+    XCTAssertNoDifference(values, [1])
 
     scheduler.advance(by: 2)
 
@@ -157,7 +157,7 @@ final class EffectThrottleTests: XCTestCase {
     scheduler.advance()
 
     // A second value is emitted right away.
-    XCTAssertEqual(values, [1, 2])
+    XCTAssertNoDifference(values, [1, 2])
 
     scheduler.advance(by: 2)
 
@@ -166,7 +166,7 @@ final class EffectThrottleTests: XCTestCase {
     scheduler.advance()
 
     // A third value is emitted right away.
-    XCTAssertEqual(values, [1, 2, 3])
+    XCTAssertNoDifference(values, [1, 2, 3])
   }
 
   func testThrottleEmitsFirstValueOnce() {
@@ -193,7 +193,7 @@ final class EffectThrottleTests: XCTestCase {
     scheduler.advance()
 
     // A value emits right away.
-    XCTAssertEqual(values, [1])
+    XCTAssertNoDifference(values, [1])
 
     scheduler.advance(by: 0.5)
 
@@ -204,6 +204,6 @@ final class EffectThrottleTests: XCTestCase {
     runThrottledEffect(value: 3)
 
     // A second value is emitted right away.
-    XCTAssertEqual(values, [1, 2])
+    XCTAssertNoDifference(values, [1, 2])
   }
 }

--- a/Tests/ComposableArchitectureTests/MemoryManagementTests.swift
+++ b/Tests/ComposableArchitectureTests/MemoryManagementTests.swift
@@ -18,9 +18,9 @@ final class MemoryManagementTests: XCTestCase {
     var count = 0
     viewStore.publisher.sink { count = $0 }.store(in: &self.cancellables)
 
-    XCTAssertEqual(count, 0)
+    XCTAssertNoDifference(count, 0)
     viewStore.send(())
-    XCTAssertEqual(count, 1)
+    XCTAssertNoDifference(count, 1)
   }
 
   func testOwnership_ViewStoreHoldsOntoStore() {
@@ -33,8 +33,8 @@ final class MemoryManagementTests: XCTestCase {
     var count = 0
     viewStore.publisher.sink { count = $0 }.store(in: &self.cancellables)
 
-    XCTAssertEqual(count, 0)
+    XCTAssertNoDifference(count, 0)
     viewStore.send(())
-    XCTAssertEqual(count, 1)
+    XCTAssertNoDifference(count, 1)
   }
 }

--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -16,7 +16,7 @@ final class ReducerTests: XCTestCase {
 
     var state = 0
     _ = reducer.run(&state, (), ())
-    XCTAssertEqual(state, 1)
+    XCTAssertNoDifference(state, 1)
   }
 
   func testCombine_EffectsAreMerged() {
@@ -53,11 +53,11 @@ final class ReducerTests: XCTestCase {
     }
     // Waiting a second causes the fast effect to fire.
     scheduler.advance(by: 1)
-    XCTAssertEqual(fastValue, 42)
+    XCTAssertNoDifference(fastValue, 42)
     // Waiting one more second causes the slow effect to fire. This proves that the effects
     // are merged together, as opposed to concatenated.
     scheduler.advance(by: 1)
-    XCTAssertEqual(slowValue, 1729)
+    XCTAssertNoDifference(slowValue, 1729)
   }
 
   func testCombine() {

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -10,11 +10,11 @@ final class StoreTests: XCTestCase {
     let reducer = Reducer<Void, Void, Void> { _, _, _ in .none }
     let store = Store(initialState: (), reducer: reducer, environment: ())
 
-    XCTAssertEqual(store.effectCancellables.count, 0)
+    XCTAssertNoDifference(store.effectCancellables.count, 0)
 
     store.send(())
 
-    XCTAssertEqual(store.effectCancellables.count, 0)
+    XCTAssertNoDifference(store.effectCancellables.count, 0)
   }
 
   func testCancellableIsRemovedWhenEffectCompletes() {
@@ -35,15 +35,15 @@ final class StoreTests: XCTestCase {
     }
     let store = Store(initialState: (), reducer: reducer, environment: ())
 
-    XCTAssertEqual(store.effectCancellables.count, 0)
+    XCTAssertNoDifference(store.effectCancellables.count, 0)
 
     store.send(.start)
 
-    XCTAssertEqual(store.effectCancellables.count, 1)
+    XCTAssertNoDifference(store.effectCancellables.count, 1)
 
     scheduler.advance(by: 2)
 
-    XCTAssertEqual(store.effectCancellables.count, 0)
+    XCTAssertNoDifference(store.effectCancellables.count, 0)
   }
 
   func testScopedStoreReceivesUpdatesFromParent() {
@@ -61,11 +61,11 @@ final class StoreTests: XCTestCase {
       .sink(receiveValue: { values.append($0) })
       .store(in: &self.cancellables)
 
-    XCTAssertEqual(values, ["0"])
+    XCTAssertNoDifference(values, ["0"])
 
     parentViewStore.send(())
 
-    XCTAssertEqual(values, ["0", "1"])
+    XCTAssertNoDifference(values, ["0", "1"])
   }
 
   func testParentStoreReceivesUpdatesFromChild() {
@@ -83,11 +83,11 @@ final class StoreTests: XCTestCase {
       .sink(receiveValue: { values.append($0) })
       .store(in: &self.cancellables)
 
-    XCTAssertEqual(values, [0])
+    XCTAssertNoDifference(values, [0])
 
     childViewStore.send(())
 
-    XCTAssertEqual(values, [0, 1])
+    XCTAssertNoDifference(values, [0, 1])
   }
 
   func testScopeWithPublisherTransform() {
@@ -109,15 +109,15 @@ final class StoreTests: XCTestCase {
       .store(in: &self.cancellables)
 
     parentStore.send(0)
-    XCTAssertEqual(outputs, ["0"])
+    XCTAssertNoDifference(outputs, ["0"])
     parentStore.send(0)
-    XCTAssertEqual(outputs, ["0"])
+    XCTAssertNoDifference(outputs, ["0"])
     parentStore.send(1)
-    XCTAssertEqual(outputs, ["0", "1"])
+    XCTAssertNoDifference(outputs, ["0", "1"])
     parentStore.send(1)
-    XCTAssertEqual(outputs, ["0", "1"])
+    XCTAssertNoDifference(outputs, ["0", "1"])
     parentStore.send(2)
-    XCTAssertEqual(outputs, ["0", "1", "2"])
+    XCTAssertNoDifference(outputs, ["0", "1", "2"])
   }
 
   func testScopeCallCount() {
@@ -132,7 +132,7 @@ final class StoreTests: XCTestCase {
         return count
       })
 
-    XCTAssertEqual(numCalls1, 1)
+    XCTAssertNoDifference(numCalls1, 1)
   }
 
   func testScopeCallCount2() {
@@ -170,33 +170,33 @@ final class StoreTests: XCTestCase {
     _ = ViewStore(store3)
     let viewStore4 = ViewStore(store4)
 
-    XCTAssertEqual(numCalls1, 1)
-    XCTAssertEqual(numCalls2, 1)
-    XCTAssertEqual(numCalls3, 1)
+    XCTAssertNoDifference(numCalls1, 1)
+    XCTAssertNoDifference(numCalls2, 1)
+    XCTAssertNoDifference(numCalls3, 1)
 
     viewStore4.send(())
 
-    XCTAssertEqual(numCalls1, 2)
-    XCTAssertEqual(numCalls2, 2)
-    XCTAssertEqual(numCalls3, 2)
+    XCTAssertNoDifference(numCalls1, 2)
+    XCTAssertNoDifference(numCalls2, 2)
+    XCTAssertNoDifference(numCalls3, 2)
 
     viewStore4.send(())
 
-    XCTAssertEqual(numCalls1, 3)
-    XCTAssertEqual(numCalls2, 3)
-    XCTAssertEqual(numCalls3, 3)
+    XCTAssertNoDifference(numCalls1, 3)
+    XCTAssertNoDifference(numCalls2, 3)
+    XCTAssertNoDifference(numCalls3, 3)
 
     viewStore4.send(())
 
-    XCTAssertEqual(numCalls1, 4)
-    XCTAssertEqual(numCalls2, 4)
-    XCTAssertEqual(numCalls3, 4)
+    XCTAssertNoDifference(numCalls1, 4)
+    XCTAssertNoDifference(numCalls2, 4)
+    XCTAssertNoDifference(numCalls3, 4)
 
     viewStore4.send(())
 
-    XCTAssertEqual(numCalls1, 5)
-    XCTAssertEqual(numCalls2, 5)
-    XCTAssertEqual(numCalls3, 5)
+    XCTAssertNoDifference(numCalls1, 5)
+    XCTAssertNoDifference(numCalls2, 5)
+    XCTAssertNoDifference(numCalls3, 5)
   }
 
   func testSynchronousEffectsSentAfterSinking() {
@@ -231,7 +231,7 @@ final class StoreTests: XCTestCase {
 
     store.send(.tap)
 
-    XCTAssertEqual(values, [1, 2, 3, 4])
+    XCTAssertNoDifference(values, [1, 2, 3, 4])
   }
 
   func testLotsOfSynchronousActions() {
@@ -248,7 +248,7 @@ final class StoreTests: XCTestCase {
 
     let store = Store(initialState: 0, reducer: reducer, environment: ())
     store.send(.incr)
-    XCTAssertEqual(ViewStore(store).state, 100_000)
+    XCTAssertNoDifference(ViewStore(store).state, 100_000)
   }
 
   func testPublisherScope() {
@@ -266,19 +266,19 @@ final class StoreTests: XCTestCase {
       .sink { outputs.append($0.state.value) }
       .store(in: &self.cancellables)
 
-    XCTAssertEqual(outputs, [0])
+    XCTAssertNoDifference(outputs, [0])
 
     parentStore.send(true)
-    XCTAssertEqual(outputs, [0, 1])
+    XCTAssertNoDifference(outputs, [0, 1])
 
     parentStore.send(false)
-    XCTAssertEqual(outputs, [0, 1])
+    XCTAssertNoDifference(outputs, [0, 1])
     parentStore.send(false)
-    XCTAssertEqual(outputs, [0, 1])
+    XCTAssertNoDifference(outputs, [0, 1])
     parentStore.send(false)
-    XCTAssertEqual(outputs, [0, 1])
+    XCTAssertNoDifference(outputs, [0, 1])
     parentStore.send(false)
-    XCTAssertEqual(outputs, [0, 1])
+    XCTAssertNoDifference(outputs, [0, 1])
   }
 
   func testIfLetAfterScope() {
@@ -310,25 +310,25 @@ final class StoreTests: XCTestCase {
       )
       .store(in: &self.cancellables)
 
-    XCTAssertEqual(outputs, [nil])
+    XCTAssertNoDifference(outputs, [nil])
 
     parentStore.send(1)
-    XCTAssertEqual(outputs, [nil, 1])
+    XCTAssertNoDifference(outputs, [nil, 1])
 
     parentStore.send(nil)
-    XCTAssertEqual(outputs, [nil, 1, nil])
+    XCTAssertNoDifference(outputs, [nil, 1, nil])
 
     parentStore.send(1)
-    XCTAssertEqual(outputs, [nil, 1, nil, 1])
+    XCTAssertNoDifference(outputs, [nil, 1, nil, 1])
 
     parentStore.send(nil)
-    XCTAssertEqual(outputs, [nil, 1, nil, 1, nil])
+    XCTAssertNoDifference(outputs, [nil, 1, nil, 1, nil])
 
     parentStore.send(1)
-    XCTAssertEqual(outputs, [nil, 1, nil, 1, nil, 1])
+    XCTAssertNoDifference(outputs, [nil, 1, nil, 1, nil, 1])
 
     parentStore.send(nil)
-    XCTAssertEqual(outputs, [nil, 1, nil, 1, nil, 1, nil])
+    XCTAssertNoDifference(outputs, [nil, 1, nil, 1, nil, 1, nil])
   }
 
   func testIfLetTwo() {
@@ -360,7 +360,7 @@ final class StoreTests: XCTestCase {
         _ = XCTWaiter.wait(for: [.init()], timeout: 0.1)
         vs.send(false)
         _ = XCTWaiter.wait(for: [.init()], timeout: 0.1)
-        XCTAssertEqual(vs.state, 3)
+        XCTAssertNoDifference(vs.state, 3)
       })
       .store(in: &self.cancellables)
   }
@@ -430,11 +430,11 @@ final class StoreTests: XCTestCase {
       .sink { emissions.append($0) }
       .store(in: &self.cancellables)
 
-    XCTAssertEqual(emissions, [0])
+    XCTAssertNoDifference(emissions, [0])
 
     viewStore.send(0)
 
-    XCTAssertEqual(emissions, [0, 3])
+    XCTAssertNoDifference(emissions, [0, 3])
   }
 
   func testBufferedActionProcessing() {
@@ -497,10 +497,10 @@ final class StoreTests: XCTestCase {
       }
       .store(in: &cancellables)
 
-    XCTAssertEqual(handledActions, [])
+    XCTAssertNoDifference(handledActions, [])
 
     parentStore.send(.button)
-    XCTAssertEqual(
+    XCTAssertNoDifference(
       handledActions,
       [
         .button,

--- a/Tests/ComposableArchitectureTests/TimerTests.swift
+++ b/Tests/ComposableArchitectureTests/TimerTests.swift
@@ -15,16 +15,16 @@ final class TimerTests: XCTestCase {
       .store(in: &self.cancellables)
 
     scheduler.advance(by: 1)
-    XCTAssertEqual(count, 1)
+    XCTAssertNoDifference(count, 1)
 
     scheduler.advance(by: 1)
-    XCTAssertEqual(count, 2)
+    XCTAssertNoDifference(count, 2)
 
     scheduler.advance(by: 1)
-    XCTAssertEqual(count, 3)
+    XCTAssertNoDifference(count, 3)
 
     scheduler.advance(by: 3)
-    XCTAssertEqual(count, 6)
+    XCTAssertNoDifference(count, 6)
   }
 
   func testInterleavingTimer() {
@@ -45,17 +45,17 @@ final class TimerTests: XCTestCase {
     .store(in: &self.cancellables)
 
     scheduler.advance(by: 1)
-    XCTAssertEqual(count2, 0)
-    XCTAssertEqual(count3, 0)
+    XCTAssertNoDifference(count2, 0)
+    XCTAssertNoDifference(count3, 0)
     scheduler.advance(by: 1)
-    XCTAssertEqual(count2, 1)
-    XCTAssertEqual(count3, 0)
+    XCTAssertNoDifference(count2, 1)
+    XCTAssertNoDifference(count3, 0)
     scheduler.advance(by: 1)
-    XCTAssertEqual(count2, 1)
-    XCTAssertEqual(count3, 1)
+    XCTAssertNoDifference(count2, 1)
+    XCTAssertNoDifference(count3, 1)
     scheduler.advance(by: 1)
-    XCTAssertEqual(count2, 2)
-    XCTAssertEqual(count3, 1)
+    XCTAssertNoDifference(count2, 2)
+    XCTAssertNoDifference(count3, 1)
   }
 
   func testTimerCancellation() {
@@ -74,11 +74,11 @@ final class TimerTests: XCTestCase {
 
     scheduler.advance(by: 2)
 
-    XCTAssertEqual(firstCount, 1)
+    XCTAssertNoDifference(firstCount, 1)
 
     scheduler.advance(by: 2)
 
-    XCTAssertEqual(firstCount, 2)
+    XCTAssertNoDifference(firstCount, 2)
 
     Effect.timer(id: CancelToken(), every: .seconds(2), on: scheduler)
       .handleEvents(receiveOutput: { _ in secondCount += 1 })
@@ -88,13 +88,13 @@ final class TimerTests: XCTestCase {
 
     scheduler.advance(by: 2)
 
-    XCTAssertEqual(firstCount, 2)
-    XCTAssertEqual(secondCount, 1)
+    XCTAssertNoDifference(firstCount, 2)
+    XCTAssertNoDifference(secondCount, 1)
 
     scheduler.advance(by: 2)
 
-    XCTAssertEqual(firstCount, 2)
-    XCTAssertEqual(secondCount, 2)
+    XCTAssertNoDifference(firstCount, 2)
+    XCTAssertNoDifference(secondCount, 2)
   }
 
   func testTimerCompletion() {
@@ -108,15 +108,15 @@ final class TimerTests: XCTestCase {
       .store(in: &self.cancellables)
 
     scheduler.advance(by: 1)
-    XCTAssertEqual(count, 1)
+    XCTAssertNoDifference(count, 1)
 
     scheduler.advance(by: 1)
-    XCTAssertEqual(count, 2)
+    XCTAssertNoDifference(count, 2)
 
     scheduler.advance(by: 1)
-    XCTAssertEqual(count, 3)
+    XCTAssertNoDifference(count, 3)
 
     scheduler.run()
-    XCTAssertEqual(count, 3)
+    XCTAssertNoDifference(count, 3)
   }
 }

--- a/Tests/ComposableArchitectureTests/ViewStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/ViewStoreTests.swift
@@ -25,13 +25,13 @@ final class ViewStoreTests: XCTestCase {
       .sink { _ in emissionCount += 1 }
       .store(in: &self.cancellables)
 
-    XCTAssertEqual(emissionCount, 1)
+    XCTAssertNoDifference(emissionCount, 1)
     viewStore.send(())
-    XCTAssertEqual(emissionCount, 1)
+    XCTAssertNoDifference(emissionCount, 1)
     viewStore.send(())
-    XCTAssertEqual(emissionCount, 1)
+    XCTAssertNoDifference(emissionCount, 1)
     viewStore.send(())
-    XCTAssertEqual(emissionCount, 1)
+    XCTAssertNoDifference(emissionCount, 1)
   }
 
   func testEqualityChecks() {
@@ -60,20 +60,20 @@ final class ViewStoreTests: XCTestCase {
     viewStore3.publisher.substate.sink { _ in }.store(in: &self.cancellables)
     viewStore4.publisher.substate.sink { _ in }.store(in: &self.cancellables)
 
-    XCTAssertEqual(0, equalityChecks)
-    XCTAssertEqual(0, subEqualityChecks)
+    XCTAssertNoDifference(0, equalityChecks)
+    XCTAssertNoDifference(0, subEqualityChecks)
     viewStore4.send(())
-    XCTAssertEqual(4, equalityChecks)
-    XCTAssertEqual(4, subEqualityChecks)
+    XCTAssertNoDifference(4, equalityChecks)
+    XCTAssertNoDifference(4, subEqualityChecks)
     viewStore4.send(())
-    XCTAssertEqual(8, equalityChecks)
-    XCTAssertEqual(8, subEqualityChecks)
+    XCTAssertNoDifference(8, equalityChecks)
+    XCTAssertNoDifference(8, subEqualityChecks)
     viewStore4.send(())
-    XCTAssertEqual(12, equalityChecks)
-    XCTAssertEqual(12, subEqualityChecks)
+    XCTAssertNoDifference(12, equalityChecks)
+    XCTAssertNoDifference(12, subEqualityChecks)
     viewStore4.send(())
-    XCTAssertEqual(16, equalityChecks)
-    XCTAssertEqual(16, subEqualityChecks)
+    XCTAssertNoDifference(16, equalityChecks)
+    XCTAssertNoDifference(16, subEqualityChecks)
   }
 
   func testAccessViewStoreStateInPublisherSink() {
@@ -95,7 +95,7 @@ final class ViewStoreTests: XCTestCase {
     viewStore.send(())
     viewStore.send(())
 
-    XCTAssertEqual([0, 1, 2, 3], results)
+    XCTAssertNoDifference([0, 1, 2, 3], results)
   }
 
   func testWillSet() {
@@ -117,7 +117,7 @@ final class ViewStoreTests: XCTestCase {
     viewStore.send(())
     viewStore.send(())
 
-    XCTAssertEqual([0, 1, 2], results)
+    XCTAssertNoDifference([0, 1, 2], results)
   }
 
   func testPublisherOwnsViewStore() {
@@ -134,7 +134,7 @@ final class ViewStoreTests: XCTestCase {
       .store(in: &self.cancellables)
 
     ViewStore(store).send(())
-    XCTAssertEqual(results, [0, 1])
+    XCTAssertNoDifference(results, [0, 1])
   }
 
   #if compiler(>=5.5)
@@ -163,9 +163,9 @@ final class ViewStoreTests: XCTestCase {
         let store = Store(initialState: false, reducer: reducer, environment: ())
         let viewStore = ViewStore(store)
 
-        XCTAssertEqual(viewStore.state, false)
+        XCTAssertNoDifference(viewStore.state, false)
         await viewStore.send(.tapped, while: { $0 })
-        XCTAssertEqual(viewStore.state, false)
+        XCTAssertNoDifference(viewStore.state, false)
         expectation.fulfill()
       }
       self.wait(for: [expectation], timeout: 1)
@@ -196,11 +196,11 @@ final class ViewStoreTests: XCTestCase {
         let store = Store(initialState: false, reducer: reducer, environment: ())
         let viewStore = ViewStore(store)
 
-        XCTAssertEqual(viewStore.state, false)
+        XCTAssertNoDifference(viewStore.state, false)
         viewStore.send(.tapped)
-        XCTAssertEqual(viewStore.state, true)
+        XCTAssertNoDifference(viewStore.state, true)
         await viewStore.suspend(while: { $0 })
-        XCTAssertEqual(viewStore.state, false)
+        XCTAssertNoDifference(viewStore.state, false)
         expectation.fulfill()
       }
       self.wait(for: [expectation], timeout: 1)


### PR DESCRIPTION
Seems like we should always prefer it when it's available?