### PR TITLE
Use proportional diffing for TestStore failures

### DIFF
--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -367,7 +367,7 @@
     ) {
       if expected != actual {
         let difference =
-        diff(expected, actual)
+        diff(expected, actual, format: .proportional)
           .map { "\($0.indent(by: 4))\n\n(Expected: −, Actual: +)" }
           ?? """
           Expected:
@@ -409,7 +409,7 @@
       let (receivedAction, state) = self.receivedActions.removeFirst()
       if expectedAction != receivedAction {
         let difference =
-        diff(expectedAction, receivedAction)
+        diff(expectedAction, receivedAction, format: .proportional)
           .map { "\($0.indent(by: 4))\n\n(Expected: −, Received: +)" }
           ?? """
           Expected:

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -222,7 +222,7 @@ final class EffectTests: XCTestCase {
       }
       .sink(receiveValue: { result = $0 })
       .store(in: &self.cancellables)
-      self.wait(for: [expectation], timeout: 0)
+      self.wait(for: [expectation], timeout: 1)
       XCTAssertEqual(result, 42)
     }
 

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -226,56 +226,56 @@ final class EffectTests: XCTestCase {
       XCTAssertEqual(result, 42)
     }
 
-  func testThrowingTask() {
-    guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else { return }
+    func testThrowingTask() {
+      guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else { return }
 
-    let expectation = self.expectation(description: "Complete")
-    struct MyError: Error {}
-    var result: Error?
-    Effect<Int, Error>.task {
-      expectation.fulfill()
-      throw MyError()
-    }
-    .sink(
-      receiveCompletion: {
-        switch $0 {
-        case .finished:
-          XCTFail()
-        case let .failure(error):
-          result = error
-        }
-      },
-      receiveValue: { _ in XCTFail() }
-    )
-    .store(in: &self.cancellables)
-    self.wait(for: [expectation], timeout: 0)
-    XCTAssertNotNil(result)
-  }
-
-  func testCancellingTask() {
-    guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else { return }
-
-    @Sendable func work() async throws -> Int {
-      var task: Task<Int, Error>!
-      task = Task {
-        await Task.sleep(NSEC_PER_MSEC)
-        try Task.checkCancellation()
-        return 42
+      let expectation = self.expectation(description: "Complete")
+      struct MyError: Error {}
+      var result: Error?
+      Effect<Int, Error>.task {
+        expectation.fulfill()
+        throw MyError()
       }
-      task.cancel()
-      return try await task.value
+      .sink(
+        receiveCompletion: {
+          switch $0 {
+          case .finished:
+            XCTFail()
+          case let .failure(error):
+            result = error
+          }
+        },
+        receiveValue: { _ in XCTFail() }
+      )
+      .store(in: &self.cancellables)
+      self.wait(for: [expectation], timeout: 1)
+      XCTAssertNotNil(result)
     }
 
-    let expectation = self.expectation(description: "Complete")
-    Effect<Int, Error>.task {
-      try await work()
+    func testCancellingTask() {
+      guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else { return }
+
+      @Sendable func work() async throws -> Int {
+        var task: Task<Int, Error>!
+        task = Task {
+          await Task.sleep(NSEC_PER_MSEC)
+          try Task.checkCancellation()
+          return 42
+        }
+        task.cancel()
+        return try await task.value
+      }
+
+      let expectation = self.expectation(description: "Complete")
+      Effect<Int, Error>.task {
+        try await work()
+      }
+      .sink(
+        receiveCompletion: { _ in expectation.fulfill() },
+        receiveValue: { _ in XCTFail() }
+      )
+      .store(in: &self.cancellables)
+      self.wait(for: [expectation], timeout: 1)
     }
-    .sink(
-      receiveCompletion: { _ in expectation.fulfill() },
-      receiveValue: { _ in XCTFail() }
-    )
-    .store(in: &self.cancellables)
-    self.wait(for: [expectation], timeout: 0.2)
-  }
   #endif
 }


### PR DESCRIPTION
Forgot to make this change when we introduced customizable diff formats.