### PR TITLE
Only warn for unused binding actions sent from view stores

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -46,7 +46,7 @@
       return .none
     }
   }
-  .binding()
+//  .binding()
 
   struct BindingFormView: View {
     let store: Store<BindingFormState, BindingFormAction>

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -46,7 +46,7 @@
       return .none
     }
   }
-//  .binding()
+  .binding()
 
   struct BindingFormView: View {
     let store: Store<BindingFormState, BindingFormAction>

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -579,7 +579,7 @@ extension BindingAction: CustomDumpReflectable {
       guard self.wasCalled else {
         runtimeWarning(
           """
-          A binding action created at "%@:%d" was not handled:
+          A binding action sent from a view store at "%@:%d" was not handled:
 
             Action:
               %@

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -561,7 +561,7 @@ extension BindingAction: CustomDumpReflectable {
 #endif
 
 #if DEBUG
-  private class BindableActionViewStoreDebugger<Value> {
+  private final class BindableActionViewStoreDebugger<Value> {
     let value: Value
     let bindableActionType: Any.Type
     let file: StaticString

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -200,10 +200,6 @@ final class DebugTests: XCTestCase {
         )
         """#
       )
-
-      // NB: Call setter to avoid runtime warning
-      var state = State()
-      action.set(&state)
     }
   #endif
 }


### PR DESCRIPTION
#1162 points out that the warning can appear at inopportune times, like in tests. We should push the warning to the view layer, instead.