### PR TITLE
Use dispatch queue specific key to check thread safety

### DIFF
--- a/Sources/ComposableArchitecture/Internal/DispatchToken.swift
+++ b/Sources/ComposableArchitecture/Internal/DispatchToken.swift
@@ -1,0 +1,16 @@
+import Foundation
+struct DispatchToken: Hashable {
+  static let specificKey = DispatchSpecificKey<Set<DispatchToken>>()
+  
+  var id: UUID
+  var queueDescription: String
+  
+  init?(dispatchQueue: DispatchQueue) {
+    guard dispatchQueue != .main else { return nil }
+    self.id = UUID()
+    self.queueDescription = "\(dispatchQueue)"
+  }
+  
+  static func == (lhs: DispatchToken, rhs: DispatchToken) -> Bool { lhs.id == rhs.id }
+  func hash(into hasher: inout Hasher) { hasher.combine(id) }
+}

--- a/Sources/ComposableArchitecture/Internal/DispatchToken.swift
+++ b/Sources/ComposableArchitecture/Internal/DispatchToken.swift
@@ -1,16 +1,13 @@
 import Foundation
-struct DispatchToken: Hashable {
+final class DispatchToken: Hashable {
   static let specificKey = DispatchSpecificKey<Set<DispatchToken>>()
-  
-  var id: UUID
-  var queueDescription: String
+  let queueDescription: String
   
   init?(dispatchQueue: DispatchQueue) {
     guard dispatchQueue != .main else { return nil }
-    self.id = UUID()
     self.queueDescription = "\(dispatchQueue)"
   }
   
-  static func == (lhs: DispatchToken, rhs: DispatchToken) -> Bool { lhs.id == rhs.id }
-  func hash(into hasher: inout Hasher) { hasher.combine(id) }
+  static func == (lhs: DispatchToken, rhs: DispatchToken) -> Bool { lhs === rhs }
+  func hash(into hasher: inout Hasher) { }
 }

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -470,11 +470,15 @@ public final class Store<State, Action> {
         return
       }
     
-      let queueDescription = DispatchQueue.getSpecific(key: DispatchToken.specificKey)?
-                                          .first?
-                                          .queueDescription
-                             ?? "\(DispatchQueue.main)"
-    
+      let queueDescription: String
+      if let token = DispatchQueue.getSpecific(key: DispatchToken.specificKey)?.first {
+        queueDescription = token.queueDescription
+      } else if Thread.isMainThread {
+        queueDescription = "\(DispatchQueue.main)"
+      } else {
+        queueDescription = "Unknown queue"
+      }
+      
       let message: String
       switch status {
       case let .effectCompletion(action):

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -121,7 +121,7 @@ public final class Store<State, Action> {
   private let reducer: (inout State, Action) -> Effect<Action, Never>
   private var bufferedActions: [Action] = []
   #if DEBUG
-  private let dispatchToken: UUID?
+    private let dispatchToken: UUID?
   #endif
 
   /// Initializes a store from an initial state, a reducer, an environment, and a dispatch queue.
@@ -140,16 +140,15 @@ public final class Store<State, Action> {
     environment: Environment,
     dispatchQueue: DispatchQueue = .main
   ) {
-    
-    let token: UUID?
-    if dispatchQueue != DispatchQueue.main {
-      token = UUID()
-      var tokens = dispatchQueue.getSpecific(key: storeDispatchSpecificKey) ?? []
-      tokens.insert(token!)
-      dispatchQueue.setSpecific(key: storeDispatchSpecificKey, value: tokens)
-    } else {
-      token = nil
-    }
+    var token: UUID? = nil
+    #if DEBUG
+      if dispatchQueue != DispatchQueue.main {
+        token = UUID()
+        var tokens = dispatchQueue.getSpecific(key: storeDispatchSpecificKey) ?? []
+        tokens.insert(token!)
+        dispatchQueue.setSpecific(key: storeDispatchSpecificKey, value: tokens)
+      }
+    #endif
     
     self.init(
       initialState: initialState,

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -132,7 +132,7 @@ public final class Store<State, Action> {
   ///   - reducer: The reducer that powers the business logic of the application.
   ///   - environment: The environment of dependencies for the application.
   ///
-  /// - Note: Use ``uncheckedThreadStore(initialState:reducer:environment:)`` if
+  /// - Note: Use ``withUncheckedThread(initialState:reducer:environment:)`` if
   /// the store receives actions on an arbitrary serial queue.
   public convenience init<Environment>(
     initialState: State,
@@ -154,7 +154,7 @@ public final class Store<State, Action> {
   ///   - initialState: The state to start the application in.
   ///   - reducer: The reducer that powers the business logic of the application.
   ///   - environment: The environment of dependencies for the application.
-  public static func uncheckedThreadStore<Environment>(
+  public static func withUncheckedThread<Environment>(
     initialState: State,
     reducer: Reducer<State, Action, Environment>,
     environment: Environment

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -536,7 +536,7 @@ final class StoreTests: XCTestCase {
       initialState: 0,
       reducer: reducer,
       environment: (),
-      dispatchQueue: queue
+      boundTo: queue
     )
     let viewStore = ViewStore(store)
     queue.async {


### PR DESCRIPTION
This is an alternative way to handle thread checks, as proposed by @mluisbrown in #802, and an alternative to #805 that should work for arbitrary queues.

The store's initializer gets an additional `dispatchQueue` argument (`.main` by default), and some `DispatchSpecificKey` is used to store some store's metadata in the `DispatchQueue`. 

Thread safety is delegated to GCD if I understand correctly.