### PR TITLE
Fix edit while filtered bug in todos example app

### DIFF
--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -66,7 +66,13 @@ let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
       return .none
 
     case let .move(source, destination):
-      state.todos.move(fromOffsets: source, toOffset: destination)
+      // Get source and destination in unfiltered todos array
+      let sourceInTodos = source
+        .map { state.filteredTodos[$0] }
+        .compactMap { state.todos.index(id: $0.id) }
+      let destinationInTodos = state.todos.index(id: state.filteredTodos[destination].id)!
+
+      state.todos.move(fromOffsets: IndexSet(sourceInTodos), toOffset: destinationInTodos)
       return Effect(value: .sortCompletedTodos)
         .delay(for: .milliseconds(100), scheduler: environment.mainQueue)
         .eraseToEffect()

--- a/Examples/Todos/TodosTests/TodosTests.swift
+++ b/Examples/Todos/TodosTests/TodosTests.swift
@@ -236,6 +236,58 @@ class TodosTests: XCTestCase {
     store.receive(.sortCompletedTodos)
   }
 
+  func testEditModeMovingWithFilter() {
+    let state = AppState(
+      todos: [
+        Todo(
+          description: "",
+          id: UUID(uuidString: "00000000-0000-0000-0000-000000000000")!,
+          isComplete: false
+        ),
+        Todo(
+          description: "",
+          id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+          isComplete: true
+        ),
+        Todo(
+          description: "",
+          id: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
+          isComplete: false
+        ),
+        Todo(
+          description: "",
+          id: UUID(uuidString: "00000000-0000-0000-0000-000000000003")!,
+          isComplete: true
+        ),
+      ]
+    )
+    let store = TestStore(
+      initialState: state,
+      reducer: appReducer,
+      environment: AppEnvironment(
+        mainQueue: self.scheduler.eraseToAnyScheduler(),
+        uuid: UUID.incrementing
+      )
+    )
+
+    store.send(.editModeChanged(.active)) {
+      $0.editMode = .active
+    }
+    store.send(.filterPicked(.completed)) {
+      $0.filter = .completed
+    }
+    store.send(.move([0], 1)) {
+      $0.todos = [
+        $0.todos[0],
+        $0.todos[2],
+        $0.todos[1],
+        $0.todos[3],
+      ]
+    }
+    self.scheduler.advance(by: .milliseconds(100))
+    store.receive(.sortCompletedTodos)
+  }
+
   func testFilteredEdit() {
     let state = AppState(
       todos: [


### PR DESCRIPTION
## Changes
Fixed a bug in Todos example app where moving items returns the wrong todos indices if the completed filter is enabled

> The issue is happening because the `source` and `destination` are captured from the `filteredTodos` array while the move operation is happening in the original `todos` array

[before]: https://user-images.githubusercontent.com/8127757/152877651-fbfecfc6-0c20-4cbd-b31c-341b96f07be9.gif
[after]: https://user-images.githubusercontent.com/8127757/152877638-78e43d4a-4e8b-4bc6-950d-d67e30337554.gif

### Before/After
| Before | After |
|-|-|
| ![Before][before] | ![After][after] |
