### PR TITLE
`Effect.cancel(ids:)` prefer sequence of ids over variadic list.

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -96,7 +96,7 @@ extension Effect {
 
   /// An effect that will cancel multiple currently in-flight effects with the given identifiers.
   ///
-  /// - Parameter ids: An sequence of effect identifiers.
+  /// - Parameter ids: A sequence of effect identifiers.
   /// - Returns: A new effect that will cancel any currently in-flight effects with the given
   ///   identifiers.
   public static func cancel<S: Sequence>(ids: S) -> Effect where S.Element == AnyHashable {

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -89,6 +89,7 @@ extension Effect {
   /// - Parameter ids: A variadic list of effect identifiers.
   /// - Returns: A new effect that will cancel any currently in-flight effects with the given
   ///   identifiers.
+  @_disfavoredOverload
   public static func cancel(ids: AnyHashable...) -> Effect {
     .cancel(ids: ids)
   }

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -96,10 +96,10 @@ extension Effect {
 
   /// An effect that will cancel multiple currently in-flight effects with the given identifiers.
   ///
-  /// - Parameter ids: An array of effect identifiers.
+  /// - Parameter ids: An sequence of effect identifiers.
   /// - Returns: A new effect that will cancel any currently in-flight effects with the given
   ///   identifiers.
-  public static func cancel(ids: [AnyHashable]) -> Effect {
+  public static func cancel<S: Sequence>(ids: S) -> Effect where S.Element == AnyHashable {
     .merge(ids.map(Effect.cancel(id:)))
   }
 }

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -324,7 +324,7 @@ final class EffectCancellationTests: XCTestCase {
 
     Effect<Int, Never>.merge(
       .cancel(ids: CancellationId(id: 1), CancellationId(id: 2)),
-      .cancel(ids: [CancellationId(id: 4), CancellationId(id: 5)])
+      .cancel(ids: [CancellationId(id: 4), CancellationId(id: 5)][...])
     )
       .sink { _ in }
       .store(in: &self.cancellables)

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -302,4 +302,34 @@ final class EffectCancellationTests: XCTestCase {
 
     XCTAssertEqual(output, [1, 2])
   }
+  
+  func testMultipleCancellations() {
+    let scheduler = DispatchQueue.test
+    var values: [Int] = []
+
+    struct CancellationId: Hashable {
+      var id: Int
+    }
+
+    let effects = [1, 2, 3, 4, 5].map { id in
+      Just(id)
+        .delay(for: 1, scheduler: scheduler)
+        .eraseToEffect()
+        .cancellable(id: CancellationId(id: id))
+    }
+
+    Effect<Int, Never>.merge(effects)
+      .sink { values.append($0) }
+      .store(in: &self.cancellables)
+
+    Effect<Int, Never>.merge(
+      .cancel(ids: CancellationId(id: 1), CancellationId(id: 2)),
+      .cancel(ids: [CancellationId(id: 4), CancellationId(id: 5)])
+    )
+      .sink { _ in }
+      .store(in: &self.cancellables)
+
+    scheduler.advance(by: 1)
+    XCTAssertEqual(values, [3])
+  }
 }


### PR DESCRIPTION
This PR disfavors the variadic cancellation to prevent a sequence of ids from being treated as a single cancellation id eg: 

```swift
case let .delete(ids):
  for id in ids {
    state.rows.remove(id: id)
  }
  return .cancel(ids: ids) // currently treated as AnyHashable(ids) instead of [AnyHashable]
```

It also changes the array parameter to a sequence to prevent the same issue for occurring with sub sequences.