### PR TITLE
Fix for attribute cycle in tic-tac-toe.

### DIFF
--- a/Examples/TicTacToe/App/RootView.swift
+++ b/Examples/TicTacToe/App/RootView.swift
@@ -42,9 +42,9 @@ struct RootView: View {
   var body: some View {
     NavigationView {
       Form {
-        Section(
-          header: Text(readMe).padding([.bottom], 16)
-        ) {
+        Text(readMe)
+
+        Section {
           Button("SwiftUI version") { self.showGame = .swiftui }
           Button("UIKit version") { self.showGame = .uikit }
         }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -74,7 +74,10 @@ public struct LoginView: View {
           isActive: viewStore.binding(
             get: \.isTwoFactorActive,
             send: {
-              // NB: https://stackoverflow.com/a/69653555
+              // NB: SwiftUI will print errors to the console about "AttributeGraph: cycle detected"
+              //     if you disable a text field while it is focused. This hack will force all
+              //     fields to unfocus before we send the action to the view store.
+              // CF: https://stackoverflow.com/a/69653555
               UIApplication.shared.sendAction(
                 #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
               )

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -42,59 +42,56 @@ public struct LoginView: View {
 
   public var body: some View {
     WithViewStore(self.store.scope(state: ViewState.init, action: LoginAction.init)) { viewStore in
-      ScrollView {
-        VStack(spacing: 16) {
-          Text(
+      Form {
+        Text(
             """
             To login use any email and "password" for the password. If your email contains the \
             characters "2fa" you will be taken to a two-factor flow, and on that screen you can \
             use "1234" for the code.
             """
+        )
+
+        Section {
+          TextField(
+            "blob@pointfree.co",
+            text: viewStore.binding(get: \.email, send: ViewAction.emailChanged)
           )
+          .autocapitalization(.none)
+          .keyboardType(.emailAddress)
+          .textContentType(.emailAddress)
 
-          VStack(alignment: .leading) {
-            Text("Email")
-            TextField(
-              "blob@pointfree.co",
-              text: viewStore.binding(get: \.email, send: ViewAction.emailChanged)
-            )
-            .autocapitalization(.none)
-            .keyboardType(.emailAddress)
-            .textContentType(.emailAddress)
-            .textFieldStyle(.roundedBorder)
-          }
-
-          VStack(alignment: .leading) {
-            Text("Password")
-            SecureField(
-              "••••••••",
-              text: viewStore.binding(get: \.password, send: ViewAction.passwordChanged)
-            )
-            .textFieldStyle(.roundedBorder)
-          }
-
-          NavigationLink(
-            destination: IfLetStore(
-              self.store.scope(state: \.twoFactor, action: LoginAction.twoFactor),
-              then: TwoFactorView.init(store:)
-            ),
-            isActive: viewStore.binding(
-              get: \.isTwoFactorActive,
-              send: { $0 ? .loginButtonTapped : .twoFactorDismissed }
-            )
-          ) {
-            Text("Log in")
-
-            if viewStore.isActivityIndicatorVisible {
-              ProgressView()
-            }
-          }
-          .disabled(viewStore.isLoginButtonDisabled)
+          SecureField(
+            "••••••••",
+            text: viewStore.binding(get: \.password, send: ViewAction.passwordChanged)
+          )
         }
-        .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
-        .disabled(viewStore.isFormDisabled)
-        .padding(.horizontal)
+
+        NavigationLink(
+          destination: IfLetStore(
+            self.store.scope(state: \.twoFactor, action: LoginAction.twoFactor),
+            then: TwoFactorView.init(store:)
+          ),
+          isActive: viewStore.binding(
+            get: \.isTwoFactorActive,
+            send: {
+              // NB: https://stackoverflow.com/a/69653555
+              UIApplication.shared.sendAction(
+                #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
+              )
+              return $0 ? .loginButtonTapped : .twoFactorDismissed
+            }
+          )
+        ) {
+          Text("Log in")
+          if viewStore.isActivityIndicatorVisible {
+            Spacer()
+            ProgressView()
+          }
+        }
+        .disabled(viewStore.isLoginButtonDisabled)
       }
+      .disabled(viewStore.isFormDisabled)
+      .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
     }
     .navigationBarTitle("Login")
   }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
@@ -36,50 +36,47 @@ public struct NewGameView: View {
   public var body: some View {
     WithViewStore(self.store.scope(state: ViewState.init, action: NewGameAction.init)) {
       viewStore in
-      ScrollView {
-        VStack(spacing: 16) {
-          VStack(alignment: .leading) {
-            Text("X Player Name")
-            TextField(
-              "Blob Sr.",
-              text: viewStore.binding(get: \.xPlayerName, send: ViewAction.xPlayerNameChanged)
-            )
-            .autocapitalization(.words)
-            .disableAutocorrection(true)
-            .textContentType(.name)
-            .textFieldStyle(.roundedBorder)
-          }
-
-          VStack(alignment: .leading) {
-            Text("O Player Name")
-            TextField(
-              "Blob Jr.",
-              text: viewStore.binding(get: \.oPlayerName, send: ViewAction.oPlayerNameChanged)
-            )
-            .autocapitalization(.words)
-            .disableAutocorrection(true)
-            .textContentType(.name)
-            .textFieldStyle(.roundedBorder)
-          }
-
-          NavigationLink(
-            destination: IfLetStore(
-              self.store.scope(state: \.game, action: NewGameAction.game),
-              then: GameView.init(store:)
-            ),
-            isActive: viewStore.binding(
-              get: \.isGameActive,
-              send: { $0 ? .letsPlayButtonTapped : .gameDismissed }
-            )
-          ) {
-            Text("Let's play!")
-          }
-          .disabled(viewStore.isLetsPlayButtonDisabled)
+      Form {
+        Section {
+          TextField(
+            "Blob Sr.",
+            text: viewStore.binding(get: \.xPlayerName, send: ViewAction.xPlayerNameChanged)
+          )
+          .autocapitalization(.words)
+          .disableAutocorrection(true)
+          .textContentType(.name)
+        } header: {
+          Text("X Player Name")
         }
-        .padding(.horizontal)
+
+        Section {
+          TextField(
+            "Blob Jr.",
+            text: viewStore.binding(get: \.oPlayerName, send: ViewAction.oPlayerNameChanged)
+          )
+          .autocapitalization(.words)
+          .disableAutocorrection(true)
+          .textContentType(.name)
+        } header: {
+          Text("O Player Name")
+        }
+
+        NavigationLink(
+          destination: IfLetStore(
+            self.store.scope(state: \.game, action: NewGameAction.game),
+            then: GameView.init(store:)
+          ),
+          isActive: viewStore.binding(
+            get: \.isGameActive,
+            send: { $0 ? .letsPlayButtonTapped : .gameDismissed }
+          )
+        ) {
+          Text("Let's play!")
+        }
+        .disabled(viewStore.isLetsPlayButtonDisabled)
+        .navigationBarTitle("New Game")
+        .navigationBarItems(trailing: Button("Logout") { viewStore.send(.logoutButtonTapped) })
       }
-      .navigationBarTitle("New Game")
-      .navigationBarItems(trailing: Button("Logout") { viewStore.send(.logoutButtonTapped) })
     }
   }
 }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
@@ -49,6 +49,13 @@ public struct TwoFactorView: View {
 
         HStack {
           Button("Submit") {
+            // NB: SwiftUI will print errors to the console about "AttributeGraph: cycle detected"
+            //     if you disable a text field while it is focused. This hack will force all
+            //     fields to unfocus before we send the action to the view store.
+            // CF: https://stackoverflow.com/a/69653555
+            UIApplication.shared.sendAction(
+              #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
+            )
             viewStore.send(.submitButtonTapped)
           }
           .disabled(viewStore.isSubmitButtonDisabled)

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
@@ -36,37 +36,33 @@ public struct TwoFactorView: View {
     WithViewStore(
       self.store.scope(state: ViewState.init, action: TwoFactorAction.init)
     ) { viewStore in
-      ScrollView {
-        VStack(spacing: 16) {
-          Text(#"To confirm the second factor enter "1234" into the form."#)
+      Form {
+        Text(#"To confirm the second factor enter "1234" into the form."#)
 
-          VStack(alignment: .leading) {
-            Text("Code")
-            TextField(
-              "1234",
-              text: viewStore.binding(get: \.code, send: ViewAction.codeChanged)
-            )
-            .keyboardType(.numberPad)
-            .textFieldStyle(.roundedBorder)
+        Section {
+          TextField(
+            "1234",
+            text: viewStore.binding(get: \.code, send: ViewAction.codeChanged)
+          )
+          .keyboardType(.numberPad)
+        }
+
+        HStack {
+          Button("Submit") {
+            viewStore.send(.submitButtonTapped)
           }
+          .disabled(viewStore.isSubmitButtonDisabled)
 
-          HStack {
-            Button("Submit") {
-              viewStore.send(.submitButtonTapped)
-            }
-            .disabled(viewStore.isSubmitButtonDisabled)
-
-            if viewStore.isActivityIndicatorVisible {
-              ProgressView()
-            }
+          if viewStore.isActivityIndicatorVisible {
+            Spacer()
+            ProgressView()
           }
         }
-        .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
-        .disabled(viewStore.isFormDisabled)
-        .padding(.horizontal)
       }
+      .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
+      .disabled(viewStore.isFormDisabled)
+      .navigationBarTitle("Confirmation Code")
     }
-    .navigationBarTitle("Confirmation Code")
   }
 }
 


### PR DESCRIPTION
Apparently there is a bug in SwiftUI that causes "AttributeGraph: cycle detected" to be printed to the console if you disable a textfield while it is focused. This doesn't have anything to do with TCA and exists in simple vanilla SwiftUI apps too.

The fix is to force all fields to unfocus before sending actions that could disable UI components.

This has come up a number of times (#363, #395, and more recently in #1111). This fix was introduced to us by @mywristbands in #363 ([SO article](https://stackoverflow.com/a/69653555)) but we didn't see it when it was originally posted. Thanks for the tip!

We also brought back `Form` views which were previously removed (#448) due to other SwiftUI bugs. It seems those bugs have been fixed because I can no longer reproduce the crash reported in #395.