### PR TITLE
Move cancellation ids to end of scopes.

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -38,9 +38,6 @@ struct EffectsCancellationEnvironment {
 let effectsCancellationReducer = Reducer<
   EffectsCancellationState, EffectsCancellationAction, EffectsCancellationEnvironment
 > { state, action, environment in
-
-  enum TriviaRequestId {}
-
   switch action {
   case .cancelButtonTapped:
     state.isTriviaRequestInFlight = false
@@ -70,6 +67,8 @@ let effectsCancellationReducer = Reducer<
     state.isTriviaRequestInFlight = false
     return .none
   }
+
+  enum TriviaRequestId {}
 }
 
 // MARK: - Application view

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -35,9 +35,6 @@ struct LongLivingEffectsEnvironment {
 let longLivingEffectsReducer = Reducer<
   LongLivingEffectsState, LongLivingEffectsAction, LongLivingEffectsEnvironment
 > { state, action, environment in
-
-  enum UserDidTakeScreenshotNotificationId {}
-
   switch action {
   case .userDidTakeScreenshotNotification:
     state.screenshotCount += 1
@@ -54,6 +51,8 @@ let longLivingEffectsReducer = Reducer<
     // When view disappears, stop the effect.
     return .cancel(id: UserDidTakeScreenshotNotificationId.self)
   }
+
+  enum UserDidTakeScreenshotNotificationId {}
 }
 
 // MARK: - SwiftUI view

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -35,9 +35,6 @@ let refreshableReducer = Reducer<
   RefreshableAction,
   RefreshableEnvironment
 > { state, action, environment in
-
-  enum CancelId {}
-
   switch action {
   case .cancelButtonTapped:
     state.isLoading = false
@@ -69,6 +66,8 @@ let refreshableReducer = Reducer<
       .catchToEffect(RefreshableAction.factResponse)
       .cancellable(id: CancelId.self)
   }
+
+  enum CancelId {}
 }
 
 #if compiler(>=5.5)

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -28,9 +28,6 @@ struct TimersEnvironment {
 
 let timersReducer = Reducer<TimersState, TimersAction, TimersEnvironment> {
   state, action, environment in
-
-  enum TimerId {}
-
   switch action {
   case .timerTicked:
     state.secondsElapsed += 1
@@ -48,6 +45,8 @@ let timersReducer = Reducer<TimersState, TimersAction, TimersEnvironment> {
       .map { _ in TimersAction.timerTicked }
       : .cancel(id: TimerId.self)
   }
+
+  enum TimerId {}
 }
 
 // MARK: - Timer feature view

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -52,9 +52,6 @@ let loadThenNavigateListReducer =
     with: Reducer<
       LoadThenNavigateListState, LoadThenNavigateListAction, LoadThenNavigateListEnvironment
     > { state, action, environment in
-
-      enum CancelId {}
-
       switch action {
       case .counter:
         return .none
@@ -87,6 +84,8 @@ let loadThenNavigateListReducer =
         )
         return .none
       }
+
+      enum CancelId {}
     }
   )
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -46,9 +46,6 @@ let navigateAndLoadListReducer =
     with: Reducer<
       NavigateAndLoadListState, NavigateAndLoadListAction, NavigateAndLoadListEnvironment
     > { state, action, environment in
-
-      enum CancelId {}
-
       switch action {
       case .counter:
         return .none
@@ -73,6 +70,8 @@ let navigateAndLoadListReducer =
         state.selection?.value = CounterState(count: state.rows[id: id]?.count ?? 0)
         return .none
       }
+
+      enum CancelId {}
     }
   )
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -39,9 +39,6 @@ let loadThenNavigateReducer =
     with: Reducer<
       LoadThenNavigateState, LoadThenNavigateAction, LoadThenNavigateEnvironment
     > { state, action, environment in
-
-      enum CancelId {}
-
       switch action {
       case .onDisappear:
         return .cancel(id: CancelId.self)
@@ -65,6 +62,8 @@ let loadThenNavigateReducer =
       case .optionalCounter:
         return .none
       }
+
+      enum CancelId {}
     }
   )
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -37,9 +37,6 @@ let navigateAndLoadReducer =
     with: Reducer<
       NavigateAndLoadState, NavigateAndLoadAction, NavigateAndLoadEnvironment
     > { state, action, environment in
-
-      enum CancelId {}
-
       switch action {
       case .setNavigation(isActive: true):
         state.isNavigationActive = true
@@ -60,6 +57,8 @@ let navigateAndLoadReducer =
       case .optionalCounter:
         return .none
       }
+
+      enum CancelId {}
     }
   )
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -39,9 +39,6 @@ let loadThenPresentReducer =
     with: Reducer<
       LoadThenPresentState, LoadThenPresentAction, LoadThenPresentEnvironment
     > { state, action, environment in
-
-      enum CancelId {}
-
       switch action {
       case .onDisappear:
         return .cancel(id: CancelId.self)
@@ -65,6 +62,8 @@ let loadThenPresentReducer =
       case .optionalCounter:
         return .none
       }
+
+      enum CancelId {}
     }
   )
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -35,9 +35,6 @@ let presentAndLoadReducer =
     with: Reducer<
       PresentAndLoadState, PresentAndLoadAction, PresentAndLoadEnvironment
     > { state, action, environment in
-
-      enum CancelId {}
-
       switch action {
       case .setSheet(isPresented: true):
         state.isSheetPresented = true
@@ -58,6 +55,8 @@ let presentAndLoadReducer =
       case .optionalCounter:
         return .none
       }
+
+      enum CancelId {}
     }
   )
 

