### PR TITLE
[Experimental] Add an `EffectBuilder` result builder

### DIFF
--- a/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
+++ b/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		DCC68EE32447C8540037F998 /* 04-HigherOrderReducers-ReusableFavoriting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC68EE22447C8540037F998 /* 04-HigherOrderReducers-ReusableFavoriting.swift */; };
 		DCE63B71245CC0B90080A23D /* 04-HigherOrderReducers-Recursion.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE63B70245CC0B90080A23D /* 04-HigherOrderReducers-Recursion.swift */; };
 		DCFE1960278DBF0600C14CCF /* CaseStudiesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCFE195F278DBF0600C14CCF /* CaseStudiesApp.swift */; };
+		E9BF588E27DE1260001467FA /* 01-GettingStarted-Counter-EffectBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BF588D27DE1260001467FA /* 01-GettingStarted-Counter-EffectBuilder.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -232,6 +233,7 @@
 		DCC68EE22447C8540037F998 /* 04-HigherOrderReducers-ReusableFavoriting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-ReusableFavoriting.swift"; sourceTree = "<group>"; };
 		DCE63B70245CC0B90080A23D /* 04-HigherOrderReducers-Recursion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-Recursion.swift"; sourceTree = "<group>"; };
 		DCFE195F278DBF0600C14CCF /* CaseStudiesApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CaseStudiesApp.swift; sourceTree = "<group>"; };
+		E9BF588D27DE1260001467FA /* 01-GettingStarted-Counter-EffectBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-GettingStarted-Counter-EffectBuilder.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -399,6 +401,7 @@
 				DC5B505025C86EBC000D8DFD /* 01-GettingStarted-Bindings-Forms.swift */,
 				DCC68EE02447C4630037F998 /* 01-GettingStarted-Composition-TwoCounters.swift */,
 				DC89C4432446111B006900B9 /* 01-GettingStarted-Counter.swift */,
+				E9BF588D27DE1260001467FA /* 01-GettingStarted-Counter-EffectBuilder.swift */,
 				CA3E421E26B8337500581ABC /* 01-GettingStarted-FocusState.swift */,
 				DCC68EDC2447A5B00037F998 /* 01-GettingStarted-OptionalState.swift */,
 				CA7BC8ED245CCFE4001FB69F /* 01-GettingStarted-SharedState.swift */,
@@ -751,6 +754,7 @@
 				CAA9ADC624465C810003A984 /* 02-Effects-Cancellation.swift in Sources */,
 				DC2E370D24573ACB00B94699 /* 04-HigherOrderReducers-StrictReducers.swift in Sources */,
 				CA5ECF92267A79F0002067FF /* FactClient.swift in Sources */,
