### PR TITLE
Improve performance of type-safe effect cancel token lookup

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -37,6 +37,7 @@ extension Effect {
       cancellablesLock.lock()
       defer { cancellablesLock.unlock() }
 
+      let id = CancelToken(id: id)
       if cancelInFlight {
         cancellationCancellables[id]?.forEach { $0.cancel() }
       }
@@ -94,5 +95,15 @@ extension Effect {
   }
 }
 
-var cancellationCancellables: [AnyHashable: Set<AnyCancellable>] = [:]
+struct CancelToken: Hashable {
+  let id: AnyHashable
+  let discriminator: ObjectIdentifier
+
+  init(id: AnyHashable) {
+    self.id = id
+    self.discriminator = ObjectIdentifier(type(of: id.base))
+  }
+}
+
+var cancellationCancellables: [CancelToken: Set<AnyCancellable>] = [:]
 let cancellablesLock = NSRecursiveLock()

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -80,7 +80,7 @@ extension Effect {
   public static func cancel(id: AnyHashable) -> Effect {
     return .fireAndForget {
       cancellablesLock.sync {
-        cancellationCancellables[id]?.forEach { $0.cancel() }
+        cancellationCancellables[.init(id: id)]?.forEach { $0.cancel() }
       }
     }
   }


### PR DESCRIPTION
Our current recommendation of using a dedicated type for effect cancel tokens unfortunately leads to the equivalent of a linear search due to Swift's default hashing behavior:

```swift
struct A: Hashable {}
struct B: Hashable {}

A().hashValue == B().hashValue // true
```

This PR introduces an internal wrapper type that includes the type's unique identifier in the hashing logic, which should improve the hashing of these identifiers:

```swift
struct CancelToken: Hashable {
  let id: AnyHashable
  let discriminator: ObjectIdentifier

  init(id: AnyHashable) {
    self.id = id
    self.discriminator = ObjectIdentifier(type(of: id.base))
  }
}

CancelToken(id: A()).hashValue == CancelToken(id: A()).hashValue // true
CancelToken(id: B()).hashValue == CancelToken(id: B()).hashValue // true
CancelToken(id: A()).hashValue == CancelToken(id: B()).hashValue // false
```