### PR TITLE
Add cancel overloads that take types

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -39,18 +39,18 @@ let effectsCancellationReducer = Reducer<
   EffectsCancellationState, EffectsCancellationAction, EffectsCancellationEnvironment
 > { state, action, environment in
 
-  struct TriviaRequestId: Hashable {}
+  enum TriviaRequestId {}
 
   switch action {
   case .cancelButtonTapped:
     state.isTriviaRequestInFlight = false
-    return .cancel(id: TriviaRequestId())
+    return .cancel(id: TriviaRequestId.self)
 
   case let .stepperChanged(value):
     state.count = value
     state.currentTrivia = nil
     state.isTriviaRequestInFlight = false
-    return .cancel(id: TriviaRequestId())
+    return .cancel(id: TriviaRequestId.self)
 
   case .triviaButtonTapped:
     state.currentTrivia = nil
@@ -59,7 +59,7 @@ let effectsCancellationReducer = Reducer<
     return environment.fact.fetch(state.count)
       .receive(on: environment.mainQueue)
       .catchToEffect(EffectsCancellationAction.triviaResponse)
-      .cancellable(id: TriviaRequestId())
+      .cancellable(id: TriviaRequestId.self)
 
   case let .triviaResponse(.success(response)):
     state.isTriviaRequestInFlight = false

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -39,7 +39,7 @@ let longLivingEffectsReducer = Reducer<
   LongLivingEffectsState, LongLivingEffectsAction, LongLivingEffectsEnvironment
 > { state, action, environment in
 
-  struct UserDidTakeScreenshotNotificationId: Hashable {}
+  enum UserDidTakeScreenshotNotificationId {}
 
   switch action {
   case .userDidTakeScreenshotNotification:
@@ -50,11 +50,11 @@ let longLivingEffectsReducer = Reducer<
     // When the view appears, start the effect that emits when screenshots are taken.
     return environment.userDidTakeScreenshot
       .map { LongLivingEffectsAction.userDidTakeScreenshotNotification }
-      .cancellable(id: UserDidTakeScreenshotNotificationId())
+      .cancellable(id: UserDidTakeScreenshotNotificationId.self)
 
   case .onDisappear:
     // When view disappears, stop the effect.
-    return .cancel(id: UserDidTakeScreenshotNotificationId())
+    return .cancel(id: UserDidTakeScreenshotNotificationId.self)
   }
 }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -36,12 +36,12 @@ let refreshableReducer = Reducer<
   RefreshableEnvironment
 > { state, action, environment in
 
-  struct CancelId: Hashable {}
+  enum CancelId {}
 
   switch action {
   case .cancelButtonTapped:
     state.isLoading = false
-    return .cancel(id: CancelId())
+    return .cancel(id: CancelId.self)
 
   case .decrementButtonTapped:
     state.count -= 1
@@ -67,7 +67,7 @@ let refreshableReducer = Reducer<
     return environment.fact.fetch(state.count)
       .delay(for: .seconds(2), scheduler: environment.mainQueue.animation())
       .catchToEffect(RefreshableAction.factResponse)
-      .cancellable(id: CancelId())
+      .cancellable(id: CancelId.self)
   }
 }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -28,7 +28,8 @@ struct TimersEnvironment {
 
 let timersReducer = Reducer<TimersState, TimersAction, TimersEnvironment> {
   state, action, environment in
-  struct TimerId: Hashable {}
+
+  enum TimerId {}
 
   switch action {
   case .timerTicked:
@@ -39,13 +40,13 @@ let timersReducer = Reducer<TimersState, TimersAction, TimersEnvironment> {
     state.isTimerActive.toggle()
     return state.isTimerActive
       ? Effect.timer(
-        id: TimerId(),
+        id: TimerId.self,
         every: 1,
         tolerance: .zero,
         on: environment.mainQueue.animation(.interpolatingSpring(stiffness: 3000, damping: 40))
       )
       .map { _ in TimersAction.timerTicked }
-      : Effect.cancel(id: TimerId())
+      : .cancel(id: TimerId.self)
   }
 }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -41,6 +41,7 @@ struct WebSocketEnvironment {
 
 let webSocketReducer = Reducer<WebSocketState, WebSocketAction, WebSocketEnvironment> {
   state, action, environment in
+
   struct WebSocketId: Hashable {}
 
   var receiveSocketMessageEffect: Effect<WebSocketAction, Never> {

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -52,14 +52,15 @@ let loadThenNavigateListReducer =
     with: Reducer<
       LoadThenNavigateListState, LoadThenNavigateListAction, LoadThenNavigateListEnvironment
     > { state, action, environment in
-      struct CancelId: Hashable {}
+
+      enum CancelId {}
 
       switch action {
       case .counter:
         return .none
 
       case .onDisappear:
-        return .cancel(id: CancelId())
+        return .cancel(id: CancelId.self)
 
       case let .setNavigation(selection: .some(navigatedId)):
         for row in state.rows {
@@ -69,14 +70,14 @@ let loadThenNavigateListReducer =
         return Effect(value: .setNavigationSelectionDelayCompleted(navigatedId))
           .delay(for: 1, scheduler: environment.mainQueue)
           .eraseToEffect()
-          .cancellable(id: CancelId(), cancelInFlight: true)
+          .cancellable(id: CancelId.self, cancelInFlight: true)
 
       case .setNavigation(selection: .none):
         if let selection = state.selection {
           state.rows[id: selection.id]?.count = selection.count
         }
         state.selection = nil
-        return .cancel(id: CancelId())
+        return .cancel(id: CancelId.self)
 
       case let .setNavigationSelectionDelayCompleted(id):
         state.rows[id: id]?.isActivityIndicatorVisible = false

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -47,7 +47,7 @@ let navigateAndLoadListReducer =
       NavigateAndLoadListState, NavigateAndLoadListAction, NavigateAndLoadListEnvironment
     > { state, action, environment in
 
-      struct CancelId: Hashable {}
+      enum CancelId {}
 
       switch action {
       case .counter:
@@ -59,14 +59,14 @@ let navigateAndLoadListReducer =
         return Effect(value: .setNavigationSelectionDelayCompleted)
           .delay(for: 1, scheduler: environment.mainQueue)
           .eraseToEffect()
-          .cancellable(id: CancelId())
+          .cancellable(id: CancelId.self)
 
       case .setNavigation(selection: .none):
         if let selection = state.selection, let count = selection.value?.count {
           state.rows[id: selection.id]?.count = count
         }
         state.selection = nil
-        return .cancel(id: CancelId())
+        return .cancel(id: CancelId.self)
 
       case .setNavigationSelectionDelayCompleted:
         guard let id = state.selection?.id else { return .none }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -40,19 +40,18 @@ let loadThenNavigateReducer =
       LoadThenNavigateState, LoadThenNavigateAction, LoadThenNavigateEnvironment
     > { state, action, environment in
 
-      struct CancelId: Hashable {}
+      enum CancelId {}
 
       switch action {
-
       case .onDisappear:
-        return .cancel(id: CancelId())
+        return .cancel(id: CancelId.self)
 
       case .setNavigation(isActive: true):
         state.isActivityIndicatorVisible = true
         return Effect(value: .setNavigationIsActiveDelayCompleted)
           .delay(for: 1, scheduler: environment.mainQueue)
           .eraseToEffect()
-          .cancellable(id: CancelId())
+          .cancellable(id: CancelId.self)
 
       case .setNavigation(isActive: false):
         state.optionalCounter = nil

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -37,19 +37,21 @@ let navigateAndLoadReducer =
     with: Reducer<
       NavigateAndLoadState, NavigateAndLoadAction, NavigateAndLoadEnvironment
     > { state, action, environment in
-      struct CancelId: Hashable {}
+
+      enum CancelId {}
+
       switch action {
       case .setNavigation(isActive: true):
         state.isNavigationActive = true
         return Effect(value: .setNavigationIsActiveDelayCompleted)
           .delay(for: 1, scheduler: environment.mainQueue)
           .eraseToEffect()
-          .cancellable(id: CancelId())
+          .cancellable(id: CancelId.self)
 
       case .setNavigation(isActive: false):
         state.isNavigationActive = false
         state.optionalCounter = nil
-        return .cancel(id: CancelId())
+        return .cancel(id: CancelId.self)
 
       case .setNavigationIsActiveDelayCompleted:
         state.optionalCounter = CounterState()

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -40,19 +40,18 @@ let loadThenPresentReducer =
       LoadThenPresentState, LoadThenPresentAction, LoadThenPresentEnvironment
     > { state, action, environment in
 
-      struct CancelId: Hashable {}
+      enum CancelId {}
 
       switch action {
-
       case .onDisappear:
-        return .cancel(id: CancelId())
+        return .cancel(id: CancelId.self)
 
       case .setSheet(isPresented: true):
         state.isActivityIndicatorVisible = true
         return Effect(value: .setSheetIsPresentedDelayCompleted)
           .delay(for: 1, scheduler: environment.mainQueue)
           .eraseToEffect()
-          .cancellable(id: CancelId())
+          .cancellable(id: CancelId.self)
 
       case .setSheet(isPresented: false):
         state.optionalCounter = nil

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -35,19 +35,21 @@ let presentAndLoadReducer =
     with: Reducer<
       PresentAndLoadState, PresentAndLoadAction, PresentAndLoadEnvironment
     > { state, action, environment in
-      struct CancelId: Hashable {}
+
+      enum CancelId {}
+
       switch action {
       case .setSheet(isPresented: true):
         state.isSheetPresented = true
         return Effect(value: .setSheetIsPresentedDelayCompleted)
           .delay(for: 1, scheduler: environment.mainQueue)
           .eraseToEffect()
-          .cancellable(id: CancelId())
+          .cancellable(id: CancelId.self)
 
       case .setSheet(isPresented: false):
         state.isSheetPresented = false
         state.optionalCounter = nil
-        return .cancel(id: CancelId())
+        return .cancel(id: CancelId.self)
 
       case .setSheetIsPresentedDelayCompleted:
         state.optionalCounter = CounterState()

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -94,7 +94,7 @@ struct LifecycleDemoView: View {
   }
 }
 
-private struct TimerId: Hashable {}
+private enum TimerId {}
 
 enum TimerAction {
   case decrementButtonTapped
@@ -124,11 +124,11 @@ private let timerReducer = Reducer<Int, TimerAction, TimerEnvironment> {
 }
 .lifecycle(
   onAppear: {
-    Effect.timer(id: TimerId(), every: 1, tolerance: 0, on: $0.mainQueue)
+    Effect.timer(id: TimerId.self, every: 1, tolerance: 0, on: $0.mainQueue)
       .map { _ in TimerAction.tick }
   },
   onDisappear: { _ in
-    .cancel(id: TimerId())
+    .cancel(id: TimerId.self)
   }
 )
 

--- a/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
@@ -31,16 +31,18 @@ let lazyNavigationReducer =
     with: Reducer<
       LazyNavigationState, LazyNavigationAction, LazyNavigationEnvironment
     > { state, action, environment in
-      struct CancelId: Hashable {}
+
+      enum CancelId {}
+
       switch action {
       case .onDisappear:
-        return .cancel(id: CancelId())
+        return .cancel(id: CancelId.self)
       case .setNavigation(isActive: true):
         state.isActivityIndicatorHidden = false
         return Effect(value: .setNavigationIsActiveDelayCompleted)
           .delay(for: 1, scheduler: environment.mainQueue)
           .eraseToEffect()
-          .cancellable(id: CancelId())
+          .cancellable(id: CancelId.self)
       case .setNavigation(isActive: false):
         state.optionalCounter = nil
         return .none

--- a/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
@@ -31,7 +31,7 @@ let eagerNavigationReducer =
       EagerNavigationState, EagerNavigationAction, EagerNavigationEnvironment
     > { state, action, environment in
 
-      struct CancelId: Hashable {}
+      enum CancelId {}
 
       switch action {
       case .setNavigation(isActive: true):
@@ -39,11 +39,11 @@ let eagerNavigationReducer =
         return Effect(value: .setNavigationIsActiveDelayCompleted)
           .delay(for: 1, scheduler: environment.mainQueue)
           .eraseToEffect()
-          .cancellable(id: CancelId())
+          .cancellable(id: CancelId.self)
       case .setNavigation(isActive: false):
         state.isNavigationActive = false
         state.optionalCounter = nil
-        return .cancel(id: CancelId())
+        return .cancel(id: CancelId.self)
       case .setNavigationIsActiveDelayCompleted:
         state.optionalCounter = CounterState()
         return .none

--- a/Examples/Search/Search/SearchView.swift
+++ b/Examples/Search/Search/SearchView.swift
@@ -42,7 +42,7 @@ let searchReducer = Reducer<SearchState, SearchAction, SearchEnvironment> {
     return .none
 
   case let .locationTapped(location):
-    struct SearchWeatherId: Hashable {}
+    enum SearchWeatherId {}
 
     state.locationWeatherRequestInFlight = location
 
@@ -50,10 +50,10 @@ let searchReducer = Reducer<SearchState, SearchAction, SearchEnvironment> {
       .weather(location.id)
       .receive(on: environment.mainQueue)
       .catchToEffect(SearchAction.locationWeatherResponse)
-      .cancellable(id: SearchWeatherId(), cancelInFlight: true)
+      .cancellable(id: SearchWeatherId.self, cancelInFlight: true)
 
   case let .searchQueryChanged(query):
-    struct SearchLocationId: Hashable {}
+    enum SearchLocationId {}
 
     state.searchQuery = query
 
@@ -62,12 +62,12 @@ let searchReducer = Reducer<SearchState, SearchAction, SearchEnvironment> {
     guard !query.isEmpty else {
       state.locations = []
       state.locationWeather = nil
-      return .cancel(id: SearchLocationId())
+      return .cancel(id: SearchLocationId.self)
     }
 
     return environment.weatherClient
       .searchLocation(query)
-      .debounce(id: SearchLocationId(), for: 0.3, scheduler: environment.mainQueue)
+      .debounce(id: SearchLocationId.self, for: 0.3, scheduler: environment.mainQueue)
       .catchToEffect(SearchAction.locationsResponse)
 
   case let .locationWeatherResponse(.failure(locationWeather)):

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
@@ -29,8 +29,6 @@ struct AppEnvironment {
 }
 
 let appReducer = Reducer<AppState, AppAction, AppEnvironment> { state, action, environment in
-  struct SpeechRecognitionId: Hashable {}
-
   switch action {
   case .dismissAuthorizationStateAlert:
     state.alert = nil

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginCore/LoginCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginCore/LoginCore.swift
@@ -92,7 +92,7 @@ public let loginReducer = Reducer<LoginState, LoginAction, LoginEnvironment>.com
 
     case .twoFactorDismissed:
       state.twoFactor = nil
-      return .cancel(id: TwoFactorTearDownToken())
+      return .cancel(id: TwoFactorTearDownToken.self)
     }
   }
 )

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
@@ -22,9 +22,7 @@ public enum TwoFactorAction: Equatable {
   case twoFactorResponse(Result<AuthenticationResponse, AuthenticationError>)
 }
 
-public struct TwoFactorTearDownToken: Hashable {
-  public init() {}
-}
+public enum TwoFactorTearDownToken {}
 
 public struct TwoFactorEnvironment {
   public var authenticationClient: AuthenticationClient
@@ -58,7 +56,7 @@ public let twoFactorReducer = Reducer<TwoFactorState, TwoFactorAction, TwoFactor
       .twoFactor(TwoFactorRequest(code: state.code, token: state.token))
       .receive(on: environment.mainQueue)
       .catchToEffect(TwoFactorAction.twoFactorResponse)
-      .cancellable(id: TwoFactorTearDownToken())
+      .cancellable(id: TwoFactorTearDownToken.self)
 
   case let .twoFactorResponse(.failure(error)):
     state.alert = .init(title: TextState(error.localizedDescription))

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -88,9 +88,9 @@ let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
       return .none
 
     case .todo(id: _, action: .checkBoxToggled):
-      struct TodoCompletionId: Hashable {}
+      enum TodoCompletionId {}
       return Effect(value: .sortCompletedTodos)
-        .debounce(id: TodoCompletionId(), for: 1, scheduler: environment.mainQueue.animation())
+        .debounce(id: TodoCompletionId.self, for: 1, scheduler: environment.mainQueue.animation())
 
     case .todo:
       return .none

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
@@ -63,7 +63,7 @@ let voiceMemoReducer = Reducer<
 
       let start = environment.mainRunLoop.now
       return .merge(
-        Effect.timer(id: TimerId(), every: 0.5, on: environment.mainRunLoop)
+        Effect.timer(id: TimerId.self, every: 0.5, on: environment.mainRunLoop)
           .map { .timerUpdated($0.date.timeIntervalSince1970 - start.date.timeIntervalSince1970) },
 
         environment.audioPlayerClient
@@ -75,7 +75,7 @@ let voiceMemoReducer = Reducer<
       memo.mode = .notPlaying
 
       return .concatenate(
-        .cancel(id: TimerId()),
+        .cancel(id: TimerId.self),
         environment.audioPlayerClient.stop().fireAndForget()
       )
     }

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
@@ -43,17 +43,17 @@ struct VoiceMemoEnvironment {
 let voiceMemoReducer = Reducer<
   VoiceMemo, VoiceMemoAction, VoiceMemoEnvironment
 > { memo, action, environment in
-  struct TimerId: Hashable {}
+  enum TimerId {}
 
   switch action {
   case .audioPlayerClient(.success(.didFinishPlaying)), .audioPlayerClient(.failure):
     memo.mode = .notPlaying
-    return .cancel(id: TimerId())
+    return .cancel(id: TimerId.self)
 
   case .delete:
     return .merge(
       environment.audioPlayerClient.stop().fireAndForget(),
-      .cancel(id: TimerId())
+      .cancel(id: TimerId.self)
     )
 
   case .playButtonTapped:

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -56,7 +56,7 @@ let voiceMemosReducer = Reducer<VoiceMemosState, VoiceMemosAction, VoiceMemosEnv
     }
   ),
   .init { state, action, environment in
-    struct TimerId: Hashable {}
+    enum TimerId {}
 
     func startRecording() -> Effect<VoiceMemosAction, Never> {
       let url = environment.temporaryDirectory()
@@ -71,7 +71,7 @@ let voiceMemosReducer = Reducer<VoiceMemosState, VoiceMemosAction, VoiceMemosEnv
         environment.audioRecorder.startRecording(url)
           .catchToEffect(VoiceMemosAction.audioRecorder),
 
-        Effect.timer(id: TimerId(), every: 1, tolerance: .zero, on: environment.mainRunLoop)
+        Effect.timer(id: TimerId.self, every: 1, tolerance: .zero, on: environment.mainRunLoop)
           .map { _ in .currentRecordingTimerUpdated }
       )
     }

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -105,7 +105,7 @@ let voiceMemosReducer = Reducer<VoiceMemosState, VoiceMemosAction, VoiceMemosEnv
       .audioRecorder(.failure):
       state.alert = .init(title: .init("Voice memo recording failed."))
       state.currentRecording = nil
-      return .cancel(id: TimerId())
+      return .cancel(id: TimerId.self)
 
     case .currentRecordingTimerUpdated:
       state.currentRecording?.duration += 1
@@ -143,7 +143,7 @@ let voiceMemosReducer = Reducer<VoiceMemosState, VoiceMemosAction, VoiceMemosEnv
         case .recording:
           state.currentRecording?.mode = .encoding
           return .concatenate(
-            .cancel(id: TimerId()),
+            .cancel(id: TimerId.self),
 
             environment.audioRecorder.currentTime()
               .compactMap { $0 }

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -5,9 +5,10 @@ extension Effect {
   /// Turns an effect into one that is capable of being canceled.
   ///
   /// To turn an effect into a cancellable one you must provide an identifier, which is used in
-  /// ``Effect/cancel(id:)`` to identify which in-flight effect should be canceled. Any hashable
-  /// value can be used for the identifier, such as a string, but you can add a bit of protection
-  /// against typos by defining a new type that conforms to `Hashable`, such as an empty struct:
+  /// ``Effect/cancel(id:)-iun1`` to identify which in-flight effect should be canceled. Any
+  /// hashable value can be used for the identifier, such as a string, but you can add a bit of
+  /// protection against typos by defining a new type for the identifier, or by defining a custom
+  /// hashable type:
   ///
   /// ```swift
   /// struct LoadUserId: Hashable {}
@@ -72,17 +73,43 @@ extension Effect {
     .eraseToEffect()
   }
 
+  /// Turns an effect into one that is capable of being canceled.
+  ///
+  /// A convenience for calling ``Effect/cancellable(id:cancelInFlight:)-17skv`` with a static type
+  /// as the effect's unique identifier.
+  ///
+  /// - Parameters:
+  ///   - id: A unique type identifying the effect.
+  ///   - cancelInFlight: Determines if any in-flight effect with the same identifier should be
+  ///     canceled before starting this new one.
+  /// - Returns: A new effect that is capable of being canceled by an identifier.
+  public func cancellable(id: Any.Type, cancelInFlight: Bool = false) -> Effect {
+    self.cancellable(id: ObjectIdentifier(id), cancelInFlight: cancelInFlight)
+  }
+
   /// An effect that will cancel any currently in-flight effect with the given identifier.
   ///
   /// - Parameter id: An effect identifier.
   /// - Returns: A new effect that will cancel any currently in-flight effect with the given
   ///   identifier.
   public static func cancel(id: AnyHashable) -> Effect {
-    return .fireAndForget {
+    .fireAndForget {
       cancellablesLock.sync {
         cancellationCancellables[.init(id: id)]?.forEach { $0.cancel() }
       }
     }
+  }
+
+  /// An effect that will cancel any currently in-flight effect with the given identifier.
+  ///
+  /// A convenience for calling ``Effect/cancel(id:)-iun1`` with a static type as the effect's
+  /// unique identifier.
+  ///
+  /// - Parameter id: A unique type identifying the effect.
+  /// - Returns: A new effect that will cancel any currently in-flight effect with the given
+  ///   identifier.
+  public static func cancel(id: Any.Type) -> Effect {
+    .cancel(id: ObjectIdentifier(id))
   }
 
   /// An effect that will cancel multiple currently in-flight effects with the given identifiers.
@@ -91,6 +118,18 @@ extension Effect {
   /// - Returns: A new effect that will cancel any currently in-flight effects with the given
   ///   identifiers.
   public static func cancel(ids: [AnyHashable]) -> Effect {
+    .merge(ids.map(Effect.cancel(id:)))
+  }
+
+  /// An effect that will cancel multiple currently in-flight effects with the given identifiers.
+  ///
+  /// A convenience for calling ``Effect/cancel(ids:)-dmwy`` with a static type as the effect's
+  /// unique identifier.
+  ///
+  /// - Parameter ids: An array of unique types identifying the effects.
+  /// - Returns: A new effect that will cancel any currently in-flight effects with the given
+  ///   identifiers.
+  public static func cancel(ids: [Any.Type]) -> Effect {
     .merge(ids.map(Effect.cancel(id:)))
   }
 }

--- a/Sources/ComposableArchitecture/Effects/Debouncing.swift
+++ b/Sources/ComposableArchitecture/Effects/Debouncing.swift
@@ -37,4 +37,24 @@ extension Effect {
       .eraseToEffect()
       .cancellable(id: id, cancelInFlight: true)
   }
+
+  /// Turns an effect into one that can be debounced.
+  ///
+  /// A convenience for calling ``Effect/debounce(id:for:scheduler:options:)-76yye`` with a static
+  /// type as the effect's unique identifier.
+  ///
+  /// - Parameters:
+  ///   - id: A unique type identifying the effect.
+  ///   - dueTime: The duration you want to debounce for.
+  ///   - scheduler: The scheduler you want to deliver the debounced output to.
+  ///   - options: Scheduler options that customize the effect's delivery of elements.
+  /// - Returns: An effect that publishes events only after a specified time elapses.
+  public func debounce<S: Scheduler>(
+    id: Any.Type,
+    for dueTime: S.SchedulerTimeType.Stride,
+    scheduler: S,
+    options: S.SchedulerOptions? = nil
+  ) -> Effect {
+    self.debounce(id: ObjectIdentifier(id), for: dueTime, scheduler: scheduler, options: options)
+  }
 }

--- a/Sources/ComposableArchitecture/Effects/Timer.swift
+++ b/Sources/ComposableArchitecture/Effects/Timer.swift
@@ -15,12 +15,12 @@ extension Effect where Failure == Never {
   /// we can see how effects emit. However, because `Timer.publish` takes a concrete `RunLoop` as
   /// its scheduler, we can't substitute in a `TestScheduler` during tests`.
   ///
-  /// That is why we provide the ``Effect/timer(id:every:tolerance:on:options:)`` effect. It allows you to create a timer that works
-  /// with any scheduler, not just a run loop, which means you can use a `DispatchQueue` or
-  /// `RunLoop` when running your live app, but use a `TestScheduler` in tests.
+  /// That is why we provide `Effect.timer`. It allows you to create a timer that works with any
+  /// scheduler, not just a run loop, which means you can use a `DispatchQueue` or `RunLoop` when
+  /// running your live app, but use a `TestScheduler` in tests.
   ///
   /// To start and stop a timer in your feature you can create the timer effect from an action
-  /// and then use the ``Effect/cancel(id:)`` effect to stop the timer:
+  /// and then use the ``Effect/cancel(id:)-iun1`` effect to stop the timer:
   ///
   /// ```swift
   /// struct AppState {
@@ -89,6 +89,7 @@ extension Effect where Failure == Never {
   ///   [`CombineSchedulers`](https://github.com/pointfreeco/combine-schedulers) module.
   ///
   /// - Parameters:
+  ///   - id: The effect's identifier.
   ///   - interval: The time interval on which to publish events. For example, a value of `0.5`
   ///     publishes an event approximately every half-second.
   ///   - scheduler: The scheduler on which the timer runs.
@@ -108,5 +109,35 @@ extension Effect where Failure == Never {
       .setFailureType(to: Failure.self)
       .eraseToEffect()
       .cancellable(id: id, cancelInFlight: true)
+  }
+
+  /// Returns an effect that repeatedly emits the current time of the given scheduler on the given
+  /// interval.
+  ///
+  /// A convenience for calling ``Effect/timer(id:every:tolerance:on:options:)-4exe6`` with a
+  /// static type as the effect's unique identifier.
+  ///
+  /// - Parameters:
+  ///   - id: A unique type identifying the effect.
+  ///   - interval: The time interval on which to publish events. For example, a value of `0.5`
+  ///     publishes an event approximately every half-second.
+  ///   - scheduler: The scheduler on which the timer runs.
+  ///   - tolerance: The allowed timing variance when emitting events. Defaults to `nil`, which
+  ///     allows any variance.
+  ///   - options: Scheduler options passed to the timer. Defaults to `nil`.
+  public static func timer<S>(
+    id: Any.Type,
+    every interval: S.SchedulerTimeType.Stride,
+    tolerance: S.SchedulerTimeType.Stride? = nil,
+    on scheduler: S,
+    options: S.SchedulerOptions? = nil
+  ) -> Effect where S: Scheduler, S.SchedulerTimeType == Output {
+    self.timer(
+      id: ObjectIdentifier(id),
+      every: interval,
+      tolerance: tolerance,
+      on: scheduler,
+      options: options
+    )
   }
 }

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -400,7 +400,7 @@ public struct Reducer<State, Action, Environment> {
   ///     let childReducer = Reducer<
   ///       ChildState, ChildAction, ChildEnvironment
   ///     > { state, action environment in
-  ///       struct MotionId: Hashable {}
+  ///       enum MotionId {}
   ///
   ///       switch action {
   ///       case .onAppear:
@@ -408,11 +408,11 @@ public struct Reducer<State, Action, Environment> {
   ///         return environment.motionClient
   ///           .start()
   ///           .map(ChildAction.motion)
-  ///           .cancellable(id: MotionId())
+  ///           .cancellable(id: MotionId.self)
   ///
   ///       case .onDisappear:
   ///         // And explicitly cancel them when the domain is torn down
-  ///         return .cancel(id: MotionId())
+  ///         return .cancel(id: MotionId.self)
   ///       ...
   ///       }
   ///     }
@@ -614,7 +614,7 @@ public struct Reducer<State, Action, Environment> {
   ///     let childReducer = Reducer<
   ///       ChildState, ChildAction, ChildEnvironment
   ///     > { state, action environment in
-  ///       struct MotionId: Hashable {}
+  ///       enum MotionId {}
   ///
   ///       switch action {
   ///       case .onAppear:
@@ -622,11 +622,11 @@ public struct Reducer<State, Action, Environment> {
   ///         return environment.motionClient
   ///           .start()
   ///           .map(ChildAction.motion)
-  ///           .cancellable(id: MotionId())
+  ///           .cancellable(id: MotionId.self)
   ///
   ///       case .onDisappear:
   ///         // And explicitly cancel them when the domain is torn down
-  ///         return .cancel(id: MotionId())
+  ///         return .cancel(id: MotionId.self)
   ///       ...
   ///       }
   ///     }

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -106,13 +106,13 @@
   /// let searchReducer = Reducer<SearchState, SearchAction, SearchEnvironment> {
   ///   state, action, environment in
   ///
-  ///     struct SearchId: Hashable {}
+  ///     enum SearchId {}
   ///
   ///     switch action {
   ///     case let .queryChanged(query):
   ///       state.query = query
   ///       return environment.request(self.query)
-  ///         .debounce(id: SearchId(), for: 0.5, scheduler: environment.mainQueue)
+  ///         .debounce(id: SearchId.self, for: 0.5, scheduler: environment.mainQueue)
   ///
   ///     case let .response(results):
   ///       state.results = results

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -130,11 +130,11 @@ final class ComposableArchitectureTests: XCTestCase {
     }
 
     let reducer = Reducer<Int, Action, Environment> { state, action, environment in
-      struct CancelId: Hashable {}
+      enum CancelId {}
 
       switch action {
       case .cancel:
-        return .cancel(id: CancelId())
+        return .cancel(id: CancelId.self)
 
       case .incr:
         state += 1
@@ -142,7 +142,7 @@ final class ComposableArchitectureTests: XCTestCase {
           .receive(on: environment.mainQueue)
           .map(Action.response)
           .eraseToEffect()
-          .cancellable(id: CancelId())
+          .cancellable(id: CancelId.self)
 
       case let .response(value):
         state = value

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -152,7 +152,7 @@ final class EffectTests: XCTestCase {
   }
 
   func testEffectSubscriberInitializer_WithCancellation() {
-    struct CancelId: Hashable {}
+    enum CancelId {}
 
     let effect = Effect<Int, Never>.run { subscriber in
       subscriber.send(1)
@@ -162,7 +162,7 @@ final class EffectTests: XCTestCase {
 
       return AnyCancellable {}
     }
-    .cancellable(id: CancelId())
+    .cancellable(id: CancelId.self)
 
     var values: [Int] = []
     var isComplete = false
@@ -173,7 +173,7 @@ final class EffectTests: XCTestCase {
     XCTAssertNoDifference(values, [1])
     XCTAssertNoDifference(isComplete, false)
 
-    Effect<Void, Never>.cancel(id: CancelId())
+    Effect<Void, Never>.cancel(id: CancelId.self)
       .sink(receiveValue: { _ in })
       .store(in: &self.cancellables)
 


### PR DESCRIPTION
While it's easy enough to create instances of hashable structs for cancel tokens, it's effectively using static info under the hood (more so as of #1077). So let's consider adding overloads that take `Any.Type` instead. In use:

```diff
-struct CancelId: Hashable {}
-return .cancel(id: CancelId())
+enum CancelId {}
+return .cancel(id: CancelId.self)
```