### PR TITLE
Add more benchmarks

### DIFF
--- a/Sources/swift-composable-architecture-benchmark/Bindings.swift
+++ b/Sources/swift-composable-architecture-benchmark/Bindings.swift
@@ -1,0 +1,33 @@
+import Benchmark
+import ComposableArchitecture
+
+let bindingSuite = BenchmarkSuite(name: "Bindings") { suite in
+  do {
+    let store = Store(
+      initialState: .init(),
+      reducer: baseReducer,
+      environment: .init())
+    let viewStore = ViewStore(store)
+
+    suite.benchmark("AdHoc") {
+      viewStore.send(.setInteger(10))
+    } tearDown: {
+      precondition(viewStore.integer == 10)
+    }
+  }
+  
+  do {
+    let store = Store(
+      initialState: .init(),
+      reducer: Reducer<BindableBaseState, BindableBaseAction, BaseEnvironment> { _, _, _ in .none }
+        .binding(),
+      environment: .init())
+    let viewStore = ViewStore(store)
+
+    suite.benchmark("Binding") {
+      viewStore.send(.set(\.$integer, 10))
+    } tearDown: {
+      precondition(viewStore.integer == 10)
+    }
+  }
+}

--- a/Sources/swift-composable-architecture-benchmark/Composition.swift
+++ b/Sources/swift-composable-architecture-benchmark/Composition.swift
@@ -1,0 +1,53 @@
+import Benchmark
+import ComposableArchitecture
+
+
+let compositionSuite = BenchmarkSuite(name: "Composition") {
+  $0.benchmarkNormalStore(label: "Reference", reducer: baseReducer)
+  // Ideally, should be the closest possible to "Base"
+  $0.benchmarkNormalStore(label: "Combined", reducer: .combine(baseReducer))
+  // Ideally, should be the closest possible to "Base"
+  $0.benchmarkNormalStore(label: "CombinedWithEmpty", reducer: .combine(baseReducer, .empty))
+}
+
+extension BenchmarkSuite {
+  func benchmarkNormalStore(label: String, reducer: Reducer<BaseState, BaseAction, BaseEnvironment>) {
+    var _store: Store<BaseState, BaseAction>?
+    self.benchmark("\(label).Instantiate") {
+      _store = .init(
+        initialState: .init(),
+        reducer: reducer,
+        environment: .init()
+      )
+    } setUp: {
+      _store = nil
+    } tearDown: {
+      precondition(_store != nil)
+    }
+
+    let store = Store(
+      initialState: .init(),
+      reducer: reducer,
+      environment: .init()
+    )
+    let viewStore = ViewStore(store)
+
+    self.benchmark("\(label).ReduceAction") {
+      viewStore.send(.reset)
+    } tearDown: {
+      precondition(viewStore.string == "")
+    }
+    
+    self.benchmark("\(label).ReduceIndirectAction") {
+      viewStore.send(.reset)
+    } tearDown: {
+      precondition(viewStore.string == "")
+    }
+    
+    self.benchmark("\(label).ReduceIndirectActionViaEnvironment") {
+      viewStore.send(.indirectResetViaEnvironment)
+    } tearDown: {
+      precondition(viewStore.string == "")
+    }
+  }
+}

--- a/Sources/swift-composable-architecture-benchmark/Composition.swift
+++ b/Sources/swift-composable-architecture-benchmark/Composition.swift
@@ -39,7 +39,7 @@ extension BenchmarkSuite {
     }
     
     self.benchmark("\(label).ReduceIndirectAction") {
-      viewStore.send(.reset)
+      viewStore.send(.indirectReset)
     } tearDown: {
       precondition(viewStore.string == "")
     }

--- a/Sources/swift-composable-architecture-benchmark/Internal/Benchmarks.swift
+++ b/Sources/swift-composable-architecture-benchmark/Internal/Benchmarks.swift
@@ -1,0 +1,47 @@
+import Benchmark
+
+extension BenchmarkSuite {
+  func benchmark(
+    _ name: String,
+    run: @escaping () throws -> Void,
+    setUp: @escaping () -> Void = {},
+    tearDown: @escaping () -> Void
+  ) {
+    self.register(
+      benchmark: Benchmarking(name: name, run: run, setUp: setUp, tearDown: tearDown)
+    )
+  }
+}
+
+struct Benchmarking: AnyBenchmark {
+  let name: String
+  let settings: [BenchmarkSetting] = []
+  private let _run: () throws -> Void
+  private let _setUp: () -> Void
+  private let _tearDown: () -> Void
+
+  init(
+    name: String,
+    run: @escaping () throws -> Void,
+    setUp: @escaping () -> Void = {},
+    tearDown: @escaping () -> Void = {}
+  ) {
+    self.name = name
+    self._run = run
+    self._setUp = setUp
+    self._tearDown = tearDown
+  }
+
+  func setUp() {
+    self._setUp()
+  }
+
+  @inline(never)
+  func run(_ state: inout BenchmarkState) throws {
+    try self._run()
+  }
+
+  func tearDown() {
+    self._tearDown()
+  }
+}

