### PR TITLE
Improve deprecation warnings for old binding helpers

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -9,7 +9,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "For improved safety, values must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\.$value'"
+        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\.$value'"
     )
     public static func set<Value>(
       _ keyPath: WritableKeyPath<Root, Value>,
@@ -27,7 +27,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "For improved safety, values must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\.$value'"
+        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\.$value'"
     )
     public static func ~= <Value>(
       keyPath: WritableKeyPath<Root, Value>,
@@ -56,7 +56,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "View store bindings must be derived via dynamic member lookup (for example, 'viewStore.$value') from values wrapped in 'BindableState' and an action type that conforms to 'BindableAction'"
+        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState'. Bindings are now derived via dynamic member lookup to that 'BindableState' (for example, 'viewStore.$value'). For dynamic member lookup to be available, the view store's action type must also conform to 'BindableAction'."
     )
     public func binding<LocalState>(
       keyPath: WritableKeyPath<State, LocalState>,
@@ -74,7 +74,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "For improved safety, values must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
+        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
     )
     public static func set<Value>(
       _ keyPath: WritableKeyPath<Root, Value>,
@@ -92,7 +92,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "For improved safety, values must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
+        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
     )
     public static func ~= <Value>(
       keyPath: WritableKeyPath<Root, Value>,
@@ -121,7 +121,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "View store bindings must be derived via dynamic member lookup (for example, 'viewStore.$value') from values wrapped in 'BindableState' and an action type that conforms to 'BindableAction'. Upgrade to Xcode 12.5 or greater for access to 'BindableState' and 'BindableAction'."
+        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState'. Bindings are now derived via dynamic member lookup to that 'BindableState' (for example, 'viewStore.$value'). For dynamic member lookup to be available, the view store's action type must also conform to 'BindableAction'. Upgrade to Xcode 12.5 or greater for access to 'BindableState' and 'BindableAction'."
     )
     public func binding<LocalState>(
       keyPath: WritableKeyPath<State, LocalState>,

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -41,7 +41,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "'Reducer.binding()' no longer takes an explicit extract function and instead relies on 'Action' conforming to 'BindableAction'"
+        "'Reducer.binding()' no longer takes an explicit extract function and instead the reducer's 'Action' type must conform to 'BindableAction'"
     )
     public func binding(action toBindingAction: @escaping (Action) -> BindingAction<State>?) -> Self
     {
@@ -56,7 +56,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState'. Bindings are now derived via dynamic member lookup to that 'BindableState' (for example, 'viewStore.$value'). For dynamic member lookup to be available, the view store's action type must also conform to 'BindableAction'."
+        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState'. Bindings are now derived via dynamic member lookup to that 'BindableState' (for example, 'viewStore.$value'). For dynamic member lookup to be available, the view store's 'Action' type must also conform to 'BindableAction'."
     )
     public func binding<LocalState>(
       keyPath: WritableKeyPath<State, LocalState>,
@@ -106,7 +106,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "'Reducer.binding()' no longer takes an explicit extract function and instead relies on 'Action' conforming to 'BindableAction'. Upgrade to Xcode 12.5 or greater for access to 'Reducer.binding()' and 'BindableAction'."
+        "'Reducer.binding()' no longer takes an explicit extract function and instead the reducer's 'Action' type must conform to 'BindableAction'. Upgrade to Xcode 12.5 or greater for access to 'Reducer.binding()' and 'BindableAction'."
     )
     public func binding(action toBindingAction: @escaping (Action) -> BindingAction<State>?) -> Self
     {
@@ -121,7 +121,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState'. Bindings are now derived via dynamic member lookup to that 'BindableState' (for example, 'viewStore.$value'). For dynamic member lookup to be available, the view store's action type must also conform to 'BindableAction'. Upgrade to Xcode 12.5 or greater for access to 'BindableState' and 'BindableAction'."
+        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState'. Bindings are now derived via dynamic member lookup to that 'BindableState' (for example, 'viewStore.$value'). For dynamic member lookup to be available, the view store's 'Action' type must also conform to 'BindableAction'. Upgrade to Xcode 12.5 or greater for access to 'BindableState' and 'BindableAction'."
     )
     public func binding<LocalState>(
       keyPath: WritableKeyPath<State, LocalState>,

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -6,7 +6,11 @@ import SwiftUI
 
 #if compiler(>=5.4)
   extension BindingAction {
-    @available(*, deprecated, message: "Values are now wrapped in 'BindableState'")
+    @available(
+      *, deprecated,
+      message:
+        "Wrap values in 'BindableState' and use key paths to the projected values, like '\.$value'"
+    )
     public static func set<Value>(
       _ keyPath: WritableKeyPath<Root, Value>,
       _ value: Value
@@ -20,7 +24,11 @@ import SwiftUI
       )
     }
 
-    @available(*, deprecated, message: "Values are now wrapped in 'BindableState'")
+    @available(
+      *, deprecated,
+      message:
+        "Wrap values in 'BindableState' and use key paths to the projected values, like '\.$value'"
+    )
     public static func ~= <Value>(
       keyPath: WritableKeyPath<Root, Value>,
       bindingAction: Self
@@ -33,7 +41,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "'Reducer.binding()' no longer takes an explicit extract function and instead relies on 'BindableAction'"
+        "'Reducer.binding()' no longer takes an explicit extract function and instead relies on 'Action' conforming to 'BindableAction'"
     )
     public func binding(action toBindingAction: @escaping (Action) -> BindingAction<State>?) -> Self
     {
@@ -46,7 +54,9 @@ import SwiftUI
 
   extension ViewStore {
     @available(
-      *, deprecated, message: "Bindings are now derived using 'BindableState' and 'BindableAction'"
+      *, deprecated,
+      message:
+        "Derive view store bindings via dynamic member lookup (for example, 'viewStore.$value') by wrapping values in 'BindableState' and conforming the action type to 'BindableAction'"
     )
     public func binding<LocalState>(
       keyPath: WritableKeyPath<State, LocalState>,
@@ -64,7 +74,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "Values are now wrapped in 'BindableState'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
+        "Wrap values in 'BindableState' and use key paths to the projected values, like '\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
     )
     public static func set<Value>(
       _ keyPath: WritableKeyPath<Root, Value>,
@@ -82,7 +92,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "Values are now wrapped in 'BindableState'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
+        "Wrap values in 'BindableState' and use key paths to the projected values, like '\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
     )
     public static func ~= <Value>(
       keyPath: WritableKeyPath<Root, Value>,
@@ -96,7 +106,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "'Reducer.binding()' no longer takes an explicit extract function and instead relies on 'BindableAction'. Upgrade to Xcode 12.5 or greater for access to 'Reducer.binding()' and 'BindableAction'."
+        "'Reducer.binding()' no longer takes an explicit extract function and instead relies on 'Action' conforming to 'BindableAction'. Upgrade to Xcode 12.5 or greater for access to 'Reducer.binding()' and 'BindableAction'."
     )
     public func binding(action toBindingAction: @escaping (Action) -> BindingAction<State>?) -> Self
     {
@@ -111,7 +121,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "Bindings are now derived using 'BindableState' and 'BindableAction'. Upgrade to Xcode 12.5 or greater for access to 'BindableState' and 'BindableAction'."
+        "Derive view store bindings via dynamic member lookup (for example, 'viewStore.$value') by wrapping values in 'BindableState' and conforming the action type to 'BindableAction'. Upgrade to Xcode 12.5 or greater for access to 'Reducer.binding()' and 'BindableAction'."
     )
     public func binding<LocalState>(
       keyPath: WritableKeyPath<State, LocalState>,

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -9,7 +9,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "Wrap values in 'BindableState' and use key paths to that 'BindableState', like '\.$value'"
+        "For improved safety, values must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\.$value'"
     )
     public static func set<Value>(
       _ keyPath: WritableKeyPath<Root, Value>,
@@ -27,7 +27,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "Wrap values in 'BindableState' and use key paths to that 'BindableState', like '\.$value'"
+        "For improved safety, values must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\.$value'"
     )
     public static func ~= <Value>(
       keyPath: WritableKeyPath<Root, Value>,
@@ -56,7 +56,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "Derive view store bindings via dynamic member lookup (for example, 'viewStore.$value') by wrapping values in 'BindableState' and conforming the action type to 'BindableAction'"
+        "View store bindings must be derived via dynamic member lookup (for example, 'viewStore.$value') from values wrapped in 'BindableState' and an action type that conforms to 'BindableAction'"
     )
     public func binding<LocalState>(
       keyPath: WritableKeyPath<State, LocalState>,
@@ -74,7 +74,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "Wrap values in 'BindableState' and use key paths to that 'BindableState', like '\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
+        "For improved safety, values must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
     )
     public static func set<Value>(
       _ keyPath: WritableKeyPath<Root, Value>,
@@ -92,7 +92,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "Wrap values in 'BindableState' and use key paths to that 'BindableState', like '\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
+        "For improved safety, values must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
     )
     public static func ~= <Value>(
       keyPath: WritableKeyPath<Root, Value>,
@@ -121,7 +121,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "Derive view store bindings via dynamic member lookup (for example, 'viewStore.$value') by wrapping values in 'BindableState' and conforming the action type to 'BindableAction'. Upgrade to Xcode 12.5 or greater for access to 'Reducer.binding()' and 'BindableAction'."
+        "View store bindings must be derived via dynamic member lookup (for example, 'viewStore.$value') from values wrapped in 'BindableState' and an action type that conforms to 'BindableAction'. Upgrade to Xcode 12.5 or greater for access to 'BindableState' and 'BindableAction'."
     )
     public func binding<LocalState>(
       keyPath: WritableKeyPath<State, LocalState>,

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -9,7 +9,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\.$value'"
+        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\\.$value'"
     )
     public static func set<Value>(
       _ keyPath: WritableKeyPath<Root, Value>,
@@ -27,7 +27,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\.$value'"
+        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\\.$value'"
     )
     public static func ~= <Value>(
       keyPath: WritableKeyPath<Root, Value>,
@@ -74,7 +74,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
+        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
     )
     public static func set<Value>(
       _ keyPath: WritableKeyPath<Root, Value>,
@@ -92,7 +92,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
+        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
     )
     public static func ~= <Value>(
       keyPath: WritableKeyPath<Root, Value>,

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -9,7 +9,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "Wrap values in 'BindableState' and use key paths to the projected values, like '\.$value'"
+        "Wrap values in 'BindableState' and use key paths to that 'BindableState', like '\.$value'"
     )
     public static func set<Value>(
       _ keyPath: WritableKeyPath<Root, Value>,
@@ -27,7 +27,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "Wrap values in 'BindableState' and use key paths to the projected values, like '\.$value'"
+        "Wrap values in 'BindableState' and use key paths to that 'BindableState', like '\.$value'"
     )
     public static func ~= <Value>(
       keyPath: WritableKeyPath<Root, Value>,
@@ -74,7 +74,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "Wrap values in 'BindableState' and use key paths to the projected values, like '\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
+        "Wrap values in 'BindableState' and use key paths to that 'BindableState', like '\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
     )
     public static func set<Value>(
       _ keyPath: WritableKeyPath<Root, Value>,
@@ -92,7 +92,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "Wrap values in 'BindableState' and use key paths to the projected values, like '\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
+        "Wrap values in 'BindableState' and use key paths to that 'BindableState', like '\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
     )
     public static func ~= <Value>(
       keyPath: WritableKeyPath<Root, Value>,


### PR DESCRIPTION
Have had some confusion about upgrade paths, so let's improve the warnings with some examples.