### PR TITLE
Add a map-style overload to eraseToEffect

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -315,6 +315,28 @@ extension Publisher {
     Effect(self)
   }
 
+  /// Turns any publisher into an ``Effect``.
+  ///
+  /// This is a convenience operator for writing ``Effect/eraseToEffect()`` followed by a
+  /// ``Effect/map(_:)``.
+  ///
+  /// ```swift
+  /// case .buttonTapped:
+  ///   return fetchUser(id: 1)
+  ///     .filter(\.isAdmin)
+  ///     .eraseToEffect(ProfileAction.adminUserFetched)
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - transform: A mapping function that converts `Output` to another type.
+  /// - Returns: An effect that wraps `self` after mapping `Output` values.
+  public func eraseToEffect<T>(
+    _ transform: @escaping (Output) -> T
+  ) -> Effect<T, Failure> {
+    self.map(transform)
+      .eraseToEffect()
+  }
+
   /// Turns any publisher into an ``Effect`` that cannot fail by wrapping its output and failure in
   /// a result.
   ///


### PR DESCRIPTION
I'm wondering if there's appetite for this sort of change? I find myself needing to map after erasing to an effect (similar to how catching to an effect also usually needs a map), since many of my dependencies' publishers don't return effects of ready-to-use actions. A convenience operator that combines `eraseToEffect` and `map` as I've implemented would be useful to have, and I bet other users of TCA would benefit as well. If it's not a big enough benefit to include in the core library, no big deal though!

