### PR TITLE
Add specialized overloads to `Effect.merge` and `Reducer.combine`

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -221,11 +221,133 @@ public struct Effect<Output, Failure: Error>: Publisher {
       }
   }
 
+  /// Merges two effects together into a single effect, which runs the effects at the same time.
+  ///
+  /// - Parameters:
+  ///   - a: An effect.
+  ///   - b: A second effect.
+  /// - Returns: A new effect
+  public static func merge(_ a: Effect, _ b: Effect) -> Effect {
+    Publishers.Merge(a, b).eraseToEffect()
+  }
+
+  /// Merges three effects together into a single effect, which runs the effects at the same time.
+  ///
+  /// - Parameters:
+  ///   - a: An effect.
+  ///   - b: A second effect.
+  ///   - c: A third effect.
+  /// - Returns: A new effect
+  public static func merge(_ a: Effect, _ b: Effect, _ c: Effect) -> Effect {
+    Publishers.Merge3(a, b, c).eraseToEffect()
+  }
+
+  /// Merges four effects together into a single effect, which runs the effects at the same time.
+  ///
+  /// - Parameters:
+  ///   - a: An effect.
+  ///   - b: A second effect.
+  ///   - c: A third effect.
+  ///   - d: A fourth effect.
+  /// - Returns: A new effect
+  public static func merge(_ a: Effect, _ b: Effect, _ c: Effect, _ d: Effect) -> Effect {
+    Publishers.Merge4(a, b, c, d).eraseToEffect()
+  }
+
+  /// Merges five effects together into a single effect, which runs the effects at the same time.
+  ///
+  /// - Parameters:
+  ///   - a: An effect.
+  ///   - b: A second effect.
+  ///   - c: A third effect.
+  ///   - d: A fourth effect.
+  ///   - e: A fifth effect.
+  /// - Returns: A new effect
+  public static func merge(
+    _ a: Effect,
+    _ b: Effect,
+    _ c: Effect,
+    _ d: Effect,
+    _ e: Effect
+  ) -> Effect {
+    Publishers.Merge5(a, b, c, d, e).eraseToEffect()
+  }
+
+  /// Merges six effects together into a single effect, which runs the effects at the same time.
+  ///
+  /// - Parameters:
+  ///   - a: An effect.
+  ///   - b: A second effect.
+  ///   - c: A third effect.
+  ///   - d: A fourth effect.
+  ///   - e: A fifth effect.
+  ///   - f: A sixth effect.
+  /// - Returns: A new effect
+  public static func merge(
+    _ a: Effect,
+    _ b: Effect,
+    _ c: Effect,
+    _ d: Effect,
+    _ e: Effect,
+    _ f: Effect
+  ) -> Effect {
+    Publishers.Merge6(a, b, c, d, e, f).eraseToEffect()
+  }
+
+  /// Merges seven effects together into a single effect, which runs the effects at the same time.
+  ///
+  /// - Parameters:
+  ///   - a: An effect.
+  ///   - b: A second effect.
+  ///   - c: A third effect.
+  ///   - d: A fourth effect.
+  ///   - e: A fifth effect.
+  ///   - f: A sixth effect.
+  ///   - g: A seventh effect.
+  /// - Returns: A new effect
+  public static func merge(
+    _ a: Effect,
+    _ b: Effect,
+    _ c: Effect,
+    _ d: Effect,
+    _ e: Effect,
+    _ f: Effect,
+    _ g: Effect
+  ) -> Effect {
+    Publishers.Merge7(a, b, c, d, e, f, g).eraseToEffect()
+  }
+
+  /// Merges eight effects together into a single effect, which runs the effects at the same time.
+  ///
+  /// - Parameters:
+  ///   - a: An effect.
+  ///   - b: A second effect.
+  ///   - c: A third effect.
+  ///   - d: A fourth effect.
+  ///   - e: A fifth effect.
+  ///   - f: A sixth effect.
+  ///   - g: A seventh effect.
+  ///   - h: An eighth effect.
+  /// - Returns: A new effect
+  public static func merge(
+    _ a: Effect,
+    _ b: Effect,
+    _ c: Effect,
+    _ d: Effect,
+    _ e: Effect,
+    _ f: Effect,
+    _ g: Effect,
+    _ h: Effect
+  ) -> Effect {
+    Publishers.Merge8(a, b, c, d, e, f, g, h).eraseToEffect()
+  }
+  
   /// Merges a variadic list of effects together into a single effect, which runs the effects at the
   /// same time.
   ///
   /// - Parameter effects: A list of effects.
   /// - Returns: A new effect
