### PR TITLE
Fix bindable deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
     strategy:
       matrix:
         xcode:
+          - 12.4
           - 12.5
           - '13.0'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         xcode:
+          - 12.4
           - 12.5
           - '13.0'
     steps:

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
@@ -7,7 +7,9 @@ struct RootState {
   var alertAndActionSheet = AlertAndSheetState()
   var animation = AnimationsState()
   var bindingBasics = BindingBasicsState()
-  var bindingForm = BindingFormState()
+  #if compiler(>=5.4)
+    var bindingForm = BindingFormState()
+  #endif
   var clock = ClockState()
   var counter = CounterState()
   var dieRoll = DieRollState()
@@ -15,7 +17,9 @@ struct RootState {
   var effectsCancellation = EffectsCancellationState()
   var effectsTimers = TimersState()
   var episodes = EpisodesState(episodes: .mocks)
-  var focusDemo = FocusDemoState()
+  #if compiler(>=5.5)
+    var focusDemo = FocusDemoState()
+  #endif
   var lifecycle = LifecycleDemoState()
   var loadThenNavigate = LoadThenNavigateState()
   var loadThenNavigateList = LoadThenNavigateListState()
@@ -39,14 +43,18 @@ enum RootAction {
   case alertAndActionSheet(AlertAndSheetAction)
   case animation(AnimationsAction)
   case bindingBasics(BindingBasicsAction)
-  case bindingForm(BindingFormAction)
+  #if compiler(>=5.4)
+    case bindingForm(BindingFormAction)
+  #endif
   case clock(ClockAction)
   case counter(CounterAction)
   case dieRoll(DieRollAction)
   case effectsBasics(EffectsBasicsAction)
   case effectsCancellation(EffectsCancellationAction)
   case episodes(EpisodesAction)
-  case focusDemo(FocusDemoAction)
+  #if compiler(>=5.5)
+    case focusDemo(FocusDemoAction)
+  #endif
   case lifecycle(LifecycleDemoAction)
   case loadThenNavigate(LoadThenNavigateAction)
   case loadThenNavigateList(LoadThenNavigateListAction)
@@ -120,12 +128,19 @@ let rootReducer = Reducer<RootState, RootAction, RootEnvironment>.combine(
       action: /RootAction.bindingBasics,
       environment: { _ in .init() }
     ),
-  bindingFormReducer
-    .pullback(
-      state: \.bindingForm,
-      action: /RootAction.bindingForm,
-      environment: { _ in .init() }
-    ),
+  .init { state, action, environment in
+    #if compiler(>=5.4)
+      return bindingFormReducer
+        .pullback(
+          state: \.bindingForm,
+          action: /RootAction.bindingForm,
+          environment: { _ in .init() }
+        )
+        .run(&state, action, environment)
+    #else
+      return .none
+    #endif
+  },
   clockReducer
     .pullback(
       state: \.clock,
@@ -162,12 +177,19 @@ let rootReducer = Reducer<RootState, RootAction, RootEnvironment>.combine(
       action: /RootAction.episodes,
       environment: { .init(favorite: $0.favorite, mainQueue: $0.mainQueue) }
     ),
-  focusDemoReducer
-    .pullback(
-      state: \.focusDemo,
-      action: /RootAction.focusDemo,
-      environment: { _ in .init() }
-    ),
+  .init { state, action, environment in
+    #if compiler(>=5.5)
+      return focusDemoReducer
+        .pullback(
+          state: \.focusDemo,
+          action: /RootAction.focusDemo,
+          environment: { _ in .init() }
+        )
+        .run(&state, action, environment)
+    #else
+      return .none
+    #endif
+  },
   lifecycleDemoReducer
     .pullback(
       state: \.lifecycle,

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -40,15 +40,17 @@ struct RootView: View {
               )
             )
 
-            NavigationLink(
-              "Form bindings",
-              destination: BindingFormView(
-                store: self.store.scope(
-                  state: \.bindingForm,
-                  action: RootAction.bindingForm
+            #if compiler(>=5.4)
+              NavigationLink(
+                "Form bindings",
+                destination: BindingFormView(
+                  store: self.store.scope(
+                    state: \.bindingForm,
+                    action: RootAction.bindingForm
+                  )
                 )
               )
-            )
+            #endif
 
             NavigationLink(
               "Optional state",

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -1,111 +1,113 @@
-import ComposableArchitecture
-import SwiftUI
+#if compiler(>=5.4)
+  import ComposableArchitecture
+  import SwiftUI
 
-private let readMe = """
-  This file demonstrates how to handle two-way bindings in the Composable Architecture using \
-  bindable state and actions.
+  private let readMe = """
+    This file demonstrates how to handle two-way bindings in the Composable Architecture using \
+    bindable state and actions.
 
-  Bindable state and actions allow you to safely eliminate the boilerplate caused by needing to \
-  have a unique action for every UI control. Instead, all UI bindings can be consolidated into a \
-  single `binding` action that holds onto a `BindingAction` value, and all bindable state can be \
-  safeguarded with the `BindableState` property wrapper.
+    Bindable state and actions allow you to safely eliminate the boilerplate caused by needing to \
+    have a unique action for every UI control. Instead, all UI bindings can be consolidated into a \
+    single `binding` action that holds onto a `BindingAction` value, and all bindable state can be \
+    safeguarded with the `BindableState` property wrapper.
 
-  It is instructive to compare this case study to the "Binding Basics" case study.
-  """
+    It is instructive to compare this case study to the "Binding Basics" case study.
+    """
 
-// The state for this screen holds a bunch of values that will drive
-struct BindingFormState: Equatable {
-  @BindableState var sliderValue = 5.0
-  @BindableState var stepCount = 10
-  @BindableState var text = ""
-  @BindableState var toggleIsOn = false
-}
-
-enum BindingFormAction: BindableAction, Equatable {
-  case binding(BindingAction<BindingFormState>)
-  case resetButtonTapped
-}
-
-struct BindingFormEnvironment {}
-
-let bindingFormReducer = Reducer<
-  BindingFormState, BindingFormAction, BindingFormEnvironment
-> {
-  state, action, _ in
-  switch action {
-  case .binding(\.$stepCount):
-    state.sliderValue = .minimum(state.sliderValue, Double(state.stepCount))
-    return .none
-
-  case .binding:
-    return .none
-
-  case .resetButtonTapped:
-    state = .init()
-    return .none
+  // The state for this screen holds a bunch of values that will drive
+  struct BindingFormState: Equatable {
+    @BindableState var sliderValue = 5.0
+    @BindableState var stepCount = 10
+    @BindableState var text = ""
+    @BindableState var toggleIsOn = false
   }
-}
-.binding()
 
-struct BindingFormView: View {
-  let store: Store<BindingFormState, BindingFormAction>
+  enum BindingFormAction: BindableAction, Equatable {
+    case binding(BindingAction<BindingFormState>)
+    case resetButtonTapped
+  }
 
-  var body: some View {
-    WithViewStore(self.store) { viewStore in
-      Form {
-        Section(header: Text(template: readMe, .caption)) {
-          HStack {
-            TextField("Type here", text: viewStore.binding(\.$text))
-              .disableAutocorrection(true)
-              .foregroundColor(viewStore.toggleIsOn ? .gray : .primary)
+  struct BindingFormEnvironment {}
 
-            Text(alternate(viewStore.text))
+  let bindingFormReducer = Reducer<
+    BindingFormState, BindingFormAction, BindingFormEnvironment
+  > {
+    state, action, _ in
+    switch action {
+    case .binding(\.$stepCount):
+      state.sliderValue = .minimum(state.sliderValue, Double(state.stepCount))
+      return .none
+
+    case .binding:
+      return .none
+
+    case .resetButtonTapped:
+      state = .init()
+      return .none
+    }
+  }
+  .binding()
+
+  struct BindingFormView: View {
+    let store: Store<BindingFormState, BindingFormAction>
+
+    var body: some View {
+      WithViewStore(self.store) { viewStore in
+        Form {
+          Section(header: Text(template: readMe, .caption)) {
+            HStack {
+              TextField("Type here", text: viewStore.binding(\.$text))
+                .disableAutocorrection(true)
+                .foregroundColor(viewStore.toggleIsOn ? .gray : .primary)
+
+              Text(alternate(viewStore.text))
+            }
+            .disabled(viewStore.toggleIsOn)
+
+            Toggle("Disable other controls", isOn: viewStore.binding(\.$toggleIsOn))
+
+            Stepper(value: viewStore.binding(\.$stepCount), in: 0...100) {
+              Text("Max slider value: \(viewStore.stepCount)")
+                .font(Font.body.monospacedDigit())
+            }
+            .disabled(viewStore.toggleIsOn)
+
+            HStack {
+              Text("Slider value: \(Int(viewStore.sliderValue))")
+                .font(Font.body.monospacedDigit())
+
+              Slider(value: viewStore.binding(\.$sliderValue), in: 0...Double(viewStore.stepCount))
+            }
+            .disabled(viewStore.toggleIsOn)
           }
-          .disabled(viewStore.toggleIsOn)
-
-          Toggle("Disable other controls", isOn: viewStore.binding(\.$toggleIsOn))
-
-          Stepper(value: viewStore.binding(\.$stepCount), in: 0...100) {
-            Text("Max slider value: \(viewStore.stepCount)")
-              .font(Font.body.monospacedDigit())
-          }
-          .disabled(viewStore.toggleIsOn)
-
-          HStack {
-            Text("Slider value: \(Int(viewStore.sliderValue))")
-              .font(Font.body.monospacedDigit())
-
-            Slider(value: viewStore.binding(\.$sliderValue), in: 0...Double(viewStore.stepCount))
-          }
-          .disabled(viewStore.toggleIsOn)
         }
       }
+      .navigationBarTitle("Bindings form")
     }
-    .navigationBarTitle("Bindings form")
   }
-}
 
-private func alternate(_ string: String) -> String {
-  string
-    .enumerated()
-    .map { idx, char in
-      idx.isMultiple(of: 2)
-        ? char.uppercased()
-        : char.lowercased()
-    }
-    .joined()
-}
+  private func alternate(_ string: String) -> String {
+    string
+      .enumerated()
+      .map { idx, char in
+        idx.isMultiple(of: 2)
+          ? char.uppercased()
+          : char.lowercased()
+      }
+      .joined()
+  }
 
-struct BindingFormView_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationView {
-      BindingFormView(
-        store: Store(
-          initialState: BindingFormState(),
-          reducer: bindingFormReducer,
-          environment: BindingFormEnvironment()
+  struct BindingFormView_Previews: PreviewProvider {
+    static var previews: some View {
+      NavigationView {
+        BindingFormView(
+          store: Store(
+            initialState: BindingFormState(),
+            reducer: bindingFormReducer,
+            environment: BindingFormEnvironment()
+          )
         )
-      )
+      }
     }
   }
-}
+#endif

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -1,49 +1,49 @@
-import ComposableArchitecture
-import SwiftUI
-
-private let readMe = """
-  This demonstrates how to make use of SwiftUI's `@FocusState` in the Composable Architecture. \
-  If you tap the "Sign in" button while a field is empty, the focus will be changed to that field.
-  """
-
-struct FocusDemoState: Equatable {
-  @BindableState var focusedField: Field? = nil
-  @BindableState var password: String = ""
-  @BindableState var username: String = ""
-
-  enum Field: String, Hashable {
-    case username, password
-  }
-}
-
-enum FocusDemoAction: BindableAction, Equatable {
-  case binding(BindingAction<FocusDemoState>)
-  case signInButtonTapped
-}
-
-struct FocusDemoEnvironment {}
-
-let focusDemoReducer = Reducer<
-  FocusDemoState,
-  FocusDemoAction,
-  FocusDemoEnvironment
-> { state, action, _ in
-  switch action {
-  case .binding:
-    return .none
-
-  case .signInButtonTapped:
-    if state.username.isEmpty {
-      state.focusedField = .username
-    } else if state.password.isEmpty {
-      state.focusedField = .password
-    }
-    return .none
-  }
-}
-.binding()
-
 #if compiler(>=5.5)
+  import ComposableArchitecture
+  import SwiftUI
+
+  private let readMe = """
+    This demonstrates how to make use of SwiftUI's `@FocusState` in the Composable Architecture. \
+    If you tap the "Sign in" button while a field is empty, the focus will be changed to that field.
+    """
+
+  struct FocusDemoState: Equatable {
+    @BindableState var focusedField: Field? = nil
+    @BindableState var password: String = ""
+    @BindableState var username: String = ""
+
+    enum Field: String, Hashable {
+      case username, password
+    }
+  }
+
+  enum FocusDemoAction: BindableAction, Equatable {
+    case binding(BindingAction<FocusDemoState>)
+    case signInButtonTapped
+  }
+
+  struct FocusDemoEnvironment {}
+
+  let focusDemoReducer = Reducer<
+    FocusDemoState,
+    FocusDemoAction,
+    FocusDemoEnvironment
+  > { state, action, _ in
+    switch action {
+    case .binding:
+      return .none
+
+    case .signInButtonTapped:
+      if state.username.isEmpty {
+        state.focusedField = .username
+      } else if state.password.isEmpty {
+        state.focusedField = .password
+      }
+      return .none
+    }
+  }
+  .binding()
+
   struct FocusDemoView: View {
     let store: Store<FocusDemoState, FocusDemoAction>
     @FocusState var focusedField: FocusDemoState.Field?

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-BindingBasicsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-BindingBasicsTests.swift
@@ -1,32 +1,34 @@
-import Combine
-import ComposableArchitecture
-import XCTest
+#if compiler(>=5.4)
+  import Combine
+  import ComposableArchitecture
+  import XCTest
 
-@testable import SwiftUICaseStudies
+  @testable import SwiftUICaseStudies
 
-class BindingFormTests: XCTestCase {
-  func testBasics() {
-    let store = TestStore(
-      initialState: BindingFormState(),
-      reducer: bindingFormReducer,
-      environment: BindingFormEnvironment()
-    )
+  class BindingFormTests: XCTestCase {
+    func testBasics() {
+      let store = TestStore(
+        initialState: BindingFormState(),
+        reducer: bindingFormReducer,
+        environment: BindingFormEnvironment()
+      )
 
-    store.send(.set(\.$sliderValue, 2)) {
-      $0.sliderValue = 2
-    }
-    store.send(.set(\.$stepCount, 1)) {
-      $0.sliderValue = 1
-      $0.stepCount = 1
-    }
-    store.send(.set(\.$text, "Blob")) {
-      $0.text = "Blob"
-    }
-    store.send(.set(\.$toggleIsOn, true)) {
-      $0.toggleIsOn = true
-    }
-    store.send(.resetButtonTapped) {
-      $0 = .init(sliderValue: 5, stepCount: 10, text: "", toggleIsOn: false)
+      store.send(.set(\.$sliderValue, 2)) {
+        $0.sliderValue = 2
+      }
+      store.send(.set(\.$stepCount, 1)) {
+        $0.sliderValue = 1
+        $0.stepCount = 1
+      }
+      store.send(.set(\.$text, "Blob")) {
+        $0.text = "Blob"
+      }
+      store.send(.set(\.$toggleIsOn, true)) {
+        $0.toggleIsOn = true
+      }
+      store.send(.resetButtonTapped) {
+        $0 = .init(sliderValue: 5, stepCount: 10, text: "", toggleIsOn: false)
+      }
     }
   }
-}
+#endif

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -58,22 +58,24 @@ extension Store {
   }
 }
 
-extension ViewStore {
-  @available(
-    *, deprecated,
-    message:
-      "Dynamic member lookup is no longer supported for bindable state. Instead of dot-chaining on the view store, e.g. 'viewStore.$value', invoke the 'binding' method on view store with a key path to the value, e.g. 'viewStore.binding(\\.$value)'. For more on this change, see: https://github.com/pointfreeco/swift-composable-architecture/pull/810"
-  )
-  public subscript<Value>(
-    dynamicMember keyPath: WritableKeyPath<State, BindableState<Value>>
-  ) -> Binding<Value>
-  where Action: BindableAction, Action.State == State, Value: Equatable {
-    self.binding(
-      get: { $0[keyPath: keyPath].wrappedValue },
-      send: { .binding(.set(keyPath, $0)) }
+#if compiler(>=5.4)
+  extension ViewStore {
+    @available(
+      *, deprecated,
+      message:
+        "Dynamic member lookup is no longer supported for bindable state. Instead of dot-chaining on the view store, e.g. 'viewStore.$value', invoke the 'binding' method on view store with a key path to the value, e.g. 'viewStore.binding(\\.$value)'. For more on this change, see: https://github.com/pointfreeco/swift-composable-architecture/pull/810"
     )
+    public subscript<Value>(
+      dynamicMember keyPath: WritableKeyPath<State, BindableState<Value>>
+    ) -> Binding<Value>
+    where Action: BindableAction, Action.State == State, Value: Equatable {
+      self.binding(
+        get: { $0[keyPath: keyPath].wrappedValue },
+        send: { .binding(.set(keyPath, $0)) }
+      )
+    }
   }
-}
+#endif
 
 // NB: Deprecated after 0.25.0:
 

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -350,7 +350,6 @@ public struct BindingAction<Root>: Equatable {
       keyPath == bindingAction.keyPath
     }
   }
-}
 #endif
 
 extension BindingAction {

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -287,20 +287,29 @@ import SwiftUI
       )
     }
   }
+#endif
 
-  /// An action that describes simple mutations to some root state at a writable key path.
-  ///
-  /// Used in conjunction with ``BindableState`` and ``BindableAction`` to safely eliminate the
-  /// boilerplate typically associated with mutating multiple fields in state.
-  ///
-  /// See the documentation for ``BindableState`` for more details.
-  public struct BindingAction<Root>: Equatable {
-    public let keyPath: PartialKeyPath<Root>
+/// An action that describes simple mutations to some root state at a writable key path.
+///
+/// Used in conjunction with ``BindableState`` and ``BindableAction`` to safely eliminate the
+/// boilerplate typically associated with mutating multiple fields in state.
+///
+/// See the documentation for ``BindableState`` for more details.
+public struct BindingAction<Root>: Equatable {
+  public let keyPath: PartialKeyPath<Root>
 
-    let set: (inout Root) -> Void
-    let value: Any
-    let valueIsEqualTo: (Any) -> Bool
+  let set: (inout Root) -> Void
+  let value: Any
+  let valueIsEqualTo: (Any) -> Bool
 
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.keyPath == rhs.keyPath && lhs.valueIsEqualTo(rhs.value)
+  }
+}
+
+
+#if compiler(>=5.4)
+  extension BindingAction {
     /// Returns an action that describes simple mutations to some root state at a writable key path
     /// to bindable state.
     ///
@@ -322,139 +331,6 @@ import SwiftUI
       )
     }
 
-    /// Transforms a binding action over some root state to some other type of root state given a
-    /// key path.
-    ///
-    /// Useful in transforming binding actions on view state into binding actions on reducer state
-    /// when the domain contains ``BindableState`` and ``BindableAction``.
-    ///
-    /// For example, we can model an app that can bind an integer count to a stepper and make a
-    /// network request to fetch a fact about that integer with the following domain:
-    ///
-    /// ```swift
-    /// struct AppState: Equatable {
-    ///   @BindableState var count = 0
-    ///   var fact: String?
-    ///   ...
-    /// }
-    ///
-    /// enum AppAction: BindableAction {
-    ///   case binding(BindingAction<AppState>
-    ///   case factButtonTapped
-    ///   case factResponse(String?)
-    ///   ...
-    /// }
-    ///
-    /// struct AppEnvironment {
-    ///   var numberFact: (Int) -> Effect<String, Error>
-    ///   ...
-    /// }
-    ///
-    /// let appReducer = Reducer<AppState, AppAction, AppEnvironment> {
-    ///   ...
-    /// }
-    /// .binding()
-    ///
-    /// struct AppView: View {
-    ///   let store: Store
-    ///
-    ///   var view: some View {
-    ///     ...
-    ///   }
-    /// }
-    /// ```
-    ///
-    /// The view may want to limit the state and actions it has access to by introducing a
-    /// view-specific domain that contains only the state and actions the view needs. Not only will
-    /// this minimize the number of times a view's `body` is computed, it will prevent the view
-    /// from accessing state or sending actions outside its purview. We can define it with its own
-    /// bindable state and bindable action:
-    ///
-    /// ```swift
-    /// extension AppView {
-    ///   struct ViewState: Equatable {
-    ///     @BindableState var count: Int
-    ///     let fact: String?
-    ///     // no access to any other state on `AppState`, like child domains
-    ///   }
-    ///
-    ///   enum ViewAction: BindableAction {
-    ///     case binding(BindingAction<ViewState>)
-    ///     case factButtonTapped
-    ///     // no access to any other action on `AppAction`, like `factResponse`
-    ///   }
-    /// }
-    /// ```
-    ///
-    /// In order to transform a `BindingAction<ViewState>` sent from the view domain into a
-    /// `BindingAction<AppState>`, we need a writable key path from `AppState` to `ViewState`. We
-    /// can synthesize one by defining a computed property on `AppState` with a getter and a setter.
-    /// The setter should communicate any mutations to bindable state back to the parent state:
-    ///
-    /// ```swift
-    /// extension AppState {
-    ///   var view: AppView.ViewState {
-    ///     get { .init(count: self.count, fact: self.fact) }
-    ///     set { self.count = newValue.count }
-    ///   }
-    /// }
-    /// ```
-    ///
-    /// With this property defined it is now possible to transform a `BindingAction<ViewState>` into
-    /// a `BindingAction<AppState>`, which means we can transform a `ViewAction` into an
-    /// `AppAction`. This is where `pullback` comes into play: we can unwrap the view action's
-    /// binding action on view state and transform it with `pullback` to work with app state. We can
-    /// define a helper that performs this transformation, as well as route any other view actions
-    /// to their reducer equivalents:
-    ///
-    /// ```swift
-    /// extension AppAction {
-    ///   static func view(_ viewAction: AppView.ViewAction) -> Self {
-    ///     switch viewAction {
-    ///     case let .binding(action):
-    ///       // transform view binding actions into app binding actions
-    ///       return .binding(action.pullback(\.view))
-    ///
-    ///     case let .factButtonTapped
-    ///       // route `ViewAction.factButtonTapped` to `AppAction.factButtonTapped`
-    ///       return .factButtonTapped
-    ///     }
-    ///   }
-    /// }
-    /// ```
-    ///
-    /// Finally, in the view we can invoke ``Store/scope(state:action:)`` with these domain
-    /// transformations to leverage the view store's binding helpers:
-    ///
-    /// ```swift
-    /// WithViewStore(
-    ///   self.store.scope(state: \.view, action: AppAction.view)
-    /// ) { viewStore in
-    ///   Stepper("\(viewStore.count)", viewStore.binding(\.$count))
-    ///   Button("Get number fact") { viewStore.send(.factButtonTapped) }
-    ///   if let fact = viewStore.fact {
-    ///     Text(fact)
-    ///   }
-    /// }
-    /// ```
-    ///
-    /// - Parameter keyPath: A key path from a new type of root state to the original root state.
-    /// - Returns: A binding action over a new type of root state.
-    public func pullback<NewRoot>(
-      _ keyPath: WritableKeyPath<NewRoot, Root>
-    ) -> BindingAction<NewRoot> {
-      .init(
-        keyPath: (keyPath as AnyKeyPath).appending(path: self.keyPath) as! PartialKeyPath<NewRoot>,
-        set: { self.set(&$0[keyPath: keyPath]) },
-        value: self.value,
-        valueIsEqualTo: self.valueIsEqualTo
-      )
-    }
-
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-      lhs.keyPath == rhs.keyPath && lhs.valueIsEqualTo(rhs.value)
-    }
-
     /// Matches a binding action by its key path.
     ///
     /// Implicitly invoked when switching on a reducer's action and pattern matching on a binding
@@ -474,19 +350,153 @@ import SwiftUI
       keyPath == bindingAction.keyPath
     }
   }
+}
+#endif
 
-  extension BindingAction: CustomDumpReflectable {
-    public var customDumpMirror: Mirror {
-      .init(
-        self,
-        children: [
-          "set": (self.keyPath, self.value)
-        ],
-        displayStyle: .enum
-      )
-    }
+extension BindingAction {
+  /// Transforms a binding action over some root state to some other type of root state given a
+  /// key path.
+  ///
+  /// Useful in transforming binding actions on view state into binding actions on reducer state
+  /// when the domain contains ``BindableState`` and ``BindableAction``.
+  ///
+  /// For example, we can model an app that can bind an integer count to a stepper and make a
+  /// network request to fetch a fact about that integer with the following domain:
+  ///
+  /// ```swift
+  /// struct AppState: Equatable {
+  ///   @BindableState var count = 0
+  ///   var fact: String?
+  ///   ...
+  /// }
+  ///
+  /// enum AppAction: BindableAction {
+  ///   case binding(BindingAction<AppState>
+  ///   case factButtonTapped
+  ///   case factResponse(String?)
+  ///   ...
+  /// }
+  ///
+  /// struct AppEnvironment {
+  ///   var numberFact: (Int) -> Effect<String, Error>
+  ///   ...
+  /// }
+  ///
+  /// let appReducer = Reducer<AppState, AppAction, AppEnvironment> {
+  ///   ...
+  /// }
+  /// .binding()
+  ///
+  /// struct AppView: View {
+  ///   let store: Store
+  ///
+  ///   var view: some View {
+  ///     ...
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// The view may want to limit the state and actions it has access to by introducing a
+  /// view-specific domain that contains only the state and actions the view needs. Not only will
+  /// this minimize the number of times a view's `body` is computed, it will prevent the view
+  /// from accessing state or sending actions outside its purview. We can define it with its own
+  /// bindable state and bindable action:
+  ///
+  /// ```swift
+  /// extension AppView {
+  ///   struct ViewState: Equatable {
+  ///     @BindableState var count: Int
+  ///     let fact: String?
+  ///     // no access to any other state on `AppState`, like child domains
+  ///   }
+  ///
+  ///   enum ViewAction: BindableAction {
+  ///     case binding(BindingAction<ViewState>)
+  ///     case factButtonTapped
+  ///     // no access to any other action on `AppAction`, like `factResponse`
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// In order to transform a `BindingAction<ViewState>` sent from the view domain into a
+  /// `BindingAction<AppState>`, we need a writable key path from `AppState` to `ViewState`. We
+  /// can synthesize one by defining a computed property on `AppState` with a getter and a setter.
+  /// The setter should communicate any mutations to bindable state back to the parent state:
+  ///
+  /// ```swift
+  /// extension AppState {
+  ///   var view: AppView.ViewState {
+  ///     get { .init(count: self.count, fact: self.fact) }
+  ///     set { self.count = newValue.count }
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// With this property defined it is now possible to transform a `BindingAction<ViewState>` into
+  /// a `BindingAction<AppState>`, which means we can transform a `ViewAction` into an
+  /// `AppAction`. This is where `pullback` comes into play: we can unwrap the view action's
+  /// binding action on view state and transform it with `pullback` to work with app state. We can
+  /// define a helper that performs this transformation, as well as route any other view actions
+  /// to their reducer equivalents:
+  ///
+  /// ```swift
+  /// extension AppAction {
+  ///   static func view(_ viewAction: AppView.ViewAction) -> Self {
+  ///     switch viewAction {
+  ///     case let .binding(action):
+  ///       // transform view binding actions into app binding actions
+  ///       return .binding(action.pullback(\.view))
+  ///
+  ///     case let .factButtonTapped
+  ///       // route `ViewAction.factButtonTapped` to `AppAction.factButtonTapped`
+  ///       return .factButtonTapped
+  ///     }
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Finally, in the view we can invoke ``Store/scope(state:action:)`` with these domain
+  /// transformations to leverage the view store's binding helpers:
+  ///
+  /// ```swift
+  /// WithViewStore(
+  ///   self.store.scope(state: \.view, action: AppAction.view)
+  /// ) { viewStore in
+  ///   Stepper("\(viewStore.count)", viewStore.binding(\.$count))
+  ///   Button("Get number fact") { viewStore.send(.factButtonTapped) }
+  ///   if let fact = viewStore.fact {
+  ///     Text(fact)
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// - Parameter keyPath: A key path from a new type of root state to the original root state.
+  /// - Returns: A binding action over a new type of root state.
+  public func pullback<NewRoot>(
+    _ keyPath: WritableKeyPath<NewRoot, Root>
+  ) -> BindingAction<NewRoot> {
+    .init(
+      keyPath: (keyPath as AnyKeyPath).appending(path: self.keyPath) as! PartialKeyPath<NewRoot>,
+      set: { self.set(&$0[keyPath: keyPath]) },
+      value: self.value,
+      valueIsEqualTo: self.valueIsEqualTo
+    )
   }
+}
 
+extension BindingAction: CustomDumpReflectable {
+  public var customDumpMirror: Mirror {
+    .init(
+      self,
+      children: [
+        "set": (self.keyPath, self.value)
+      ],
+      displayStyle: .enum
+    )
+  }
+}
+
+#if compiler(>=5.4)
   extension Reducer where Action: BindableAction, State == Action.State {
     /// Returns a reducer that applies ``BindingAction`` mutations to `State` before running this
     /// reducer's logic.

--- a/Tests/ComposableArchitectureTests/BindingTests.swift
+++ b/Tests/ComposableArchitectureTests/BindingTests.swift
@@ -1,37 +1,39 @@
-import ComposableArchitecture
-import XCTest
+#if compiler(>=5.4)
+  import ComposableArchitecture
+  import XCTest
 
-final class BindingTests: XCTestCase {
-  func testNestedBindableState() {
-    struct State: Equatable {
-      @BindableState var nested = Nested()
+  final class BindingTests: XCTestCase {
+    func testNestedBindableState() {
+      struct State: Equatable {
+        @BindableState var nested = Nested()
 
-      struct Nested: Equatable {
-        var field = ""
+        struct Nested: Equatable {
+          var field = ""
+        }
       }
-    }
 
-    enum Action: BindableAction, Equatable {
-      case binding(BindingAction<State>)
-    }
-
-    let reducer = Reducer<State, Action, ()> { state, action, _ in
-      switch action {
-      case .binding(\.$nested.field):
-        state.nested.field += "!"
-        return .none
-      default:
-        return .none
+      enum Action: BindableAction, Equatable {
+        case binding(BindingAction<State>)
       }
+
+      let reducer = Reducer<State, Action, ()> { state, action, _ in
+        switch action {
+        case .binding(\.$nested.field):
+          state.nested.field += "!"
+          return .none
+        default:
+          return .none
+        }
+      }
+      .binding()
+
+      let store = Store(initialState: .init(), reducer: reducer, environment: ())
+
+      let viewStore = ViewStore(store)
+
+      viewStore.binding(\.$nested.field).wrappedValue = "Hello"
+
+      XCTAssertNoDifference(viewStore.state, .init(nested: .init(field: "Hello!")))
     }
-    .binding()
-
-    let store = Store(initialState: .init(), reducer: reducer, environment: ())
-
-    let viewStore = ViewStore(store)
-
-    viewStore.binding(\.$nested.field).wrappedValue = "Hello"
-
-    XCTAssertNoDifference(viewStore.state, .init(nested: .init(field: "Hello!")))
   }
-}
+#endif

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -111,21 +111,23 @@ final class DebugTests: XCTestCase {
     )
   }
 
-  func testBindingAction() {
-    struct State {
-      @BindableState var width = 0
-    }
+  #if compiler(>=5.4)
+    func testBindingAction() {
+      struct State {
+        @BindableState var width = 0
+      }
 
-    var dump = ""
-    customDump(BindingAction.set(\State.$width, 50), to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      #"""
-      BindingAction.set(
-        WritableKeyPath<State, BindableState<Int>>,
-        50
+      var dump = ""
+      customDump(BindingAction.set(\State.$width, 50), to: &dump)
+      XCTAssertNoDifference(
+        dump,
+        #"""
+        BindingAction.set(
+          WritableKeyPath<State, BindableState<Int>>,
+          50
+        )
+        """#
       )
-      """#
-    )
-  }
+    }
+  #endif
 }


### PR DESCRIPTION
The most recent release broke support for Xcode 12.4, which we didn't have in CI. This restores it, and should hopefully address the issues that came up in #813.