### PR TITLE
✨ Add support for accessibility modifiers on TextState

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/TextState.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/TextState.swift
@@ -218,6 +218,15 @@ extension TextState {
     case localized(LocalizedStringKey, tableName: String?, bundle: Bundle?, comment: StaticString?)
     case verbatim(String)
 
+    var rawValue: String {
+      switch self {
+      case let .localized(key, tn, b, c):
+        return key.formatted(tableName: tn, bundle: b, comment: c)
+      case let .verbatim(str):
+        return str
+      }
+    }
+
     public init(_ content: String) {
       self = .verbatim(content)
     }
@@ -270,7 +279,7 @@ extension TextState {
     }
   }
 
-  public enum AccessibilityTextContentType: Equatable, Hashable {
+  public enum AccessibilityTextContentType: String, Equatable, Hashable {
     case console, fileSystem, messaging, narrative, plain, sourceCode, spreadsheet, wordProcessing
 
     #if compiler(>=5.5.1)
@@ -290,7 +299,7 @@ extension TextState {
     #endif
   }
 
-  public enum AccessibilityHeadingLevel: Equatable, Hashable {
+  public enum AccessibilityHeadingLevel: String, Equatable, Hashable {
     case h1, h2, h3, h4, h5, h6, unspecified
 
     #if compiler(>=5.5.1)
@@ -532,13 +541,15 @@ extension TextState: CustomDumpRepresentable {
           .strikethrough(active: false, color: _),
           .underline(active: false, color: _):
           break
-        // TODO: Handle custom dump accessibility output
-        case let .accessibilityLabel(value):
-          return output
+        case let .accessibilityLabel(label):
+          let tag = "accessibility-label"
+          output = "<\(tag)=\(label.rawValue)>\(output)</\(tag)>"
         case let .accessibilityHeading(headingLevel):
-          return output
+          let tag = "accessibility-heading-level"
+          output = "<\(tag)=\(headingLevel.rawValue)>\(output)</\(tag)>"
         case let .accessibilityTextContentType(type):
-          return output
+          let tag = "accessibility-text-content-type"
+          output = "<\(tag)=\(type.rawValue)>\(output)</\(tag)>"
         }
       }
       return output

--- a/Sources/ComposableArchitecture/SwiftUI/TextState.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/TextState.swift
@@ -273,36 +273,40 @@ extension TextState {
   public enum AccessibilityTextContentType: Equatable, Hashable {
     case console, fileSystem, messaging, narrative, plain, sourceCode, spreadsheet, wordProcessing
 
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    var toSwiftUI: SwiftUI.AccessibilityTextContentType {
-      switch self {
-      case .console: return .console
-      case .fileSystem: return .fileSystem
-      case .messaging: return .messaging
-      case .narrative: return .narrative
-      case .plain: return .plain
-      case .sourceCode: return .sourceCode
-      case .spreadsheet: return .spreadsheet
-      case .wordProcessing: return .wordProcessing
+    #if compiler(>=5.5.1)
+      @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+      var toSwiftUI: SwiftUI.AccessibilityTextContentType {
+        switch self {
+        case .console: return .console
+        case .fileSystem: return .fileSystem
+        case .messaging: return .messaging
+        case .narrative: return .narrative
+        case .plain: return .plain
+        case .sourceCode: return .sourceCode
+        case .spreadsheet: return .spreadsheet
+        case .wordProcessing: return .wordProcessing
+        }
       }
-    }
+    #endif
   }
 
   public enum AccessibilityHeadingLevel: Equatable, Hashable {
     case h1, h2, h3, h4, h5, h6, unspecified
 
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    var toSwiftUI: SwiftUI.AccessibilityHeadingLevel {
-      switch self {
-      case .h1: return .h1
-      case .h2: return .h2
-      case .h3: return .h3
-      case .h4: return .h4
-      case .h5: return .h5
-      case .h6: return .h6
-      case .unspecified: return .unspecified
+    #if compiler(>=5.5.1)
+      @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+      var toSwiftUI: SwiftUI.AccessibilityHeadingLevel {
+        switch self {
+        case .h1: return .h1
+        case .h2: return .h2
+        case .h3: return .h3
+        case .h4: return .h4
+        case .h5: return .h5
+        case .h6: return .h6
+        case .unspecified: return .unspecified
+        }
       }
-    }
+    #endif
   }
 }
 
@@ -372,6 +376,7 @@ extension Text {
         return text.tracking(tracking)
       case let .underline(active, color):
         return text.underline(active, color: color)
+      #if compiler(>=5.5.1)
       case let .accessibilityLabel(value):
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
           switch value {
@@ -395,6 +400,12 @@ extension Text {
         } else {
           return text
         }
+      #else
+      case .accessibilityLabel,
+          .accessibilityTextContentType,
+          .accessibilityHeading:
+        return text
+      #endif
       }
     }
   }


### PR DESCRIPTION
The `accessibilityLabel` modifier does not work all that well with the `TextState` as there's a different return type for iOS 14 and iOS 15. The former is defined as an extension on `ModifiedContent` while latter on `Text`. With that in mind, it makes sense to support the more recent modifiers.

I currently managed to build this only for iOS. For macOS the compiler complains about wrong return type `ModifiedContent<...>`. The source code designates  `@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)` so it should in theory work.

TODO:
- [x] Add custom dump of accessibility modifiers
- [x] Compile for other than iOS target platform