+  @_disfavoredOverload
   public static func merge(
     _ effects: Effect...
   ) -> Effect {

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -113,6 +113,7 @@ public struct Reducer<State, Action, Environment> {
   ///
   /// - Parameter reducers: A list of reducers.
   /// - Returns: A single reducer.
+  @_disfavoredOverload
   public static func combine(_ reducers: Reducer...) -> Reducer {
     .combine(reducers)
   }
@@ -169,8 +170,185 @@ public struct Reducer<State, Action, Environment> {
   /// - Parameter reducers: An array of reducers.
   /// - Returns: A single reducer.
   public static func combine(_ reducers: [Reducer]) -> Reducer {
-    Self { value, action, environment in
-      .merge(reducers.map { $0.reducer(&value, action, environment) })
+    Self { state, action, environment in
+      .merge(reducers.map { $0.reducer(&state, action, environment) })
+    }
+  }
+  
+  /// Combines two reducers into a single one by running each one on state in order, and merging all of the effects.
+  ///
+  /// - Parameters:
+  ///   - a: A reducer.
+  ///   - b: A second reducer.
+  /// - Returns: A single reducer.
+  public static func combine(_ a: Reducer, _ b: Reducer) -> Reducer {
+    Self { state, action, environment in
+      .merge(
+        a.run(&state, action, environment),
+        b.run(&state, action, environment)
+      )
+    }
+  }
+
+  /// Combines three reducers into a single one by running each one on state in order, and merging all of the effects.
+  ///
+  /// - Parameters:
+  ///   - a: A reducer.
+  ///   - b: A second reducer.
+  ///   - c: A third reducer.
+  /// - Returns: A single reducer.
+  public static func combine(_ a: Reducer, _ b: Reducer, _ c: Reducer) -> Reducer {
+    Self { state, action, environment in
+      .merge(
+        a.run(&state, action, environment),
+        b.run(&state, action, environment),
+        c.run(&state, action, environment)
+      )
+    }
+  }
+
+  /// Combines four reducers into a single one by running each one on state in order, and merging all of the effects.
+  ///
+  /// - Parameters:
+  ///   - a: A reducer.
+  ///   - b: A second reducer.
+  ///   - c: A third reducer.
+  ///   - d: A fourth reducer.
+  /// - Returns: A single reducer.
+  public static func combine(_ a: Reducer, _ b: Reducer, _ c: Reducer, _ d: Reducer) -> Reducer {
+    Self { state, action, environment in
+      .merge(
+        a.run(&state, action, environment),
+        b.run(&state, action, environment),
+        c.run(&state, action, environment),
+        d.run(&state, action, environment)
+      )
+    }
+  }
+
+  /// Combines five reducers into a single one by running each one on state in order, and merging all of the effects.
+  ///
+  /// - Parameters:
+  ///   - a: A reducer.
+  ///   - b: A second reducer.
+  ///   - c: A third reducer.
+  ///   - d: A fourth reducer.
+  ///   - e: A fifth reducer.
+  /// - Returns: A single reducer.
+  public static func combine(
+    _ a: Reducer,
+    _ b: Reducer,
+    _ c: Reducer,
+    _ d: Reducer,
+    _ e: Reducer
+  ) -> Reducer {
+    Self { state, action, environment in
+      .merge(
+        a.run(&state, action, environment),
+        b.run(&state, action, environment),
+        c.run(&state, action, environment),
+        d.run(&state, action, environment),
+        e.run(&state, action, environment)
+      )
+    }
+  }
+
+  /// Combines six reducers into a single one by running each one on state in order, and merging all of the effects.
+  ///
+  /// - Parameters:
+  ///   - a: A reducer.
+  ///   - b: A second reducer.
+  ///   - c: A third reducer.
+  ///   - d: A fourth reducer.
+  ///   - e: A fifth reducer.
+  ///   - f: A sixth reducer.
+  /// - Returns: A single reducer.
+  public static func combine(
+    _ a: Reducer,
+    _ b: Reducer,
+    _ c: Reducer,
+    _ d: Reducer,
+    _ e: Reducer,
+    _ f: Reducer
+  ) -> Reducer {
+    Self { state, action, environment in
+      .merge(
+        a.run(&state, action, environment),
+        b.run(&state, action, environment),
+        c.run(&state, action, environment),
+        d.run(&state, action, environment),
+        e.run(&state, action, environment),
+        f.run(&state, action, environment)
+      )
+    }
+  }
+
+  /// Combines seven reducers into a single one by running each one on state in order, and merging all of the effects.
+  ///
+  /// - Parameters:
+  ///   - a: A reducer.
+  ///   - b: A second reducer.
+  ///   - c: A third reducer.
+  ///   - d: A fourth reducer.
+  ///   - e: A fifth reducer.
+  ///   - f: A sixth reducer.
+  ///   - g: A seventh reducer.
+  /// - Returns: A single reducer.
+  public static func combine(
+    _ a: Reducer,
+    _ b: Reducer,
+    _ c: Reducer,
+    _ d: Reducer,
+    _ e: Reducer,
+    _ f: Reducer,
+    _ g: Reducer
+  ) -> Reducer {
+    Self { state, action, environment in
+      .merge(
+        a.run(&state, action, environment),
+        b.run(&state, action, environment),
+        c.run(&state, action, environment),
+        d.run(&state, action, environment),
+        e.run(&state, action, environment),
+        f.run(&state, action, environment),
+        g.run(&state, action, environment)
+      )
+    }
+  }
+
+  /// Combines eight reducers into a single one by running each one on state in order, and merging all of the effects.
+  ///
+  /// - Parameters:
+  ///   - a: A reducer.
+  ///   - b: A second reducer.
+  ///   - c: A third reducer.
+  ///   - d: A fourth reducer.
+  ///   - e: A fifth reducer.
+  ///   - f: A sixth reducer.
+  ///   - g: A seventh reducer.
+  ///   - h: An eighth reducer.
+  /// - Returns: A single reducer.
+  public static func combine(
+    _ a: Reducer,
+    _ b: Reducer,
+    _ c: Reducer,
+    _ d: Reducer,
+    _ e: Reducer,
+    _ f: Reducer,
+    _ g: Reducer,
+    _ h: Reducer
+  ) -> Reducer {
+    Self { state, action, environment in
+      .merge(
+        a.run(&state, action, environment),
+        b.run(&state, action, environment),
+        c.run(&state, action, environment),
+        d.run(&state, action, environment),
+        e.run(&state, action, environment),
+        f.run(&state, action, environment),
+        g.run(&state, action, environment),
+        h.run(&state, action, environment)
+      )
     }
   }
 

--- a/Sources/swift-composable-architecture-benchmark/BasicStoreScope.swift
+++ b/Sources/swift-composable-architecture-benchmark/BasicStoreScope.swift
@@ -1,0 +1,33 @@
+import Benchmark
+import ComposableArchitecture
+
+let basicStoreScopeSuite = BenchmarkSuite(name: "Basic Store Scope") { suite in
+  let counterReducer = Reducer<Int, Void, Void> { state, _, _ in
+    state &+= 1
+    return .none
+  }
+
+  let store1 = Store(initialState: 0, reducer: counterReducer, environment: ())
+  let store2 = store1.scope { $0 }
+  let store3 = store2.scope { $0 }
+  let store4 = store3.scope { $0 }
+
+  let viewStore1 = ViewStore(store1)
+  let viewStore2 = ViewStore(store2)
+  let viewStore3 = ViewStore(store3)
+  let viewStore4 = ViewStore(store4)
+
+  suite.benchmark("Depth 1") {
+    viewStore1.send(())
+  }
+
+  suite.benchmark("Depth 2") {
+    viewStore2.send(())
+  }
+  suite.benchmark("Depth 3") {
+    viewStore3.send(())
+  }
+  suite.benchmark("Depth 4") {
+    viewStore4.send(())
+  }
+}

--- a/Sources/swift-composable-architecture-benchmark/Effects.swift
+++ b/Sources/swift-composable-architecture-benchmark/Effects.swift
@@ -3,19 +3,19 @@ import ComposableArchitecture
 
 let effectsSuite = BenchmarkSuite(name: "Effects") { suite in
 
-  suite.benchmark(".merge([a, b])") {
+  suite.benchmark("merge([a, b])") {
     _ = Effect<Void, Never>.merge([.none, .none]).sink {}
   }
 
-  suite.benchmark(".merge(a, b)") {
+  suite.benchmark("merge(a, b)") {
     _ = Effect<Void, Never>.merge(.none, .none).sink {}
   }
 
-  suite.benchmark(".merge([a, b, c, d, e, f, g, h])") {
+  suite.benchmark("merge([a, b, c, d, e, f, g, h])") {
     _ = Effect<Void, Never>.merge([.none, .none, .none, .none, .none, .none, .none, .none]).sink {}
   }
 
-  suite.benchmark(".merge(a, b, c, d, e, f, g, h)") {
+  suite.benchmark("merge(a, b, c, d, e, f, g, h)") {
     _ = Effect<Void, Never>.merge(.none, .none, .none, .none, .none, .none, .none, .none).sink {}
   }
 }

--- a/Sources/swift-composable-architecture-benchmark/Effects.swift
+++ b/Sources/swift-composable-architecture-benchmark/Effects.swift
@@ -1,0 +1,21 @@
+import Benchmark
+import ComposableArchitecture
+
+let effectsSuite = BenchmarkSuite(name: "Effects") { suite in
+
+  suite.benchmark(".merge([a, b])") {
+    _ = Effect<Void, Never>.merge([.none, .none]).sink {}
+  }
+
+  suite.benchmark(".merge(a, b)") {
+    _ = Effect<Void, Never>.merge(.none, .none).sink {}
+  }
+
+  suite.benchmark(".merge([a, b, c, d, e, f, g, h])") {
+    _ = Effect<Void, Never>.merge([.none, .none, .none, .none, .none, .none, .none, .none]).sink {}
+  }
+
+  suite.benchmark(".merge(a, b, c, d, e, f, g, h)") {
+    _ = Effect<Void, Never>.merge(.none, .none, .none, .none, .none, .none, .none, .none).sink {}
+  }
+}

--- a/Sources/swift-composable-architecture-benchmark/Reducer.swift
+++ b/Sources/swift-composable-architecture-benchmark/Reducer.swift
@@ -1,0 +1,55 @@
+import Benchmark
+import ComposableArchitecture
+
+let reducerSuite = BenchmarkSuite(name: "Reducer") { suite in
+
+  let reducer = Reducer<Int, Void, Void> { state, _, _ in
+    state &+= 1
+    return .none
+  }
+
+  do {
+    let reducers = Reducer<Int, Void, Void>.combine([reducer, reducer])
+
+    let store = Store(initialState: 0, reducer: reducers, environment: ())
+    let viewStore = ViewStore(store)
+
+    suite.benchmark("combine([a, b])") {
+      viewStore.send(())
+    }
+  }
+
+  do {
+    let reducers = Reducer<Int, Void, Void>.combine(reducer, reducer)
+
+    let store = Store(initialState: 0, reducer: reducers, environment: ())
+    let viewStore = ViewStore(store)
+
+    suite.benchmark("combine(a, b)") {
+      viewStore.send(())
+    }
+  }
+  do {
+    let reducers = Reducer<Int, Void, Void>
+      .combine([reducer, reducer, reducer, reducer, reducer, reducer, reducer, reducer])
+
+    let store = Store(initialState: 0, reducer: reducers, environment: ())
+    let viewStore = ViewStore(store)
+
+    suite.benchmark("combine([a, b, c, d, e, f, g, h])") {
+      viewStore.send(())
+    }
+  }
+
+  do {
+    let reducers = Reducer<Int, Void, Void>
+      .combine(reducer, reducer, reducer, reducer, reducer, reducer, reducer, reducer)
+
+    let store = Store(initialState: 0, reducer: reducers, environment: ())
+    let viewStore = ViewStore(store)
+
+    suite.benchmark("combine(a, b, c, d, e, f, g, h)") {
+      viewStore.send(())
+    }
+  }
+}

--- a/Sources/swift-composable-architecture-benchmark/Reducer.swift
+++ b/Sources/swift-composable-architecture-benchmark/Reducer.swift
@@ -29,6 +29,7 @@ let reducerSuite = BenchmarkSuite(name: "Reducer") { suite in
       viewStore.send(())
     }
   }
+  
   do {
     let reducers = Reducer<Int, Void, Void>
       .combine([reducer, reducer, reducer, reducer, reducer, reducer, reducer, reducer])

--- a/Sources/swift-composable-architecture-benchmark/main.swift
+++ b/Sources/swift-composable-architecture-benchmark/main.swift
@@ -1,42 +1,10 @@
 import Benchmark
 import ComposableArchitecture
 
-let counterReducer = Reducer<Int, Bool, Void> { state, action, _ in
-  if action {
-    state += 1
-  } else {
-    state = 0
-  }
-  return .none
-}
-
-let store1 = Store(initialState: 0, reducer: counterReducer, environment: ())
-let store2 = store1.scope { $0 }
-let store3 = store2.scope { $0 }
-let store4 = store3.scope { $0 }
-
-let viewStore1 = ViewStore(store1)
-let viewStore2 = ViewStore(store2)
-let viewStore3 = ViewStore(store3)
-let viewStore4 = ViewStore(store4)
-
-benchmark("Scoping (1)") {
-  viewStore1.send(true)
-}
-viewStore1.send(false)
-
-benchmark("Scoping (2)") {
-  viewStore2.send(true)
-}
-viewStore1.send(false)
-
-benchmark("Scoping (3)") {
-  viewStore3.send(true)
-}
-viewStore1.send(false)
-
-benchmark("Scoping (4)") {
-  viewStore4.send(true)
-}
-
-Benchmark.main()
+Benchmark.main(
+  [
+    basicStoreScopeSuite,
+    effectsSuite,
+    reducerSuite,
+  ]
+)


### PR DESCRIPTION
This PR adds additional overloads to `Effect.merge` and `Reducer.combine` to take advantage of the specialized merge publishers rather than defaulting to `Publishers.MergeMany`. Additional benchmarks have also been added.

```
name                                      time         std        iterations
----------------------------------------------------------------------------
Effects.merge([a, b])                      7275.000 ns ±  36.93 %     184188 <- Before 
Effects.merge(a, b)                        6001.000 ns ±  42.96 %     226572 <- After
Effects.merge([a, b, c, d, e, f, g, h])   15660.000 ns ±  29.94 %      82214 <- Before
Effects.merge(a, b, c, d, e, f, g, h)     12124.000 ns ±  38.70 %     105266 <- After
```

```
name                                      time         std        iterations
----------------------------------------------------------------------------
Reducer.combine([a, b])                   12251.000 ns ±  53.21 %     102758 <- Before
Reducer.combine(a, b)                      9703.000 ns ±  36.59 %     129784 <- After
Reducer.combine([a, b, c, d, e, f, g, h]) 21670.000 ns ±  40.42 %      60340 <- Before
Reducer.combine(a, b, c, d, e, f, g, h)   15953.000 ns ±  37.13 %      74157 <- After
```

Notes: 
- Could revert benchmark changes. They are mainly to give an indication of changes in performance. 
- Alternative parameter names could be used `combine(_ a: Reducer, _ b: Reducer)` vs `combine(_ r0: Reducer, _ r1: Reducer)`
- Unsure about related docs and formatting. 
