### PR TITLE
Make TestStore's state visible

### DIFF
--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -176,7 +176,7 @@
     private var inFlightEffects: Set<LongLivingEffect> = []
     var receivedActions: [(action: Action, state: State)] = []
     private let reducer: Reducer<State, Action, Environment>
-    private var state: State
+    public private(set) var state: State
     private var store: Store<State, TestAction>!
     private let toLocalState: (State) -> LocalState
 


### PR DESCRIPTION
This should allow people to perform assertions outside of the send/check sequence.
This follows https://twitter.com/alexito4/status/1532380971567308800