### PR TITLE
Fix typo in `BindingAction.pullback(_:)` docs

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -369,7 +369,7 @@ extension BindingAction {
   /// }
   ///
   /// enum AppAction: BindableAction {
-  ///   case binding(BindingAction<AppState>
+  ///   case binding(BindingAction<AppState>)
   ///   case factButtonTapped
   ///   case factResponse(String?)
   ///   ...


### PR DESCRIPTION
Noticed a small typo where the action enum case was missing a closing parentheses. :P