### PR TITLE
Fix iOS 14 alert/confirmationDialog runtime crash

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -208,30 +208,63 @@ extension View {
   ///   - dismissal: An action to send when the alert is dismissed through non-user actions, such
   ///     as when an alert is automatically dismissed by the system. Use this action to `nil` out
   ///     the associated alert state.
-  public func alert<Action>(
+  @ViewBuilder public func alert<Action>(
     _ store: Store<AlertState<Action>?, Action>,
     dismiss: Action
   ) -> some View {
-    WithViewStore(store, removeDuplicates: { $0?.id == $1?.id }) { viewStore in
-      #if compiler(>=5.5)
-        if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
-          self.alert(
-            (viewStore.state?.title).map { Text($0) } ?? Text(""),
-            isPresented: viewStore.binding(send: dismiss).isPresent(),
-            presenting: viewStore.state,
-            actions: { $0.toSwiftUIActions(send: viewStore.send) },
-            message: { $0.message.map { Text($0) } }
+    #if compiler(>=5.5)
+      if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
+        self.modifier(
+          NewAlertModifier(
+            viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
+            dismiss: dismiss
           )
-        } else {
-          self.alert(item: viewStore.binding(send: dismiss)) { state in
-            state.toSwiftUIAlert(send: viewStore.send)
-          }
-        }
-      #else
-        self.alert(item: viewStore.binding(send: dismiss)) { state in
-          state.toSwiftUIAlert(send: viewStore.send)
-        }
-      #endif
+        )
+      } else {
+        self.modifier(
+          OldAlertModifier(
+            viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
+            dismiss: dismiss
+          )
+        )
+      }
+    #else
+      self.modifier(
+        OldAlertModifier(
+          viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
+          dismiss: dismiss
+        )
+      )
+    #endif
+  }
+}
+
+#if compiler(>=5.5)
+  // NB: Workaround for iOS 14 runtime crashes during iOS 15 availability checks.
+  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+  private struct NewAlertModifier<Action>: ViewModifier {
+    @ObservedObject var viewStore: ViewStore<AlertState<Action>?, Action>
+    let dismiss: Action
+
+    func body(content: Content) -> some View {
+      content.alert(
+        (viewStore.state?.title).map { Text($0) } ?? Text(""),
+        isPresented: viewStore.binding(send: dismiss).isPresent(),
+        presenting: viewStore.state,
+        actions: { $0.toSwiftUIActions(send: viewStore.send) },
+        message: { $0.message.map { Text($0) } }
+      )
+    }
+  }
+#endif
+
+private struct OldAlertModifier<Action>: ViewModifier {
+  @ObservedObject var viewStore: ViewStore<AlertState<Action>?, Action>
+  let dismiss: Action
+
+  func body(content: Content) -> some View {
+    content.alert(item: viewStore.binding(send: dismiss)) { state in
+      state.toSwiftUIAlert(send: viewStore.send)
     }
   }
 }

--- a/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
@@ -252,7 +252,7 @@ extension View {
           )
         #endif
       }
-    #else
+    #elseif !os(macOS)
       self.modifier(
         OldConfirmationDialogModifier(
           viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
@@ -293,7 +293,7 @@ private struct OldConfirmationDialogModifier<Action>: ViewModifier {
 
   func body(content: Content) -> some View {
     #if !os(macOS)
-      content.actionSheet(item: viewStore.binding(send: dismiss)) { state in
+      return content.actionSheet(item: viewStore.binding(send: dismiss)) { state in
         state.toSwiftUIActionSheet(send: viewStore.send)
       }
     #endif

--- a/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
@@ -296,6 +296,8 @@ private struct OldConfirmationDialogModifier<Action>: ViewModifier {
       return content.actionSheet(item: viewStore.binding(send: dismiss)) { state in
         state.toSwiftUIActionSheet(send: viewStore.send)
       }
+    #else
+      return EmptyView()
     #endif
   }
 }

--- a/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
@@ -230,35 +230,73 @@ extension View {
   @available(macOS 12, *)
   @available(tvOS 13, *)
   @available(watchOS 6, *)
-  public func confirmationDialog<Action>(
+  @ViewBuilder public func confirmationDialog<Action>(
     _ store: Store<ConfirmationDialogState<Action>?, Action>,
     dismiss: Action
   ) -> some View {
-
-    WithViewStore(store, removeDuplicates: { $0?.id == $1?.id }) { viewStore in
-      #if compiler(>=5.5)
-        if #available(iOS 15, tvOS 15, watchOS 8, *) {
-          self.confirmationDialog(
-            (viewStore.state?.title).map { Text($0) } ?? Text(""),
-            isPresented: viewStore.binding(send: dismiss).isPresent(),
-            titleVisibility: viewStore.state?.titleVisibility.toSwiftUI ?? .automatic,
-            presenting: viewStore.state,
-            actions: { $0.toSwiftUIActions(send: viewStore.send) },
-            message: { $0.message.map { Text($0) } }
+    #if compiler(>=5.5)
+      if #available(iOS 15, tvOS 15, watchOS 8, *) {
+        self.modifier(
+          NewConfirmationDialogModifier(
+            viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
+            dismiss: dismiss
           )
-        } else {
-          #if !os(macOS)
-            self.actionSheet(item: viewStore.binding(send: dismiss)) { state in
-              state.toSwiftUIActionSheet(send: viewStore.send)
-            }
-          #endif
-        }
-      #elseif !os(macOS)
-        self.actionSheet(item: viewStore.binding(send: dismiss)) { state in
-          state.toSwiftUIActionSheet(send: viewStore.send)
-        }
-      #endif
+        )
+      } else {
+        #if !os(macOS)
+          self.modifier(
+            OldConfirmationDialogModifier(
+              viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
+              dismiss: dismiss
+            )
+          )
+        #endif
+      }
+    #else
+      self.modifier(
+        OldConfirmationDialogModifier(
+          viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
+          dismiss: dismiss
+        )
+      )
+    #endif
+  }
+}
+
+#if compiler(>=5.5)
+  // NB: Workaround for iOS 14 runtime crashes during iOS 15 availability checks.
+  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+  private struct NewConfirmationDialogModifier<Action>: ViewModifier {
+    @ObservedObject var viewStore: ViewStore<ConfirmationDialogState<Action>?, Action>
+    let dismiss: Action
+
+    func body(content: Content) -> some View {
+      content.confirmationDialog(
+        (viewStore.state?.title).map { Text($0) } ?? Text(""),
+        isPresented: viewStore.binding(send: dismiss).isPresent(),
+        titleVisibility: viewStore.state?.titleVisibility.toSwiftUI ?? .automatic,
+        presenting: viewStore.state,
+        actions: { $0.toSwiftUIActions(send: viewStore.send) },
+        message: { $0.message.map { Text($0) } }
+      )
     }
+  }
+#endif
+
+@available(iOS 13, *)
+@available(macOS 12, *)
+@available(tvOS 13, *)
+@available(watchOS 6, *)
+private struct OldConfirmationDialogModifier<Action>: ViewModifier {
+  @ObservedObject var viewStore: ViewStore<ConfirmationDialogState<Action>?, Action>
+  let dismiss: Action
+
+  func body(content: Content) -> some View {
+    #if !os(macOS)
+      content.actionSheet(item: viewStore.binding(send: dismiss)) { state in
+        state.toSwiftUIActionSheet(send: viewStore.send)
+      }
+    #endif
   }
 }
 


### PR DESCRIPTION
Took a bunch of experimentation to figure out something that fixes #928, but this appears to work!