### PR TITLE
Conform `WithViewStore` to `Commands`

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -153,7 +153,7 @@ extension WithViewStore: DynamicViewContent where State: Collection, Content: Dy
 @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
 extension WithViewStore: Scene where Content: Scene {
   /// Initializes a structure that transforms a store into an observable view store in order to
-  /// compute views from store state.
+  /// compute scenes from store state.
   ///
   /// - Parameters:
   ///   - store: A store.

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -216,3 +216,75 @@ extension WithViewStore where State == Void, Content: Scene {
     self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
   }
 }
+
+@available(iOS 14.0, macOS 11.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension WithViewStore: Commands where Content: Commands {
+  /// Initializes a structure that transforms a store into an observable view store in order to
+  /// compute commands from store state.
+  ///
+  /// - Parameters:
+  ///   - store: A store.
+  ///   - isDuplicate: A function to determine when two `State` values are equal. When values are
+  ///     equal, repeat view computations are removed,
+  ///   - content: A function that can generate content from a view store.
+  public init(
+    _ store: Store<State, Action>,
+    removeDuplicates isDuplicate: @escaping (State, State) -> Bool,
+    file: StaticString = #fileID,
+    line: UInt = #line,
+    @CommandsBuilder content: @escaping (ViewStore<State, Action>) -> Content
+  ) {
+    self.init(
+      store: store,
+      removeDuplicates: isDuplicate,
+      file: file,
+      line: line,
+      content: content
+    )
+  }
+  public var body: some Commands {
+    self._body
+  }
+}
+
+@available(iOS 14.0, macOS 11.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension WithViewStore where State: Equatable, Content: Commands {
+  /// Initializes a structure that transforms a store into an observable view store in order to
+  /// compute commands from equatable store state.
+  ///
+  /// - Parameters:
+  ///   - store: A store of equatable state.
+  ///   - content: A function that can generate content from a view store.
+  public init(
+    _ store: Store<State, Action>,
+    file: StaticString = #fileID,
+    line: UInt = #line,
+    @CommandsBuilder content: @escaping (ViewStore<State, Action>) -> Content
+  ) {
+    self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
+  }
+}
+
+@available(iOS 14.0, macOS 11.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension WithViewStore where State == Void, Content: Commands {
+  /// Initializes a structure that transforms a store into an observable view store in order to
+  /// compute commands from equatable store state.
+  ///
+  /// - Parameters:
+  ///   - store: A store of equatable state.
+  ///   - content: A function that can generate content from a view store.
+  public init(
+    _ store: Store<State, Action>,
+    file: StaticString = #fileID,
+    line: UInt = #line,
+    @CommandsBuilder content: @escaping (ViewStore<State, Action>) -> Content
+  ) {
+    self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
+  }
+}

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -127,7 +127,7 @@ extension WithViewStore where State: Equatable, Content: View {
 
 extension WithViewStore where State == Void, Content: View {
   /// Initializes a structure that transforms a store into an observable view store in order to
-  /// compute views from equatable store state.
+  /// compute views from void store state.
   ///
   /// - Parameters:
   ///   - store: A store of equatable state.
@@ -202,7 +202,7 @@ extension WithViewStore where State: Equatable, Content: Scene {
 @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
 extension WithViewStore where State == Void, Content: Scene {
   /// Initializes a structure that transforms a store into an observable view store in order to
-  /// compute scenes from equatable store state.
+  /// compute scenes from void store state.
   ///
   /// - Parameters:
   ///   - store: A store of equatable state.
@@ -274,7 +274,7 @@ extension WithViewStore where State: Equatable, Content: Commands {
 @available(watchOS, unavailable)
 extension WithViewStore where State == Void, Content: Commands {
   /// Initializes a structure that transforms a store into an observable view store in order to
-  /// compute commands from equatable store state.
+  /// compute commands from void store state.
   ///
   /// - Parameters:
   ///   - store: A store of equatable state.

--- a/Tests/ComposableArchitectureTests/WithViewStoreAppTest.swift
+++ b/Tests/ComposableArchitectureTests/WithViewStoreAppTest.swift
@@ -1,4 +1,4 @@
-// NB: This file gathers coverage of `WithViewStore` use as a `Scene`.
+// NB: This file gathers coverage of `WithViewStore` use as a `Scene` and `Commands`.
 
 import ComposableArchitecture
 import SwiftUI
@@ -34,5 +34,16 @@ struct TestApp: App {
         }
       #endif
     }
+    #if os(iOS) || os(macOS)
+    .commands {
+      WithViewStore(self.store) { viewStore in
+        CommandMenu("Other Commands") {
+          Button("Increment") {
+            viewStore.send(())
+          }
+        }
+      }
+    }
+    #endif
   }
 }


### PR DESCRIPTION
Following #1112, this makes `WithViewStore` conform to `Commands` when appropriate. This should allow to bundle `Commands` in their own type like Apple does in their [`Landmarks`](https://developer.apple.com/tutorials/swiftui) tutorials, and still have access to `WithViewStore`. This brings up two additional questions:
- Should we review SwiftUI for similar situations, like `ToolbarContent` for example, and conform `WithViewStore` for them too?
- Should we reimplement Apple SwiftUI tutorial apps using TCA (it's maybe already done somewhere else)?