### PR TITLE
Don't use Store.scope or ViewStore.send in TestStore

### DIFF
--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -347,13 +347,7 @@
         )
       }
       var expectedState = self.toLocalState(self.snapshotState)
-      ViewStore(
-        self.store.scope(
-          state: self.toLocalState,
-          action: { .init(origin: .send($0), file: file, line: line) }
-        )
-      )
-      .send(action)
+      self.store.send(.init(origin: .send(action), file: file, line: line))
       do {
         try update(&expectedState)
       } catch {


### PR DESCRIPTION
Very small bit of cleanup. We're doing some acrobatics that aren't necessary in the test store.