--- a/Sources/swift-composable-architecture-benchmark/Model.swift
+++ b/Sources/swift-composable-architecture-benchmark/Model.swift
@@ -1,0 +1,72 @@
+import ComposableArchitecture
+
+// MARK: - States
+struct BaseState: Equatable {
+  var string: String = ""
+  var integer: Int = 0
+}
+
+struct BindableBaseState: Equatable {
+  @BindableState var string: String = ""
+  @BindableState var integer: Int = 0
+}
+
+struct RootState: Equatable {
+  var base: BaseState = .init()
+}
+
+// MARK: - Actions
+enum BaseAction {
+  case reset
+  case setString(String)
+  case setInteger(Int)
+  case indirectReset
+  case indirectResetViaEnvironment
+}
+
+enum BindableBaseAction: BindableAction {
+  case binding(BindingAction<BindableBaseState>)
+  case reset
+  case setString(String)
+  case setInteger(Int)
+  case indirectReset
+  case indirectResetViaEnvironment
+}
+
+enum RootAction {
+  case base(BaseAction)
+}
+
+// MARK: - Environments
+struct BaseEnvironment {
+  var effect: Effect<BaseAction, Never> {
+    Effect(value: .reset)
+  }
+}
+
+// MARK: - Reducers
+let baseReducer: Reducer<BaseState, BaseAction, BaseEnvironment> = .init {
+  state, action, environment in
+  switch action {
+  case .reset:
+    state.integer = 0
+    state.string = ""
+    return .none
+  case let .setString(string):
+    state.string = string
+    return .none
+  case let .setInteger(integer):
+    state.integer = integer
+    return .none
+  case .indirectReset:
+    return Effect(value: .reset)
+  case .indirectResetViaEnvironment:
+    return environment.effect
+  }
+}
+
+let rootReducer = baseReducer.pullback(
+  state: \RootState.base,
+  action: /RootAction.base,
+  environment: { $0 }
+)

