### PR TITLE
feat: Let a store know about it's parent

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -133,6 +133,7 @@ public final class Store<State, Action> {
   var effectCancellables: [UUID: AnyCancellable] = [:]
   private var isSending = false
   var parentCancellable: AnyCancellable?
+  var parentStoreID: ObjectIdentifier?
   private let reducer: (inout State, Action) -> Effect<Action, Never>
   var state: CurrentValueSubject<State, Never>
   #if DEBUG
@@ -341,6 +342,7 @@ public final class Store<State, Action> {
         guard !isSending else { return }
         localStore?.state.value = toLocalState(newValue)
       }
+    localStore.parentStoreID = ObjectIdentifier(self)
     return localStore
   }
 
@@ -388,6 +390,11 @@ public final class Store<State, Action> {
         self.effectCancellables[uuid] = effectCancellable
       }
     }
+  }
+  
+  /// Checks if the current store is a parent for the passed store
+  public func isParent<LocalState, LocalAction>(for store: Store<LocalState, LocalAction>) -> Bool {
+    store.parentStoreID == ObjectIdentifier(self)
   }
 
   /// Returns a "stateless" store by erasing state to `Void`.


### PR DESCRIPTION
This feature might be needed for recursive navigation in UIKit
I can give you access to a private repo to ensure that it's needed
> TLDR
> - On change of ids in the recursive navigation stack I update recursive controllers in RecursiveNavigationController
> - After controllers stack is updated accordingly to the state I scope parent module to this controllers
> - I want to avoid redundant scoping and currently I set parent store as an associated object to the child to check if the store shouldn't be scoped
> - I have to use a custom scope method to set an associated object (both a custom method and an associatedobject api is a bit confusing)

Implementation
- I created `_ParentTraking` internal protocol to erase store's type for a parent and to specify an ability to get the next parent
- `Store` is now `_ParentTracking`
- I added 2 instance methods to `Store` type `isParent(for:)` and `isDirectParent(for:)` to get the information if the store is a parent to another one

The change is additive and won't affect any users