### PR TITLE
Added effect helper for tasks returning Result

### DIFF
--- a/Sources/ComposableArchitecture/Beta/Concurrency.swift
+++ b/Sources/ComposableArchitecture/Beta/Concurrency.swift
@@ -140,7 +140,8 @@ import SwiftUI
     ///     `Task.currentPriority`.
     ///   - operation: The operation to execute which returns a result instead of throwing.
     /// - Returns: An effect wrapping the given asynchronous work.
-    public static func taskResult(
+    @_disfavoredOverload
+    public static func task(
       priority: TaskPriority? = nil,
       operation: @escaping @Sendable () async -> Result<Output, Failure>
     ) -> Self {

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -286,7 +286,7 @@ final class EffectTests: XCTestCase {
     struct MyError: Error {}
     var result: Int?
 
-    Effect<Int, MyError>.taskResult {
+    Effect<Int, MyError>.task {
       expectation.fulfill()
       return .success(42)
     }
@@ -314,7 +314,7 @@ final class EffectTests: XCTestCase {
     struct MyError: Error {}
     var result: MyError?
 
-    Effect<Int, MyError>.taskResult {
+    Effect<Int, MyError>.task {
       expectation.fulfill()
       return .failure(MyError())
     }


### PR DESCRIPTION
I ended up wrapping the URLSession in a layer in my application. Using async for this layer helped to make the code clearer. Since I had introduced typed errors, I did not want to go back to untyped throws. Which means I ended up writing async function returning `Result`.

I added this small extension on Effect to easily bridge this use case.