### PR TITLE
Async fire-and-forget

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -246,18 +246,9 @@ public struct Effect<Output, Failure: Error>: Publisher {
   ///
   /// - Parameter work: A closure encapsulating some work to execute in the real world.
   /// - Returns: An effect.
-  public static func fireAndForget(_ work: @escaping () -> Void) -> Effect {
-    // NB: Ideally we'd return a `Deferred` wrapping an `Empty(completeImmediately: true)`, but
-    //     due to a bug in iOS 13.2 that publisher will never complete. The bug was fixed in
-    //     iOS 13.3, but to remain compatible with iOS 13.2 and higher we need to do a little
-    //     trickery to make sure the deferred publisher completes.
-    Deferred { () -> Publishers.CompactMap<Result<Output?, Failure>.Publisher, Output> in
-      work()
-      return Just<Output?>(nil)
-        .setFailureType(to: Failure.self)
-        .compactMap { $0 }
-    }
-    .eraseToEffect()
+  public static func fireAndForget(_ work: @escaping @Sendable () async -> Void) -> Effect {
+    Effect<Void, Never>.task { await work() }
+      .fireAndForget()
   }
 
   /// Transforms all elements from the upstream effect with a provided closure.

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -260,7 +260,7 @@ final class EffectTests: XCTestCase {
       XCTAssertNotNil(result)
     }
 
-    func testCancellingTask() {
+    func testCancellingTask_Failable() {
       @Sendable func work() async throws -> Int {
         try await Task.sleep(nanoseconds: NSEC_PER_MSEC)
         XCTFail()
@@ -268,6 +268,28 @@ final class EffectTests: XCTestCase {
       }
 
       Effect<Int, Error>.task { try await work() }
+        .sink(
+          receiveCompletion: { _ in XCTFail() },
+          receiveValue: { _ in XCTFail() }
+        )
+        .store(in: &self.cancellables)
+
+      self.cancellables = []
+
+      _ = XCTWaiter.wait(for: [.init()], timeout: 1.1)
+    }
+
+    func testCancellingTask_Infalable() {
+      @Sendable func work() async -> Int {
+        do {
+          try await Task.sleep(nanoseconds: NSEC_PER_MSEC)
+          XCTFail()
+        } catch {
+        }
+        return 42
+      }
+
+      Effect<Int, Never >.task { await work() }
         .sink(
           receiveCompletion: { _ in XCTFail() },
           receiveValue: { _ in XCTFail() }


### PR DESCRIPTION
This has come up before (#868), and we think it will be useful, especially with some new features coming soon to TCA that make it play nicer with Swift's concurrency tools.