### PR TITLE
Show runtime warnings when the stack allocation reaches 95%

### DIFF
--- a/Sources/ComposableArchitecture/Internal/StackStatus.swift
+++ b/Sources/ComposableArchitecture/Internal/StackStatus.swift
@@ -7,7 +7,6 @@ struct StackStatus {
 
   init() {
     let thread = pthread_self()
-    let stackSize = UInt(pthread_get_stacksize_np(thread))
     let stackAddress = UInt(bitPattern: pthread_get_stackaddr_np(thread))
     var used: UInt = 0
     withUnsafeMutablePointer(to: &used) {
@@ -19,7 +18,7 @@ struct StackStatus {
         ? stackAddress - pointerAddress
         : pointerAddress - stackAddress
     }
-    self.stackSize = stackSize
+    self.stackSize = UInt(pthread_get_stacksize_np(thread))
     self.used = used
   }
 }

--- a/Sources/ComposableArchitecture/Internal/StackStatus.swift
+++ b/Sources/ComposableArchitecture/Internal/StackStatus.swift
@@ -1,0 +1,25 @@
+struct StackStatus {
+  let stackSize: UInt
+  let used: UInt
+
+  var available: UInt { stackSize - used }
+  var usedFraction: Double { Double(used) / Double(stackSize) }
+
+  init() {
+    let thread = pthread_self()
+    let stackSize = UInt(pthread_get_stacksize_np(thread))
+    let stackAddress = UInt(bitPattern: pthread_get_stackaddr_np(thread))
+    var used: UInt = 0
+    withUnsafeMutablePointer(to: &used) {
+      let pointerAddress = UInt(bitPattern: $0)
+      // Stack goes down on x86/64 and arm, but we rectify the result in any case this code
+      // executes on another architecture using a different convention.
+      $0.pointee =
+        stackAddress > pointerAddress
+        ? stackAddress - pointerAddress
+        : pointerAddress - stackAddress
+    }
+    self.stackSize = stackSize
+    self.used = used
+  }
+}

--- a/Sources/ComposableArchitecture/Internal/StackStatus.swift
+++ b/Sources/ComposableArchitecture/Internal/StackStatus.swift
@@ -1,24 +1,26 @@
-struct StackStatus {
-  let stackSize: UInt
-  let used: UInt
+#if DEBUG
+  struct StackStatus {
+    let stackSize: UInt
+    let used: UInt
 
-  var available: UInt { stackSize - used }
-  var usedFraction: Double { Double(used) / Double(stackSize) }
+    var available: UInt { stackSize - used }
+    var usedFraction: Double { Double(used) / Double(stackSize) }
 
-  init() {
-    let thread = pthread_self()
-    let stackAddress = UInt(bitPattern: pthread_get_stackaddr_np(thread))
-    var used: UInt = 0
-    withUnsafeMutablePointer(to: &used) {
-      let pointerAddress = UInt(bitPattern: $0)
-      // Stack goes down on x86/64 and arm, but we rectify the result in any case this code
-      // executes on another architecture using a different convention.
-      $0.pointee =
-        stackAddress > pointerAddress
-        ? stackAddress - pointerAddress
-        : pointerAddress - stackAddress
+    init() {
+      let thread = pthread_self()
+      let stackAddress = UInt(bitPattern: pthread_get_stackaddr_np(thread))
+      var used: UInt = 0
+      withUnsafeMutablePointer(to: &used) {
+        let pointerAddress = UInt(bitPattern: $0)
+        // Stack goes down on x86/64 and arm, but we rectify the result in any case this code
+        // executes on another architecture using a different convention.
+        $0.pointee =
+          stackAddress > pointerAddress
+          ? stackAddress - pointerAddress
+          : pointerAddress - stackAddress
+      }
+      self.stackSize = UInt(pthread_get_stacksize_np(thread))
+      self.used = used
     }
-    self.stackSize = UInt(pthread_get_stacksize_np(thread))
-    self.used = used
   }
-}
+#endif

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -527,15 +527,15 @@ public final class Store<State, Action> {
       guard self.stackChecksEnabled else { return }
       // Disable in scoped stores
       guard self.parentCancellable == nil else { return }
-      let threshold: Double = 0.95
+      let threshold: UInt = 50_000
       let status = StackStatus()
-      guard status.usedFraction > threshold else { return }
+      guard status.available < threshold else { return }
       
       // We warn only once, but scoped stores could pass through on `init` as their
       // parent cancellable is nil at this point. So we use the `threadDictionary`.
       // This path is only hit once per store lifetime, and only when the stack depth is
       // beyond the threshold.
-      let threadDictionaryKey = "co.pointfree.ComposableArchitecture.stack-checked-warned"
+      let threadDictionaryKey = "co.pointfree.ComposableArchitecture.stack-check-warned"
       guard Thread.current.threadDictionary[threadDictionaryKey] == nil else { return }
       defer {
         self.stackChecksEnabled = false
@@ -568,7 +568,8 @@ public final class Store<State, Action> {
         #advice-use-copy-on-write-semantics-for-large-values" for example). If the property is an \
         "enum", you can simply mark it as "indirect", producing the same effect.
         
-        "Array", "Set", "Dictionary" or "IdentifiedArray" are already storing their content on the heap.
+        "Array", "Set", "Dictionary" or "IdentifiedArray" are already storing their content on the \
+        heap.
         """,
         [
           String(format: "%.0f%%", status.usedFraction * 100),

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -426,105 +426,104 @@ public final class Store<State, Action> {
     #endif
   }
 
-  @inline(__always)
-  private func threadCheck(event: Event) {
-    #if DEBUG
-      guard self.mainThreadChecksEnabled && !Thread.isMainThread
-      else { return }
-
-      switch event {
-      case let .effectCompletion(action):
-        runtimeWarning(
-          """
-          An effect completed on a non-main thread. …
-
-            Effect returned from:
-              %@
-
-          Make sure to use ".receive(on:)" on any effects that execute on background threads to \
-          receive their output on the main thread, or create your store via "Store.unchecked" to \
-          opt out of the main thread checker.
-
-          The "Store" class is not thread-safe, and so all interactions with an instance of \
-          "Store" (including all of its scopes and derived view stores) must be done on the same \
-          thread.
-          """,
-          [debugCaseOutput(action)]
-        )
-
-      case .`init`:
-        runtimeWarning(
-          """
-          A store initialized on a non-main thread. …
-
-          If a store is intended to be used on a background thread, create it via \
-          "Store.unchecked" to opt out of the main thread checker.
-
-          The "Store" class is not thread-safe, and so all interactions with an instance of \
-          "Store" (including all of its scopes and derived view stores) must be done on the same \
-          thread.
-          """
-        )
-
-      case .scope:
-        runtimeWarning(
-          """
-          "Store.scope" was called on a non-main thread. …
-
-          Make sure to use "Store.scope" on the main thread, or create your store via \
-          "Store.unchecked" to opt out of the main thread checker.
-
-          The "Store" class is not thread-safe, and so all interactions with an instance of \
-          "Store" (including all of its scopes and derived view stores) must be done on the same \
-          thread.
-          """
-        )
-
-      case let .send(action, originatingAction: nil):
-        runtimeWarning(
-          """
-          "ViewStore.send" was called on a non-main thread with: %@ …
-
-          Make sure that "ViewStore.send" is always called on the main thread, or create your \
-          store via "Store.unchecked" to opt out of the main thread checker.
-
-          The "Store" class is not thread-safe, and so all interactions with an instance of \
-          "Store" (including all of its scopes and derived view stores) must be done on the same \
-          thread.
-          """,
-          [debugCaseOutput(action)]
-        )
-
-      case let .send(action, originatingAction: .some(originatingAction)):
-        runtimeWarning(
-          """
-          An effect published an action on a non-main thread. …
-
-            Effect published:
-              %@
-
-            Effect returned from:
-              %@
-
-          Make sure to use ".receive(on:)" on any effects that execute on background threads to \
-          receive their output on the main thread, or create this store via "Store.unchecked" to \
-          disable the main thread checker.
-
-          The "Store" class is not thread-safe, and so all interactions with an instance of \
-          "Store" (including all of its scopes and derived view stores) must be done on the same \
-          thread.
-          """,
-          [
-            debugCaseOutput(action),
-            debugCaseOutput(originatingAction),
-          ]
-        )
-      }
-    #endif
-  }
-  
-  private func stackCheck(event: Event) {
   #if DEBUG
+  private func threadCheck(event: Event) {
+    guard self.mainThreadChecksEnabled && !Thread.isMainThread
+    else { return }
+
+    switch event {
+    case let .effectCompletion(action):
+      runtimeWarning(
+        """
+        An effect completed on a non-main thread. …
+
+          Effect returned from:
+            %@
+
+        Make sure to use ".receive(on:)" on any effects that execute on background threads to \
+        receive their output on the main thread, or create your store via "Store.unchecked" to \
+        opt out of the main thread checker.
+
+        The "Store" class is not thread-safe, and so all interactions with an instance of \
+        "Store" (including all of its scopes and derived view stores) must be done on the same \
+        thread.
+        """,
+        [debugCaseOutput(action)]
+      )
+
+    case .`init`:
+      runtimeWarning(
+        """
+        A store initialized on a non-main thread. …
+
+        If a store is intended to be used on a background thread, create it via \
+        "Store.unchecked" to opt out of the main thread checker.
+
+        The "Store" class is not thread-safe, and so all interactions with an instance of \
+        "Store" (including all of its scopes and derived view stores) must be done on the same \
+        thread.
+        """
+      )
+
+    case .scope:
+      runtimeWarning(
+        """
+        "Store.scope" was called on a non-main thread. …
+
+        Make sure to use "Store.scope" on the main thread, or create your store via \
+        "Store.unchecked" to opt out of the main thread checker.
+
+        The "Store" class is not thread-safe, and so all interactions with an instance of \
+        "Store" (including all of its scopes and derived view stores) must be done on the same \
+        thread.
+        """
+      )
+
+    case let .send(action, originatingAction: nil):
+      runtimeWarning(
+        """
+        "ViewStore.send" was called on a non-main thread with: %@ …
+
+        Make sure that "ViewStore.send" is always called on the main thread, or create your \
+        store via "Store.unchecked" to opt out of the main thread checker.
+
+        The "Store" class is not thread-safe, and so all interactions with an instance of \
+        "Store" (including all of its scopes and derived view stores) must be done on the same \
+        thread.
+        """,
+        [debugCaseOutput(action)]
+      )
+
+    case let .send(action, originatingAction: .some(originatingAction)):
+      runtimeWarning(
+        """
+        An effect published an action on a non-main thread. …
+
+          Effect published:
+            %@
+
+          Effect returned from:
+            %@
+
+        Make sure to use ".receive(on:)" on any effects that execute on background threads to \
+        receive their output on the main thread, or create this store via "Store.unchecked" to \
+        disable the main thread checker.
+
+        The "Store" class is not thread-safe, and so all interactions with an instance of \
+        "Store" (including all of its scopes and derived view stores) must be done on the same \
+        thread.
+        """,
+        [
+          debugCaseOutput(action),
+          debugCaseOutput(originatingAction),
+        ]
+      )
+    }
+  }
+  #endif
+  
+  #if DEBUG
+  private func stackCheck(event: Event) {
     guard self.stackChecksEnabled else { return }
     // Disable in scoped stores
     guard self.parentCancellable == nil else { return }
@@ -544,44 +543,44 @@ public final class Store<State, Action> {
     }
     
     runtimeWarning(
-    """
-    The thread's stack depth is reaching %@ of its capacity. …
-    
-      Stack size:
-        %@
-    
-      Used stack memory:
-        %@
-    
-      Available stack memory:
-        %@
-    
-      Size on the stack of the State managed by this store:
-        %@
-    
-    If the stack deepens more, it risks to overflow and the app will crash.
-        
-    The state that this store manages is occupying %@ bytes on the stack. If this value is \
-    too large with respect to the stack size and your app logic, you can relocate some of its \
-    properties on the heap. If a property is a value type, you can try to "box" it into a \
-    reference type. One way to achieve this is using a dedicated property wrapper (See \
-    "https://github.com/apple/swift/blob/main/docs/OptimizationTips.rst\
-    #advice-use-copy-on-write-semantics-for-large-values" for example). If the property is an \
-    "enum", you can simply mark it as "indirect", producing the same effect.
-    
-    "Array", "Set", "Dictionary" or "IdentifiedArray" are already storing their content on the heap.
-    """,
-    [
-      String(format: "%.0f%%", status.usedFraction * 100),
-      "\(status.stackSize)",
-      "\(status.used)",
-      "\(status.available)",
-      "\(MemoryLayout<State>.size)",
-      "\(MemoryLayout<State>.size)"
-    ]
+      """
+      The thread's stack depth is reaching %@ of its capacity. …
+      
+        Stack size:
+          %@
+      
+        Used stack memory:
+          %@
+      
+        Available stack memory:
+          %@
+      
+        Size on the stack of the State managed by this store:
+          %@
+      
+      If the stack deepens more, it risks to overflow and the app will crash.
+          
+      The state that this store manages is occupying %@ bytes on the stack. If this value is \
+      too large with respect to the stack size and your app logic, you can relocate some of its \
+      properties on the heap. If a property is a value type, you can try to "box" it into a \
+      reference type. One way to achieve this is using a dedicated property wrapper (See \
+      "https://github.com/apple/swift/blob/main/docs/OptimizationTips.rst\
+      #advice-use-copy-on-write-semantics-for-large-values" for example). If the property is an \
+      "enum", you can simply mark it as "indirect", producing the same effect.
+      
+      "Array", "Set", "Dictionary" or "IdentifiedArray" are already storing their content on the heap.
+      """,
+      [
+        String(format: "%.0f%%", status.usedFraction * 100),
+        "\(status.stackSize)",
+        "\(status.used)",
+        "\(status.available)",
+        "\(MemoryLayout<State>.size)",
+        "\(MemoryLayout<State>.size)"
+      ]
     )
-  #endif
   }
+  #endif
 
   private init<Environment>(
     initialState: State,

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -553,12 +553,12 @@ public final class Store<State, Action> {
           Available stack memory:
             %@
         
-          Size on the stack of the State managed by this store:
+          Size on the stack of the %@ state managed by this store:
             %@
         
         If the stack deepens more, it risks to overflow and the app will crash.
             
-        The state that this store manages is occupying %@ bytes on the stack. If this value is \
+        The state that this store manages is occupying %@ on the stack. If this value is \
         too large with respect to the stack size and your app logic, you can relocate some of its \
         properties on the heap. If a property is a value type, you can try to "box" it into a \
         reference type. One way to achieve this is using a dedicated property wrapper (See \
@@ -571,11 +571,12 @@ public final class Store<State, Action> {
         """,
         [
           String(format: "%.0f%%", status.usedFraction * 100),
-          "\(status.stackSize)",
-          "\(status.used)",
-          "\(status.available)",
-          "\(MemoryLayout<State>.size)",
-          "\(MemoryLayout<State>.size)"
+          "\(status.stackSize) bytes",
+          "\(status.used) bytes",
+          "\(status.available) bytes",
+          "\(State.self)",
+          "\(MemoryLayout<State>.size) bytes",
+          "\(MemoryLayout<State>.size) bytes"
         ]
       )
     }

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -535,11 +535,11 @@ public final class Store<State, Action> {
       // parent cancellable is nil at this point. So we use the `threadDictionary`.
       // This path is only hit once per store lifetime, and only when the stack depth is
       // beyond the threshold.
-      let threadDictionaryKey = "co.pointfree.ComposableArchitecture.stack-check-warned"
-      guard Thread.current.threadDictionary[threadDictionaryKey] == nil else { return }
+      guard Thread.current.threadDictionary[ObjectIdentifier(StackStatus.self)] == nil
+      else { return }
       defer {
         self.stackChecksEnabled = false
-        Thread.current.threadDictionary[threadDictionaryKey] = ()
+        Thread.current.threadDictionary[ObjectIdentifier(StackStatus.self)] = ()
       }
       
       runtimeWarning(

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -182,7 +182,7 @@ public final class Store<State, Action> {
       reducer: reducer,
       environment: environment,
       mainThreadChecksEnabled: false,
-      stackChecksEnabled: true
+      stackChecksEnabled: false
     )
   }
 

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -532,9 +532,7 @@ public final class Store<State, Action> {
       guard status.available < threshold else { return }
       
       // We warn only once, but scoped stores could pass through on `init` as their
-      // parent cancellable is nil at this point. So we use the `threadDictionary`.
-      // This path is only hit once per store lifetime, and only when the stack depth is
-      // beyond the threshold.
+      // parent cancellable is nil at this point.
       guard Thread.current.threadDictionary[ObjectIdentifier(StackStatus.self)] == nil
       else { return }
       defer {

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -526,7 +526,7 @@ public final class Store<State, Action> {
   private func stackCheck(event: Event) {
   #if DEBUG
     guard self.stackChecksEnabled else { return }
-    let threshold: Double = 0.95
+    let threshold: Double = 0.85
     let status = StackStatus()
     guard status.usedFraction > threshold else { return }
     let stateSize = MemoryLayout<State>.size

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -582,7 +582,7 @@ public final class Store<State, Action> {
     }
   #endif
 
-  init<Environment>(
+  private init<Environment>(
     initialState: State,
     reducer: Reducer<State, Action, Environment>,
     environment: Environment,

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -582,7 +582,7 @@ public final class Store<State, Action> {
     }
   #endif
 
-  private init<Environment>(
+  init<Environment>(
     initialState: State,
     reducer: Reducer<State, Action, Environment>,
     environment: Environment,

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -529,7 +529,7 @@ public final class Store<State, Action> {
       guard self.parentCancellable == nil else { return }
       let threshold: UInt = 50_000
       let status = StackStatus()
-      guard status.available < threshold else { return }
+      if status.available > threshold { return }
       
       // We warn only once, but scoped stores could pass through on `init` as their
       // parent cancellable is nil at this point.

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -527,7 +527,7 @@ public final class Store<State, Action> {
       guard self.stackChecksEnabled else { return }
       // Disable in scoped stores
       guard self.parentCancellable == nil else { return }
-      let threshold: Double = 0.85
+      let threshold: Double = 0.95
       let status = StackStatus()
       guard status.usedFraction > threshold else { return }
       

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -141,7 +141,7 @@ public final class Store<State, Action> {
   var state: CurrentValueSubject<State, Never>
   #if DEBUG
     private let mainThreadChecksEnabled: Bool
-    private let stackChecksEnabled: Bool
+    var stackChecksEnabled: Bool
   #endif
 
   /// Initializes a store from an initial state, a reducer, and an environment.
@@ -343,6 +343,9 @@ public final class Store<State, Action> {
       },
       environment: ()
     )
+    #if DEBUG
+    localStore.stackChecksEnabled = stackChecksEnabled
+    #endif
     localStore.parentCancellable = self.state
       .dropFirst()
       .sink { [weak localStore] newValue in

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -235,6 +235,9 @@
         },
         environment: ()
       )
+      #if DEBUG
+      store.stackChecksEnabled = false
+      #endif
     }
 
     deinit {

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -233,9 +233,7 @@
             .eraseToEffect { .init(origin: .receive($0), file: action.file, line: action.line) }
 
         },
-        environment: (),
-        mainThreadChecksEnabled: true,
-        stackChecksEnabled: false
+        environment: ()
       )
     }
 

--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -233,11 +233,10 @@
             .eraseToEffect { .init(origin: .receive($0), file: action.file, line: action.line) }
 
         },
-        environment: ()
+        environment: (),
+        mainThreadChecksEnabled: true,
+        stackChecksEnabled: false
       )
-      #if DEBUG
-      store.stackChecksEnabled = false
-      #endif
     }
 
     deinit {


### PR DESCRIPTION
Following #752, this PR makes `Store` show runtime warnings when the stack depth reaches 95%. There are many things to discuss, so obviously a draft for now.

Right now, each store can present such warnings, but it should maybe be restricted to the root store only.

As runtime warnings are inconvenient to write with their `StaticString`, I'm waiting for feedback to decide if we should produce different messages depending on the nature of the event (when receiving an action, the action itself could be the type responsible for a stack overflow).

I've unified Thread checks and Stack checks under the same banner and renamed `ThreadStatus` into `StoreEvent` accordingly.

Right now, the threshold is at 95%. This is tricky because we don't want false positives, but we also want at least one warning to be emitted before reaching the overflow. In the discussions, I've seen folks reporting 20kB states. When the stack size is 512kB (iOS, background), that's around 5%, so I guess 95% it's a fair value. We can probably go down to 90/92% to have more headroom. We could also adjust automatically according to the stack size if we assume that a 20kB state is already problematic, and emit warnings when we reach around 50kB from the end.

When the warning is emitted, the user can see the current stack status and the store's state size. I've added a few comments about workarounds. Nothing definitive of course, but I think you'll get the idea.

What do you think about this?