### PR TITLE
Fix memory leak caused by `Effect.cancellable`

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -47,6 +47,7 @@ extension Effect {
       cancellationCancellable = AnyCancellable {
         cancellablesLock.sync {
           cancellationSubject.send(())
+          cancellationSubject.send(completion: .finished)
           cancellationCancellables[id]?.remove(cancellationCancellable)
           if cancellationCancellables[id]?.isEmpty == .some(true) {
             cancellationCancellables[id] = nil


### PR DESCRIPTION
This PR should fix #993 which was introduced by #949.

It looks like `PrefixUntilOutput` might keep the output publisher alive until receiving a completion. This is something I overlooked. 