### PR TITLE
Add animation operator to Effect.

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Animation.swift
+++ b/Sources/ComposableArchitecture/Effects/Animation.swift
@@ -1,7 +1,7 @@
 import Combine
 import SwiftUI
 
-extension Publisher {
+extension Effect {
   /// Wraps the emission of each element with SwiftUI's `withAnimation`.
   ///
   /// This publisher is most useful when using with ``Effect/task(priority:operation:)-2czg0``
@@ -16,7 +16,7 @@ extension Publisher {
   ///
   /// - Parameter animation: An animation.
   /// - Returns: A publisher.
-  public func animation(_ animation: Animation? = .default) -> Effect<Output, Failure> {
+  public func animation(_ animation: Animation? = .default) -> Self {
     AnimatedPublisher(upstream: self, animation: animation)
       .eraseToEffect()
   }

--- a/Sources/ComposableArchitecture/Effects/Animation.swift
+++ b/Sources/ComposableArchitecture/Effects/Animation.swift
@@ -1,0 +1,64 @@
+import Combine
+import SwiftUI
+
+extension Publisher {
+  /// Wraps the emission of each element with SwiftUI's `withAnimation`.
+  ///
+  /// This publisher is most useful when using with ``Effect/task(priority:operation:)-2czg0``
+  ///
+  /// ```swift
+  /// case .buttonTapped:
+  ///   return .task {
+  ///     .activityResponse(await environment.apiClient.fetchActivity())
+  ///   }
+  ///   .animation()
+  /// ```
+  ///
+  /// - Parameter animation: An animation.
+  /// - Returns: A publisher.
+  public func animation(_ animation: Animation? = .default) -> Effect<Output, Failure> {
+    AnimatedPublisher(upstream: self, animation: animation)
+      .eraseToEffect()
+  }
+}
+
+private struct AnimatedPublisher<Upstream: Publisher>: Publisher {
+  typealias Output = Upstream.Output
+  typealias Failure = Upstream.Failure
+
+  var upstream: Upstream
+  var animation: Animation?
+
+  func receive<S: Combine.Subscriber>(subscriber: S)
+  where S.Input == Output, S.Failure == Failure {
+    let conduit = Subscriber(downstream: subscriber, animation: self.animation)
+    self.upstream.receive(subscriber: conduit)
+  }
+
+  private class Subscriber<Downstream: Combine.Subscriber>: Combine.Subscriber {
+    typealias Input = Downstream.Input
+    typealias Failure = Downstream.Failure
+
+    let downstream: Downstream
+    let animation: Animation?
+
+    init(downstream: Downstream, animation: Animation?) {
+      self.downstream = downstream
+      self.animation = animation
+    }
+
+    func receive(subscription: Subscription) {
+      self.downstream.receive(subscription: subscription)
+    }
+
+    func receive(_ input: Input) -> Subscribers.Demand {
+      withAnimation(self.animation) {
+        self.downstream.receive(input)
+      }
+    }
+
+    func receive(completion: Subscribers.Completion<Failure>) {
+      self.downstream.receive(completion: completion)
+    }
+  }
+}

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -176,8 +176,8 @@
 
     /// The current state.
     ///
-    /// When read from a trailing closure assertion in ``send`` or ``receive``, it will equal the
-    /// `inout` state passed to the closure.
+    /// When read from a trailing closure assertion in ``send(_:_:file:line:)`` or
+    /// ``receive(_:_:file:line:)``, it will equal the `inout` state passed to the closure.
     public private(set) var state: State
 
     private let file: StaticString


### PR DESCRIPTION
This was brought up a long time ago by @mayoff in the Swift [forums](https://forums.swift.org/t/an-alternative-take-on-animating-asynchronous-effects/45000), but at the time we didn't think it was necessary since scheduler animations seemed to cover all its use cases. However, with some of the concurrency updates we will be bringing to the library soon this kind of operator is going to be handy when used with `Effect.task`.