### PR TITLE
Fix invalid web socket server URL

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -70,7 +70,7 @@ let webSocketReducer = Reducer<WebSocketState, WebSocketAction, WebSocketEnviron
 
     case .disconnected:
       state.connectivityState = .connecting
-      return environment.webSocket.open(WebSocketId(), URL(string: "wss://echo.websocket.org")!, [])
+      return environment.webSocket.open(WebSocketId(), URL(string: "wss://echo.websocket.events")!, [])
         .receive(on: environment.mainQueue)
         .map(WebSocketAction.webSocket)
         .eraseToEffect()


### PR DESCRIPTION
> echo.websocket.org was shut down sometime in 2021 when the company was acquired and changed their name. Try going to [www.websocket.org](http://www.websocket.org/) and you'll see the service is not longer available.
>
> https://stackoverflow.com/a/70438302

I replaced `wss://echo.websocket.org` with `wss://echo.websocket.events` (which is provided by the answerer of the link above) since the `.org` one is no longer available.