### PR TITLE
Alternative to `CurrentValueSubject` in `ViewStore`

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Create.swift
+++ b/Sources/ComposableArchitecture/Internal/Create.swift
@@ -23,7 +23,7 @@
 import Combine
 import Darwin
 
-class DemandBuffer<S: Subscriber> {
+final class DemandBuffer<S: Subscriber> {
   private var buffer = [S.Input]()
   private let subscriber: S
   private var completion: Subscribers.Completion<S.Failure>?

--- a/Sources/ComposableArchitecture/Internal/Create.swift
+++ b/Sources/ComposableArchitecture/Internal/Create.swift
@@ -23,7 +23,7 @@
 import Combine
 import Darwin
 
-private class DemandBuffer<S: Subscriber> {
+class DemandBuffer<S: Subscriber> {
   private var buffer = [S.Input]()
   private let subscriber: S
   private var completion: Subscribers.Completion<S.Failure>?

--- a/Sources/ComposableArchitecture/Internal/CurrentValueRelay.swift
+++ b/Sources/ComposableArchitecture/Internal/CurrentValueRelay.swift
@@ -1,0 +1,58 @@
+import Combine
+import Foundation
+
+class CurrentValueRelay<Output>: Publisher {
+  typealias Failure = Never
+
+  private var currentValue: Output
+  private var subscriptions: [Subscription<AnySubscriber<Output, Failure>>] = []
+
+  var value: Output {
+    get { self.currentValue }
+    set { self.send(newValue) }
+  }
+
+  init(_ value: Output) {
+    self.currentValue = value
+  }
+
+  func receive<S>(subscriber: S)
+    where S: Subscriber, Never == S.Failure, Output == S.Input
+  {
+    let subscription = Subscription(downstream: AnySubscriber(subscriber))
+    self.subscriptions.append(subscription)
+    subscriber.receive(subscription: subscription)
+    subscription.forwardValueToBuffer(self.currentValue)
+  }
+
+  func send(_ value: Output) {
+    self.currentValue = value
+    for subscription in subscriptions {
+      subscription.forwardValueToBuffer(value)
+    }
+  }
+}
+
+extension CurrentValueRelay {
+  class Subscription<Downstream: Subscriber>: Combine.Subscription
+    where Output == Downstream.Input, Failure == Downstream.Failure
+  {
+    private var demandBuffer: DemandBuffer<Downstream>?
+
+    init(downstream: Downstream) {
+      self.demandBuffer = DemandBuffer(subscriber: downstream)
+    }
+
+    func forwardValueToBuffer(_ value: Output) {
+      _ = demandBuffer?.buffer(value: value)
+    }
+
+    func request(_ demand: Subscribers.Demand) {
+      _ = demandBuffer?.demand(demand)
+    }
+
+    func cancel() {
+      demandBuffer = nil
+    }
+  }
+}

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -58,7 +58,7 @@ public final class ViewStore<State, Action>: ObservableObject {
   public private(set) lazy var objectWillChange = ObservableObjectPublisher()
 
   private let _send: (Action) -> Void
-  fileprivate let _state: CurrentValueSubject<State, Never>
+  fileprivate let _state: CurrentValueRelay<State>
   private var viewCancellable: AnyCancellable?
 
   /// Initializes a view store from a store.
@@ -72,7 +72,7 @@ public final class ViewStore<State, Action>: ObservableObject {
     removeDuplicates isDuplicate: @escaping (State, State) -> Bool
   ) {
     self._send = store.send
-    self._state = CurrentValueSubject(store.state.value)
+    self._state = CurrentValueRelay(store.state.value)
 
     self.viewCancellable = store.state
       .removeDuplicates(by: isDuplicate)

--- a/Tests/ComposableArchitectureTests/ViewStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/ViewStoreTests.swift
@@ -137,6 +137,37 @@ final class ViewStoreTests: XCTestCase {
     XCTAssertNoDifference(results, [0, 1])
   }
 
+  func testStorePublisherSubscriptionOrder() {
+    let reducer = Reducer<Int, Void, Void> { count, _, _ in
+      count += 1
+      return .none
+    }
+    let store = Store(initialState: 0, reducer: reducer, environment: ())
+    let viewStore = ViewStore(store)
+
+    var results: [Int] = []
+
+    viewStore.publisher
+      .sink { _ in results.append(0) }
+      .store(in: &self.cancellables)
+
+    viewStore.publisher
+      .sink { _ in results.append(1) }
+      .store(in: &self.cancellables)
+
+    viewStore.publisher
+      .sink { _ in results.append(2) }
+      .store(in: &self.cancellables)
+
+    XCTAssertNoDifference(results, [0, 1, 2])
+
+    for _ in 0 ..< 9 {
+      viewStore.send(())
+    }
+
+    XCTAssertNoDifference(results, Array(repeating: [0, 1, 2], count: 10).flatMap { $0 })
+  }
+
   #if compiler(>=5.5)
     func testSendWhile() {
       guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else { return }


### PR DESCRIPTION
This is a proof of concept as a way to provide consistent ordering for StorePublisher subscribers (discussed in #698). @mbrandonw mentioned:

> It would be great if it could be fixed at the library level

so I thought I'd give it a try. Pretty sure it will need to be made thread safe and have some extensive tests/benchmarks added.

I can see the benefits of sticking with CurrentValueSubject and I haven't thoroughly tested this... just checking to see if it's something worth exploring further. I used [CombineExt/CurrentValueRelay](https://github.com/CombineCommunity/CombineExt/blob/main/Sources/Relays/CurrentValueRelay.swift) as a starting point.