+				E9BF588E27DE1260001467FA /* 01-GettingStarted-Counter-EffectBuilder.swift in Sources */,
 				DC9EB4172450CBD2005F413B /* UIViewRepresented.swift in Sources */,
 				CA6AC2652451135C00C71CB3 /* CircularProgressView.swift in Sources */,
 				CA6AC2642451135C00C71CB3 /* ReusableComponents-Download.swift in Sources */,

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
@@ -12,6 +12,7 @@ struct RootState {
   #endif
   var clock = ClockState()
   var counter = CounterState()
+  var counterBuilder = CounterBuilderState()
   var dieRoll = DieRollState()
   var effectsBasics = EffectsBasicsState()
   var effectsCancellation = EffectsCancellationState()
@@ -48,6 +49,7 @@ enum RootAction {
   #endif
   case clock(ClockAction)
   case counter(CounterAction)
+  case counterBuilder(CounterBuilderAction)
   case dieRoll(DieRollAction)
   case effectsBasics(EffectsBasicsAction)
   case effectsCancellation(EffectsCancellationAction)
@@ -152,6 +154,12 @@ let rootReducer = Reducer<RootState, RootAction, RootEnvironment>.combine(
     .pullback(
       state: \.counter,
       action: /RootAction.counter,
+      environment: { _ in .init() }
+    ),
+  counterBuilderReducer
+    .pullback(
+      state: \.counterBuilder,
+      action: /RootAction.counterBuilder,
       environment: { _ in .init() }
     ),
   dieRollReducer

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -19,6 +19,16 @@ struct RootView: View {
                 )
               )
             )
+            
+            NavigationLink(
+              "Basics - EffectBuilder",
+              destination: CounterBuilderDemoView(
+                store: self.store.scope(
+                  state: \.counterBuilder,
+                  action: RootAction.counterBuilder
+                )
+              )
+            )
 
             NavigationLink(
               "Pullback and combine",

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter-EffectBuilder.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter-EffectBuilder.swift
@@ -1,0 +1,88 @@
+import ComposableArchitecture
+import SwiftUI
+
+private let readMe = """
+  This screen demonstrates the basics of the Composable Architecture in an archetypal counter \
+  application.
+
+  The domain of the application is modeled using simple data types that correspond to the mutable \
+  state of the application and any actions that can affect that state or the outside world.
+  """
+
+struct CounterBuilderState: Equatable {
+  var count = 0
+}
+
+enum CounterBuilderAction: Equatable {
+  case decrementButtonTapped
+  case incrementButtonTapped
+  
+  case doubleIncrementButtonTapped
+  case doubleDecrementButtonTapped
+}
+
+struct CounterBuilderEnvironment {}
+
+let counterBuilderReducer = Reducer<CounterBuilderState, CounterBuilderAction, CounterBuilderEnvironment> { state, action, _ in
+  switch action {
+  case .decrementButtonTapped:
+    state.count -= 1
+  case .incrementButtonTapped:
+    state.count += 1
+  case .doubleDecrementButtonTapped:
+    if state.count >= 2 {
+      CounterBuilderAction.decrementButtonTapped
+      CounterBuilderAction.decrementButtonTapped
+    }
+  case .doubleIncrementButtonTapped:
+    CounterBuilderAction.incrementButtonTapped
+    CounterBuilderAction.incrementButtonTapped
+  }
+}
+
+struct CounterBuilderView: View {
+  let store: Store<CounterBuilderState, CounterBuilderAction>
+
+  var body: some View {
+    WithViewStore(self.store) { viewStore in
+      HStack {
+        Button("−−") { viewStore.send(.doubleDecrementButtonTapped) }
+          .disabled(viewStore.state.count < 2)
+        Button("−") { viewStore.send(.decrementButtonTapped) }
+        Text("\(viewStore.count)")
+          .font(.body.monospacedDigit())
+        Button("+") { viewStore.send(.incrementButtonTapped) }
+        Button("++") { viewStore.send(.doubleIncrementButtonTapped) }
+      }
+    }
+  }
+}
+
+struct CounterBuilderDemoView: View {
+  let store: Store<CounterBuilderState, CounterBuilderAction>
+
+  var body: some View {
+    Form {
+      Section(header: Text(readMe)) {
+        CounterBuilderView(store: self.store)
+          .buttonStyle(.borderless)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+    }
+    .navigationBarTitle("Counter demo")
+  }
+}
+
+struct CounterBuilderView_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationView {
+      CounterBuilderDemoView(
+        store: Store(
+          initialState: CounterBuilderState(),
+          reducer: counterBuilderReducer,
+          environment: CounterBuilderEnvironment()
+        )
+      )
+    }
+  }
+}

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -14,7 +14,7 @@ import Foundation
 /// constructing some common types of effects.
 public struct Effect<Output, Failure: Error>: Publisher {
   public let upstream: AnyPublisher<Output, Failure>
-
+  let isNone: Bool
   /// Initializes an effect that wraps a publisher. Each emission of the wrapped publisher will be
   /// emitted by the effect.
   ///
@@ -39,6 +39,7 @@ public struct Effect<Output, Failure: Error>: Publisher {
   /// - Parameter publisher: A publisher.
   public init<P: Publisher>(_ publisher: P) where P.Output == Output, P.Failure == Failure {
     self.upstream = publisher.eraseToAnyPublisher()
+    self.isNone = false
   }
 
   public func receive<S>(
@@ -72,7 +73,12 @@ public struct Effect<Output, Failure: Error>: Publisher {
   /// An effect that does nothing and completes immediately. Useful for situations where you must
   /// return an effect, but you don't need to do anything.
   public static var none: Effect {
-    Empty(completeImmediately: true).eraseToEffect()
+    Effect(none: Empty(completeImmediately: true))
+  }
+  
+  init(none: Empty<Output, Failure>) {
+    self.upstream = none.eraseToAnyPublisher()
+    self.isNone = true
   }
 
   /// Creates an effect that can supply a single value asynchronously in the future.

--- a/Sources/ComposableArchitecture/Effects/EffectBuilder.swift
+++ b/Sources/ComposableArchitecture/Effects/EffectBuilder.swift
@@ -1,0 +1,118 @@
+import Combine
+
+extension Effect {
+  public init(@EffectBuilder effects: (Self.Type) -> Self) {
+    self = effects(Self.self)
+  }
+  public init(@EffectBuilder effects: () -> Self) {
+    self = effects()
+  }
+}
+
+extension Effect {
+  @resultBuilder
+  public enum EffectBuilder {
+
+    public static func buildExpression(_ expression: Void) -> Effect {
+      .none
+    }
+
+    public static func buildExpression(_ expression: Output) -> Effect {
+      Effect(value: expression)
+    }
+
+    public static func buildExpression(_ expression: Failure) -> Effect {
+      Effect(error: expression)
+    }
+
+    public static func buildExpression(_ expression: Effect) -> Effect {
+      expression
+    }
+
+    public static func buildBlock(_ components: Effect...) -> Effect {
+      .merge(components)
+    }
+
+    public static func buildOptional(_ component: Effect?) -> Effect {
+      component ?? .none
+    }
+
+    public static func buildEither(first component: Effect) -> Effect {
+      component
+    }
+
+    public static func buildEither(second component: Effect) -> Effect {
+      component
+    }
+
+    public static func buildArray(_ components: [Effect]) -> Effect {
+      .merge(components)
+    }
+
+    public static func buildLimitedAvailability(_ component: Effect) -> Effect {
+      component
+    }
+  }
+}
+
+//---
+
+private enum Action {
+  case action1
+  case action2
+}
+
+private let reducer = Reducer<Void, Action, Void>.init { _, _, _ in
+  Effect {
+    .action1
+    //    $0.init(value: .action2)
+    //      .delay(for: .seconds(3), scheduler: DispatchQueue.main.eraseToAnyScheduler())
+    //      .eraseToEffect()
+    $0.fireAndForget {
+
+    }
+    if 4.isZero {
+      .action2
+    }
+    $0.none
+    Effect {
+      Action.action2
+      Action.action1
+    }
+
+    $0.future({ _ in
+
+    })
+
+    Effect {
+
+    }
+
+    $0.fireAndForget {
+
+    }
+
+    Effect.FFuture { _ in }.effect
+  }
+}
+
+public protocol EffectDeclarating {
+  associatedtype Output
+  associatedtype Failure where Failure: Error
+  var effect: Effect<Output, Failure> { get }
+}
+
+extension Effect {
+  public struct FFuture: EffectDeclarating {
+    public init(attemptToFulfill: @escaping (@escaping (Result<Output, Failure>) -> Void) -> Void) {
+      self.effect = .future(attemptToFulfill)
+    }
+    public let effect: Effect<Output, Failure>
+  }
+}
+
+//public static func future(
+//  _ attemptToFulfill: @escaping (@escaping (Result<Output, Failure>) -> Void) -> Void
+//) -> Effect {
+//  Deferred { Future(attemptToFulfill) }.eraseToEffect()
+//}

--- a/Sources/ComposableArchitecture/Effects/EffectBuilder.swift
+++ b/Sources/ComposableArchitecture/Effects/EffectBuilder.swift
@@ -1,12 +1,15 @@
 import Combine
 
 extension Effect {
-//  public init(@Builder effects: (Self.Type) -> Self) {
-//    self = effects(Self.self)
-//  }
+  public init(@Builder effects: (Self.Type) -> Self) {
+    self = effects(Self.self)
+  }
+  
   public init(@Builder effects: () -> Self) {
     self = effects()
   }
+  
+  var isNotNone: Bool { !isNone }
 }
 
 extension Effect {
@@ -29,7 +32,7 @@ extension Effect {
     }
 
     public static func buildBlock(_ components: Effect...) -> Effect {
-      .merge(components)
+      .merge(components.filter(\.isNotNone))
     }
 
     public static func buildOptional(_ component: Effect?) -> Effect {
@@ -45,7 +48,7 @@ extension Effect {
     }
 
     public static func buildArray(_ components: [Effect]) -> Effect {
-      .merge(components)
+      .merge(components.filter(\.isNotNone))
     }
 
     public static func buildLimitedAvailability(_ component: Effect) -> Effect {
@@ -53,82 +56,3 @@ extension Effect {
     }
   }
 }
-
-
-
-
-//---
-
-private enum Action {
-  case action1
-  case action2
-}
-var i: Int = 0
-private let reducer = Reducer<Void, Action, Void>.init { _, _, _ in
-//  Effect {
-    .action1
-    //    $0.init(value: .action2)
-    //      .delay(for: .seconds(3), scheduler: DispatchQueue.main.eraseToAnyScheduler())
-    //      .eraseToEffect()
-//    $0.fireAndForget {
-//
-//    }
-    if 4.isZero {
-      .action2
-    }
-//    $0.none
-//    Effect {
-//      Action.action2
-//      Action.action1
-//    }
-//
-//    $0.future({ _ in
-//
-//    })
-
-    Effect {
-
-    }
-
-    switch i {
-    case 0:
-      .action2
-    case 1:
-      var x = 5
-      if x.isMultiple(of: 6) {
-        x += 1
-      }
-      if x > 5 {
-        .action1
-      }
-
-    default:
-      .none
-    }
-
-//
-
-    Effect.FFuture { _ in }.effect
-//  }
-}
-
-public protocol EffectDeclarating {
-  associatedtype Output
-  associatedtype Failure where Failure: Error
-  var effect: Effect<Output, Failure> { get }
-}
-
-extension Effect {
-  public struct FFuture: EffectDeclarating {
-    public init(attemptToFulfill: @escaping (@escaping (Result<Output, Failure>) -> Void) -> Void) {
-      self.effect = .future(attemptToFulfill)
-    }
-    public let effect: Effect<Output, Failure>
-  }
-}
-
-//public static func future(
-//  _ attemptToFulfill: @escaping (@escaping (Result<Output, Failure>) -> Void) -> Void
-//) -> Effect {
-//  Deferred { Future(attemptToFulfill) }.eraseToEffect()
-//}

--- a/Sources/ComposableArchitecture/Effects/EffectBuilder.swift
+++ b/Sources/ComposableArchitecture/Effects/EffectBuilder.swift
@@ -1,18 +1,17 @@
 import Combine
 
 extension Effect {
-  public init(@EffectBuilder effects: (Self.Type) -> Self) {
-    self = effects(Self.self)
-  }
-  public init(@EffectBuilder effects: () -> Self) {
+//  public init(@Builder effects: (Self.Type) -> Self) {
+//    self = effects(Self.self)
+//  }
+  public init(@Builder effects: () -> Self) {
     self = effects()
   }
 }
 
 extension Effect {
   @resultBuilder
-  public enum EffectBuilder {
-
+  public enum Builder {
     public static func buildExpression(_ expression: Void) -> Effect {
       .none
     }
@@ -55,45 +54,62 @@ extension Effect {
   }
 }
 
+
+
+
 //---
 
 private enum Action {
   case action1
   case action2
 }
-
+var i: Int = 0
 private let reducer = Reducer<Void, Action, Void>.init { _, _, _ in
-  Effect {
+//  Effect {
     .action1
     //    $0.init(value: .action2)
     //      .delay(for: .seconds(3), scheduler: DispatchQueue.main.eraseToAnyScheduler())
     //      .eraseToEffect()
-    $0.fireAndForget {
-
-    }
+//    $0.fireAndForget {
+//
+//    }
     if 4.isZero {
       .action2
     }
-    $0.none
+//    $0.none
+//    Effect {
+//      Action.action2
+//      Action.action1
+//    }
+//
+//    $0.future({ _ in
+//
+//    })
+
     Effect {
-      Action.action2
-      Action.action1
-    }
-
-    $0.future({ _ in
-
-    })
-
-    Effect {
 
     }
 
-    $0.fireAndForget {
+    switch i {
+    case 0:
+      .action2
+    case 1:
+      var x = 5
+      if x.isMultiple(of: 6) {
+        x += 1
+      }
+      if x > 5 {
+        .action1
+      }
 
+    default:
+      .none
     }
+
+//
 
     Effect.FFuture { _ in }.effect
-  }
+//  }
 }
 
 public protocol EffectDeclarating {

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -53,7 +53,7 @@ public struct Reducer<State, Action, Environment> {
   ///
   /// - Parameter reducer: A function signature that takes state, action and
   ///   environment.
-  public init(_ reducer: @escaping (inout State, Action, Environment) -> Effect<Action, Never>) {
+  public init(@Effect<Action, Never>.Builder _ reducer: @escaping (inout State, Action, Environment) -> Effect<Action, Never>) {
     self.reducer = reducer
   }
 


### PR DESCRIPTION
Hello,
This is an experiment following the idea pitched in #1018. An `EffectBuilder` result builder type is introduced. It leads to an interesting (but quite dangerous, see below) syntax. There are two entry points to the reducer:
- An `Effect` initializer with a builder closure (two variants in reality, see below)
- The main `Reducer` initializer!

A few notes/observations:
- The builder is mostly an array builder of merged effects.
- Each expression in the reducer generates an `Effect`! It generates `.none` most of the time for `state` changes or variable declarations. This is quite inefficient, but more permissive than SwiftUI's `ViewBuilder`.
- I've added a `isNone` property to `Effect` in order to filter them out easily when merging them. This can maybe be used to optimize the current version of the library too.
- The builder syntax doesn't pair well with static methods, as any static`.xxx` is often understood as a method call on the previous line.
- Because of this, and to avoid redefining new types, the `Effect` initializer accepts an argument-less closure or a closure with an argument that is the type of the effect and upon which we can call static methods:
```swift
Effect {
  $0.fireAndForget { … } // $0 == Effect<Output, Failure>
}
```
- I made `Output/Action` build `Effect(value:)` and `Failure` build `Effect(error:)`, mostly to see how it would look.
- I've added a new Counter-Builder CaseStudy that uses the `EffectBuilder` (opt-in by not using `return`s). The result is quite interesting, but we can generate effects by mistake too easily!
- The builder was implemented as a subtype of `Effect` to share its generics, mostly by convenience. It probably interferes with type inference in some configurations.

In its current shape, the builder is maybe too permissive. We generate merged `Effects` very easily. Cases are also automatically promoted to `.none` by default. Static methods can't be called using inference most of the time. Introducting new top-level types instead is possible but would quickly clash with existing names like `Future` for example, and would furthermore prevent to use code completion for discovery.

It is very nice that both `EffectBuilder` and raw closure variants of the `Reducer` initializer can be used by coercion. Adding `@Effect<>.Builder` to the `Reducer initializer didn't break a single line of existing code in tests and `CaseStudies`.

This PR is only for experimental purposes. Feel free to provide any feedback!
@stephencelis, I'm doing a draft PR as it is easier to pinpoint lines of codes to discuss and evolve things. Please let me know if you prefer that I create discussions for this kind of thing instead.