### PR TITLE
Add automatic binding support

### DIFF
--- a/Tests/ComposableArchitectureTests/BindingTests.swift
+++ b/Tests/ComposableArchitectureTests/BindingTests.swift
@@ -35,5 +35,38 @@
 
       XCTAssertNoDifference(viewStore.state, .init(nested: .init(field: "Hello!")))
     }
+
+    func testAutomaticBinding() {
+      struct State: Equatable {
+        @BindableState var nested = Nested()
+
+        struct Nested: Equatable {
+          var field = ""
+        }
+      }
+
+      enum Action: BindableAction, Equatable {
+        case binding(BindingAction<State>)
+      }
+
+      let reducer = Reducer<State, Action, ()> { state, action, _ in
+        switch action {
+        case .binding(\.$nested.field):
+          state.nested.field += "!"
+          return .none
+        default:
+          return .none
+        }
+      }
+      // look, ma, no .binding()!
+
+      let store = Store(initialState: .init(), reducer: reducer, environment: ())
+
+      let viewStore = ViewStore(store)
+
+      viewStore.binding(\.$nested.field).wrappedValue = "Hello"
+
+      XCTAssertNoDifference(viewStore.state, .init(nested: .init(field: "Hello!")))
+    }
   }
 #endif


### PR DESCRIPTION
This is a proof-of-concept that it is possible to make `Reducer.init(_:)` automatically add `.binding()` when the action is a `BindableAction<State>`. I made it after forgetting to add `.binding()` one too many times, and also hearing from friends that they frequently make this mistake, and even go so far as to avoid `BindableAction` entirely because of how easy it is to forget.

It's a proof of concept because it has a major problem: if you use this in existing code with explicit `.binding()`, all your `.binding()` calls will be duplicated. Would love to talk about options to avoid this. Here's one option:

If we decide that automatic binding is good, and we never want `.binding()` to be explicit, we could change `.binding()` to be a deprecated no-op with a suggestion to delete it.

Another option would be to add a private property to `Reducer` called `hasHadBindingApplied` or something like that, and `.binding()` would look for that property and become a no-op if it's true. That option sounds less composable, however, so I don't love it.

Also, I haven't looked at the upcoming protocol-based Reducer work, so I don't know how any of this would translate over.