### PR TITLE
Fix `WithViewStore` issues with `View`s using escaping closures

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -108,8 +108,8 @@ struct AnimationsView: View {
   let store: Store<AnimationsState, AnimationsAction>
 
   var body: some View {
-    GeometryReader { proxy in
-      WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store) { viewStore in
+      GeometryReader { proxy in
         VStack(alignment: .leading) {
           ZStack(alignment: .center) {
             Text(template: readMe, .body)

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -52,72 +52,65 @@ let timersReducer = Reducer<TimersState, TimersAction, TimersEnvironment> {
 // MARK: - Timer feature view
 
 struct TimersView: View {
-  // NB: We are using an explicit `ObservedObject` for the view store here instead of
-  // `WithViewStore` due to a SwiftUI bug where `GeometryReader`s inside `WithViewStore` will
-  // not properly update.
-  //
-  // Feedback filed: https://gist.github.com/mbrandonw/cc5da3d487bcf7c4f21c27019a440d18
-  @ObservedObject var viewStore: ViewStore<TimersState, TimersAction>
-
-  init(store: Store<TimersState, TimersAction>) {
-    self.viewStore = ViewStore(store)
-  }
+  let store: Store<TimersState, TimersAction>
 
   var body: some View {
-    VStack {
-      Text(template: readMe, .body)
+    WithViewStore(store) { viewStore in
+      VStack {
+        Text(template: readMe, .body)
 
-      ZStack {
-        Circle()
-          .fill(
-            AngularGradient(
-              gradient: Gradient(
-                colors: [
-                  .blue.opacity(0.3),
-                  .blue,
-                  .blue,
-                  .green,
-                  .green,
-                  .yellow,
-                  .yellow,
-                  .red,
-                  .red,
-                  .purple,
-                  .purple,
-                  .purple.opacity(0.3),
-                ]
-              ),
-              center: .center
+        ZStack {
+          Circle()
+            .fill(
+              AngularGradient(
+                gradient: Gradient(
+                  colors: [
+                    .blue.opacity(0.3),
+                    .blue,
+                    .blue,
+                    .green,
+                    .green,
+                    .yellow,
+                    .yellow,
+                    .red,
+                    .red,
+                    .purple,
+                    .purple,
+                    .purple.opacity(0.3),
+                  ]
+                ),
+                center: .center
+              )
             )
-          )
-          .rotationEffect(.degrees(-90))
+            .rotationEffect(.degrees(-90))
 
-        GeometryReader { proxy in
-          Path { path in
-            path.move(to: CGPoint(x: proxy.size.width / 2, y: proxy.size.height / 2))
-            path.addLine(to: CGPoint(x: proxy.size.width / 2, y: 0))
+          GeometryReader { proxy in
+            Path { path in
+              path.move(to: CGPoint(x: proxy.size.width / 2, y: proxy.size.height / 2))
+              path.addLine(to: CGPoint(x: proxy.size.width / 2, y: 0))
+            }
+            .stroke(Color.black, lineWidth: 3)
+            .rotationEffect(.degrees(Double(viewStore.secondsElapsed) * 360 / 60))
           }
-          .stroke(Color.black, lineWidth: 3)
-          .rotationEffect(.degrees(Double(self.viewStore.secondsElapsed) * 360 / 60))
         }
-      }
-      .frame(width: 280, height: 280)
-      .padding(.bottom, 16)
+        .frame(width: 280, height: 280)
+        .padding(.bottom, 16)
 
-      Button(action: { self.viewStore.send(.toggleTimerButtonTapped) }) {
-        HStack {
-          Text(self.viewStore.isTimerActive ? "Stop" : "Start")
+        Button(action: { viewStore.send(.toggleTimerButtonTapped) }) {
+          HStack {
+            Text(viewStore.isTimerActive ? "Stop" : "Start")
+          }
+          .foregroundColor(.white)
+          .padding()
+          .background(viewStore.isTimerActive ? Color.red : .blue)
+          .cornerRadius(16)
         }
-        .foregroundColor(.white)
-        .padding()
-        .background(self.viewStore.isTimerActive ? Color.red : .blue)
-        .cornerRadius(16)
-      }
 
-      Spacer()
+        Spacer()
+      }
+      .padding()
+      .navigationBarTitle("Timers")
     }
-    .padding()
-    .navigationBarTitle("Timers")
   }
 }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -77,72 +77,65 @@ let clockReducer = Reducer<ClockState, ClockAction, ClockEnvironment>.combine(
 )
 
 struct ClockView: View {
-  // NB: We are using an explicit `ObservedObject` for the view store here instead of
-  // `WithViewStore` due to a SwiftUI bug where `GeometryReader`s inside `WithViewStore` will
-  // not properly update.
-  //
-  // Feedback filed: https://gist.github.com/mbrandonw/cc5da3d487bcf7c4f21c27019a440d18
-  @ObservedObject var viewStore: ViewStore<ClockState, ClockAction>
-
-  init(store: Store<ClockState, ClockAction>) {
-    self.viewStore = ViewStore(store)
-  }
-
+  let store: Store<ClockState, ClockAction>
+  
   var body: some View {
-    VStack {
-      Text(template: readMe, .body)
+    WithViewStore(store) { viewStore in
+      VStack {
+        Text(template: readMe, .body)
 
-      ZStack {
-        Circle()
-          .fill(
-            AngularGradient(
-              gradient: Gradient(
-                colors: [
-                  .blue.opacity(0.3),
-                  .blue,
-                  .blue,
-                  .green,
-                  .green,
-                  .yellow,
-                  .yellow,
-                  .red,
-                  .red,
-                  .purple,
-                  .purple,
-                  .purple.opacity(0.3),
-                ]
-              ),
-              center: .center
+        ZStack {
+          Circle()
+            .fill(
+              AngularGradient(
+                gradient: Gradient(
+                  colors: [
+                    .blue.opacity(0.3),
+                    .blue,
+                    .blue,
+                    .green,
+                    .green,
+                    .yellow,
+                    .yellow,
+                    .red,
+                    .red,
+                    .purple,
+                    .purple,
+                    .purple.opacity(0.3),
+                  ]
+                ),
+                center: .center
+              )
             )
-          )
-          .rotationEffect(.degrees(-90))
+            .rotationEffect(.degrees(-90))
 
-        GeometryReader { proxy in
-          Path { path in
-            path.move(to: CGPoint(x: proxy.size.width / 2, y: proxy.size.height / 2))
-            path.addLine(to: CGPoint(x: proxy.size.width / 2, y: 0))
+          GeometryReader { proxy in
+            Path { path in
+              path.move(to: CGPoint(x: proxy.size.width / 2, y: proxy.size.height / 2))
+              path.addLine(to: CGPoint(x: proxy.size.width / 2, y: 0))
+            }
+            .stroke(Color.black, lineWidth: 3)
+            .rotationEffect(.degrees(Double(viewStore.secondsElapsed) * 360 / 60))
           }
-          .stroke(Color.black, lineWidth: 3)
-          .rotationEffect(.degrees(Double(self.viewStore.secondsElapsed) * 360 / 60))
         }
-      }
-      .frame(width: 280, height: 280)
-      .padding(.bottom, 64)
+        .frame(width: 280, height: 280)
+        .padding(.bottom, 64)
 
-      Button(action: { self.viewStore.send(.toggleTimerButtonTapped) }) {
-        HStack {
-          Text(self.viewStore.isTimerActive ? "Stop" : "Start")
+        Button(action: { viewStore.send(.toggleTimerButtonTapped) }) {
+          HStack {
+            Text(viewStore.isTimerActive ? "Stop" : "Start")
+          }
+          .foregroundColor(.white)
+          .padding()
+          .background(viewStore.isTimerActive ? Color.red : .blue)
+          .cornerRadius(16)
         }
-        .foregroundColor(.white)
-        .padding()
-        .background(self.viewStore.isTimerActive ? Color.red : .blue)
-        .cornerRadius(16)
-      }
 
-      Spacer()
+        Spacer()
+      }
+      .padding()
+      .navigationBarTitle("Elm-like subscriptions")
     }
-    .padding()
-    .navigationBarTitle("Elm-like subscriptions")
   }
 }
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
@@ -29,8 +29,8 @@ public struct GameView: View {
   }
 
   public var body: some View {
-    GeometryReader { proxy in
-      WithViewStore(self.store.scope(state: ViewState.init)) { viewStore in
+    WithViewStore(self.store.scope(state: ViewState.init)) { viewStore in
+      GeometryReader { proxy in
         VStack(spacing: 0.0) {
           VStack {
             Text(viewStore.title)

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
@@ -96,55 +96,45 @@ let voiceMemoReducer = Reducer<
 }
 
 struct VoiceMemoView: View {
-  // NB: We are using an explicit `ObservedObject` for the view store here instead of
-  // `WithViewStore` due to a SwiftUI bug where `GeometryReader`s inside `WithViewStore` will
-  // not properly update.
-  //
-  // Feedback filed: https://gist.github.com/mbrandonw/cc5da3d487bcf7c4f21c27019a440d18
-  @ObservedObject var viewStore: ViewStore<VoiceMemo, VoiceMemoAction>
-
-  init(store: Store<VoiceMemo, VoiceMemoAction>) {
-    self.viewStore = ViewStore(store)
-  }
+  let store: Store<VoiceMemo, VoiceMemoAction>
 
   var body: some View {
-    HStack {
-      TextField(
-        "Untitled, \(self.viewStore.date.formatted(date: .numeric, time: .shortened))",
-        text: self.viewStore.binding(
-          get: \.title, send: VoiceMemoAction.titleTextFieldChanged)
+    WithViewStore(store) { viewStore in
+      let currentTime = viewStore.mode.progress.map { $0 * viewStore.duration } ?? viewStore.duration
+      HStack {
+        TextField(
+          "Untitled, \(viewStore.date.formatted(date: .numeric, time: .shortened))",
+          text: viewStore.binding(
+            get: \.title, send: VoiceMemoAction.titleTextFieldChanged)
+        )
+
+        Spacer()
+
+        dateComponentsFormatter.string(from: currentTime).map {
+          Text($0)
+            .font(.footnote.monospacedDigit())
+            .foregroundColor(Color(.systemGray))
+        }
+
+        Button(action: { viewStore.send(.playButtonTapped) }) {
+          Image(systemName: viewStore.mode.isPlaying ? "stop.circle" : "play.circle")
+            .font(.system(size: 22))
+        }
+      }
+      .buttonStyle(.borderless)
+      .frame(maxHeight: .infinity, alignment: .center)
+      .padding(.horizontal)
+      .listRowBackground(viewStore.mode.isPlaying ? Color(.systemGray6) : .clear)
+      .listRowInsets(EdgeInsets())
+      .background(
+        Color(.systemGray5)
+          .frame(maxWidth: viewStore.mode.isPlaying ? .infinity : 0)
+          .animation(
+            viewStore.mode.isPlaying ? .linear(duration: viewStore.duration) : nil,
+            value: viewStore.mode.isPlaying
+          ),
+        alignment: .leading
       )
-
-      Spacer()
-
-      dateComponentsFormatter.string(from: self.currentTime).map {
-        Text($0)
-          .font(.footnote.monospacedDigit())
-          .foregroundColor(Color(.systemGray))
-      }
-
-      Button(action: { self.viewStore.send(.playButtonTapped) }) {
-        Image(systemName: self.viewStore.mode.isPlaying ? "stop.circle" : "play.circle")
-          .font(.system(size: 22))
-      }
     }
-    .buttonStyle(.borderless)
-    .frame(maxHeight: .infinity, alignment: .center)
-    .padding(.horizontal)
-    .listRowBackground(self.viewStore.mode.isPlaying ? Color(.systemGray6) : .clear)
-    .listRowInsets(EdgeInsets())
-    .background(
-      Color(.systemGray5)
-        .frame(maxWidth: self.viewStore.mode.isPlaying ? .infinity : 0)
-        .animation(
-          self.viewStore.mode.isPlaying ? .linear(duration: self.viewStore.duration) : nil,
-          value: self.viewStore.mode.isPlaying
-        ),
-      alignment: .leading
-    )
-  }
-
-  var currentTime: TimeInterval {
-    self.viewStore.mode.progress.map { $0 * self.viewStore.duration } ?? self.viewStore.duration
   }
 }

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -88,7 +88,7 @@ public struct WithViewStore<State, Action, Content> {
         )
       }
     #endif
-    return self.content(self.viewStore.newInstance())
+    return self.content(ViewStore(self.viewStore))
   }
 }
 

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -88,7 +88,7 @@ public struct WithViewStore<State, Action, Content> {
         )
       }
     #endif
-    return self.content(self.viewStore)
+    return self.content(viewStore.newInstance())
   }
 }
 

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -4,20 +4,6 @@ import SwiftUI
 
 /// A structure that transforms a store into an observable view store in order to compute views from
 /// store state.
-///
-/// Due to a bug in SwiftUI, there are times that use of this view can interfere with some core
-/// views provided by SwiftUI. The known problematic views are:
-///
-///   * If a `GeometryReader` or `ScrollViewReader` is used inside a ``WithViewStore`` it will not
-///     receive state updates correctly. To work around you either need to reorder the views so that
-///     the `GeometryReader` or `ScrollViewReader` wraps ``WithViewStore``, or, if that is not
-///     possible, then you must hold onto an explicit
-///     `@ObservedObject var viewStore: ViewStore<State, Action>` in your view in lieu of using this
-///     helper (see [here](https://gist.github.com/mbrandonw/cc5da3d487bcf7c4f21c27019a440d18)).
-///   * If you create a `Stepper` via the `Stepper.init(onIncrement:onDecrement:label:)` initializer
-///     inside a ``WithViewStore`` it will behave erratically. To work around you should use the
-///     initializer that takes a binding (see
-///     [here](https://gist.github.com/mbrandonw/dee2ceac2c316a1619cfdf1dc7945f66)).
 public struct WithViewStore<State, Action, Content> {
   private let content: (ViewStore<State, Action>) -> Content
   #if DEBUG

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -88,7 +88,7 @@ public struct WithViewStore<State, Action, Content> {
         )
       }
     #endif
-    return self.content(viewStore.newInstance())
+    return self.content(self.viewStore.newInstance())
   }
 }
 

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -282,7 +282,7 @@ public final class ViewStore<State, Action>: ObservableObject {
 
 extension ViewStore {
   func newInstance() -> ViewStore<State, Action> {
-    ViewStore(_send: _send, _state: _state)
+    ViewStore(_send: _send, _state: _state, viewCancellable: viewCancellable)
   }
 }
 

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -83,6 +83,16 @@ public final class ViewStore<State, Action>: ObservableObject {
       }
   }
 
+  fileprivate init(
+    _send: @escaping (Action) -> Void,
+    _state: CurrentValueRelay<State>,
+    viewCancellable: AnyCancellable? = nil
+  ) {
+    self._send = _send
+    self._state = _state
+    self.viewCancellable = viewCancellable
+  }
+
   /// A publisher that emits when state changes.
   ///
   /// This publisher supports dynamic member lookup so that you can pluck out a specific field in
@@ -267,6 +277,12 @@ public final class ViewStore<State, Action>: ObservableObject {
   ) -> LocalState {
     get { state.rawValue(self.state) }
     set { self.send(action.rawValue(newValue)) }
+  }
+}
+
+extension ViewStore {
+  func newInstance() -> ViewStore<State, Action> {
+    ViewStore(_send: _send, _state: _state, viewCancellable: viewCancellable)
   }
 }
 

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -282,7 +282,7 @@ public final class ViewStore<State, Action>: ObservableObject {
 
 extension ViewStore {
   func newInstance() -> ViewStore<State, Action> {
-    ViewStore(_send: _send, _state: _state, viewCancellable: viewCancellable)
+    ViewStore(_send: _send, _state: _state)
   }
 }
 


### PR DESCRIPTION
This PR follows the discussion #1012 and implements the solution proposed by @iampatbrown.

I've reordered the "Animations" case from `CaseStudies`, and it indeed fixes the issue with `GeometryReader`. 
It also seems to solve the `Stepper` issues! I'll check with `ScrollViewReader` later.
I'll hunt other uses and mentions in the documentation in a second step if the implementation is greenlighted.

I've used `newInstance()` instead of `copy()` because the latter could suggest that both instances would behave separately once generated. This is of course open to discussion.

Please let me know what you think!
