### PR TITLE
Update failure message for better order.

### DIFF
--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -394,7 +394,7 @@
 
         XCTFail(
           """
-          State change does not match expectation: …
+          A state change does not match expectation: …
 
           \(difference)
           """,

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -262,26 +262,21 @@ final class EffectTests: XCTestCase {
 
     func testCancellingTask() {
       @Sendable func work() async throws -> Int {
-        var task: Task<Int, Error>!
-        task = Task {
-          try? await Task.sleep(nanoseconds: NSEC_PER_MSEC)
-          try Task.checkCancellation()
-          return 42
-        }
-        task.cancel()
-        return try await task.value
+        try await Task.sleep(nanoseconds: NSEC_PER_MSEC)
+        XCTFail()
+        return 42
       }
 
-      let expectation = self.expectation(description: "Complete")
-      Effect<Int, Error>.task {
-        try await work()
-      }
-      .sink(
-        receiveCompletion: { _ in expectation.fulfill() },
-        receiveValue: { _ in XCTFail() }
-      )
-      .store(in: &self.cancellables)
-      self.wait(for: [expectation], timeout: 1)
+      Effect<Int, Error>.task { try await work() }
+        .sink(
+          receiveCompletion: { _ in XCTFail() },
+          receiveValue: { _ in XCTFail() }
+        )
+        .store(in: &self.cancellables)
+
+      self.cancellables = []
+
+      _ = XCTWaiter.wait(for: [.init()], timeout: 1.1)
     }
   #endif
 }


### PR DESCRIPTION
Apparently Xcode orders multiple XCTest failures on the same line alphabetically, which means that the messages can sometimes show up in a counterintuitive order. A slight change of the message makes for a better order.

Also added a test to make sure that cancelling `Effect.task` works as we expect.