### PR TITLE
Clean up `Store.ifLet`

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -322,20 +322,13 @@ public final class Store<State, Action> {
     action fromLocalAction: @escaping (LocalAction) -> Action
   ) -> AnyPublisher<Store<LocalState, LocalAction>, Never>
   where P.Output == LocalState, P.Failure == Never {
-
-    func extractLocalState(_ state: State) -> LocalState? {
-      var localState: LocalState?
-      _ = toLocalState(Just(state).eraseToAnyPublisher())
-        .sink { localState = $0 }
-      return localState
-    }
-
     return toLocalState(self.state.eraseToAnyPublisher())
       .map { initialState in
         var localState = initialState
         return self.scope(
           state: { state in
-            localState = extractLocalState(state) ?? localState
+            _ = toLocalState(Just(state).eraseToAnyPublisher())
+              .sink { localState = $0 }
             return localState
           },
           action: fromLocalAction

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -331,15 +331,23 @@ public final class Store<State, Action> {
     }
 
     return toLocalState(self.state.eraseToAnyPublisher())
-      .map { initialState in
-        var localState = initialState
-        return self.scope(
-          state: { state in
-            localState = extractLocalState(state) ?? localState
-            return localState
+      .map { localState in
+        let localStore = Store<LocalState, LocalAction>(
+          initialState: localState,
+          reducer: .init { localState, localAction, _ in
+            self.send(fromLocalAction(localAction))
+            localState = extractLocalState(self.state.value) ?? localState
+            return .none
           },
-          action: fromLocalAction
+          environment: ()
         )
+
+        localStore.parentCancellable = self.state
+          .sink { [weak localStore] state in
+            guard let localStore = localStore else { return }
+            localStore.state.value = extractLocalState(state) ?? localStore.state.value
+          }
+        return localStore
       }
       .eraseToAnyPublisher()
   }

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -331,11 +331,23 @@ public final class Store<State, Action> {
     }
 
     return toLocalState(self.state.eraseToAnyPublisher())
-      .map { initialState in
-        self.scope(
-          state: { extractLocalState($0) ?? initialState },
-          action: fromLocalAction
+      .map { localState in
+        let localStore = Store<LocalState, LocalAction>(
+          initialState: localState,
+          reducer: .init { localState, localAction, _ in
+            self.send(fromLocalAction(localAction))
+            localState = extractLocalState(self.state.value) ?? localState
+            return .none
+          },
+          environment: ()
         )
+
+        localStore.parentCancellable = self.state
+          .sink { [weak localStore] state in
+            guard let localStore = localStore else { return }
+            localStore.state.value = extractLocalState(state) ?? localStore.state.value
+          }
+        return localStore
       }
       .eraseToAnyPublisher()
   }

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -52,11 +52,16 @@ extension Store {
     return self.state
       .removeDuplicates(by: { ($0 != nil) == ($1 != nil) })
       .sink { state in
-        if let state = state {
-          unwrap(self.scope(state: { $0 ?? state }))
+        if var state = state {
+          unwrap(self.scope {
+            state = $0 ?? state
+            return state
+          })
         } else {
           `else`()
         }
       }
   }
 }
+
+

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -49,32 +49,14 @@ extension Store {
     then unwrap: @escaping (Store<Wrapped, Action>) -> Void,
     else: @escaping () -> Void = {}
   ) -> Cancellable where State == Wrapped? {
-    let elseCancellable =
-      self
-      .publisherScope(
-        state: { state in
-          state
-            .removeDuplicates(by: { ($0 != nil) == ($1 != nil) })
+    return self.state
+      .removeDuplicates(by: { ($0 != nil) == ($1 != nil) })
+      .sink { state in
+        if let state = state {
+          unwrap(self.scope(state: { $0 ?? state }))
+        } else {
+          `else`()
         }
-      )
-      .sink { store in
-        if store.state.value == nil { `else`() }
       }
-
-    let unwrapCancellable =
-      self
-      .publisherScope(
-        state: { state in
-          state
-            .removeDuplicates(by: { ($0 != nil) == ($1 != nil) })
-            .compactMap { $0 }
-        }
-      )
-      .sink(receiveValue: unwrap)
-
-    return AnyCancellable {
-      elseCancellable.cancel()
-      unwrapCancellable.cancel()
-    }
   }
 }


### PR DESCRIPTION
I was playing around with `.publisherScope` and noticed you might be able to shorten `Store.ifLet`. The tests pass but I don't really know the implications of this change.