### PR TITLE
Conform BindableState to CustomDebugStringConvertible

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -226,6 +226,12 @@ import SwiftUI
     }
   }
 
+  extension BindableState: CustomDebugStringConvertible where Value: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        self.wrappedValue.debugDescription
+    }
+  }
+
   /// An action type that exposes a `binding` case for the purpose of reducing.
   ///
   /// Used in conjunction with ``BindableState`` to safely eliminate the boilerplate typically


### PR DESCRIPTION
This ensures that bindable state properties are displayed in a useful way when using `.dump` snapshot tests on your app state.

Fixes #776 