### PR TITLE
Deprecate dynamic member lookup on view stores in favor of ViewStore.binding

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -55,7 +55,7 @@ struct BindingFormView: View {
       Form {
         Section(header: Text(template: readMe, .caption)) {
           HStack {
-            TextField("Type here", text: viewStore.$text)
+            TextField("Type here", text: viewStore.binding(\.$text))
               .disableAutocorrection(true)
               .foregroundColor(viewStore.toggleIsOn ? .gray : .primary)
 
@@ -63,9 +63,9 @@ struct BindingFormView: View {
           }
           .disabled(viewStore.toggleIsOn)
 
-          Toggle("Disable other controls", isOn: viewStore.$toggleIsOn)
+          Toggle("Disable other controls", isOn: viewStore.binding(\.$toggleIsOn))
 
-          Stepper(value: viewStore.$stepCount, in: 0...100) {
+          Stepper(value: viewStore.binding(\.$stepCount), in: 0...100) {
             Text("Max slider value: \(viewStore.stepCount)")
               .font(Font.body.monospacedDigit())
           }
@@ -75,7 +75,7 @@ struct BindingFormView: View {
             Text("Slider value: \(Int(viewStore.sliderValue))")
               .font(Font.body.monospacedDigit())
 
-            Slider(value: viewStore.$sliderValue, in: 0...Double(viewStore.stepCount))
+            Slider(value: viewStore.binding(\.$sliderValue), in: 0...Double(viewStore.stepCount))
           }
           .disabled(viewStore.toggleIsOn)
         }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -54,10 +54,10 @@ let focusDemoReducer = Reducer<
           Text(template: readMe, .caption)
 
           VStack {
-            TextField("Username", text: viewStore.$username)
+            TextField("Username", text: viewStore.binding(\.$username))
               .focused($focusedField, equals: .username)
 
-            SecureField("Password", text: viewStore.$password)
+            SecureField("Password", text: viewStore.binding(\.$password))
               .focused($focusedField, equals: .password)
 
             Button("Sign In") {
@@ -68,7 +68,7 @@ let focusDemoReducer = Reducer<
           Spacer()
         }
         .padding()
-        .synchronize(viewStore.$focusedField, self.$focusedField)
+        .synchronize(viewStore.binding(\.$focusedField), self.$focusedField)
       }
       .navigationBarTitle("Focus demo")
     }

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -2,6 +2,25 @@ import CasePaths
 import Combine
 import SwiftUI
 
+// NB: Deprecated after 0.27.1:
+
+extension ViewStore {
+  @available(
+    *, deprecated,
+    message:
+      "Dynamic member lookup is no longer supported for bindable state. Instead of dot-chaining on the view store, e.g. 'viewStore.$value', invoke the 'binding' method on view store with a key path to the value, e.g. 'viewStore.binding(\\.$value)'. For more on this change, see: https://github.com/pointfreeco/swift-composable-architecture/pull/810"
+  )
+  public subscript<Value>(
+    dynamicMember keyPath: WritableKeyPath<State, BindableState<Value>>
+  ) -> Binding<Value>
+  where Action: BindableAction, Action.State == State, Value: Equatable {
+    self.binding(
+      get: { $0[keyPath: keyPath].wrappedValue },
+      send: { .binding(.set(keyPath, $0)) }
+    )
+  }
+}
+
 // NB: Deprecated after 0.25.0:
 
 #if compiler(>=5.4)
@@ -56,7 +75,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState'. Bindings are now derived via dynamic member lookup to that 'BindableState' (for example, 'viewStore.$value'). For dynamic member lookup to be available, the view store's 'Action' type must also conform to 'BindableAction'."
+        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState'. Bindings are now derived via 'ViewStore.binding' with a key path to that 'BindableState' (for example, 'viewStore.binding(\\.$value)'). For dynamic member lookup to be available, the view store's 'Action' type must also conform to 'BindableAction'."
     )
     public func binding<LocalState>(
       keyPath: WritableKeyPath<State, LocalState>,
@@ -121,7 +140,7 @@ import SwiftUI
     @available(
       *, deprecated,
       message:
-        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState'. Bindings are now derived via dynamic member lookup to that 'BindableState' (for example, 'viewStore.$value'). For dynamic member lookup to be available, the view store's 'Action' type must also conform to 'BindableAction'. Upgrade to Xcode 12.5 or greater for access to 'BindableState' and 'BindableAction'."
+        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState'. Bindings are now derived via 'ViewStore.binding' with a key path to that 'BindableState' (for example, 'viewStore.binding(\\.$value)'). For dynamic member lookup to be available, the view store's 'Action' type must also conform to 'BindableAction'. Upgrade to Xcode 12.5 or greater for access to 'BindableState' and 'BindableAction'."
     )
     public func binding<LocalState>(
       keyPath: WritableKeyPath<State, LocalState>,

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -122,12 +122,11 @@ import SwiftUI
   /// .binding()
   /// ```
   ///
-  /// Binding actions are constructed and sent to the store through the projected value of the
-  /// bindable state property wrapper in a syntax that is as familiar and succinct as vanilla
-  /// SwiftUI:
+  /// Binding actions are constructed and sent to the store by calling ``ViewStore/binding(_:)``
+  /// with a key path to the bindable state:
   ///
   /// ```swift
-  /// TextField("Display name", text: viewStore.$displayName)
+  /// TextField("Display name", text: viewStore.binding(\.$displayName))
   /// ```
   ///
   /// Should you need to layer additional functionality over these bindings, your reducer can
@@ -171,13 +170,13 @@ import SwiftUI
       self.wrappedValue = wrappedValue
     }
 
-    /// A projection can be used to derive bindings from a view store via dynamic member lookup.
+    /// A projection that can be used to derive bindings from a view store.
     ///
     /// Use the projected value to derive bindings from a view store with properties annotated with
     /// `@BindableState`. To get the `projectedValue`, prefix the property with `$`:
     ///
     /// ```swift
-    /// TextField("Display name", text: viewStore.$displayName)
+    /// TextField("Display name", text: viewStore.binding(\.$displayName))
     /// ```
     ///
     /// See ``BindableState`` for more details.
@@ -193,12 +192,8 @@ import SwiftUI
     public subscript<Subject>(
       dynamicMember keyPath: WritableKeyPath<Value, Subject>
     ) -> BindableState<Subject> {
-      get {
-        .init(wrappedValue: self.wrappedValue[keyPath: keyPath])
-      }
-      set {
-        self.wrappedValue[keyPath: keyPath] = newValue.wrappedValue
-      }
+      get { .init(wrappedValue: self.wrappedValue[keyPath: keyPath]) }
+      set { self.wrappedValue[keyPath: keyPath] = newValue.wrappedValue }
     }
   }
 
@@ -282,12 +277,11 @@ import SwiftUI
     ///
     /// - Parameter keyPath: A key path to a specific bindable state.
     /// - Returns: A new binding.
-    public subscript<Value>(
-      dynamicMember keyPath: WritableKeyPath<State, BindableState<Value>>
+    public func binding<Value>(
+      _ keyPath: WritableKeyPath<State, BindableState<Value>>
     ) -> Binding<Value>
     where Action: BindableAction, Action.State == State, Value: Equatable {
-      
-      return self.binding(
+      self.binding(
         get: { $0[keyPath: keyPath].wrappedValue },
         send: { .binding(.set(keyPath, $0)) }
       )
@@ -436,7 +430,7 @@ import SwiftUI
     /// WithViewStore(
     ///   self.store.scope(state: \.view, action: AppAction.view)
     /// ) { viewStore in
-    ///   Stepper("\(viewStore.count)", viewStore.$count)
+    ///   Stepper("\(viewStore.count)", viewStore.binding(\.$count))
     ///   Button("Get number fact") { viewStore.send(.factButtonTapped) }
     ///   if let fact = viewStore.fact {
     ///     Text(fact)
@@ -477,9 +471,7 @@ import SwiftUI
       keyPath: WritableKeyPath<Root, BindableState<Value>>,
       bindingAction: Self
     ) -> Bool {
-      print(keyPath)
-      print(bindingAction.keyPath)
-      return keyPath == bindingAction.keyPath
+      keyPath == bindingAction.keyPath
     }
   }
 

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -193,8 +193,12 @@ import SwiftUI
     public subscript<Subject>(
       dynamicMember keyPath: WritableKeyPath<Value, Subject>
     ) -> BindableState<Subject> {
-      get { .init(wrappedValue: self.wrappedValue[keyPath: keyPath]) }
-      set { self.wrappedValue[keyPath: keyPath] = newValue.wrappedValue }
+      get {
+        .init(wrappedValue: self.wrappedValue[keyPath: keyPath])
+      }
+      set {
+        self.wrappedValue[keyPath: keyPath] = newValue.wrappedValue
+      }
     }
   }
 
@@ -282,7 +286,8 @@ import SwiftUI
       dynamicMember keyPath: WritableKeyPath<State, BindableState<Value>>
     ) -> Binding<Value>
     where Action: BindableAction, Action.State == State, Value: Equatable {
-      self.binding(
+      
+      return self.binding(
         get: { $0[keyPath: keyPath].wrappedValue },
         send: { .binding(.set(keyPath, $0)) }
       )
@@ -472,7 +477,9 @@ import SwiftUI
       keyPath: WritableKeyPath<Root, BindableState<Value>>,
       bindingAction: Self
     ) -> Bool {
-      keyPath == bindingAction.keyPath
+      print(keyPath)
+      print(bindingAction.keyPath)
+      return keyPath == bindingAction.keyPath
     }
   }
 

--- a/Tests/ComposableArchitectureTests/BindingTests.swift
+++ b/Tests/ComposableArchitectureTests/BindingTests.swift
@@ -1,0 +1,44 @@
+import ComposableArchitecture
+import XCTest
+
+final class BindingTests: XCTestCase {
+  func testNestedBindableState() {
+    struct State: Equatable {
+      @BindableState var nested = Nested()
+
+      struct Nested: Equatable {
+        @BindableState var field = ""
+        var more = More()
+
+        struct More: Equatable {
+          var more =  ""
+        }
+      }
+    }
+
+    enum Action: BindableAction, Equatable {
+      case binding(BindingAction<State>)
+    }
+
+    let reducer = Reducer<State, Action, ()> { state, action, _ in
+      switch action {
+      case .binding(\.$nested.field):
+        state.nested.field += "!"
+        return .none
+      default:
+        return .none
+      }
+    }
+    .binding()
+
+    let store = Store(initialState: .init(), reducer: reducer, environment: ())
+
+    // TODO: `let` breaks this, fix with reference writable key path
+    let viewStore = ViewStore(store)
+
+     viewStore.$nested.$field.wrappedValue.wrappedValue = "Hello"
+//    viewStore.$nested.more.more.wrappedValue = "Hello"
+
+    XCTAssertNoDifference(viewStore.state, .init(nested: .init(field: "Hello!")))
+  }
+}

--- a/Tests/ComposableArchitectureTests/BindingTests.swift
+++ b/Tests/ComposableArchitectureTests/BindingTests.swift
@@ -7,12 +7,7 @@ final class BindingTests: XCTestCase {
       @BindableState var nested = Nested()
 
       struct Nested: Equatable {
-        @BindableState var field = ""
-        var more = More()
-
-        struct More: Equatable {
-          var more =  ""
-        }
+        var field = ""
       }
     }
 
@@ -33,11 +28,9 @@ final class BindingTests: XCTestCase {
 
     let store = Store(initialState: .init(), reducer: reducer, environment: ())
 
-    // TODO: `let` breaks this, fix with reference writable key path
     let viewStore = ViewStore(store)
 
-     viewStore.$nested.$field.wrappedValue.wrappedValue = "Hello"
-//    viewStore.$nested.more.more.wrappedValue = "Hello"
+    viewStore.binding(\.$nested.field).wrappedValue = "Hello"
 
     XCTAssertNoDifference(viewStore.state, .init(nested: .init(field: "Hello!")))
   }


### PR DESCRIPTION
Fixes #809.

In #765, we introduced a safer, conciser way of deriving SwiftUI bindings from view stores by leveraging dynamic member lookup:

```swift
// before:
viewStore.binding(keyPath: \.displayName, action: SettingsAction.binding)

// after:
viewStore.$displayName
```

This syntax worked great for the most part, but it unfortunately broke the ability to layer additional reducer logic on mutations to a particular nested field:

```swift
// Only associates the '.$userSettings' portion of the key path with the action sent to the reducer.
TextField("Display name", text: viewStore.$userSettings.displayName)

// reducer
case .binding(\.$userSettings.displayName): // 😳 Never matches!
  // some additional logic here
```

This PR deprecates the super-concise syntax for something that's still concise, but not _quite_ as concise. By explicitly passing the full key path to the view store, we can ensure that the reducer can match on it:

```swift
viewStore.binding(\.$userSettings.displayName)
```

It would be nice to conciseness of dynamic member lookup, but we're not sure it's possible.