### PR TITLE
[Feature] - BindingAction.append operator

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -329,6 +329,21 @@ public struct BindingAction<Root>: Equatable {
         valueIsEqualTo: { $0 as? Value == value }
       )
     }
+      
+    public static func append<Element>(
+      _ keyPath: WritableKeyPath<Root, BindableState<[Element]>>,
+      _ element: Element
+      ) -> Self {
+        .init(
+        keyPath: keyPath,
+        set: {
+            let value = $0[keyPath: keyPath].wrappedValue
+            $0[keyPath: keyPath].wrappedValue = value + [element]
+        },
+        value: element,
+        valueIsEqualTo: { _ in false }
+          )
+      }
 
     /// Matches a binding action by its key path.
     ///


### PR DESCRIPTION
Sometimes with bindable properties that are arrays, its useful to append a value rather than just set it. To that end, this PR adds an `.append` operator.

Example:

```swift
.binding(.append(\.$identifiers, id))
```