### PR TITLE
Add reset button to form binding case

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -79,6 +79,11 @@
               Slider(value: viewStore.binding(\.$sliderValue), in: 0...Double(viewStore.stepCount))
             }
             .disabled(viewStore.toggleIsOn)
+              
+            Button("Reset") {
+              viewStore.send(.resetButtonTapped)
+            }
+            .foregroundColor(.red)
           }
         }
       }


### PR DESCRIPTION
There is a `.resetButtonTapped` action which indicates that a reset method should exist, but it is not there yet.

This pull request adds a reset button to the view and it sends the `.resetButtonTapped` to trigger a reset.