### PR TITLE
Add throttle overloads that take types

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Throttling.swift
+++ b/Sources/ComposableArchitecture/Effects/Throttling.swift
@@ -58,6 +58,29 @@ extension Effect {
       .eraseToEffect()
       .cancellable(id: id, cancelInFlight: true)
   }
+
+  /// Throttles an effect so that it only publishes one output per given interval.
+  ///
+  /// A convenience for calling ``Effect/throttle(id:for:scheduler:latest:)-5jfpx`` with a static
+  /// type as the effect's unique identifier.
+  ///
+  /// - Parameters:
+  ///   - id: The effect's identifier.
+  ///   - interval: The interval at which to find and emit the most recent element, expressed in
+  ///     the time system of the scheduler.
+  ///   - scheduler: The scheduler you want to deliver the throttled output to.
+  ///   - latest: A boolean value that indicates whether to publish the most recent element. If
+  ///     `false`, the publisher emits the first element received during the interval.
+  /// - Returns: An effect that emits either the most-recent or first element received during the
+  ///   specified interval.
+  public func throttle<S>(
+    id: Any.Type,
+    for interval: S.SchedulerTimeType.Stride,
+    scheduler: S,
+    latest: Bool
+  ) -> Effect where S: Scheduler {
+    self.throttle(id: ObjectIdentifier(id), for: interval, scheduler: scheduler, latest: latest)
+  }
 }
 
 var throttleTimes: [AnyHashable: Any] = [:]

--- a/Tests/ComposableArchitectureTests/EffectThrottleTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectThrottleTests.swift
@@ -12,14 +12,14 @@ final class EffectThrottleTests: XCTestCase {
     var effectRuns = 0
 
     func runThrottledEffect(value: Int) {
-      struct CancelToken: Hashable {}
+      enum CancelToken {}
 
       Deferred { () -> Just<Int> in
         effectRuns += 1
         return Just(value)
       }
       .eraseToEffect()
-      .throttle(id: CancelToken(), for: 1, scheduler: scheduler.eraseToAnyScheduler(), latest: true)
+      .throttle(id: CancelToken.self, for: 1, scheduler: scheduler.eraseToAnyScheduler(), latest: true)
       .sink { values.append($0) }
       .store(in: &self.cancellables)
     }
@@ -64,7 +64,7 @@ final class EffectThrottleTests: XCTestCase {
     var effectRuns = 0
 
     func runThrottledEffect(value: Int) {
-      struct CancelToken: Hashable {}
+      enum CancelToken {}
 
       Deferred { () -> Just<Int> in
         effectRuns += 1
@@ -72,7 +72,7 @@ final class EffectThrottleTests: XCTestCase {
       }
       .eraseToEffect()
       .throttle(
-        id: CancelToken(), for: 1, scheduler: scheduler.eraseToAnyScheduler(), latest: false
+        id: CancelToken.self, for: 1, scheduler: scheduler.eraseToAnyScheduler(), latest: false
       )
       .sink { values.append($0) }
       .store(in: &self.cancellables)
@@ -131,14 +131,14 @@ final class EffectThrottleTests: XCTestCase {
     var effectRuns = 0
 
     func runThrottledEffect(value: Int) {
-      struct CancelToken: Hashable {}
+      enum CancelToken {}
 
       Deferred { () -> Just<Int> in
         effectRuns += 1
         return Just(value)
       }
       .eraseToEffect()
-      .throttle(id: CancelToken(), for: 1, scheduler: scheduler.eraseToAnyScheduler(), latest: true)
+      .throttle(id: CancelToken.self, for: 1, scheduler: scheduler.eraseToAnyScheduler(), latest: true)
       .sink { values.append($0) }
       .store(in: &self.cancellables)
     }
@@ -174,7 +174,7 @@ final class EffectThrottleTests: XCTestCase {
     var effectRuns = 0
 
     func runThrottledEffect(value: Int) {
-      struct CancelToken: Hashable {}
+      enum CancelToken {}
 
       Deferred { () -> Just<Int> in
         effectRuns += 1
@@ -182,7 +182,7 @@ final class EffectThrottleTests: XCTestCase {
       }
       .eraseToEffect()
       .throttle(
-        id: CancelToken(), for: 1, scheduler: scheduler.eraseToAnyScheduler(), latest: false
+        id: CancelToken.self, for: 1, scheduler: scheduler.eraseToAnyScheduler(), latest: false
       )
       .sink { values.append($0) }
       .store(in: &self.cancellables)


### PR DESCRIPTION
Given that Effect cancellation now has endpoints that can take types as identifiers and those were extended to debounce, it seems natural to expose the same functionality for throttle.