### PR TITLE
Remove `Sendable` warning in `ViewStore.suspend(while:)`

### DIFF
--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -477,7 +477,7 @@ private struct HashableWrapper<Value>: Hashable {
     }
   }
 
-  private class Box<Value> {
+  private class Box<Value>: @unchecked Sendable {
     var wrappedValue: Value
 
     init(wrappedValue: Value) {

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -477,7 +477,7 @@ private struct HashableWrapper<Value>: Hashable {
     }
   }
 
-  private class Box<Value>: @unchecked Sendable {
+  private final class Box<Value>: @unchecked Sendable {
     var wrappedValue: Value
 
     init(wrappedValue: Value) {


### PR DESCRIPTION
Swift 5.6 (from Xcode 13.3 beta 1) complains that the `Box` value touched in the `Sendable` handler of `.withTaskCancellationHandler` is not `Sendable`. This kind of warnings will show by default with Swift 5.6 and [will become errors with Swift 6](https://forums.swift.org/t/concurrency-in-swift-5-and-6/49337#concurrency-in-swift-5-and-6-2).

This PR marks `Box` as `@unchecked Sendable`. The `@unchecked` is required by `Box.Value==AnyCancellable` which is not `Sendable` by itself. This removes the warning at build time, but it fixes nothing on the concurrency aspect. Conditional conformance of `Box` to `Sendable` would require us to conform `AnyCancellable` to `Sendable` ourselves, which is most likely a bad idea.

I've also marked `Box` as final, [as recommended](https://developer.apple.com/swift/blog/?id=27). (I've furthermore wrongfully mentioned it as `ViewStore.Box` in the commit message. This is a top-level class)

I don't know if there are better/safer alternatives without migrating more things to "async/await".

EDIT: CI failed in some unrelated test.