### PR TITLE
Effect.cancel(ids:) prefer array of ids and deprecate variadic overload

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -86,20 +86,10 @@ extension Effect {
 
   /// An effect that will cancel multiple currently in-flight effects with the given identifiers.
   ///
-  /// - Parameter ids: A variadic list of effect identifiers.
+  /// - Parameter ids: An array of effect identifiers.
   /// - Returns: A new effect that will cancel any currently in-flight effects with the given
   ///   identifiers.
-  @_disfavoredOverload
-  public static func cancel(ids: AnyHashable...) -> Effect {
-    .cancel(ids: ids)
-  }
-
-  /// An effect that will cancel multiple currently in-flight effects with the given identifiers.
-  ///
-  /// - Parameter ids: A sequence of effect identifiers.
-  /// - Returns: A new effect that will cancel any currently in-flight effects with the given
-  ///   identifiers.
-  public static func cancel<S: Sequence>(ids: S) -> Effect where S.Element == AnyHashable {
+  public static func cancel(ids: [AnyHashable]) -> Effect {
     .merge(ids.map(Effect.cancel(id:)))
   }
 }

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -3,6 +3,20 @@ import Combine
 import SwiftUI
 import XCTestDynamicOverlay
 
+// NB: Deprecated after 0.34.0:
+
+extension Effect {
+  @available(
+    *,
+    deprecated,
+    message: "For improved safety, using a variadic list is no longer supported. Use an array of identifiers instead. For more on this change, see: https://github.com/pointfreeco/swift-composable-architecture/pull/1041"
+  )
+  @_disfavoredOverload
+  public static func cancel(ids: AnyHashable...) -> Effect {
+    .cancel(ids: ids)
+  }
+}
+
 // NB: Deprecated after 0.31.0:
 
 extension Reducer {

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -9,7 +9,7 @@ extension Effect {
   @available(
     *,
     deprecated,
-    message: "For improved safety, using a variadic list is no longer supported. Use an array of identifiers instead. For more on this change, see: https://github.com/pointfreeco/swift-composable-architecture/pull/1041"
+    message: "Using a variadic list is no longer supported. Use an array of identifiers instead. For more on this change, see: https://github.com/pointfreeco/swift-composable-architecture/pull/1041"
   )
   @_disfavoredOverload
   public static func cancel(ids: AnyHashable...) -> Effect {


### PR DESCRIPTION
As discussed in #1009

Making this a draft so I can add more information tomorrow. Ran out of time. 

I had a quick look on GitHub and only found a couple of projects using the variadic overload.