### PR TITLE
Make AlertState.ButtonAction.type public

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -165,7 +165,7 @@ public struct AlertState<Action> {
   }
 
   public struct ButtonAction {
-    let type: ActionType
+    public let type: ActionType
 
     public static func send(_ action: Action) -> Self {
       .init(type: .send(action))
@@ -175,7 +175,7 @@ public struct AlertState<Action> {
       .init(type: .animatedSend(action, animation: animation))
     }
 
-    enum ActionType {
+    public enum ActionType {
       case send(Action)
       case animatedSend(Action, animation: Animation?)
     }
@@ -313,7 +313,7 @@ extension AlertState.Button: Equatable where Action: Equatable {}
 
 extension AlertState.ButtonAction: Hashable where Action: Hashable {}
 extension AlertState.ButtonAction.ActionType: Hashable where Action: Hashable {
-  func hash(into hasher: inout Hasher) {
+  public func hash(into hasher: inout Hasher) {
     switch self {
     case let .send(action), let .animatedSend(action, animation: _):
       hasher.combine(action)


### PR DESCRIPTION
The `type` property of `AlertState.ButtonAction` has internal access. I believe this to be an error because many other properties of `AlertState` and its nested types are public.

I ran into this "issue" when updating [Construct](https://github.com/Thomvis/Construct) to the latest version of TCA. In Construct, I define a set of functions that allow me to "pullback" an AlertState from the local to a global `Action`. This requires me to read a button action's type, as shown [here](https://github.com/Thomvis/Construct/blob/a2a80b1906577d3521c2e85d155ab6908c972df0/Construct/Foundation/Extensions.swift#L237).

Thanks for considering this PR for an upcoming release of TCA! ✌️ 