### PR TITLE
Reuse `Store`s & `ViewStore`s

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
@@ -304,7 +304,7 @@ let rootReducer = Reducer<RootState, RootAction, RootEnvironment>.combine(
       environment: { .init(mainQueue: $0.mainQueue, webSocket: $0.webSocket) }
     )
 )
-//.debug()
+.debug()
 .signpost()
 
 private func liveFetchNumber() -> Effect<Int, Never> {

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
@@ -304,7 +304,7 @@ let rootReducer = Reducer<RootState, RootAction, RootEnvironment>.combine(
       environment: { .init(mainQueue: $0.mainQueue, webSocket: $0.webSocket) }
     )
 )
-.debug()
+//.debug()
 .signpost()
 
 private func liveFetchNumber() -> Effect<Int, Never> {

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -60,7 +60,7 @@ struct TimersView: View {
   @ObservedObject var viewStore: ViewStore<TimersState, TimersAction>
 
   init(store: Store<TimersState, TimersAction>) {
-    self.viewStore = ViewStore(store)
+    self.viewStore = store.viewStore
   }
 
   var body: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -85,7 +85,7 @@ struct ClockView: View {
   @ObservedObject var viewStore: ViewStore<ClockState, ClockAction>
 
   init(store: Store<ClockState, ClockAction>) {
-    self.viewStore = ViewStore(store)
+    self.viewStore = store.viewStore
   }
 
   var body: some View {

--- a/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
@@ -31,7 +31,7 @@ final class CounterViewController: UIViewController {
   var cancellables: Set<AnyCancellable> = []
 
   init(store: Store<CounterState, CounterAction>) {
-    self.viewStore = ViewStore(store)
+    self.viewStore = store.viewStore
     super.init(nibName: nil, bundle: nil)
   }
 

--- a/Examples/CaseStudies/UIKitCaseStudies/ListsOfState.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/ListsOfState.swift
@@ -29,7 +29,7 @@ final class CountersTableViewController: UITableViewController {
 
   init(store: Store<CounterListState, CounterListAction>) {
     self.store = store
-    self.viewStore = ViewStore(store)
+    self.viewStore = store.viewStore
     super.init(nibName: nil, bundle: nil)
   }
 

--- a/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
@@ -61,7 +61,7 @@ class LazyNavigationViewController: UIViewController {
 
   init(store: Store<LazyNavigationState, LazyNavigationAction>) {
     self.store = store
-    self.viewStore = ViewStore(store)
+    self.viewStore = store.viewStore
     super.init(nibName: nil, bundle: nil)
   }
 

--- a/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
@@ -60,7 +60,7 @@ class EagerNavigationViewController: UIViewController {
 
   init(store: Store<EagerNavigationState, EagerNavigationAction>) {
     self.store = store
-    self.viewStore = ViewStore(store)
+    self.viewStore = store.viewStore
     super.init(nibName: nil, bundle: nil)
   }
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameUIKit/GameViewController.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameUIKit/GameViewController.swift
@@ -29,7 +29,7 @@ public final class GameViewController: UIViewController {
 
   public init(store: Store<GameState, GameAction>) {
     self.store = store
-    self.viewStore = ViewStore(store.scope(state: ViewState.init))
+    self.viewStore = store.scope(state: ViewState.init).viewStore
     super.init(nibName: nil, bundle: nil)
   }
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginUIKit/LoginViewController.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginUIKit/LoginViewController.swift
@@ -40,7 +40,7 @@ public class LoginViewController: UIViewController {
 
   public init(store: Store<LoginState, LoginAction>) {
     self.store = store
-    self.viewStore = ViewStore(store.scope(state: ViewState.init, action: LoginAction.init))
+    self.viewStore = store.scope(state: ViewState.init, action: LoginAction.init).viewStore
     super.init(nibName: nil, bundle: nil)
   }
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/NewGameUIKit/NewGameViewController.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/NewGameUIKit/NewGameViewController.swift
@@ -33,7 +33,7 @@ public class NewGameViewController: UIViewController {
 
   public init(store: Store<NewGameState, NewGameAction>) {
     self.store = store
-    self.viewStore = ViewStore(store.scope(state: ViewState.init, action: NewGameAction.init))
+    self.viewStore = store.scope(state: ViewState.init, action: NewGameAction.init)
     super.init(nibName: nil, bundle: nil)
   }
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/NewGameUIKit/NewGameViewController.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/NewGameUIKit/NewGameViewController.swift
@@ -33,7 +33,7 @@ public class NewGameViewController: UIViewController {
 
   public init(store: Store<NewGameState, NewGameAction>) {
     self.store = store
-    self.viewStore = store.scope(state: ViewState.init, action: NewGameAction.init)
+    self.viewStore = store.scope(state: ViewState.init, action: NewGameAction.init).viewStore
     super.init(nibName: nil, bundle: nil)
   }
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorUIKit/TwoFactorViewController.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorUIKit/TwoFactorViewController.swift
@@ -30,7 +30,7 @@ public final class TwoFactorViewController: UIViewController {
 
   public init(store: Store<TwoFactorState, TwoFactorAction>) {
     self.store = store
-    self.viewStore = ViewStore(store.scope(state: ViewState.init, action: TwoFactorAction.init))
+    self.viewStore = store.scope(state: ViewState.init, action: TwoFactorAction.init)
     super.init(nibName: nil, bundle: nil)
   }
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorUIKit/TwoFactorViewController.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorUIKit/TwoFactorViewController.swift
@@ -30,7 +30,7 @@ public final class TwoFactorViewController: UIViewController {
 
   public init(store: Store<TwoFactorState, TwoFactorAction>) {
     self.store = store
-    self.viewStore = store.scope(state: ViewState.init, action: TwoFactorAction.init)
+    self.viewStore = store.scope(state: ViewState.init, action: TwoFactorAction.init).viewStore
     super.init(nibName: nil, bundle: nil)
   }
 

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -93,7 +93,7 @@ struct AppView: View {
 
   init(store: Store<AppState, AppAction>) {
     self.store = store
-    self.viewStore = ViewStore(self.store.scope(state: ViewState.init(state:)))
+    self.viewStore = store.scope(state: ViewState.init(state:)).viewStore
   }
 
   struct ViewState: Equatable {

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
@@ -104,7 +104,7 @@ struct VoiceMemoView: View {
   @ObservedObject var viewStore: ViewStore<VoiceMemo, VoiceMemoAction>
 
   init(store: Store<VoiceMemo, VoiceMemoAction>) {
-    self.viewStore = ViewStore(store)
+    self.viewStore = store.viewStore
   }
 
   var body: some View {

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -516,6 +516,7 @@ extension ForEachStore {
   {
     let data = store.state.value
     self.data = data
+    self.scopeIdentifier = nil
     self.content = {
       WithViewStore(store.scope(state: { $0.map { $0[keyPath: id] } })) { viewStore in
         ForEach(Array(viewStore.state.enumerated()), id: \.element) { index, _ in

--- a/Sources/ComposableArchitecture/Internal/WeakCache.swift
+++ b/Sources/ComposableArchitecture/Internal/WeakCache.swift
@@ -37,7 +37,7 @@ final class WeakCache<Key, Value> where Key: Hashable, Value: AnyObject {
   
   func performMaintenanceIfNeeded() {
     maintenanceCounter += 1
-    if maintenanceCounter >= 1000 {
+    if maintenanceCounter >= 100 {
       wrappers = wrappers.filter { $0.value.value != nil }
       maintenanceCounter = 0
     }

--- a/Sources/ComposableArchitecture/Internal/WeakCache.swift
+++ b/Sources/ComposableArchitecture/Internal/WeakCache.swift
@@ -1,0 +1,45 @@
+final class WeakCache<Key, Value> where Key: Hashable, Value: AnyObject {
+  init() {}
+  
+  private struct WeakObject {
+    weak var value: Value?
+    init(_ value: Value) {
+      self.value = value
+    }
+  }
+
+  private var maintenanceCounter: Int = 0
+  private var wrappers: [Key: WeakObject] = [:]
+    
+  subscript(key: Key) -> Value? {
+    get {
+      defer { performMaintenanceIfNeeded() }
+      if let weakWrapper = wrappers[key] {
+        if let value = weakWrapper.value {
+          return value
+        } else {
+          wrappers[key] = nil
+        }
+      }
+      return nil
+    }
+    
+    set {
+      defer { performMaintenanceIfNeeded() }
+      if let newValue = newValue {
+        wrappers[key] = .init(newValue)
+      } else {
+        wrappers[key] = nil
+      }
+      performMaintenanceIfNeeded()
+    }
+  }
+  
+  func performMaintenanceIfNeeded() {
+    maintenanceCounter += 1
+    if maintenanceCounter >= 1000 {
+      wrappers = wrappers.filter { $0.value.value != nil }
+      maintenanceCounter = 0
+    }
+  }
+}

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -434,8 +434,8 @@ public struct Reducer<State, Action, Environment> {
   ///     }
   ///     ```
   ///
-  ///     Use ``Store/scope(state:action:)`` with ``SwitchStore`` to ensure that views can only send
-  ///     child actions when the child domain is available.
+  ///     Use ``Store/scope(state:action:scopeIdentifier:)`` with ``SwitchStore`` to ensure that
+  ///     views can only send child actions when the child domain is available.
   ///
   ///     ```swift
   ///     SwitchStore(self.parentStore) {
@@ -644,8 +644,9 @@ public struct Reducer<State, Action, Environment> {
   ///     }
   ///     ```
   ///
-  ///     Use ``Store/scope(state:action:)`` with ``IfLetStore`` or ``Store/ifLet(then:else:)`` to
-  ///     ensure that views can only send child actions when the child domain is non-`nil`.
+  ///     Use ``Store/scope(state:action:scopeIdentifier:)`` with ``IfLetStore`` or
+  ///     ``Store/ifLet(then:else:)`` to ensure that views can only send child actions when the
+  ///     child domain is non-`nil`.
   ///
   ///     ```swift
   ///     IfLetStore(

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -538,7 +538,7 @@ public final class Store<State, Action> {
   }
 }
 
-public struct SharedStoreConfiguration {
+public enum SharedStoreConfiguration {
   public static var isAutomaticReuseOfStoreAndViewStoreInstancesEnabled = true
 }
 

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -325,13 +325,14 @@ public final class Store<State, Action> {
     state toLocalState: @escaping (State) -> LocalState,
     action fromLocalAction: @escaping (LocalAction) -> Action,
     file: StaticString = #fileID,
-    line: UInt = #line
+    line: UInt = #line,
+    column: UInt = #column
   ) -> Store<LocalState, LocalAction> {
     scope(
       state: toLocalState,
       action: fromLocalAction,
       scopeIdentifier: SharedStoreConfiguration.shouldInferScopeIdenfiers
-        ? ScopeIdentifier(file: file, line: line)
+        ? ScopeIdentifier(file: file, line: line, column: column)
         : nil
     )
   }
@@ -399,13 +400,14 @@ public final class Store<State, Action> {
   public func scope<LocalState>(
     state toLocalState: @escaping (State) -> LocalState,
     file: StaticString = #fileID,
-    line: UInt = #line
+    line: UInt = #line,
+    column: UInt = #column
   ) -> Store<LocalState, Action> {
     self.scope(
       state: toLocalState,
       action: { $0 },
       scopeIdentifier: SharedStoreConfiguration.shouldInferScopeIdenfiers
-      ? ScopeIdentifier(file: file, line: line)
+      ? ScopeIdentifier(file: file, line: line, column: column)
       : nil
     )
   }
@@ -588,7 +590,7 @@ public struct ScopeIdentifier: Hashable {
     #endif
   }
 
-  public init(file: StaticString, line: UInt, column: Int? = nil) {
+  public init(file: StaticString, line: UInt, column: UInt? = nil) {
     self.id = "\(file)-l.\(line)c.\(column ?? 0)"
     #if DEBUG
       self.description = "\(file)-l.\(line)c.\(column ?? 0)"

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -331,7 +331,7 @@ public final class Store<State, Action> {
     scope(
       state: toLocalState,
       action: fromLocalAction,
-      scopeIdentifier: SharedStoreConfiguration.shouldInferScopeIdenfiers
+      scopeIdentifier: SharedStoreConfiguration.shouldInferScopeIdentifiers
         ? ScopeIdentifier(file: file, line: line, column: column)
         : nil
     )
@@ -406,7 +406,7 @@ public final class Store<State, Action> {
     self.scope(
       state: toLocalState,
       action: { $0 },
-      scopeIdentifier: SharedStoreConfiguration.shouldInferScopeIdenfiers
+      scopeIdentifier: SharedStoreConfiguration.shouldInferScopeIdentifiers
       ? ScopeIdentifier(file: file, line: line, column: column)
       : nil
     )
@@ -574,7 +574,7 @@ public enum SharedStoreConfiguration {
     public static let all: PrintOptions = [.store, .viewStore]
   }
   
-  public static var shouldInferScopeIdenfiers = true
+  public static var shouldInferScopeIdentifiers = true
   public static var printOptions: PrintOptions = .nonReusable
 }
 

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -5,8 +5,8 @@ import Foundation
 /// around to views that need to interact with the application.
 ///
 /// You will typically construct a single one of these at the root of your application, and then use
-/// the ``scope(state:action:)`` method to derive more focused stores that can be passed to
-/// subviews:
+/// the ``scope(state:action:scopeIdentifier:)`` method to derive more focused stores that can be
+/// passed to subviews:
 ///
 /// ```swift
 /// @main
@@ -29,10 +29,10 @@ import Foundation
 ///
 /// ### Scoping
 ///
-/// The most important operation defined on ``Store`` is the ``scope(state:action:)`` method, which
-/// allows you to transform a store into one that deals with local state and actions. This is
-/// necessary for passing stores to subviews that only care about a small portion of the entire
-/// application's domain.
+/// The most important operation defined on ``Store`` is the
+/// ``scope(state:action:scopeIdentifier:)`` method, which allows you to transform a store into one
+/// that deals with local state and actions. This is necessary for passing stores to subviews that
+/// only care about a small portion of the entire application's domain.
 ///
 /// For example, if an application has a tab view at its root with tabs for activity, search, and
 /// profile, then we can model the domain like this:
@@ -51,9 +51,9 @@ import Foundation
 /// }
 /// ```
 ///
-/// We can construct a view for each of these domains by applying ``scope(state:action:)`` to a
-/// store that holds onto the full app domain in order to transform it into a store for each
-/// sub-domain:
+/// We can construct a view for each of these domains by applying
+/// ``scope(state:action:scopeIdentifier:)`` to a store that holds onto the full app domain in order
+/// to transform it into a store for each sub-domain:
 ///
 /// ```swift
 /// struct AppView: View {
@@ -116,8 +116,9 @@ import Foundation
 /// The store performs some basic thread safety checks in order to help catch mistakes. Stores
 /// constructed via the initializer ``Store/init(initialState:reducer:environment:)`` are assumed
 /// to run only on the main thread, and so a check is executed immediately to make sure that is the
-/// case. Further, all actions sent to the store and all scopes (see ``Store/scope(state:action:)``)
-/// of the store are also checked to make sure that work is performed on the main thread.
+/// case. Further, all actions sent to the store and all scopes (see
+/// ``Store/scope(state:action:scopeIdentifier:)``) of the store are also checked to make sure that
+/// work is performed on the main thread.
 ///
 /// If you need a store that runs on a non-main thread, which should be very rare and you should
 /// have a very good reason to do so, then you can construct a store via the

--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -216,14 +216,14 @@ extension View {
       if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
         self.modifier(
           NewAlertModifier(
-            viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
+            viewStore: store.viewStore(removeDuplicates: { $0?.id == $1?.id }),
             dismiss: dismiss
           )
         )
       } else {
         self.modifier(
           OldAlertModifier(
-            viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
+            viewStore: store.viewStore(removeDuplicates: { $0?.id == $1?.id }),
             dismiss: dismiss
           )
         )
@@ -231,7 +231,7 @@ extension View {
     #else
       self.modifier(
         OldAlertModifier(
-          viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
+          viewStore: store.viewStore(removeDuplicates: { $0?.id == $1?.id }),
           dismiss: dismiss
         )
       )

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -453,8 +453,8 @@ extension BindingAction {
   /// }
   /// ```
   ///
-  /// Finally, in the view we can invoke ``Store/scope(state:action:)`` with these domain
-  /// transformations to leverage the view store's binding helpers:
+  /// Finally, in the view we can invoke ``Store/scope(state:action:scopeIdentifier:)`` with these
+  /// domain transformations to leverage the view store's binding helpers:
   ///
   /// ```swift
   /// WithViewStore(

--- a/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
@@ -238,7 +238,7 @@ extension View {
       if #available(iOS 15, tvOS 15, watchOS 8, *) {
         self.modifier(
           NewConfirmationDialogModifier(
-            viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
+            viewStore: store.viewStore(removeDuplicates:  { $0?.id == $1?.id }),
             dismiss: dismiss
           )
         )
@@ -246,7 +246,7 @@ extension View {
         #if !os(macOS)
           self.modifier(
             OldConfirmationDialogModifier(
-              viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
+              viewStore: store.viewStore(removeDuplicates: { $0?.id == $1?.id }),
               dismiss: dismiss
             )
           )
@@ -255,7 +255,7 @@ extension View {
     #elseif !os(macOS)
       self.modifier(
         OldConfirmationDialogModifier(
-          viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
+          viewStore: store.viewStore(removeDuplicates: { $0?.id == $1?.id }),
           dismiss: dismiss
         )
       )

--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -99,7 +99,7 @@ where Data: Collection, ID: Hashable, Content: View {
     self = .init(
       store,
       reuseIdentifier:
-      SharedStoreConfiguration.shouldInferScopeIdenfiers
+      SharedStoreConfiguration.shouldInferScopeIdentifiers
         ? ScopeIdentifier(file: file, line: line, column: column)
         : nil,
       content: content

--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -98,7 +98,7 @@ where Data: Collection, ID: Hashable, Content: View {
     self = .init(
       store,
       reuseIdentifier:
-      SharedStoreConfiguration.isAutomaticReuseOfStoreAndViewStoreInstancesEnabled
+      SharedStoreConfiguration.shouldInferScopeIdenfiers
         ? ScopeIdentifier(file: file, line: line)
         : nil,
       content: content

--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -86,6 +86,7 @@ where Data: Collection, ID: Hashable, Content: View {
     _ store: Store<IdentifiedArray<ID, EachState>, (ID, EachAction)>,
     file: StaticString = #fileID,
     line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping (Store<EachState, EachAction>) -> EachContent
   )
   where
@@ -99,7 +100,7 @@ where Data: Collection, ID: Hashable, Content: View {
       store,
       reuseIdentifier:
       SharedStoreConfiguration.shouldInferScopeIdenfiers
-        ? ScopeIdentifier(file: file, line: line)
+        ? ScopeIdentifier(file: file, line: line, column: column)
         : nil,
       content: content
     )

--- a/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
@@ -58,7 +58,7 @@ public struct IfLetStore<State, Action, Content>: View where Content: View {
               state = $0 ?? state
               return state
             },
-            scopeIdentifier: SharedStoreConfiguration.shouldInferScopeIdenfiers
+            scopeIdentifier: SharedStoreConfiguration.shouldInferScopeIdentifiers
               ? "Optional Unwrapping"
               : nil
             )
@@ -89,7 +89,7 @@ public struct IfLetStore<State, Action, Content>: View where Content: View {
             state = $0 ?? state
             return state
           },
-          scopeIdentifier: SharedStoreConfiguration.shouldInferScopeIdenfiers
+          scopeIdentifier: SharedStoreConfiguration.shouldInferScopeIdentifiers
             ? "Optional Unwrapping"
             : nil
         ))

--- a/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
@@ -54,10 +54,14 @@ public struct IfLetStore<State, Action, Content>: View where Content: View {
       if var state = viewStore.state {
         return ViewBuilder.buildEither(
           first: ifContent(
-            store.scope {
+            store.scope(state: {
               state = $0 ?? state
               return state
-            }
+            },
+            scopeIdentifier: SharedStoreConfiguration.isAutomaticReuseOfStoreAndViewStoreInstancesEnabled
+              ? "Optional Unwrapping"
+              : nil
+            )
           )
         )
       } else {
@@ -81,11 +85,14 @@ public struct IfLetStore<State, Action, Content>: View where Content: View {
     self.content = { viewStore in
       if var state = viewStore.state {
         return ifContent(
-          store.scope {
+          store.scope(state: {
             state = $0 ?? state
             return state
-          }
-        )
+          },
+          scopeIdentifier: SharedStoreConfiguration.isAutomaticReuseOfStoreAndViewStoreInstancesEnabled
+            ? "Optional Unwrapping"
+            : nil
+        ))
       } else {
         return nil
       }

--- a/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
@@ -58,7 +58,7 @@ public struct IfLetStore<State, Action, Content>: View where Content: View {
               state = $0 ?? state
               return state
             },
-            scopeIdentifier: SharedStoreConfiguration.isAutomaticReuseOfStoreAndViewStoreInstancesEnabled
+            scopeIdentifier: SharedStoreConfiguration.shouldInferScopeIdenfiers
               ? "Optional Unwrapping"
               : nil
             )
@@ -89,7 +89,7 @@ public struct IfLetStore<State, Action, Content>: View where Content: View {
             state = $0 ?? state
             return state
           },
-          scopeIdentifier: SharedStoreConfiguration.isAutomaticReuseOfStoreAndViewStoreInstancesEnabled
+          scopeIdentifier: SharedStoreConfiguration.shouldInferScopeIdenfiers
             ? "Optional Unwrapping"
             : nil
         ))

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -91,13 +91,14 @@ where Content: View {
     action fromLocalAction: @escaping (LocalAction) -> GlobalAction,
     file: StaticString = #fileID,
     line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder then content: @escaping (Store<LocalState, LocalAction>) -> Content
   ) {
     self.init(
       state: toLocalState,
       action: fromLocalAction,
       caseIdentifier:  SharedStoreConfiguration.shouldInferScopeIdenfiers
-      ? ScopeIdentifier(file: file, line: line)
+      ? ScopeIdentifier(file: file, line: line, column: column)
       : nil,
       then: content
     )
@@ -140,13 +141,14 @@ extension CaseLet where GlobalAction == LocalAction {
     state toLocalState: @escaping (GlobalState) -> LocalState?,
     file: StaticString = #fileID,
     line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder then content: @escaping (Store<LocalState, LocalAction>) -> Content
   ) {
     self.init(
       state: toLocalState,
       action: { $0 },
       caseIdentifier: SharedStoreConfiguration.shouldInferScopeIdenfiers
-      ? ScopeIdentifier(file: file, line: line)
+      ? ScopeIdentifier(file: file, line: line, column: column)
       : nil,
       then: content
     )
@@ -191,6 +193,9 @@ public struct Default<Content>: View where Content: View {
 extension SwitchStore {
   public init<State1, Action1, Content1, DefaultContent>(
     _ store: Store<State, Action>,
+    file: StaticString = #fileID,
+    line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
@@ -210,7 +215,13 @@ extension SwitchStore {
   {
     self.init(store: store) {
       let content = content().value
-      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
+      return WithViewStore(
+        store,
+        removeDuplicates: { enumTag($0) == enumTag($1) },
+        file: file,
+        line: line,
+        column: column
+      ) { viewStore in
         if content.0.toLocalState(viewStore.state) != nil {
           content.0
         } else {
@@ -224,6 +235,7 @@ extension SwitchStore {
     _ store: Store<State, Action>,
     file: StaticString = #fileID,
     line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping () -> CaseLet<State, Action, State1, Action1, Content1>
   )
   where
@@ -236,7 +248,7 @@ extension SwitchStore {
       >
     >
   {
-    self.init(store) {
+    self.init(store, file: file, line: line, column: column) {
       content()
       Default { _ExhaustivityCheckView<State, Action>(file: file, line: line) }
     }
@@ -244,6 +256,9 @@ extension SwitchStore {
 
   public init<State1, Action1, Content1, State2, Action2, Content2, DefaultContent>(
     _ store: Store<State, Action>,
+    file: StaticString = #fileID,
+    line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
@@ -267,7 +282,13 @@ extension SwitchStore {
   {
     self.init(store: store) {
       let content = content().value
-      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
+      return WithViewStore(
+        store,
+        removeDuplicates: { enumTag($0) == enumTag($1) },
+        file: file,
+        line: line,
+        column: column
+      ) { viewStore in
         if content.0.toLocalState(viewStore.state) != nil {
           content.0
         } else if content.1.toLocalState(viewStore.state) != nil {
@@ -283,6 +304,7 @@ extension SwitchStore {
     _ store: Store<State, Action>,
     file: StaticString = #fileID,
     line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
@@ -304,7 +326,7 @@ extension SwitchStore {
     >
   {
     let content = content()
-    self.init(store) {
+    self.init(store, file: file, line: line, column: column) {
       content.value.0
       content.value.1
       Default { _ExhaustivityCheckView<State, Action>(file: file, line: line) }
@@ -318,6 +340,9 @@ extension SwitchStore {
     DefaultContent
   >(
     _ store: Store<State, Action>,
+    file: StaticString = #fileID,
+    line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
@@ -345,7 +370,13 @@ extension SwitchStore {
   {
     self.init(store: store) {
       let content = content().value
-      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
+      return WithViewStore(
+        store,
+        removeDuplicates: { enumTag($0) == enumTag($1) },
+        file: file,
+        line: line,
+        column: column
+      ) { viewStore in
         if content.0.toLocalState(viewStore.state) != nil {
           content.0
         } else if content.1.toLocalState(viewStore.state) != nil {
@@ -363,6 +394,7 @@ extension SwitchStore {
     _ store: Store<State, Action>,
     file: StaticString = #fileID,
     line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
@@ -388,7 +420,7 @@ extension SwitchStore {
     >
   {
     let content = content()
-    self.init(store) {
+    self.init(store, file: file, line: line, column: column) {
       content.value.0
       content.value.1
       content.value.2
@@ -404,6 +436,9 @@ extension SwitchStore {
     DefaultContent
   >(
     _ store: Store<State, Action>,
+    file: StaticString = #fileID,
+    line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
@@ -435,7 +470,13 @@ extension SwitchStore {
   {
     self.init(store: store) {
       let content = content().value
-      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
+      return WithViewStore(
+        store,
+        removeDuplicates: { enumTag($0) == enumTag($1) },
+        file: file,
+        line: line,
+        column: column
+      ) { viewStore in
         if content.0.toLocalState(viewStore.state) != nil {
           content.0
         } else if content.1.toLocalState(viewStore.state) != nil {
@@ -460,6 +501,7 @@ extension SwitchStore {
     _ store: Store<State, Action>,
     file: StaticString = #fileID,
     line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
@@ -489,7 +531,7 @@ extension SwitchStore {
     >
   {
     let content = content()
-    self.init(store) {
+    self.init(store, file: file, line: line, column: column) {
       content.value.0
       content.value.1
       content.value.2
@@ -507,6 +549,9 @@ extension SwitchStore {
     DefaultContent
   >(
     _ store: Store<State, Action>,
+    file: StaticString = #fileID,
+    line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
@@ -542,7 +587,13 @@ extension SwitchStore {
   {
     self.init(store: store) {
       let content = content().value
-      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
+      return WithViewStore(
+        store,
+        removeDuplicates: { enumTag($0) == enumTag($1) },
+        file: file,
+        line: line,
+        column: column
+      ) { viewStore in
         if content.0.toLocalState(viewStore.state) != nil {
           content.0
         } else if content.1.toLocalState(viewStore.state) != nil {
@@ -570,6 +621,7 @@ extension SwitchStore {
     _ store: Store<State, Action>,
     file: StaticString = #fileID,
     line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
@@ -603,7 +655,7 @@ extension SwitchStore {
     >
   {
     let content = content()
-    self.init(store) {
+    self.init(store, file: file, line: line, column: column) {
       content.value.0
       content.value.1
       content.value.2
@@ -623,6 +675,9 @@ extension SwitchStore {
     DefaultContent
   >(
     _ store: Store<State, Action>,
+    file: StaticString = #fileID,
+    line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
@@ -662,7 +717,13 @@ extension SwitchStore {
   {
     self.init(store: store) {
       let content = content().value
-      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
+      return WithViewStore(
+        store,
+        removeDuplicates: { enumTag($0) == enumTag($1) },
+        file: file,
+        line: line,
+        column: column
+      ) { viewStore in
         if content.0.toLocalState(viewStore.state) != nil {
           content.0
         } else if content.1.toLocalState(viewStore.state) != nil {
@@ -693,6 +754,7 @@ extension SwitchStore {
     _ store: Store<State, Action>,
     file: StaticString = #fileID,
     line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
@@ -730,7 +792,7 @@ extension SwitchStore {
     >
   {
     let content = content()
-    self.init(store) {
+    self.init(store, file: file, line: line, column: column) {
       content.value.0
       content.value.1
       content.value.2
@@ -752,6 +814,9 @@ extension SwitchStore {
     DefaultContent
   >(
     _ store: Store<State, Action>,
+    file: StaticString = #fileID,
+    line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
@@ -795,7 +860,13 @@ extension SwitchStore {
   {
     self.init(store: store) {
       let content = content().value
-      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
+      return WithViewStore(
+        store,
+        removeDuplicates: { enumTag($0) == enumTag($1) },
+        file: file,
+        line: line,
+        column: column
+      ) { viewStore in
         if content.0.toLocalState(viewStore.state) != nil {
           content.0
         } else if content.1.toLocalState(viewStore.state) != nil {
@@ -829,6 +900,7 @@ extension SwitchStore {
     _ store: Store<State, Action>,
     file: StaticString = #fileID,
     line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
@@ -870,7 +942,7 @@ extension SwitchStore {
     >
   {
     let content = content()
-    self.init(store) {
+    self.init(store, file: file, line: line, column: column) {
       content.value.0
       content.value.1
       content.value.2
@@ -894,6 +966,9 @@ extension SwitchStore {
     DefaultContent
   >(
     _ store: Store<State, Action>,
+    file: StaticString = #fileID,
+    line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
@@ -941,7 +1016,13 @@ extension SwitchStore {
   {
     self.init(store: store) {
       let content = content().value
-      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
+      return WithViewStore(
+        store,
+        removeDuplicates: { enumTag($0) == enumTag($1) },
+        file: file,
+        line: line,
+        column: column
+      ) { viewStore in
         if content.0.toLocalState(viewStore.state) != nil {
           content.0
         } else if content.1.toLocalState(viewStore.state) != nil {
@@ -978,6 +1059,7 @@ extension SwitchStore {
     _ store: Store<State, Action>,
     file: StaticString = #fileID,
     line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
@@ -1023,7 +1105,7 @@ extension SwitchStore {
     >
   {
     let content = content()
-    self.init(store) {
+    self.init(store, file: file, line: line, column: column) {
       content.value.0
       content.value.1
       content.value.2
@@ -1049,6 +1131,9 @@ extension SwitchStore {
     DefaultContent
   >(
     _ store: Store<State, Action>,
+    file: StaticString = #fileID,
+    line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
@@ -1100,7 +1185,13 @@ extension SwitchStore {
   {
     self.init(store: store) {
       let content = content().value
-      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
+      return WithViewStore(
+        store,
+        removeDuplicates: { enumTag($0) == enumTag($1) },
+        file: file,
+        line: line,
+        column: column
+      ) { viewStore in
         if content.0.toLocalState(viewStore.state) != nil {
           content.0
         } else if content.1.toLocalState(viewStore.state) != nil {
@@ -1140,6 +1231,7 @@ extension SwitchStore {
     _ store: Store<State, Action>,
     file: StaticString = #fileID,
     line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
@@ -1189,7 +1281,7 @@ extension SwitchStore {
     >
   {
     let content = content()
-    self.init(store) {
+    self.init(store, file: file, line: line, column: column) {
       content.value.0
       content.value.1
       content.value.2

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -97,7 +97,7 @@ where Content: View {
     self.init(
       state: toLocalState,
       action: fromLocalAction,
-      caseIdentifier:  SharedStoreConfiguration.shouldInferScopeIdenfiers
+      caseIdentifier:  SharedStoreConfiguration.shouldInferScopeIdentifiers
       ? ScopeIdentifier(file: file, line: line, column: column)
       : nil,
       then: content
@@ -147,7 +147,7 @@ extension CaseLet where GlobalAction == LocalAction {
     self.init(
       state: toLocalState,
       action: { $0 },
-      caseIdentifier: SharedStoreConfiguration.shouldInferScopeIdenfiers
+      caseIdentifier: SharedStoreConfiguration.shouldInferScopeIdentifiers
       ? ScopeIdentifier(file: file, line: line, column: column)
       : nil,
       then: content

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -96,7 +96,7 @@ where Content: View {
     self.init(
       state: toLocalState,
       action: fromLocalAction,
-      caseIdentifier:  SharedStoreConfiguration.isAutomaticReuseOfStoreAndViewStoreInstancesEnabled
+      caseIdentifier:  SharedStoreConfiguration.shouldInferScopeIdenfiers
       ? ScopeIdentifier(file: file, line: line)
       : nil,
       then: content
@@ -145,7 +145,7 @@ extension CaseLet where GlobalAction == LocalAction {
     self.init(
       state: toLocalState,
       action: { $0 },
-      caseIdentifier: SharedStoreConfiguration.isAutomaticReuseOfStoreAndViewStoreInstancesEnabled
+      caseIdentifier: SharedStoreConfiguration.shouldInferScopeIdenfiers
       ? ScopeIdentifier(file: file, line: line)
       : nil,
       then: content

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -33,6 +33,7 @@ public struct WithViewStore<State, Action, Content> {
     removeDuplicates isDuplicate: @escaping (State, State) -> Bool,
     file: StaticString = #fileID,
     line: UInt = #line,
+    column: UInt = #column,
     content: @escaping (ViewStore<State, Action>) -> Content
   ) {
     self.content = content
@@ -45,7 +46,12 @@ public struct WithViewStore<State, Action, Content> {
         return previousState
       }
     #endif
-    self.viewStore = store.viewStore(file: file, line: line, removeDuplicates: isDuplicate)
+    self.viewStore = store.viewStore(
+      file: file,
+      line: line,
+      column: column,
+      removeDuplicates: isDuplicate
+    )
   }
 
   /// Prints debug information to the console whenever the view is computed.
@@ -106,6 +112,7 @@ extension WithViewStore: View where Content: View {
     removeDuplicates isDuplicate: @escaping (State, State) -> Bool,
     file: StaticString = #fileID,
     line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping (ViewStore<State, Action>) -> Content
   ) {
     self.init(
@@ -113,6 +120,7 @@ extension WithViewStore: View where Content: View {
       removeDuplicates: isDuplicate,
       file: file,
       line: line,
+      column: column,
       content: content
     )
   }
@@ -133,9 +141,10 @@ extension WithViewStore where State: Equatable, Content: View {
     _ store: Store<State, Action>,
     file: StaticString = #fileID,
     line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping (ViewStore<State, Action>) -> Content
   ) {
-    self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
+    self.init(store, removeDuplicates: ==, file: file, line: line, column: column, content: content)
   }
 }
 
@@ -150,9 +159,10 @@ extension WithViewStore where State == Void, Content: View {
     _ store: Store<State, Action>,
     file: StaticString = #fileID,
     line: UInt = #line,
+    column: UInt = #column,
     @ViewBuilder content: @escaping (ViewStore<State, Action>) -> Content
   ) {
-    self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
+    self.init(store, removeDuplicates: ==, file: file, line: line, column: column, content: content)
   }
 }
 
@@ -179,6 +189,7 @@ extension WithViewStore: Scene where Content: Scene {
     removeDuplicates isDuplicate: @escaping (State, State) -> Bool,
     file: StaticString = #fileID,
     line: UInt = #line,
+    column: UInt = #column,
     @SceneBuilder content: @escaping (ViewStore<State, Action>) -> Content
   ) {
     self.init(
@@ -186,6 +197,7 @@ extension WithViewStore: Scene where Content: Scene {
       removeDuplicates: isDuplicate,
       file: file,
       line: line,
+      column: column,
       content: content
     )
   }
@@ -207,9 +219,10 @@ extension WithViewStore where State: Equatable, Content: Scene {
     _ store: Store<State, Action>,
     file: StaticString = #fileID,
     line: UInt = #line,
+    column: UInt = #column,
     @SceneBuilder content: @escaping (ViewStore<State, Action>) -> Content
   ) {
-    self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
+    self.init(store, removeDuplicates: ==, file: file, line: line, column: column, content: content)
   }
 }
 
@@ -225,8 +238,9 @@ extension WithViewStore where State == Void, Content: Scene {
     _ store: Store<State, Action>,
     file: StaticString = #fileID,
     line: UInt = #line,
+    column: UInt = #column,
     @SceneBuilder content: @escaping (ViewStore<State, Action>) -> Content
   ) {
-    self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
+    self.init(store, removeDuplicates: ==, file: file, line: line, column: column, content: content)
   }
 }

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -45,7 +45,7 @@ public struct WithViewStore<State, Action, Content> {
         return previousState
       }
     #endif
-    self.viewStore = ViewStore(store, removeDuplicates: isDuplicate)
+    self.viewStore = store.viewStore(file: file, line: line, removeDuplicates: isDuplicate)
   }
 
   /// Prints debug information to the console whenever the view is computed.

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -60,7 +60,7 @@ extension Store {
                 return state
               },
               scopeIdentifier:
-                SharedStoreConfiguration.isAutomaticReuseOfStoreAndViewStoreInstancesEnabled
+                SharedStoreConfiguration.shouldInferScopeIdenfiers
                 ? "Optional Unwrapping"
                 : nil)
           )

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -60,7 +60,7 @@ extension Store {
                 return state
               },
               scopeIdentifier:
-                SharedStoreConfiguration.shouldInferScopeIdenfiers
+                SharedStoreConfiguration.shouldInferScopeIdentifiers
                 ? "Optional Unwrapping"
                 : nil)
           )

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -54,10 +54,15 @@ extension Store {
       .sink { state in
         if var state = state {
           unwrap(
-            self.scope {
-              state = $0 ?? state
-              return state
-            }
+            self.scope(
+              state: {
+                state = $0 ?? state
+                return state
+              },
+              scopeIdentifier:
+                SharedStoreConfiguration.isAutomaticReuseOfStoreAndViewStoreInstancesEnabled
+                ? "Optional Unwrapping"
+                : nil)
           )
         } else {
           `else`()

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -507,7 +507,7 @@ extension Store {
   ) -> ViewStore<State, Action> {
     let reuseIdentifier =
       SharedStoreConfiguration.shouldInferScopeIdenfiers
-        ? ScopeIdentifier(file: file, line: line)
+        ? ScopeIdentifier(file: file, line: line, column: column)
         : nil
     return viewStore(reuseIdentifier: reuseIdentifier, removeDuplicates: isDuplicate)
   }

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -506,7 +506,7 @@ extension Store {
     removeDuplicates isDuplicate: @escaping (State, State) -> Bool
   ) -> ViewStore<State, Action> {
     let reuseIdentifier =
-      SharedStoreConfiguration.shouldInferScopeIdenfiers
+      SharedStoreConfiguration.shouldInferScopeIdentifiers
         ? ScopeIdentifier(file: file, line: line, column: column)
         : nil
     return viewStore(reuseIdentifier: reuseIdentifier, removeDuplicates: isDuplicate)

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -494,7 +494,7 @@ extension Store {
     removeDuplicates isDuplicate: @escaping (State, State) -> Bool
   ) -> ViewStore<State, Action> {
     let reuseIdentifier =
-      SharedStoreConfiguration.isAutomaticReuseOfStoreAndViewStoreInstancesEnabled
+      SharedStoreConfiguration.shouldInferScopeIdenfiers
         ? ScopeIdentifier(file: file, line: line)
         : nil
     return viewStore(reuseIdentifier: reuseIdentifier, removeDuplicates: isDuplicate)
@@ -511,22 +511,22 @@ extension Store {
         fatalError("Tried to reuse the wrong ViewStore instance.")
       }
       #if DEBUG
-        if SharedStoreConfiguration.printViewStoreReuseStatus {
+       if SharedStoreConfiguration.printOptions.contains(.reusableViewStore) {
           print("Reusing ViewStore<\(State.self), \(Action.self)> with id: \(reuseIdentifier)")
         }
       #endif
       return viewStore
     } else if reuseIdentifier == nil {
       #if DEBUG
-        if SharedStoreConfiguration.printViewStoreReuseStatus {
-          print("Initializing uncached ViewStore<\(State.self), \(Action.self)>")
+        if SharedStoreConfiguration.printOptions.contains(.nonReusableViewStore) {
+          print("Initializing non-reusable ViewStore<\(State.self), \(Action.self)>")
         }
       #endif
     }
     let viewStore = ViewStore(self, removeDuplicates: isDuplicate)
     if let reuseIdentifier = reuseIdentifier {
       #if DEBUG
-        if SharedStoreConfiguration.printViewStoreReuseStatus {
+        if SharedStoreConfiguration.printOptions.contains(.reusableViewStore) {
           print("Caching ViewStore<\(State.self), \(Action.self)> with id: \(reuseIdentifier)")
         }
       #endif

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -67,8 +67,20 @@ public final class ViewStore<State, Action>: ObservableObject {
   ///   - store: A store.
   ///   - isDuplicate: A function to determine when two `State` values are equal. When values are
   ///     equal, repeat view computations are removed.
-  public init(
+  public convenience init(
     _ store: Store<State, Action>,
+    removeDuplicates isDuplicate: @escaping (State, State) -> Bool
+  ) {
+    #if DEBUG
+      if SharedStoreConfiguration.printOptions.contains(.nonReusableViewStore) {
+        print("Initializing non-reusable ViewStore<\(State.self), \(Action.self)>")
+      }
+    #endif
+    self.init(_store: store, removeDuplicates: isDuplicate)
+  }
+  
+  internal init(
+    _store store: Store<State, Action>,
     removeDuplicates isDuplicate: @escaping (State, State) -> Bool
   ) {
     self._send = { store.send($0) }
@@ -523,7 +535,7 @@ extension Store {
         }
       #endif
     }
-    let viewStore = ViewStore(self, removeDuplicates: isDuplicate)
+    let viewStore = ViewStore(_store: self, removeDuplicates: isDuplicate)
     if let reuseIdentifier = reuseIdentifier {
       #if DEBUG
         if SharedStoreConfiguration.printOptions.contains(.reusableViewStore) {

--- a/Sources/swift-composable-architecture-benchmark/main.swift
+++ b/Sources/swift-composable-architecture-benchmark/main.swift
@@ -15,10 +15,10 @@ let store2 = store1.scope { $0 }
 let store3 = store2.scope { $0 }
 let store4 = store3.scope { $0 }
 
-let viewStore1 = ViewStore(store1)
-let viewStore2 = ViewStore(store2)
-let viewStore3 = ViewStore(store3)
-let viewStore4 = ViewStore(store4)
+let viewStore1 = store1.viewStore
+let viewStore2 = store2.viewStore
+let viewStore3 = store3.viewStore
+let viewStore4 = store4.viewStore
 
 benchmark("Scoping (1)") {
   viewStore1.send(true)

--- a/Tests/ComposableArchitectureTests/BindingTests.swift
+++ b/Tests/ComposableArchitectureTests/BindingTests.swift
@@ -29,7 +29,7 @@
 
       let store = Store(initialState: .init(), reducer: reducer, environment: ())
 
-      let viewStore = ViewStore(store)
+      let viewStore = store.viewStore
 
       viewStore.binding(\.$nested.field).wrappedValue = "Hello"
 

--- a/Tests/ComposableArchitectureTests/MemoryManagementTests.swift
+++ b/Tests/ComposableArchitectureTests/MemoryManagementTests.swift
@@ -13,7 +13,7 @@ final class MemoryManagementTests: XCTestCase {
     let store = Store(initialState: 0, reducer: counterReducer, environment: ())
       .scope(state: { "\($0)" })
       .scope(state: { Int($0)! })
-    let viewStore = ViewStore(store)
+    let viewStore = store.viewStore
 
     var count = 0
     viewStore.publisher.sink { count = $0 }.store(in: &self.cancellables)
@@ -28,7 +28,7 @@ final class MemoryManagementTests: XCTestCase {
       state += 1
       return .none
     }
-    let viewStore = ViewStore(Store(initialState: 0, reducer: counterReducer, environment: ()))
+    let viewStore = Store(initialState: 0, reducer: counterReducer, environment: ()).viewStore
 
     var count = 0
     viewStore.publisher.sink { count = $0 }.store(in: &self.cancellables)

--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -171,13 +171,13 @@ final class ReducerTests: XCTestCase {
       )
     }
 
-    let viewStore = ViewStore(
-      Store(
-        initialState: .init(),
-        reducer: reducer,
-        environment: ()
-      )
+    let viewStore = Store(
+      initialState: .init(),
+      reducer: reducer,
+      environment: ()
     )
+    .viewStore
+    
     viewStore.send(.incrWithBool(true))
 
     self.wait(for: [logsExpectation], timeout: 2)

--- a/Tests/ComposableArchitectureTests/ViewStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/ViewStoreTests.swift
@@ -18,7 +18,7 @@ final class ViewStoreTests: XCTestCase {
       environment: ()
     )
 
-    let viewStore = ViewStore(store)
+    let viewStore = store.viewStore
 
     var emissionCount = 0
     viewStore.publisher
@@ -46,10 +46,10 @@ final class ViewStoreTests: XCTestCase {
     let store3 = store2.scope(state: { $0 })
     let store4 = store3.scope(state: { $0 })
 
-    let viewStore1 = ViewStore(store1)
-    let viewStore2 = ViewStore(store2)
-    let viewStore3 = ViewStore(store3)
-    let viewStore4 = ViewStore(store4)
+    let viewStore1 = store1.viewStore
+    let viewStore2 = store2.viewStore
+    let viewStore3 = store3.viewStore
+    let viewStore4 = store4.viewStore
 
     viewStore1.publisher.sink { _ in }.store(in: &self.cancellables)
     viewStore2.publisher.sink { _ in }.store(in: &self.cancellables)
@@ -83,7 +83,7 @@ final class ViewStoreTests: XCTestCase {
     }
 
     let store = Store(initialState: 0, reducer: reducer, environment: ())
-    let viewStore = ViewStore(store)
+    let viewStore = store.viewStore
 
     var results: [Int] = []
 
@@ -105,7 +105,7 @@ final class ViewStoreTests: XCTestCase {
     }
 
     let store = Store(initialState: 0, reducer: reducer, environment: ())
-    let viewStore = ViewStore(store)
+    let viewStore = store.viewStore
 
     var results: [Int] = []
 
@@ -128,12 +128,12 @@ final class ViewStoreTests: XCTestCase {
     let store = Store(initialState: 0, reducer: reducer, environment: ())
 
     var results: [Int] = []
-    ViewStore(store)
+    store.viewStore
       .publisher
       .sink { results.append($0) }
       .store(in: &self.cancellables)
 
-    ViewStore(store).send(())
+    store.viewStore.send(())
     XCTAssertNoDifference(results, [0, 1])
   }
 
@@ -143,7 +143,7 @@ final class ViewStoreTests: XCTestCase {
       return .none
     }
     let store = Store(initialState: 0, reducer: reducer, environment: ())
-    let viewStore = ViewStore(store)
+    let viewStore = store.viewStore
 
     var results: [Int] = []
 
@@ -190,7 +190,7 @@ final class ViewStoreTests: XCTestCase {
         }
 
         let store = Store(initialState: false, reducer: reducer, environment: ())
-        let viewStore = ViewStore(store)
+        let viewStore = store.viewStore
 
         XCTAssertNoDifference(viewStore.state, false)
         await viewStore.send(.tapped, while: { $0 })
@@ -221,7 +221,7 @@ final class ViewStoreTests: XCTestCase {
         }
 
         let store = Store(initialState: false, reducer: reducer, environment: ())
-        let viewStore = ViewStore(store)
+        let viewStore = store.viewStore
 
         XCTAssertNoDifference(viewStore.state, false)
         viewStore.send(.tapped)


### PR DESCRIPTION
Today's discussion about `StateObject`'s (#934) made me try to tackle this related problem again, as `@StateObject` would ultimately not be required if the `ViewStore` instances are preserved.
This is by no mean a complete PR, as there are probably many sharp edges.

To sum up, the `Store` caches weakly its scoped children and viewStores. Each store owns its cache and reuses instances when possible.

### ViewStore
The designated way to create a viewStore is by calling the `.viewStore` property on Store's of `Equatable`, or the `.viewStore(deduplicate:)` method in the general case. When possible, the same viewStore instance will be returned each time. `ViewStore(store)` doesn't return a cached instance (because it's an initializer of a reference type, we can't assign an existing instance to `self`).  `WithViewStore`'s are using the cached value when possible, however.

### ScopeIdentifier
There is a new type called `ScopeIdentifier` that identifies a specific scope configuration. This `scopeIdentifier` is used to key the cached child stores instances. The same type is used to key the `ViewStore`'s cache.

We should provide a `ScopeIdentifier` when scoping a store or creating a `ViewStore`. `ForEachStore`, `SwitchStore`, and `CaseLet` views are accepting such `ScopeIdentifier?` as an argument. If the value is `nil`, caching is disabled. `IfLsetStore` doesn't need any `ScopeIdentifier` as the operation is univocal.

Because providing a `ScopeIdentifier` each time a store is scoped is annoying, a contextual identifier can be automatically derived using the `#fileID` and `#line` of the calling function. Furthermore, a static `SharedStoreConfiguration` type was added. This type has one static property called `isAutomaticReuseOfStoreAndViewStoreInstancesEnabled: Bool` . 

**When this value is set to `true` (the default for now), current clients of TCA are automatically reusing `Store` and `ViewStore` without having to touch the client's code**.

This automatic `scopeIdentifier` derivation should work in most cases, and this is probably the most complex issue with the subject. At the top of my head, it will fail:
- If the same store is scoped twice on the same line. One can make automatic identifiers a little more resilient by augmenting them with `LocalState.self` and `LocalAction.self`, or maybe with the `#column` value.
- If scoping is parametric and can change during the lifetime of the `store`, that is if the functions (not their values) that are transforming `LocalState` and `LocalAction` are changing. This looks quite contrived, but this is theoretically possible.

ViewStore reusing is more simple, as the only variable is the deduplication function which is involved less frequently and very likely static.

I particularly like the `store.viewStore` naming, as I find it more logical. Maybe it should be ultimately renamed `view`.

I didn't write the documentation for the new overloads yet, as I'm awaiting feedback. @mbrandonw, @stephencelis, please let me know if something is not clear.