--- a/Sources/swift-composable-architecture-benchmark/Scoping.swift
+++ b/Sources/swift-composable-architecture-benchmark/Scoping.swift
@@ -16,8 +16,20 @@ let scopingSuite = BenchmarkSuite(name: "Scoping") { suite in
   do {
     let store = Store(initialState: .init(), reducer: rootReducer, environment: .init())
     var scoped: Store<BaseState, BaseAction>?
-    suite.benchmark("Scoped.Instantiate") {
+    suite.benchmark("Scoped.Instantiate.KeyPath") {
       scoped = store.scope(state: \.base, action: RootAction.base)
+    } setUp: {
+      scoped = nil
+    } tearDown: {
+      precondition(scoped != nil)
+    }
+  }
+  
+  do {
+    let store = Store(initialState: .init(), reducer: rootReducer, environment: .init())
+    var scoped: Store<BaseState, BaseAction>?
+    suite.benchmark("Scoped.Instantiate.Closure") {
+      scoped = store.scope(state: { $0.base }, action: RootAction.base)
     } setUp: {
       scoped = nil
     } tearDown: {

--- a/Sources/swift-composable-architecture-benchmark/Scoping.swift
+++ b/Sources/swift-composable-architecture-benchmark/Scoping.swift
@@ -82,7 +82,7 @@ let scopingSuite = BenchmarkSuite(name: "Scoping") { suite in
     }
     viewStore1.send(false)
 
-    suite.benchmark("Chain.2") {
+    suite.benchmark("Chain.3") {
       viewStore4.send(true)
     }
   }

--- a/Sources/swift-composable-architecture-benchmark/Scoping.swift
+++ b/Sources/swift-composable-architecture-benchmark/Scoping.swift
@@ -1,0 +1,85 @@
+import Benchmark
+import ComposableArchitecture
+
+let scopingSuite = BenchmarkSuite(name: "Scoping") { suite in
+  do {
+    var store: Store<BaseState, BaseAction>?
+    suite.benchmark("Standalone.Instantiate") {
+      store = .init(initialState: .init(), reducer: baseReducer, environment: .init())
+    } tearDown: {
+      precondition(store != nil)
+    }
+  }
+
+  do {
+    let store = Store(initialState: .init(), reducer: rootReducer, environment: .init())
+    var scoped: Store<BaseState, BaseAction>?
+    suite.benchmark("Scoped.Instantiate") {
+      scoped = store.scope(state: \.base, action: RootAction.base)
+    } tearDown: {
+      precondition(scoped != nil)
+    }
+  }
+
+  do {
+    let store = Store(initialState: .init(), reducer: baseReducer, environment: .init())
+    let viewStore = ViewStore(store)
+
+    suite.benchmark("Standalone.ReduceAction") {
+      viewStore.send(.setInteger(1))
+    } tearDown: {
+      precondition(viewStore.integer == 1)
+    }
+  }
+
+  do {
+    let store = Store(initialState: .init(), reducer: rootReducer, environment: .init())
+    let scoped = store.scope(state: \.base, action: RootAction.base)
+    let viewStore = ViewStore(scoped)
+    suite.benchmark("Scoped.ReduceAction") {
+      viewStore.send(.setInteger(1))
+    } tearDown: {
+      precondition(viewStore.integer == 1)
+    }
+  }
+  
+  do {
+    let counterReducer = Reducer<Int, Bool, Void> { state, action, _ in
+      if action {
+        state += 1
+      } else {
+        state = 0
+      }
+      return .none
+    }
+
+    let store1 = Store(initialState: 0, reducer: counterReducer, environment: ())
+    let store2 = store1.scope { $0 }
+    let store3 = store2.scope { $0 }
+    let store4 = store3.scope { $0 }
+
+    let viewStore1 = ViewStore(store1)
+    let viewStore2 = ViewStore(store2)
+    let viewStore3 = ViewStore(store3)
+    let viewStore4 = ViewStore(store4)
+
+    suite.benchmark("Chain.0") {
+      viewStore1.send(true)
+    }
+    viewStore1.send(false)
+
+    suite.benchmark("Chain.1") {
+      viewStore2.send(true)
+    }
+    viewStore1.send(false)
+
+    suite.benchmark("Chain.2") {
+      viewStore3.send(true)
+    }
+    viewStore1.send(false)
+
+    suite.benchmark("Chain.2") {
+      viewStore4.send(true)
+    }
+  }
+}

--- a/Sources/swift-composable-architecture-benchmark/Scoping.swift
+++ b/Sources/swift-composable-architecture-benchmark/Scoping.swift
@@ -6,6 +6,8 @@ let scopingSuite = BenchmarkSuite(name: "Scoping") { suite in
     var store: Store<BaseState, BaseAction>?
     suite.benchmark("Standalone.Instantiate") {
       store = .init(initialState: .init(), reducer: baseReducer, environment: .init())
+    } setUp: {
+      store = nil
     } tearDown: {
       precondition(store != nil)
     }
@@ -16,6 +18,8 @@ let scopingSuite = BenchmarkSuite(name: "Scoping") { suite in
     var scoped: Store<BaseState, BaseAction>?
     suite.benchmark("Scoped.Instantiate") {
       scoped = store.scope(state: \.base, action: RootAction.base)
+    } setUp: {
+      scoped = nil
     } tearDown: {
       precondition(scoped != nil)
     }

--- a/Sources/swift-composable-architecture-benchmark/ViewStores.swift
+++ b/Sources/swift-composable-architecture-benchmark/ViewStores.swift
@@ -1,0 +1,34 @@
+import Benchmark
+import ComposableArchitecture
+
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
+
+let viewStoreSuite = BenchmarkSuite(name: "ViewStore") { suite in
+  do {
+    let store = Store(initialState: .init(), reducer: baseReducer, environment: .init())
+    var viewStore: ViewStore<BaseState, BaseAction>?
+    suite.benchmark("Intantiate") {
+      viewStore = ViewStore(store)
+    } tearDown: {
+      precondition(viewStore != nil)
+    }
+  }
+  
+  #if canImport(SwiftUI)
+  do {
+    let store = Store(initialState: .init(), reducer: baseReducer, environment: .init())
+    var view: WithViewStore<BaseState, BaseAction, Color>?
+    let color = Color.clear
+    var body: Color?
+    suite.benchmark("Intantiate.WithViewStore->Body") {
+      body = WithViewStore(store) { _ in
+        color
+      }.body
+    } tearDown: {
+      precondition(body != nil)
+    }
+  }
+  #endif
+}

--- a/Sources/swift-composable-architecture-benchmark/main.swift
+++ b/Sources/swift-composable-architecture-benchmark/main.swift
@@ -7,4 +7,5 @@ Benchmark.main([
   bindingSuite,
   compositionSuite,
   scopingSuite,
+  viewStoreSuite,
 ])

--- a/Sources/swift-composable-architecture-benchmark/main.swift
+++ b/Sources/swift-composable-architecture-benchmark/main.swift
@@ -1,42 +1,10 @@
 import Benchmark
 import ComposableArchitecture
 
-let counterReducer = Reducer<Int, Bool, Void> { state, action, _ in
-  if action {
-    state += 1
-  } else {
-    state = 0
-  }
-  return .none
-}
-
-let store1 = Store(initialState: 0, reducer: counterReducer, environment: ())
-let store2 = store1.scope { $0 }
-let store3 = store2.scope { $0 }
-let store4 = store3.scope { $0 }
-
-let viewStore1 = ViewStore(store1)
-let viewStore2 = ViewStore(store2)
-let viewStore3 = ViewStore(store3)
-let viewStore4 = ViewStore(store4)
-
-benchmark("Scoping (1)") {
-  viewStore1.send(true)
-}
-viewStore1.send(false)
-
-benchmark("Scoping (2)") {
-  viewStore2.send(true)
-}
-viewStore1.send(false)
-
-benchmark("Scoping (3)") {
-  viewStore3.send(true)
-}
-viewStore1.send(false)
-
-benchmark("Scoping (4)") {
-  viewStore4.send(true)
-}
-
-Benchmark.main()
+Benchmark.main([
+  defaultBenchmarkSuite,
+  
+  bindingSuite,
+  compositionSuite,
+  scopingSuite,
+])


### PR DESCRIPTION
In its current state, the library has very few and unidimensional benchmarks. I think that better coverage can't hurt, especially with the upcoming work in experimental branches.

I've added a few benchmarks to assess various metrics from the library, measuring the time it takes to:
- Instantiate a store;
- Reduce an action that sets a value in the state;
- Reduce an action that sends another action;
- Reduce an action that sends an action extracted from the environment (1);
- Perform these actions with a reference reducer, the same one wrapped with `.combine`, and the same one combined with `.empty` (2);
- Set a value through a binding vs manually;
- Scope a store;
- Reduce the action of a scoped store;
- Reduce an action through various levels of scoping (the current benchmarks).

(1) and (2) are there mostly in prevision of the `proto` branches, where `Environment` handling and reducer composition are expected to change significantly.

Running the suites on `main` gives:
```text
name                                                             time         std        iterations
---------------------------------------------------------------------------------------------------
Bindings.AdHoc                                                    2250.000 ns ±  28.16 %     586579
Bindings.Binding                                                  3541.000 ns ±  77.31 %     391998

Composition.Reference.Instantiate                                  167.000 ns ±  43.30 %    1000000
Composition.Reference.ReduceAction                                2250.000 ns ±  12.09 %     606411
Composition.Reference.ReduceIndirectAction                        4541.000 ns ±   7.50 %     302367
Composition.Reference.ReduceIndirectActionViaEnvironment          4583.000 ns ±  19.97 %     302824

Composition.Combined.Instantiate                                   167.000 ns ± 101.85 %    1000000
Composition.Combined.ReduceAction                                 5292.000 ns ±  17.77 %     258861
Composition.Combined.ReduceIndirectAction                        10833.000 ns ±  15.77 %     124340
Composition.Combined.ReduceIndirectActionViaEnvironment          10792.000 ns ±  14.27 %     127728

Composition.CombinedWithEmpty.Instantiate                          167.000 ns ±  95.68 %    1000000
Composition.CombinedWithEmpty.ReduceAction                        6333.000 ns ±  15.54 %     218620
Composition.CombinedWithEmpty.ReduceIndirectAction               13041.000 ns ±  10.45 %     106062
Composition.CombinedWithEmpty.ReduceIndirectActionViaEnvironment 13042.000 ns ±  11.78 %     104510

Scoping.Standalone.Instantiate                                     167.000 ns ±  97.32 %    1000000
Scoping.Scoped.Instantiate                                        1500.000 ns ±  28.81 %     911710

Scoping.Standalone.ReduceAction                                   2250.000 ns ±  14.81 %     604678
Scoping.Scoped.ReduceAction                                       5500.000 ns ±  12.83 %     249153

Scoping.Chain.0                                                   4584.000 ns ±  16.29 %     299323
Scoping.Chain.1                                                   6459.000 ns ±   5.60 %     210243
Scoping.Chain.2                                                   8166.000 ns ±  27.06 %     169969
Scoping.Chain.3                                                  10084.000 ns ±  13.95 %     132491
```
I could make a few comments about these results, but that's not the topic of this PR. 

There are probably many other interesting things to keep in check. I'm thus keeping the PR as a draft for now.

What do you think about it?