### PR TITLE
Improved way to get SwiftUI image handle

### DIFF
--- a/Sources/ComposableArchitecture/Internal/RuntimeWarnings.swift
+++ b/Sources/ComposableArchitecture/Internal/RuntimeWarnings.swift
@@ -8,9 +8,18 @@
   // Feedback filed: https://gist.github.com/stephencelis/a8d06383ed6ccde3e5ef5d1b3ad52bbc
   let rw = (
     dso: { () -> UnsafeMutableRawPointer in
-      var info = Dl_info()
-      dladdr(dlsym(dlopen(nil, RTLD_LAZY), "LocalizedString"), &info)
-      return info.dli_fbase
+      let count = _dyld_image_count()
+      for i in 0..<count {
+        if let name = _dyld_get_image_name(i) {
+          let swiftString = String(cString: name)
+          if swiftString.hasSuffix("SwiftUI") {
+            if let pointer = UnsafeMutableRawPointer(bitPattern: _dyld_get_image_vmaddr_slide(i)) {
+              return pointer
+            }
+          }
+        }
+      }
+      fatalError("Import SwiftUI to use this")
     }(),
     log: OSLog(subsystem: "com.apple.runtime-issues", category: "ComposableArchitecture")
   )

--- a/Sources/ComposableArchitecture/Internal/RuntimeWarnings.swift
+++ b/Sources/ComposableArchitecture/Internal/RuntimeWarnings.swift
@@ -12,9 +12,9 @@
       for i in 0..<count {
         if let name = _dyld_get_image_name(i) {
           let swiftString = String(cString: name)
-          if swiftString.hasSuffix("SwiftUI") {
-            if let pointer = UnsafeMutableRawPointer(bitPattern: _dyld_get_image_vmaddr_slide(i)) {
-              return pointer
+          if swiftString.hasSuffix("/SwiftUI") {
+            if let header = _dyld_get_image_header(i) {
+              return UnsafeMutableRawPointer(mutating: UnsafeRawPointer(header))
             }
           }
         }

--- a/Sources/ComposableArchitecture/Internal/RuntimeWarnings.swift
+++ b/Sources/ComposableArchitecture/Internal/RuntimeWarnings.swift
@@ -19,7 +19,7 @@
           }
         }
       }
-      fatalError("Import SwiftUI to use this")
+      return UnsafeMutableRawPointer(mutating: #dsohandle)
     }(),
     log: OSLog(subsystem: "com.apple.runtime-issues", category: "ComposableArchitecture")
   )


### PR DESCRIPTION
Hi!
I love this new runtime warning feature, however I think there's a better way to get SwiftUI image handle than hardcode a SwiftUI symbol name. In this PR, I iterate over dyld images and search SwiftUI directly. I think this approach is more straightforward.