### PR TITLE
Make TestStore.state public

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
@@ -1,5 +1,5 @@
 import Combine
-import ComposableArchitecture
+@testable import ComposableArchitecture
 import XCTest
 
 @testable import SwiftUICaseStudies

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
@@ -1,5 +1,5 @@
 import Combine
-@testable import ComposableArchitecture
+import ComposableArchitecture
 import XCTest
 
 @testable import SwiftUICaseStudies

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -176,7 +176,7 @@
     private var inFlightEffects: Set<LongLivingEffect> = []
     var receivedActions: [(action: Action, state: State)] = []
     private let reducer: Reducer<State, Action, Environment>
-    private var state: State
+    public private(set) var state: State
     private var store: Store<State, TestAction>!
     private let toLocalState: (State) -> LocalState
 
@@ -355,8 +355,13 @@
         )
       }
       var expectedState = self.toLocalState(self.state)
+      let previousState = self.state
       self.store.send(.init(origin: .send(action), file: file, line: line))
       do {
+        let currentState = self.state
+        self.state = previousState
+        defer { self.state = currentState }
+
         try self.expectedStateShouldChange(
           expected: &expectedState,
           update: update,

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -148,4 +148,43 @@ class TestStoreTests: XCTestCase {
       }
     }
   }
+
+  func testStateAccess() {
+    enum Action { case a, b, c, d }
+    let store = TestStore(
+      initialState: 0,
+      reducer: Reducer<Int, Action, Void> { count, action, _ in
+        switch action {
+        case .a:
+          count += 1
+          return .merge(.init(value: .b), .init(value: .c), .init(value: .d))
+        case .b, .c, .d:
+          count += 1
+          return .none
+        }
+      },
+      environment: ()
+    )
+
+    store.send(.a) {
+      $0 = 1
+      XCTAssertEqual(store.state, 0)
+    }
+    XCTAssertEqual(store.state, 1)
+    store.receive(.b) {
+      $0 = 2
+      XCTAssertEqual(store.state, 1)
+    }
+    XCTAssertEqual(store.state, 2)
+    store.receive(.c) {
+      $0 = 3
+      XCTAssertEqual(store.state, 2)
+    }
+    XCTAssertEqual(store.state, 3)
+    store.receive(.d) {
+      $0 = 4
+      XCTAssertEqual(store.state, 3)
+    }
+    XCTAssertEqual(store.state, 4)
+  }
 }


### PR DESCRIPTION
This PR makes it so that `TestStore.state` is public, _and_ so that `TestStore.state` inside a `.send {...}` and `.receive {...}` is equal to the state of the feature before the action is sent/received. This closes the escape hatch that worried me about publicizing this property.

See #1124 for more discussion.