### PR TITLE
Modernize case study using Notification Center

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
@@ -312,8 +312,3 @@ private func liveFetchNumber() -> Effect<Int, Never> {
     .delay(for: 1, scheduler: DispatchQueue.main)
     .eraseToEffect()
 }
-
-private let liveUserDidTakeScreenshot = NotificationCenter.default
-  .publisher(for: UIApplication.userDidTakeScreenshotNotification)
-  .map { _ in () }
-  .eraseToEffect()

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
@@ -82,7 +82,7 @@ struct RootEnvironment {
   var favorite: (UUID, Bool) -> Effect<Bool, Error>
   var fetchNumber: () -> Effect<Int, Never>
   var mainQueue: AnySchedulerOf<DispatchQueue>
-  var userDidTakeScreenshot: Effect<Void, Never>
+  var notificationCenter: NotificationCenter
   var uuid: () -> UUID
   var webSocket: WebSocketClient
 
@@ -93,7 +93,7 @@ struct RootEnvironment {
     favorite: favorite(id:isFavorite:),
     fetchNumber: liveFetchNumber,
     mainQueue: .main,
-    userDidTakeScreenshot: liveUserDidTakeScreenshot,
+    notificationCenter: .default,
     uuid: UUID.init,
     webSocket: .live
   )
@@ -220,7 +220,7 @@ let rootReducer = Reducer<RootState, RootAction, RootEnvironment>.combine(
     .pullback(
       state: \.longLivingEffects,
       action: /RootAction.longLivingEffects,
-      environment: { .init(userDidTakeScreenshot: $0.userDidTakeScreenshot) }
+      environment: { .init(notificationCenter: $0.notificationCenter) }
     ),
   mapAppReducer
     .pullback(

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -30,7 +30,7 @@ struct LongLivingEffectsEnvironment {
   // An effect that emits Void whenever the user takes a screenshot of the device. We use this
   // instead of `NotificationCenter.default.publisher` directly in the reducer so that we can test
   // it.
-  var userDidTakeScreenshot: Effect<Void, Never>
+  var notificationCenter: NotificationCenter
 }
 
 // MARK: - Business logic
@@ -48,8 +48,10 @@ let longLivingEffectsReducer = Reducer<
 
   case .onAppear:
     // When the view appears, start the effect that emits when screenshots are taken.
-    return environment.userDidTakeScreenshot
-      .map { LongLivingEffectsAction.userDidTakeScreenshotNotification }
+    return environment.notificationCenter
+      .publisher(for: UIApplication.userDidTakeScreenshotNotification)
+      .map { _ in LongLivingEffectsAction.userDidTakeScreenshotNotification }
+      .eraseToEffect()
       .cancellable(id: UserDidTakeScreenshotNotificationId.self)
 
   case .onDisappear:
@@ -103,7 +105,7 @@ struct EffectsLongLiving_Previews: PreviewProvider {
         initialState: LongLivingEffectsState(),
         reducer: longLivingEffectsReducer,
         environment: LongLivingEffectsEnvironment(
-          userDidTakeScreenshot: .none
+          notificationCenter: .default
         )
       )
     )

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -27,9 +27,6 @@ enum LongLivingEffectsAction {
 }
 
 struct LongLivingEffectsEnvironment {
-  // An effect that emits Void whenever the user takes a screenshot of the device. We use this
-  // instead of `NotificationCenter.default.publisher` directly in the reducer so that we can test
-  // it.
   var notificationCenter: NotificationCenter
 }
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
@@ -6,21 +6,20 @@ import XCTest
 
 class LongLivingEffectsTests: XCTestCase {
   func testReducer() {
-    // A passthrough subject to simulate the screenshot notification
-    let screenshotTaken = PassthroughSubject<Void, Never>()
+    let notificationCenter = NotificationCenter()
 
     let store = TestStore(
       initialState: .init(),
       reducer: longLivingEffectsReducer,
       environment: .init(
-        userDidTakeScreenshot: Effect(screenshotTaken)
+        notificationCenter: notificationCenter
       )
     )
 
     store.send(.onAppear)
 
     // Simulate a screenshot being taken
-    screenshotTaken.send()
+    notificationCenter.post(name: UIApplication.userDidTakeScreenshotNotification, object: nil)
     store.receive(.userDidTakeScreenshotNotification) {
       $0.screenshotCount = 1
     }
@@ -29,6 +28,6 @@ class LongLivingEffectsTests: XCTestCase {
 
     // Simulate a screenshot being taken to show no effects
     // are executed.
-    screenshotTaken.send()
+    notificationCenter.post(name: UIApplication.userDidTakeScreenshotNotification, object: nil)
   }
 }


### PR DESCRIPTION
We have a few case studies that could probably be polished up a bit, and this is one that stood out to me. Seems nicer to use a Notification Center directly in the reducer instead of control it with a wrapper effect.