### PR TITLE
Fix "BindableState: Codable" strategies

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -204,13 +204,23 @@ import SwiftUI
 
   extension BindableState: Decodable where Value: Decodable {
     public init(from decoder: Decoder) throws {
-      self.init(wrappedValue: try Value(from: decoder))
+      do {
+        let container = try decoder.singleValueContainer()
+        self.init(wrappedValue: try container.decode(Value.self))
+      } catch {
+        self.init(wrappedValue: try Value(from: decoder))
+      }
     }
   }
 
   extension BindableState: Encodable where Value: Encodable {
     public func encode(to encoder: Encoder) throws {
-      try self.wrappedValue.encode(to: encoder)
+      do {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.wrappedValue)
+      } catch {
+        try self.wrappedValue.encode(to: encoder)
+      }
     }
   }
 


### PR DESCRIPTION
[This forum post](https://forums.swift.org/t/propery-wrapper-decoding-difference-between-singlevaluecontainer-and-init-from-decoder/51918) reminded me that we had to work around a bug in Tagged:

https://github.com/pointfreeco/swift-tagged/blob/73f93e1fb534b88ba467ae90f8730167e804a32d/Sources/Tagged/Tagged.swift#L67-L75

I'm not sure if there's a bug filed for this behavior or not.