--- a/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
@@ -31,9 +31,6 @@ let lazyNavigationReducer =
     with: Reducer<
       LazyNavigationState, LazyNavigationAction, LazyNavigationEnvironment
     > { state, action, environment in
-
-      enum CancelId {}
-
       switch action {
       case .onDisappear:
         return .cancel(id: CancelId.self)
@@ -53,6 +50,8 @@ let lazyNavigationReducer =
       case .optionalCounter:
         return .none
       }
+
+      enum CancelId {}
     }
   )
 

--- a/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
@@ -30,9 +30,6 @@ let eagerNavigationReducer =
     with: Reducer<
       EagerNavigationState, EagerNavigationAction, EagerNavigationEnvironment
     > { state, action, environment in
-
-      enum CancelId {}
-
       switch action {
       case .setNavigation(isActive: true):
         state.isNavigationActive = true
@@ -50,6 +47,8 @@ let eagerNavigationReducer =
       case .optionalCounter:
         return .none
       }
+
+      enum CancelId {}
     }
   )
 

--- a/Examples/Search/Search/SearchView.swift
+++ b/Examples/Search/Search/SearchView.swift
@@ -68,8 +68,6 @@ let searchReducer = Reducer<SearchState, SearchAction, SearchEnvironment> {
     return .none
 
   case let .searchQueryChanged(query):
-    enum SearchLocationId {}
-
     state.searchQuery = query
 
     // When the query is cleared we can clear the search results, but we have to make sure to cancel
@@ -85,6 +83,8 @@ let searchReducer = Reducer<SearchState, SearchAction, SearchEnvironment> {
       .debounce(id: SearchLocationId.self, for: 0.3, scheduler: environment.mainQueue)
       .catchToEffect(SearchAction.searchResponse)
 
+    enum SearchLocationId {}
+
   case .searchResponse(.failure):
     state.results = []
     return .none
@@ -94,8 +94,6 @@ let searchReducer = Reducer<SearchState, SearchAction, SearchEnvironment> {
     return .none
 
   case let .searchResultTapped(location):
-    enum SearchWeatherId {}
-
     state.resultForecastRequestInFlight = location
 
     return environment.weatherClient
@@ -104,6 +102,8 @@ let searchReducer = Reducer<SearchState, SearchAction, SearchEnvironment> {
       .catchToEffect()
       .map { .forecastResponse(location.id, $0) }
       .cancellable(id: SearchWeatherId.self, cancelInFlight: true)
+
+    enum SearchWeatherId {}
   }
 }
 

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -88,9 +88,10 @@ let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
       return .none
 
     case .todo(id: _, action: .checkBoxToggled):
-      enum TodoCompletionId {}
       return Effect(value: .sortCompletedTodos)
         .debounce(id: TodoCompletionId.self, for: 1, scheduler: environment.mainQueue.animation())
+
+      enum TodoCompletionId {}
 
     case .todo:
       return .none

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
@@ -43,8 +43,6 @@ struct VoiceMemoEnvironment {
 let voiceMemoReducer = Reducer<
   VoiceMemo, VoiceMemoAction, VoiceMemoEnvironment
 > { memo, action, environment in
-  enum TimerId {}
-
   switch action {
   case .audioPlayerClient(.success(.didFinishPlaying)), .audioPlayerClient(.failure):
     memo.mode = .notPlaying
@@ -93,6 +91,8 @@ let voiceMemoReducer = Reducer<
     memo.title = text
     return .none
   }
+
+  enum TimerId {}
 }
 
 struct VoiceMemoView: View {

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -56,8 +56,6 @@ let voiceMemosReducer = Reducer<VoiceMemosState, VoiceMemosAction, VoiceMemosEnv
     }
   ),
   .init { state, action, environment in
-    enum TimerId {}
-
     func startRecording() -> Effect<VoiceMemosAction, Never> {
       let url = environment.temporaryDirectory()
         .appendingPathComponent(environment.uuid().uuidString)
@@ -179,6 +177,8 @@ let voiceMemosReducer = Reducer<VoiceMemosState, VoiceMemosAction, VoiceMemosEnv
     case .voiceMemo:
       return .none
     }
+
+    enum TimerId {}
   }
 )
 

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -130,8 +130,6 @@ final class ComposableArchitectureTests: XCTestCase {
     }
 
     let reducer = Reducer<Int, Action, Environment> { state, action, environment in
-      enum CancelId {}
-
       switch action {
       case .cancel:
         return .cancel(id: CancelId.self)
@@ -148,6 +146,8 @@ final class ComposableArchitectureTests: XCTestCase {
         state = value
         return .none
       }
+
+      enum CancelId {}
     }
 
     let scheduler = DispatchQueue.test


### PR DESCRIPTION
You used to get warnings for moving ID types to the end of scopes after `return` statements (see https://github.com/apple/swift/issues/56805), but that's not the case anymore. By moving the IDs to the end of the scope we can remove unnecessary details from the top of our reducers.