### PR TITLE
Remove duplicate debug

### DIFF
--- a/Examples/TicTacToe/App/RootView.swift
+++ b/Examples/TicTacToe/App/RootView.swift
@@ -30,7 +30,7 @@ enum GameType: Identifiable {
 struct RootView: View {
   let store = Store(
     initialState: AppState(),
-    reducer: appReducer.debug(),
+    reducer: appReducer,
     environment: AppEnvironment(
       authenticationClient: .live,
       mainQueue: .main


### PR DESCRIPTION
The tic-tac-toe example double prints all the actions. This is because .debug is applied twice to the appReducer. Once in RootView.swift and once in AppCore.swift. This PR removes it from RootView.swift.