### PR TITLE
[Feature] - Async/Await fire and forget method for Effect

### DIFF
--- a/Sources/ComposableArchitecture/Beta/Concurrency.swift
+++ b/Sources/ComposableArchitecture/Beta/Concurrency.swift
@@ -111,7 +111,7 @@ import SwiftUI
       ///   - priority: Priority of the underlying task.
       ///   - work: The work to execute.
       /// - Returns: An effect wrapping the given asynchronous work.
-      static func fireAndForget(priority: Task.Priority?, _ work: @Sendable @escaping () async -> Void) -> Effect {
+      static func fireAndForget(priority: TaskPriority?, _ work: @Sendable @escaping () async -> Void) -> Effect {
           Deferred { () -> AnyPublisher<Output, Failure> in
               // create a future with void and never types
               Future<Void, Never> { seal in

--- a/Sources/ComposableArchitecture/Beta/Concurrency.swift
+++ b/Sources/ComposableArchitecture/Beta/Concurrency.swift
@@ -111,7 +111,7 @@ import SwiftUI
       ///   - priority: Priority of the underlying task.
       ///   - work: The work to execute.
       /// - Returns: An effect wrapping the given asynchronous work.
-      static func fireAndForget(priority: TaskPriority?, _ work: @Sendable @escaping () async -> Void) -> Effect {
+      static func fireAndForget(priority: TaskPriority? = nil, _ work: @Sendable @escaping () async -> Void) -> Effect {
           Deferred { () -> AnyPublisher<Output, Failure> in
               // create a future with void and never types
               Future<Void, Never> { seal in

--- a/Sources/ComposableArchitecture/Beta/Concurrency.swift
+++ b/Sources/ComposableArchitecture/Beta/Concurrency.swift
@@ -111,7 +111,7 @@ import SwiftUI
       ///   - priority: Priority of the underlying task.
       ///   - work: The work to execute.
       /// - Returns: An effect wrapping the given asynchronous work.
-      static func fireAndForget(priority: Task.Priority?, _ work: @escaping () async -> Void) -> Effect {
+      static func fireAndForget(priority: Task.Priority?, _ work: @Sendable @escaping () async -> Void) -> Effect {
           Deferred { () -> AnyPublisher<Output, Failure> in
               // create a future with void and never types
               Future<Void, Never> { seal in


### PR DESCRIPTION
This PR adds a `fireAndForget` method to `Effect` for the async/await concurrency apis. The function is defined as:

https://github.com/pointfreeco/swift-composable-architecture/blob/81c3da674d6f400e55984d6ddb36db71169d257a/Sources/ComposableArchitecture/Beta/Concurrency.swift#L107-L136

It takes a `Sendable` escaping closure and the implementation is very similar to the non-async fire and forget method.

### Points to Address

Two quick things I wanted to make sure were squared away before getting this reviewed and merged:

1. This project uses a fairly non-standard spacing scheme and I had a hard time matching the syntax formatting in the package. What's the right indention for this project, two spaces? And is there a linting file I can run?

2. I was curious about this comment in the code:

```
    /// Note that due to the lack of tools to control the execution of asynchronous work in Swift,
    /// it is not recommended to use this function in reducers directly. Doing so will introduce
    /// thread hops into your effects that will make testing difficult. You will be responsible for
    /// adding explicit expectations to wait for small amounts of time so that effects can deliver
    /// their output.
```

By "thread hopping" are you referring to the fact that the new concurrency model doesn't guarantee that a thread that suspends will be the same one that resumes the work? I was just confused because when I hear "thread hopping" I think of full-blown context switches like what happens in GCD.

It sounds like its less of an issue with concurrency and more an issue with XCTest always forcing things to be on the main thread? 
