### PR TITLE
Add AnimatedAction

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -153,7 +153,7 @@ struct AnimationsView: View {
             .padding([.horizontal, .bottom])
           #if compiler(>=5.4)
           Button("Center") {
-            viewStore.send(.animated(.with(.spring(), action: .tapped(proxy.center))))
+            viewStore.send(.tapped(proxy.center).animation(.spring()))
           }
           .padding([.horizontal, .bottom])
           #endif

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -202,7 +202,7 @@ struct AnimationsView_Previews: PreviewProvider {
 }
 
 #if compiler(<5.4)
-  // Make the `.animation()` higher reducer compile on older versions of Swift.
+  // Makes the `.animation()` higher reducer compile on older versions of Swift.
   public extension Reducer where Action: AnimatableAction {
     func animations<S>(scheduler: @escaping (Environment) -> S) -> Self where S: Scheduler { self }
   }

--- a/Sources/ComposableArchitecture/SwiftUI/Animation.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Animation.swift
@@ -22,19 +22,19 @@ public struct AnimatedAction<Action> {
   
   /// Creates an animated action from an action and a animation.
   /// - Parameters:
-  ///   - animation: an `Animation`
   ///   - action: an `Action`
+  ///   - animation: an `Animation`
   /// - Returns: An action animating `action` with the animation `animation`.
-  public static func with(_ animation: Animation, action: Action) -> Self {
+  public static func action(_ action: Action, with animation: Animation) -> Self {
     .init(action: action, transaction: Transaction(animation: animation))
   }
   
   /// Creates an animated action from an action and a transaction.
   /// - Parameters:
-  ///   - transaction: a `Transaction`
   ///   - action: an `Action`
+  ///   - transaction: a `Transaction`
   /// - Returns: An action animating `action` with the transaction `transaction`.
-  public static func with(_ transaction: Transaction, action: Action) -> Self {
+  public static func action(_ action: Action, with transaction: Transaction) -> Self {
     .init(action: action, transaction: transaction)
   }
 }
@@ -62,6 +62,23 @@ public protocol AnimatableAction {
   /// ```
   /// - Returns: A animated action.
   static func animated(_ action: AnimatedAction<Self>) -> Self
+}
+
+extension AnimatableAction {
+  
+  /// Wrap an action in an ``AnimatedAction<Self>``
+  /// - Parameter animation: The animation to use.
+  /// - Returns: A `.animated` version of `self` with the animation `animation`.
+  public func animation(_ animation: Animation) -> Self {
+    .animated(.action(self, with: animation))
+  }
+  
+  /// Wrap an action in an ``AnimatedAction<Self>``
+  /// - Parameter transaction: The transaction to use.
+  /// - Returns: A `.animated` version of `self` with the transaction `transaction`.
+  public func transaction(_ transaction: Transaction) -> Self {
+    .animated(.action(self, with: transaction))
+  }
 }
 
 #if compiler(>=5.4)

--- a/Sources/ComposableArchitecture/SwiftUI/Animation.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Animation.swift
@@ -12,3 +12,89 @@ extension ViewStore {
     }
   }
 }
+
+// MARK: Animated Actions
+
+/// A type that wraps an action as an animated action.
+public struct AnimatedAction<Action> {
+  let action: Action
+  let transaction: Transaction
+  
+  /// Creates an animated action from an action and a animation.
+  /// - Parameters:
+  ///   - animation: an `Animation`
+  ///   - action: an `Action`
+  /// - Returns: An action animating `action` with the animation `animation`.
+  public static func with(_ animation: Animation, action: Action) -> Self {
+    .init(action: action, transaction: Transaction(animation: animation))
+  }
+  
+  /// Creates an animated action from an action and a transaction.
+  /// - Parameters:
+  ///   - transaction: a `Transaction`
+  ///   - action: an `Action`
+  /// - Returns: An action animating `action` with the transaction `transaction`.
+  public static func with(_ transaction: Transaction, action: Action) -> Self {
+    .init(action: action, transaction: transaction)
+  }
+}
+
+extension AnimatedAction: Equatable where Action: Equatable {
+  public static func == (lhs: AnimatedAction<Action>, rhs: AnimatedAction<Action>) -> Bool {
+    guard
+      lhs.action == rhs.action,
+      // FIXME: Is this correct?
+        lhs.transaction.animation == rhs.transaction.animation,
+        lhs.transaction.disablesAnimations == rhs.transaction.disablesAnimations,
+        lhs.transaction.isContinuous == rhs.transaction.isContinuous
+    else { return false }
+    return true
+  }
+}
+
+/// An action type that exposes a `animated` case that holds an ``AnimatedAction``.
+public protocol AnimatableAction {
+  /// Embeds an animated action in this action type.
+  ///
+  ///  - Note: When installed in an `enum`, declare this as:
+  /// ```swift
+  /// indirect case animated(AnimatedAction<Self>)
+  /// ```
+  /// - Returns: A animated action.
+  static func animated(_ action: AnimatedAction<Self>) -> Self
+}
+
+#if compiler(>=5.4)
+  import Combine
+  import CombineSchedulers
+  extension Reducer where Action: AnimatableAction {
+    /// Returns a reducer that schedules `AnimatedAction.action` onto the provided `Scheduler`'s
+    /// animations or transactions.
+    ///
+    /// The `Action` type should conform to `AnimatableAction`:
+    ///
+    /// ```swift
+    /// enum SettingsAction: AnimatableAction {
+    ///   ...
+    ///   indirect case animated(AnimatedAction<Self>)
+    /// }
+    /// ```
+    /// - Parameters:
+    ///   - scheduler: A function or a `KeyPath` that extracts a `Scheduler` from the environment.
+    /// - Returns: A reducer that animates `.animated()` actions.
+    public func animations<S>(scheduler: @escaping (Environment) -> S) -> Self where S: Scheduler {
+      Self { state, action, environment in
+        guard let animatingAction = (/Action.animated).extract(from: action)
+        else {
+          return self.run(&state, action, environment)
+        }
+        return Effect(value: animatingAction.action)
+          .receive(on: scheduler(environment)
+            .eraseToAnyScheduler()
+            .transaction(animatingAction.transaction)
+          )
+          .eraseToEffect()
+      }
+    }
+  }
+#endif


### PR DESCRIPTION
This PR allows to promote any action into an animated action from the call site, including those who have unanimated asynchronous effects. 

It works in a similar fashion as `Binding`s: You conform the `Action` to some protocol with a special `case`, and you create a new reducer using the `.animations()` higher order reducer. When you send an action you want to animate, you wrap it as
```
.animated(.with(.spring(), action: theAction))
```

Under the hood, the higher order reducer re-emits the action on the scheduler's animation or transaction. The scheduler is specified as a `KeyPath` from the `Environment`.

I've encountered a few cases where none of the `ViewStore` animation variants I tried was working in sibling features when simply setting a value in the local state (which bubbled up, then down to the siblings). Re-emitting the action on `.mainQueue.animation()` did solve the issue, so I've implemented this abstraction. I don't know how to properly hierarchize this kind of animation with the other ones (from `binding.animation` and `ViewStore.send` for example). It's already a complex topic by itself, and maybe some generalization is possible. 

What do you think about it?