### PR TITLE
Let consumers decide whether to print out messages for other build configurations than DEBUG

### DIFF
--- a/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
@@ -31,11 +31,10 @@ public enum ActionFormat {
 extension Reducer {
   /// Prints debug messages describing all received actions and state mutations.
   ///
+  /// Printing is only done in debug (`#if DEBUG`) builds.
+  ///
   /// - Parameters:
   ///   - prefix: A string with which to prefix all debug messages.
-  ///   - shouldPrintInOtherBuildConfiguration: A boolean value that indicates
-  ///     whether to print out messages for other build configurations (e.g. `RELEASE`, `ALPHA`, etc..)
-  ///     than `DEBUG`.
   ///   - toDebugEnvironment: A function that transforms an environment into a debug environment by
   ///     describing a print function and a queue to print from. Defaults to a function that ignores
   ///     the environment and returns a default ``DebugEnvironment`` that uses Swift's `print`
@@ -43,7 +42,6 @@ extension Reducer {
   /// - Returns: A reducer that prints debug messages for all received actions.
   public func debug(
     _ prefix: String = "",
-    shouldPrintInOtherBuildConfigurations: Bool = false,
     actionFormat: ActionFormat = .prettyPrint,
     environment toDebugEnvironment: @escaping (Environment) -> DebugEnvironment = { _ in
       DebugEnvironment()
@@ -51,7 +49,6 @@ extension Reducer {
   ) -> Reducer {
     self.debug(
       prefix,
-      shouldPrintInOtherBuildConfigurations: shouldPrintInOtherBuildConfigurations,
       state: { $0 },
       action: .self,
       actionFormat: actionFormat,
@@ -86,53 +83,9 @@ extension Reducer {
     )
   }
 
-  /// Prints debug messages describing all received actions and state mutations.
+  /// Prints debug messages describing all received local actions and local state mutations.
   ///
-  /// - Parameters:
-  ///   - prefix: A string with which to prefix all debug messages.
-  ///   - shouldPrintInOtherBuildConfiguration: A boolean value that indicates
-  ///     whether to print out messages for other build configurations (e.g. `RELEASE`, `ALPHA`, etc..)
-  ///     than `DEBUG`.
-  ///   - toDebugEnvironment: A function that transforms an environment into a debug environment by
-  ///     describing a print function and a queue to print from. Defaults to a function that ignores
-  ///     the environment and returns a default ``DebugEnvironment`` that uses Swift's `print`
-  ///     function and a background queue.
-  /// - Returns: A reducer that prints debug messages for all received actions.
-  public func debug<LocalState, LocalAction>(
-    _ prefix: String = "",
-    shouldPrintInOtherBuildConfigurations: Bool = false,
-    state toLocalState: @escaping (State) -> LocalState,
-    action toLocalAction: CasePath<Action, LocalAction>,
-    actionFormat: ActionFormat = .prettyPrint,
-    environment toDebugEnvironment: @escaping (Environment) -> DebugEnvironment = { _ in
-      DebugEnvironment()
-    }
-  ) -> Reducer {
-    #if DEBUG
-    return printOut(
-      prefix,
-      state: toLocalState,
-      action: toLocalAction,
-      actionFormat: actionFormat,
-      environment: toDebugEnvironment
-    )
-    #else
-    switch shouldPrintInOtherBuildConfigurations {
-    case true:
-      return printOut(
-        prefix,
-        state: toLocalState,
-        action: toLocalAction,
-        actionFormat: actionFormat,
-        environment: toDebugEnvironment
-      )
-    case false:
-      return self
-    }
-    #endif
-  }
-
-  /// Prints messages describing all received local actions and local state mutations.
+  /// Printing is only done in debug (`#if DEBUG`) builds.
   ///
   /// - Parameters:
   ///   - prefix: A string with which to prefix all debug messages.
@@ -143,7 +96,66 @@ extension Reducer {
   ///     the environment and returns a default ``DebugEnvironment`` that uses Swift's `print`
   ///     function and a background queue.
   /// - Returns: A reducer that prints debug messages for all received actions.
-  private func printOut<LocalState, LocalAction>(
+  public func debug<LocalState, LocalAction>(
+    _ prefix: String = "",
+    state toLocalState: @escaping (State) -> LocalState,
+    action toLocalAction: CasePath<Action, LocalAction>,
+    actionFormat: ActionFormat = .prettyPrint,
+    environment toDebugEnvironment: @escaping (Environment) -> DebugEnvironment = { _ in
+      DebugEnvironment()
+    }
+  ) -> Reducer {
+    #if DEBUG
+      return .init { state, action, environment in
+        let previousState = toLocalState(state)
+        let effects = self.run(&state, action, environment)
+        guard let localAction = toLocalAction.extract(from: action) else { return effects }
+        let nextState = toLocalState(state)
+        let debugEnvironment = toDebugEnvironment(environment)
+        return .merge(
+          .fireAndForget {
+            debugEnvironment.queue.async {
+              var actionOutput = ""
+              if actionFormat == .prettyPrint {
+                customDump(localAction, to: &actionOutput, indent: 2)
+              } else {
+                actionOutput.write(debugCaseOutput(localAction).indent(by: 2))
+              }
+              let stateOutput =
+                LocalState.self == Void.self
+                ? ""
+                : diff(previousState, nextState).map { "\($0)\n" } ?? "  (No state changes)\n"
+              debugEnvironment.printer(
+                """
+                \(prefix.isEmpty ? "" : "\(prefix): ")received action:
+                \(actionOutput)
+                \(stateOutput)
+                """
+              )
+            }
+          },
+          effects
+        )
+      }
+    #else
+      return self
+    #endif
+  }
+
+  /// Prints messages describing all received local actions and local state mutations.
+  ///
+  /// Printing is done in any build configurations.
+  ///
+  /// - Parameters:
+  ///   - prefix: A string with which to prefix all debug messages.
+  ///   - toLocalState: A function that filters state to be printed.
+  ///   - toLocalAction: A case path that filters actions that are printed.
+  ///   - toDebugEnvironment: A function that transforms an environment into a debug environment by
+  ///     describing a print function and a queue to print from. Defaults to a function that ignores
+  ///     the environment and returns a default ``DebugEnvironment`` that uses Swift's `print`
+  ///     function and a background queue.
+  /// - Returns: A reducer that prints debug messages for all received actions.
+  public func print<LocalState, LocalAction>(
     _ prefix: String = "",
     state toLocalState: @escaping (State) -> LocalState,
     action toLocalAction: CasePath<Action, LocalAction>,


### PR DESCRIPTION
Currently the `.debug()` reducer defined in `ReducerDebugging.swift` prints only in `DEBUG` builds.
As stated [here](https://github.com/pointfreeco/swift-composable-architecture/blob/1a2dd2d505ba968243cf5a67bf0151abef6099f5/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift#L34)

These changes let consumers decide whether to print messages for other build configurations than `DEBUG`.
The motivation and use-case for these changes is the following: 
If your app relies heavily on a third-party library which runs its production code/implementation only while in RELEASE mode, then the `.debug()` reducer won't print out any messages, making it difficult to debug.

What do you think about it?