### PR TITLE
Add support for task cancellation when using ViewStore.send(_:while).

### DIFF
--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -524,7 +524,7 @@ private struct HashableWrapper<Value>: Hashable {
     ///   - cancellationHandler: A closure that will be called if the suspend task is cancelled.
     public func suspend(
       while predicate: @escaping (State) -> Bool,
-      onCancel cancellationHandler: (() -> Void)?
+      onCancel cancellationHandler: (() -> Void)? = nil
     ) async {
       let cancellable = Box<AnyCancellable?>(wrappedValue: nil)
       try? await withTaskCancellationHandler(

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -526,11 +526,14 @@ private struct HashableWrapper<Value>: Hashable {
       while predicate: @escaping (State) -> Bool,
       onCancel cancellationHandler: (() -> Void)? = nil
     ) async {
-      let cancellable = Box<AnyCancellable?>(wrappedValue: nil)
+      let cancellable = Box<AnyCancellable?>(
+        wrappedValue: nil,
+        cancellationHandler: cancellationHandler
+      )
       try? await withTaskCancellationHandler(
         handler: {
           cancellable.wrappedValue?.cancel()
-          cancellationHandler?()
+          cancellable.cancellationHandler?()
         },
         operation: {
           try Task.checkCancellation()
@@ -555,9 +558,11 @@ private struct HashableWrapper<Value>: Hashable {
 
   private class Box<Value> {
     var wrappedValue: Value
+    var cancellationHandler: (() -> Void)?
 
-    init(wrappedValue: Value) {
+    init(wrappedValue: Value, cancellationHandler: (() -> Void)?) {
       self.wrappedValue = wrappedValue
+      self.cancellationHandler = cancellationHandler
     }
   }
 #endif


### PR DESCRIPTION
This adds the ability for sending a cancellation action to the view store when calling `ViewStore.send(_:while)` inside a SwiftUI `.task` modifier, in turn making it possible to start and cancel long-running effects..

To implement this, I had to remove the iOS 15 specific implementation that uses the `AsyncPublisher` API as I couldn't see any obvious way of hooking into the cancellation (or if it even supports cancellation).

I originally considered just exposing the `cancellationHandler` parameter on the `send` methods but I believe that the most common use case when calling `.send` inside a `.task` modifier will be to send a cancellation action to the store in order to cancel a long-running effect.

If users need to perform some custom cancellation handling, they have the option of calling `ViewStore.send()` followed by `ViewStore.suspend()` inside the `.task` modifier and passing in a custom cancellation handler that way, but I've optimised the high-level APIs for what I think most people will need.

Solves #1000 