### PR TITLE
Force effect tasks to be on @MainActor.

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Concurrency.swift
+++ b/Sources/ComposableArchitecture/Effects/Concurrency.swift
@@ -40,7 +40,7 @@ import SwiftUI
     ) -> Self where Failure == Never {
       var task: Task<Void, Never>?
       return .future { callback in
-        task = Task(priority: priority) {
+        task = Task(priority: priority) { @MainActor in
           guard !Task.isCancelled else { return }
           let output = await operation()
           guard !Task.isCancelled else { return }
@@ -85,7 +85,7 @@ import SwiftUI
     ) -> Self where Failure == Error {
       Deferred<Publishers.HandleEvents<PassthroughSubject<Output, Failure>>> {
         let subject = PassthroughSubject<Output, Failure>()
-        let task = Task(priority: priority) {
+        let task = Task(priority: priority) { @MainActor in
           do {
             try Task.checkCancellation()
             let output = try await operation()


### PR DESCRIPTION
This should fix #1130, but it's also something we will be doing in our upcoming TCA concurrency updates, so might as well get a little bit of this in now.

Effectively this means that one no longer needs to do `Effect.task { @MainActor ... }` if using this API inside a reducer. It will be done automatically for you, and you don't even need `.receive(on: ...)`.

_However_, we still do [not recommend](https://github.com/pointfreeco/swift-composable-architecture/blob/bd919feddb51e08e66fdb89ca92588de1f38c710/Sources/ComposableArchitecture/Effects/Concurrency.swift#L23-L30) using `Effect.task` directly in a reducer unless you are willing to deal with the annoyances that come with it when testing. In particular, you either need to add some super short expectations in order to allow the task to do its work, or you need to make your test `async` and sprinkle in some `await Task.yield()`s.

Our upcoming concurrency tools for TCA will make this much nicer.