### PR TITLE
Rename `ViewStore.suspend(while:)` to `yield(while:)`

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -3,6 +3,15 @@ import Combine
 import SwiftUI
 import XCTestDynamicOverlay
 
+// NB: Deprecated after 0.36.0:
+
+extension ViewStore {
+  @available(*, deprecated, renamed: "yield(while:)")
+  public func suspend(while predicate: @escaping (State) -> Bool) async {
+    await self.yield(while: predicate)
+  }
+}
+
 // NB: Deprecated after 0.34.0:
 
 extension Effect {

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -440,7 +440,7 @@ private struct HashableWrapper<Value>: Hashable {
       while predicate: @escaping (State) -> Bool
     ) async {
       self.send(action)
-      await self.suspend(while: predicate)
+      await self.yield(while: predicate)
     }
 
     /// Sends an action into the store and then suspends while a piece of state is `true`.
@@ -458,14 +458,17 @@ private struct HashableWrapper<Value>: Hashable {
       while predicate: @escaping (State) -> Bool
     ) async {
       withAnimation(animation) { self.send(action) }
-      await self.suspend(while: predicate)
+      await self.yield(while: predicate)
     }
 
-    /// Suspends while a predicate on state is `true`.
+    /// Suspends the current task while a predicate on state is `true`.
+    ///
+    /// If you want to suspend at the same time you send an action to the view store, use
+    /// ``send(_:while:)``.
     ///
     /// - Parameter predicate: A predicate on `State` that determines for how long this method
     ///   should suspend.
-    public func suspend(while predicate: @escaping (State) -> Bool) async {
+    public func yield(while predicate: @escaping (State) -> Bool) async {
       if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
         _ = await self.publisher
           .values

--- a/Tests/ComposableArchitectureTests/ViewStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/ViewStoreTests.swift
@@ -226,7 +226,7 @@ final class ViewStoreTests: XCTestCase {
         XCTAssertNoDifference(viewStore.state, false)
         viewStore.send(.tapped)
         XCTAssertNoDifference(viewStore.state, true)
-        await viewStore.suspend(while: { $0 })
+        await viewStore.yield(while: { $0 })
         XCTAssertNoDifference(viewStore.state, false)
         expectation.fulfill()
       }


### PR DESCRIPTION
The naming of `ViewStore.suspend(while:)` was inspired by `Task.suspend()`, which was deprecated and renamed to `Task.yield()` long ago. Let's do the same here and call it `ViewStore.yield(while:)`.
