### PR TITLE
Clean up compiler checks.

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
@@ -7,18 +7,14 @@ struct RootState {
   var alertAndConfirmationDialog = AlertAndConfirmationDialogState()
   var animation = AnimationsState()
   var bindingBasics = BindingBasicsState()
-  #if compiler(>=5.4)
-    var bindingForm = BindingFormState()
-  #endif
+  var bindingForm = BindingFormState()
   var clock = ClockState()
   var counter = CounterState()
   var effectsBasics = EffectsBasicsState()
   var effectsCancellation = EffectsCancellationState()
   var effectsTimers = TimersState()
   var episodes = EpisodesState(episodes: .mocks)
-  #if compiler(>=5.5)
-    var focusDemo = FocusDemoState()
-  #endif
+  var focusDemo = FocusDemoState()
   var lifecycle = LifecycleDemoState()
   var loadThenNavigate = LoadThenNavigateState()
   var loadThenNavigateList = LoadThenNavigateListState()
@@ -42,17 +38,13 @@ enum RootAction {
   case alertAndConfirmationDialog(AlertAndConfirmationDialogAction)
   case animation(AnimationsAction)
   case bindingBasics(BindingBasicsAction)
-  #if compiler(>=5.4)
-    case bindingForm(BindingFormAction)
-  #endif
+  case bindingForm(BindingFormAction)
   case clock(ClockAction)
   case counter(CounterAction)
   case effectsBasics(EffectsBasicsAction)
   case effectsCancellation(EffectsCancellationAction)
   case episodes(EpisodesAction)
-  #if compiler(>=5.5)
-    case focusDemo(FocusDemoAction)
-  #endif
+  case focusDemo(FocusDemoAction)
   case lifecycle(LifecycleDemoAction)
   case loadThenNavigate(LoadThenNavigateAction)
   case loadThenNavigateList(LoadThenNavigateListAction)
@@ -126,20 +118,12 @@ let rootReducer = Reducer<RootState, RootAction, RootEnvironment>.combine(
       action: /RootAction.bindingBasics,
       environment: { _ in .init() }
     ),
-  .init { state, action, environment in
-    #if compiler(>=5.4)
-      return
-        bindingFormReducer
-        .pullback(
-          state: \.bindingForm,
-          action: /RootAction.bindingForm,
-          environment: { _ in .init() }
-        )
-        .run(&state, action, environment)
-    #else
-      return .none
-    #endif
-  },
+  bindingFormReducer
+    .pullback(
+      state: \.bindingForm,
+      action: /RootAction.bindingForm,
+      environment: { _ in .init() }
+    ),
   clockReducer
     .pullback(
       state: \.clock,
@@ -170,20 +154,12 @@ let rootReducer = Reducer<RootState, RootAction, RootEnvironment>.combine(
       action: /RootAction.episodes,
       environment: { .init(favorite: $0.favorite, mainQueue: $0.mainQueue) }
     ),
-  .init { state, action, environment in
-    #if compiler(>=5.5)
-      return
-        focusDemoReducer
-        .pullback(
-          state: \.focusDemo,
-          action: /RootAction.focusDemo,
-          environment: { _ in .init() }
-        )
-        .run(&state, action, environment)
-    #else
-      return .none
-    #endif
-  },
+  focusDemoReducer
+    .pullback(
+      state: \.focusDemo,
+      action: /RootAction.focusDemo,
+      environment: { _ in .init() }
+    ),
   lifecycleDemoReducer
     .pullback(
       state: \.lifecycle,

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -40,17 +40,15 @@ struct RootView: View {
               )
             )
 
-            #if compiler(>=5.4)
-              NavigationLink(
-                "Form bindings",
-                destination: BindingFormView(
-                  store: self.store.scope(
-                    state: \.bindingForm,
-                    action: RootAction.bindingForm
-                  )
+            NavigationLink(
+              "Form bindings",
+              destination: BindingFormView(
+                store: self.store.scope(
+                  state: \.bindingForm,
+                  action: RootAction.bindingForm
                 )
               )
-            #endif
+            )
 
             NavigationLink(
               "Optional state",
@@ -82,17 +80,15 @@ struct RootView: View {
               )
             )
 
-            #if compiler(>=5.5)
-              NavigationLink(
-                "Focus State",
-                destination: FocusDemoView(
-                  store: self.store.scope(
-                    state: \.focusDemo,
-                    action: RootAction.focusDemo
-                  )
+            NavigationLink(
+              "Focus State",
+              destination: FocusDemoView(
+                store: self.store.scope(
+                  state: \.focusDemo,
+                  action: RootAction.focusDemo
                 )
               )
-            #endif
+            )
 
             NavigationLink(
               "Animations",
@@ -135,17 +131,15 @@ struct RootView: View {
               )
             )
 
-            #if compiler(>=5.5)
-              NavigationLink(
-                "Refreshable",
-                destination: RefreshableView(
-                  store: self.store.scope(
-                    state: \.refreshable,
-                    action: RootAction.refreshable
-                  )
+            NavigationLink(
+              "Refreshable",
+              destination: RefreshableView(
+                store: self.store.scope(
+                  state: \.refreshable,
+                  action: RootAction.refreshable
                 )
               )
-            #endif
+            )
 
             NavigationLink(
               "Timers",

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -1,122 +1,120 @@
-#if compiler(>=5.4)
-  import ComposableArchitecture
-  import SwiftUI
+import ComposableArchitecture
+import SwiftUI
 
-  private let readMe = """
-    This file demonstrates how to handle two-way bindings in the Composable Architecture using \
-    bindable state and actions.
+private let readMe = """
+  This file demonstrates how to handle two-way bindings in the Composable Architecture using \
+  bindable state and actions.
 
-    Bindable state and actions allow you to safely eliminate the boilerplate caused by needing to \
-    have a unique action for every UI control. Instead, all UI bindings can be consolidated into a \
-    single `binding` action that holds onto a `BindingAction` value, and all bindable state can be \
-    safeguarded with the `BindableState` property wrapper.
+  Bindable state and actions allow you to safely eliminate the boilerplate caused by needing to \
+  have a unique action for every UI control. Instead, all UI bindings can be consolidated into a \
+  single `binding` action that holds onto a `BindingAction` value, and all bindable state can be \
+  safeguarded with the `BindableState` property wrapper.
 
-    It is instructive to compare this case study to the "Binding Basics" case study.
-    """
+  It is instructive to compare this case study to the "Binding Basics" case study.
+  """
 
-  // The state for this screen holds a bunch of values that will drive
-  struct BindingFormState: Equatable {
-    @BindableState var sliderValue = 5.0
-    @BindableState var stepCount = 10
-    @BindableState var text = ""
-    @BindableState var toggleIsOn = false
+// The state for this screen holds a bunch of values that will drive
+struct BindingFormState: Equatable {
+  @BindableState var sliderValue = 5.0
+  @BindableState var stepCount = 10
+  @BindableState var text = ""
+  @BindableState var toggleIsOn = false
+}
+
+enum BindingFormAction: BindableAction, Equatable {
+  case binding(BindingAction<BindingFormState>)
+  case resetButtonTapped
+}
+
+struct BindingFormEnvironment {}
+
+let bindingFormReducer = Reducer<
+  BindingFormState, BindingFormAction, BindingFormEnvironment
+> {
+  state, action, _ in
+  switch action {
+  case .binding(\.$stepCount):
+    state.sliderValue = .minimum(state.sliderValue, Double(state.stepCount))
+    return .none
+
+  case .binding:
+    return .none
+
+  case .resetButtonTapped:
+    state = BindingFormState()
+    return .none
   }
+}
+.binding()
 
-  enum BindingFormAction: BindableAction, Equatable {
-    case binding(BindingAction<BindingFormState>)
-    case resetButtonTapped
-  }
+struct BindingFormView: View {
+  let store: Store<BindingFormState, BindingFormAction>
 
-  struct BindingFormEnvironment {}
+  var body: some View {
+    WithViewStore(self.store) { viewStore in
+      Form {
+        Section(header: Text(template: readMe, .caption)) {
+          HStack {
+            TextField("Type here", text: viewStore.binding(\.$text))
+              .disableAutocorrection(true)
+              .foregroundColor(viewStore.toggleIsOn ? .gray : .primary)
 
-  let bindingFormReducer = Reducer<
-    BindingFormState, BindingFormAction, BindingFormEnvironment
-  > {
-    state, action, _ in
-    switch action {
-    case .binding(\.$stepCount):
-      state.sliderValue = .minimum(state.sliderValue, Double(state.stepCount))
-      return .none
-
-    case .binding:
-      return .none
-
-    case .resetButtonTapped:
-      state = BindingFormState()
-      return .none
-    }
-  }
-  .binding()
-
-  struct BindingFormView: View {
-    let store: Store<BindingFormState, BindingFormAction>
-
-    var body: some View {
-      WithViewStore(self.store) { viewStore in
-        Form {
-          Section(header: Text(template: readMe, .caption)) {
-            HStack {
-              TextField("Type here", text: viewStore.binding(\.$text))
-                .disableAutocorrection(true)
-                .foregroundColor(viewStore.toggleIsOn ? .gray : .primary)
-
-              Text(alternate(viewStore.text))
-            }
-            .disabled(viewStore.toggleIsOn)
-
-            Toggle(
-              "Disable other controls",
-              isOn: viewStore.binding(\.$toggleIsOn)
-                .resignFirstResponder()
-            )
-
-            Stepper(value: viewStore.binding(\.$stepCount), in: 0...100) {
-              Text("Max slider value: \(viewStore.stepCount)")
-                .font(.body.monospacedDigit())
-            }
-            .disabled(viewStore.toggleIsOn)
-
-            HStack {
-              Text("Slider value: \(Int(viewStore.sliderValue))")
-                .font(.body.monospacedDigit())
-
-              Slider(value: viewStore.binding(\.$sliderValue), in: 0...Double(viewStore.stepCount))
-            }
-            .disabled(viewStore.toggleIsOn)
-
-            Button("Reset") {
-              viewStore.send(.resetButtonTapped)
-            }
-            .foregroundColor(.red)
+            Text(alternate(viewStore.text))
           }
+          .disabled(viewStore.toggleIsOn)
+
+          Toggle(
+            "Disable other controls",
+            isOn: viewStore.binding(\.$toggleIsOn)
+              .resignFirstResponder()
+          )
+
+          Stepper(value: viewStore.binding(\.$stepCount), in: 0...100) {
+            Text("Max slider value: \(viewStore.stepCount)")
+              .font(.body.monospacedDigit())
+          }
+          .disabled(viewStore.toggleIsOn)
+
+          HStack {
+            Text("Slider value: \(Int(viewStore.sliderValue))")
+              .font(.body.monospacedDigit())
+
+            Slider(value: viewStore.binding(\.$sliderValue), in: 0...Double(viewStore.stepCount))
+          }
+          .disabled(viewStore.toggleIsOn)
+
+          Button("Reset") {
+            viewStore.send(.resetButtonTapped)
+          }
+          .foregroundColor(.red)
         }
       }
-      .navigationBarTitle("Bindings form")
     }
+    .navigationBarTitle("Bindings form")
   }
+}
 
-  private func alternate(_ string: String) -> String {
-    string
-      .enumerated()
-      .map { idx, char in
-        idx.isMultiple(of: 2)
-          ? char.uppercased()
-          : char.lowercased()
-      }
-      .joined()
-  }
+private func alternate(_ string: String) -> String {
+  string
+    .enumerated()
+    .map { idx, char in
+      idx.isMultiple(of: 2)
+        ? char.uppercased()
+        : char.lowercased()
+    }
+    .joined()
+}
 
-  struct BindingFormView_Previews: PreviewProvider {
-    static var previews: some View {
-      NavigationView {
-        BindingFormView(
-          store: Store(
-            initialState: BindingFormState(),
-            reducer: bindingFormReducer,
-            environment: BindingFormEnvironment()
-          )
+struct BindingFormView_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationView {
+      BindingFormView(
+        store: Store(
+          initialState: BindingFormState(),
+          reducer: bindingFormReducer,
+          environment: BindingFormEnvironment()
         )
-      }
+      )
     }
   }
-#endif
+}

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -1,101 +1,99 @@
-#if compiler(>=5.5)
-  import ComposableArchitecture
-  import SwiftUI
+import ComposableArchitecture
+import SwiftUI
 
-  private let readMe = """
-    This demonstrates how to make use of SwiftUI's `@FocusState` in the Composable Architecture. \
-    If you tap the "Sign in" button while a field is empty, the focus will be changed to that field.
-    """
+private let readMe = """
+  This demonstrates how to make use of SwiftUI's `@FocusState` in the Composable Architecture. \
+  If you tap the "Sign in" button while a field is empty, the focus will be changed to that field.
+  """
 
-  struct FocusDemoState: Equatable {
-    @BindableState var focusedField: Field? = nil
-    @BindableState var password: String = ""
-    @BindableState var username: String = ""
+struct FocusDemoState: Equatable {
+  @BindableState var focusedField: Field? = nil
+  @BindableState var password: String = ""
+  @BindableState var username: String = ""
 
-    enum Field: String, Hashable {
-      case username, password
+  enum Field: String, Hashable {
+    case username, password
+  }
+}
+
+enum FocusDemoAction: BindableAction, Equatable {
+  case binding(BindingAction<FocusDemoState>)
+  case signInButtonTapped
+}
+
+struct FocusDemoEnvironment {}
+
+let focusDemoReducer = Reducer<
+  FocusDemoState,
+  FocusDemoAction,
+  FocusDemoEnvironment
+> { state, action, _ in
+  switch action {
+  case .binding:
+    return .none
+
+  case .signInButtonTapped:
+    if state.username.isEmpty {
+      state.focusedField = .username
+    } else if state.password.isEmpty {
+      state.focusedField = .password
     }
+    return .none
   }
+}
+.binding()
 
-  enum FocusDemoAction: BindableAction, Equatable {
-    case binding(BindingAction<FocusDemoState>)
-    case signInButtonTapped
-  }
+struct FocusDemoView: View {
+  let store: Store<FocusDemoState, FocusDemoAction>
+  @FocusState var focusedField: FocusDemoState.Field?
 
-  struct FocusDemoEnvironment {}
+  var body: some View {
+    WithViewStore(self.store) { viewStore in
+      VStack(alignment: .leading, spacing: 32) {
+        Text(template: readMe, .caption)
 
-  let focusDemoReducer = Reducer<
-    FocusDemoState,
-    FocusDemoAction,
-    FocusDemoEnvironment
-  > { state, action, _ in
-    switch action {
-    case .binding:
-      return .none
+        VStack {
+          TextField("Username", text: viewStore.binding(\.$username))
+            .focused($focusedField, equals: .username)
 
-    case .signInButtonTapped:
-      if state.username.isEmpty {
-        state.focusedField = .username
-      } else if state.password.isEmpty {
-        state.focusedField = .password
-      }
-      return .none
-    }
-  }
-  .binding()
+          SecureField("Password", text: viewStore.binding(\.$password))
+            .focused($focusedField, equals: .password)
 
-  struct FocusDemoView: View {
-    let store: Store<FocusDemoState, FocusDemoAction>
-    @FocusState var focusedField: FocusDemoState.Field?
-
-    var body: some View {
-      WithViewStore(self.store) { viewStore in
-        VStack(alignment: .leading, spacing: 32) {
-          Text(template: readMe, .caption)
-
-          VStack {
-            TextField("Username", text: viewStore.binding(\.$username))
-              .focused($focusedField, equals: .username)
-
-            SecureField("Password", text: viewStore.binding(\.$password))
-              .focused($focusedField, equals: .password)
-
-            Button("Sign In") {
-              viewStore.send(.signInButtonTapped)
-            }
+          Button("Sign In") {
+            viewStore.send(.signInButtonTapped)
           }
-
-          Spacer()
         }
-        .padding()
-        .synchronize(viewStore.binding(\.$focusedField), self.$focusedField)
+
+        Spacer()
       }
-      .navigationBarTitle("Focus demo")
+      .padding()
+      .synchronize(viewStore.binding(\.$focusedField), self.$focusedField)
     }
+    .navigationBarTitle("Focus demo")
   }
+}
 
-  extension View {
-    func synchronize<Value>(
-      _ first: Binding<Value>,
-      _ second: FocusState<Value>.Binding
-    ) -> some View {
-      self
-        .onChange(of: first.wrappedValue) { second.wrappedValue = $0 }
-        .onChange(of: second.wrappedValue) { first.wrappedValue = $0 }
-    }
+extension View {
+  func synchronize<Value>(
+    _ first: Binding<Value>,
+    _ second: FocusState<Value>.Binding
+  ) -> some View {
+    self
+      .onChange(of: first.wrappedValue) { second.wrappedValue = $0 }
+      .onChange(of: second.wrappedValue) { first.wrappedValue = $0 }
   }
+}
 
-  struct FocusDemo_Previews: PreviewProvider {
-    static var previews: some View {
-      NavigationView {
-        FocusDemoView(
-          store: Store(
-            initialState: FocusDemoState(),
-            reducer: focusDemoReducer,
-            environment: FocusDemoEnvironment()
-          )
+struct FocusDemo_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationView {
+      FocusDemoView(
+        store: Store(
+          initialState: FocusDemoState(),
+          reducer: focusDemoReducer,
+          environment: FocusDemoEnvironment()
         )
-      }
+      )
     }
   }
-#endif
+}

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -71,51 +71,49 @@ let refreshableReducer = Reducer<
   }
 }
 
-#if compiler(>=5.5)
-  struct RefreshableView: View {
-    let store: Store<RefreshableState, RefreshableAction>
+struct RefreshableView: View {
+  let store: Store<RefreshableState, RefreshableAction>
 
-    var body: some View {
-      WithViewStore(self.store) { viewStore in
-        List {
-          Text(template: readMe, .body)
+  var body: some View {
+    WithViewStore(self.store) { viewStore in
+      List {
+        Text(template: readMe, .body)
 
-          HStack {
-            Button("-") { viewStore.send(.decrementButtonTapped) }
-            Text("\(viewStore.count)")
-            Button("+") { viewStore.send(.incrementButtonTapped) }
-          }
-          .buttonStyle(.plain)
+        HStack {
+          Button("-") { viewStore.send(.decrementButtonTapped) }
+          Text("\(viewStore.count)")
+          Button("+") { viewStore.send(.incrementButtonTapped) }
+        }
+        .buttonStyle(.plain)
 
-          if let fact = viewStore.fact {
-            Text(fact)
-              .bold()
-          }
-          if viewStore.isLoading {
-            Button("Cancel") {
-              viewStore.send(.cancelButtonTapped, animation: .default)
-            }
+        if let fact = viewStore.fact {
+          Text(fact)
+            .bold()
+        }
+        if viewStore.isLoading {
+          Button("Cancel") {
+            viewStore.send(.cancelButtonTapped, animation: .default)
           }
         }
-        .refreshable {
-          await viewStore.send(.refresh, while: \.isLoading)
-        }
+      }
+      .refreshable {
+        await viewStore.send(.refresh, while: \.isLoading)
       }
     }
   }
+}
 
-  struct Refreshable_Previews: PreviewProvider {
-    static var previews: some View {
-      RefreshableView(
-        store: Store(
-          initialState: RefreshableState(),
-          reducer: refreshableReducer,
-          environment: RefreshableEnvironment(
-            fact: .live,
-            mainQueue: .main
-          )
+struct Refreshable_Previews: PreviewProvider {
+  static var previews: some View {
+    RefreshableView(
+      store: Store(
+        initialState: RefreshableState(),
+        reducer: refreshableReducer,
+        environment: RefreshableEnvironment(
+          fact: .live,
+          mainQueue: .main
         )
       )
-    }
+    )
   }
-#endif
+}

--- a/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
@@ -12,41 +12,18 @@ struct FactClient {
 // Typically this live implementation of the dependency would live in its own module so that the
 // main feature doesn't need to compile it.
 extension FactClient {
-  #if compiler(>=5.5)
-    static let live = Self(
-      fetch: { number in
-        Effect.task {
-          try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
-          do {
-            let (data, _) = try await URLSession.shared
-              .data(from: URL(string: "http://numbersapi.com/\(number)/trivia")!)
-            return String(decoding: data, as: UTF8.self)
-          } catch {
-            return "\(number) is a good number Brent"
-          }
-        }
-        .setFailureType(to: Error.self)
-        .eraseToEffect()
+  static let live = Self(
+    fetch: { number in
+      Effect.task {
+        try await Task.sleep(nanoseconds: NSEC_PER_SEC)
+        let (data, _) = try await URLSession.shared
+          .data(from: URL(string: "http://numbersapi.com/\(number)/trivia")!)
+        return String(decoding: data, as: UTF8.self)
       }
-    )
-  #else
-    static let live = Self(
-      fetch: { number in
-        URLSession.shared.dataTaskPublisher(
-          for: URL(string: "http://numbersapi.com/\(number)/trivia")!
-        )
-        .map { data, _ in String(decoding: data, as: UTF8.self) }
-        .catch { _ in
-          // Sometimes numbersapi.com can be flakey, so if it ever fails we will just
-          // default to a mock response.
-          Just("\(number) is a good number Brent")
-            .delay(for: 1, scheduler: DispatchQueue.main)
-        }
-        .setFailureType(to: Error.self)
-        .eraseToEffect()
-      }
-    )
-  #endif
+      .mapError { _ in Error() }
+      .eraseToEffect()
+    }
+  )
 }
 
 #if DEBUG

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-BindingBasicsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-BindingBasicsTests.swift
@@ -1,34 +1,32 @@
-#if compiler(>=5.4)
-  import Combine
-  import ComposableArchitecture
-  import XCTest
+import Combine
+import ComposableArchitecture
+import XCTest
 
-  @testable import SwiftUICaseStudies
+@testable import SwiftUICaseStudies
 
-  class BindingFormTests: XCTestCase {
-    func testBasics() {
-      let store = TestStore(
-        initialState: BindingFormState(),
-        reducer: bindingFormReducer,
-        environment: BindingFormEnvironment()
-      )
+class BindingFormTests: XCTestCase {
+  func testBasics() {
+    let store = TestStore(
+      initialState: BindingFormState(),
+      reducer: bindingFormReducer,
+      environment: BindingFormEnvironment()
+    )
 
-      store.send(.set(\.$sliderValue, 2)) {
-        $0.sliderValue = 2
-      }
-      store.send(.set(\.$stepCount, 1)) {
-        $0.sliderValue = 1
-        $0.stepCount = 1
-      }
-      store.send(.set(\.$text, "Blob")) {
-        $0.text = "Blob"
-      }
-      store.send(.set(\.$toggleIsOn, true)) {
-        $0.toggleIsOn = true
-      }
-      store.send(.resetButtonTapped) {
-        $0 = BindingFormState(sliderValue: 5, stepCount: 10, text: "", toggleIsOn: false)
-      }
+    store.send(.set(\.$sliderValue, 2)) {
+      $0.sliderValue = 2
+    }
+    store.send(.set(\.$stepCount, 1)) {
+      $0.sliderValue = 1
+      $0.stepCount = 1
+    }
+    store.send(.set(\.$text, "Blob")) {
+      $0.text = "Blob"
+    }
+    store.send(.set(\.$toggleIsOn, true)) {
+      $0.toggleIsOn = true
+    }
+    store.send(.resetButtonTapped) {
+      $0 = BindingFormState(sliderValue: 5, stepCount: 10, text: "", toggleIsOn: false)
     }
   }
-#endif
+}

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -362,153 +362,86 @@ extension Store {
   }
 }
 
-#if compiler(>=5.4)
-  extension ViewStore where Action: BindableAction, Action.State == State {
-    @available(
-      *, deprecated,
-      message:
-        "Dynamic member lookup is no longer supported for bindable state. Instead of dot-chaining on the view store, e.g. 'viewStore.$value', invoke the 'binding' method on view store with a key path to the value, e.g. 'viewStore.binding(\\.$value)'. For more on this change, see: https://github.com/pointfreeco/swift-composable-architecture/pull/810"
+extension ViewStore where Action: BindableAction, Action.State == State {
+  @available(
+    *, deprecated,
+    message:
+      "Dynamic member lookup is no longer supported for bindable state. Instead of dot-chaining on the view store, e.g. 'viewStore.$value', invoke the 'binding' method on view store with a key path to the value, e.g. 'viewStore.binding(\\.$value)'. For more on this change, see: https://github.com/pointfreeco/swift-composable-architecture/pull/810"
+  )
+  public subscript<Value: Equatable>(
+    dynamicMember keyPath: WritableKeyPath<State, BindableState<Value>>
+  ) -> Binding<Value> {
+    self.binding(
+      get: { $0[keyPath: keyPath].wrappedValue },
+      send: { .binding(.set(keyPath, $0)) }
     )
-    public subscript<Value: Equatable>(
-      dynamicMember keyPath: WritableKeyPath<State, BindableState<Value>>
-    ) -> Binding<Value> {
-      self.binding(
-        get: { $0[keyPath: keyPath].wrappedValue },
-        send: { .binding(.set(keyPath, $0)) }
-      )
-    }
   }
-#endif
+}
 
 // NB: Deprecated after 0.25.0:
 
-#if compiler(>=5.4)
-  extension BindingAction {
-    @available(
-      *, deprecated,
-      message:
-        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\\.$value'"
+extension BindingAction {
+  @available(
+    *, deprecated,
+    message:
+      "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\\.$value'"
+  )
+  public static func set<Value: Equatable>(
+    _ keyPath: WritableKeyPath<Root, Value>,
+    _ value: Value
+  ) -> Self {
+    .init(
+      keyPath: keyPath,
+      set: { $0[keyPath: keyPath] = value },
+      value: value,
+      valueIsEqualTo: { $0 as? Value == value }
     )
-    public static func set<Value: Equatable>(
-      _ keyPath: WritableKeyPath<Root, Value>,
-      _ value: Value
-    ) -> Self {
-      .init(
-        keyPath: keyPath,
-        set: { $0[keyPath: keyPath] = value },
-        value: value,
-        valueIsEqualTo: { $0 as? Value == value }
-      )
-    }
-
-    @available(
-      *, deprecated,
-      message:
-        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\\.$value'"
-    )
-    public static func ~= <Value>(
-      keyPath: WritableKeyPath<Root, Value>,
-      bindingAction: Self
-    ) -> Bool {
-      keyPath == bindingAction.keyPath
-    }
   }
 
-  extension Reducer {
-    @available(
-      *, deprecated,
-      message:
-        "'Reducer.binding()' no longer takes an explicit extract function and instead the reducer's 'Action' type must conform to 'BindableAction'"
-    )
-    public func binding(action toBindingAction: @escaping (Action) -> BindingAction<State>?) -> Self
-    {
-      Self { state, action, environment in
-        toBindingAction(action)?.set(&state)
-        return self.run(&state, action, environment)
-      }
-    }
+  @available(
+    *, deprecated,
+    message:
+      "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\\.$value'"
+  )
+  public static func ~= <Value>(
+    keyPath: WritableKeyPath<Root, Value>,
+    bindingAction: Self
+  ) -> Bool {
+    keyPath == bindingAction.keyPath
   }
+}
 
-  extension ViewStore {
-    @available(
-      *, deprecated,
-      message:
-        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState'. Bindings are now derived via 'ViewStore.binding' with a key path to that 'BindableState' (for example, 'viewStore.binding(\\.$value)'). For dynamic member lookup to be available, the view store's 'Action' type must also conform to 'BindableAction'."
-    )
-    public func binding<LocalState: Equatable>(
-      keyPath: WritableKeyPath<State, LocalState>,
-      send action: @escaping (BindingAction<State>) -> Action
-    ) -> Binding<LocalState> {
-      self.binding(
-        get: { $0[keyPath: keyPath] },
-        send: { action(.set(keyPath, $0)) }
-      )
+extension Reducer {
+  @available(
+    *, deprecated,
+    message:
+      "'Reducer.binding()' no longer takes an explicit extract function and instead the reducer's 'Action' type must conform to 'BindableAction'"
+  )
+  public func binding(action toBindingAction: @escaping (Action) -> BindingAction<State>?) -> Self
+  {
+    Self { state, action, environment in
+      toBindingAction(action)?.set(&state)
+      return self.run(&state, action, environment)
     }
   }
-#else
-  extension BindingAction {
-    @available(
-      *, deprecated,
-      message:
-        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
-    )
-    public static func set<Value: Equatable>(
-      _ keyPath: WritableKeyPath<Root, Value>,
-      _ value: Value
-    ) -> Self {
-      .init(
-        keyPath: keyPath,
-        set: { $0[keyPath: keyPath] = value },
-        value: value,
-        valueIsEqualTo: { $0 as? Value == value }
-      )
-    }
+}
 
-    @available(
-      *, deprecated,
-      message:
-        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\\.$value'. Upgrade to Xcode 12.5 or greater for access to 'BindableState'."
+extension ViewStore {
+  @available(
+    *, deprecated,
+    message:
+      "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState'. Bindings are now derived via 'ViewStore.binding' with a key path to that 'BindableState' (for example, 'viewStore.binding(\\.$value)'). For dynamic member lookup to be available, the view store's 'Action' type must also conform to 'BindableAction'."
+  )
+  public func binding<LocalState: Equatable>(
+    keyPath: WritableKeyPath<State, LocalState>,
+    send action: @escaping (BindingAction<State>) -> Action
+  ) -> Binding<LocalState> {
+    self.binding(
+      get: { $0[keyPath: keyPath] },
+      send: { action(.set(keyPath, $0)) }
     )
-    public static func ~= <Value>(
-      keyPath: WritableKeyPath<Root, Value>,
-      bindingAction: Self
-    ) -> Bool {
-      keyPath == bindingAction.keyPath
-    }
   }
-
-  extension Reducer {
-    @available(
-      *, deprecated,
-      message:
-        "'Reducer.binding()' no longer takes an explicit extract function and instead the reducer's 'Action' type must conform to 'BindableAction'. Upgrade to Xcode 12.5 or greater for access to 'Reducer.binding()' and 'BindableAction'."
-    )
-    public func binding(action toBindingAction: @escaping (Action) -> BindingAction<State>?) -> Self
-    {
-      Self { state, action, environment in
-        toBindingAction(action)?.set(&state)
-        return self.run(&state, action, environment)
-      }
-    }
-  }
-
-  extension ViewStore {
-    @available(
-      *, deprecated,
-      message:
-        "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState'. Bindings are now derived via 'ViewStore.binding' with a key path to that 'BindableState' (for example, 'viewStore.binding(\\.$value)'). For dynamic member lookup to be available, the view store's 'Action' type must also conform to 'BindableAction'. Upgrade to Xcode 12.5 or greater for access to 'BindableState' and 'BindableAction'."
-    )
-    public func binding<LocalState: Equatable>(
-      keyPath: WritableKeyPath<State, LocalState>,
-      send action: @escaping (BindingAction<State>) -> Action
-    ) -> Binding<LocalState> {
-      self.binding(
-        get: { $0[keyPath: keyPath] },
-        send: { action(.set(keyPath, $0)) }
-      )
-    }
-  }
-#endif
+}
 
 // NB: Deprecated after 0.23.0:
 

--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -185,17 +185,15 @@ public struct AlertState<Action> {
     case cancel
     case destructive
 
-    #if compiler(>=5.5)
-      @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
-      var toSwiftUI: SwiftUI.ButtonRole {
-        switch self {
-        case .cancel:
-          return .cancel
-        case .destructive:
-          return .destructive
-        }
+    @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+    var toSwiftUI: SwiftUI.ButtonRole {
+      switch self {
+      case .cancel:
+        return .cancel
+      case .destructive:
+        return .destructive
       }
-    #endif
+    }
   }
 }
 
@@ -212,51 +210,40 @@ extension View {
     _ store: Store<AlertState<Action>?, Action>,
     dismiss: Action
   ) -> some View {
-    #if compiler(>=5.5)
-      if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
-        self.modifier(
-          NewAlertModifier(
-            viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
-            dismiss: dismiss
-          )
+    if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
+      self.modifier(
+        NewAlertModifier(
+          viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
+          dismiss: dismiss
         )
-      } else {
-        self.modifier(
-          OldAlertModifier(
-            viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
-            dismiss: dismiss
-          )
-        )
-      }
-    #else
+      )
+    } else {
       self.modifier(
         OldAlertModifier(
           viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
           dismiss: dismiss
         )
       )
-    #endif
+    }
   }
 }
 
-#if compiler(>=5.5)
-  // NB: Workaround for iOS 14 runtime crashes during iOS 15 availability checks.
-  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
-  private struct NewAlertModifier<Action>: ViewModifier {
-    @ObservedObject var viewStore: ViewStore<AlertState<Action>?, Action>
-    let dismiss: Action
+// NB: Workaround for iOS 14 runtime crashes during iOS 15 availability checks.
+@available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+private struct NewAlertModifier<Action>: ViewModifier {
+  @ObservedObject var viewStore: ViewStore<AlertState<Action>?, Action>
+  let dismiss: Action
 
-    func body(content: Content) -> some View {
-      content.alert(
-        (viewStore.state?.title).map { Text($0) } ?? Text(""),
-        isPresented: viewStore.binding(send: dismiss).isPresent(),
-        presenting: viewStore.state,
-        actions: { $0.toSwiftUIActions(send: viewStore.send) },
-        message: { $0.message.map { Text($0) } }
-      )
-    }
+  func body(content: Content) -> some View {
+    content.alert(
+      (viewStore.state?.title).map { Text($0) } ?? Text(""),
+      isPresented: viewStore.binding(send: dismiss).isPresent(),
+      presenting: viewStore.state,
+      actions: { $0.toSwiftUIActions(send: viewStore.send) },
+      message: { $0.message.map { Text($0) } }
+    )
   }
-#endif
+}
 
 private struct OldAlertModifier<Action>: ViewModifier {
   @ObservedObject var viewStore: ViewStore<AlertState<Action>?, Action>
@@ -388,29 +375,25 @@ extension AlertState.Button {
     }
   }
 
-  #if compiler(>=5.5)
-    @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
-    func toSwiftUIButton(send: @escaping (Action) -> Void) -> some View {
-      SwiftUI.Button(
-        role: self.role?.toSwiftUI,
-        action: self.toSwiftUIAction(send: send)
-      ) {
-        Text(self.label)
-      }
+  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+  func toSwiftUIButton(send: @escaping (Action) -> Void) -> some View {
+    SwiftUI.Button(
+      role: self.role?.toSwiftUI,
+      action: self.toSwiftUIAction(send: send)
+    ) {
+      Text(self.label)
     }
-  #endif
+  }
 }
 
 extension AlertState {
-  #if compiler(>=5.5)
-    @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
-    @ViewBuilder
-    fileprivate func toSwiftUIActions(send: @escaping (Action) -> Void) -> some View {
-      ForEach(self.buttons.indices, id: \.self) {
-        self.buttons[$0].toSwiftUIButton(send: send)
-      }
+  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+  @ViewBuilder
+  fileprivate func toSwiftUIActions(send: @escaping (Action) -> Void) -> some View {
+    ForEach(self.buttons.indices, id: \.self) {
+      self.buttons[$0].toSwiftUIButton(send: send)
     }
-  #endif
+  }
 
   fileprivate func toSwiftUIAlert(send: @escaping (Action) -> Void) -> SwiftUI.Alert {
     if self.buttons.count == 2 {

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -1,306 +1,302 @@
 import CustomDump
 import SwiftUI
 
-// NB: `BindableAction` can produce crashes in Xcode 12.4 (Swift 5.3) and earlier due to an enum
-//     protocol witness bug: https://bugs.swift.org/browse/SR-14041
-#if compiler(>=5.4)
-  /// A property wrapper type that can designate properties of app state that can be directly
-  /// bindable in SwiftUI views.
+/// A property wrapper type that can designate properties of app state that can be directly
+/// bindable in SwiftUI views.
+///
+/// Along with an action type that conforms to the ``BindableAction`` protocol, this type can be
+/// used to safely eliminate the boilerplate that is typically incurred when working with multiple
+/// mutable fields on state.
+///
+/// For example, a settings screen may model its state with the following struct:
+///
+/// ```swift
+/// struct SettingsState {
+///   var digest = Digest.daily
+///   var displayName = ""
+///   var enableNotifications = false
+///   var isLoading = false
+///   var protectMyPosts = false
+///   var sendEmailNotifications = false
+///   var sendMobileNotifications = false
+/// }
+/// ```
+///
+/// The majority of these fields should be editable by the view, and in the Composable
+/// Architecture this means that each field requires a corresponding action that can be sent to
+/// the store. Typically this comes in the form of an enum with a case per field:
+///
+/// ```swift
+/// enum SettingsAction {
+///   case digestChanged(Digest)
+///   case displayNameChanged(String)
+///   case enableNotificationsChanged(Bool)
+///   case protectMyPostsChanged(Bool)
+///   case sendEmailNotificationsChanged(Bool)
+///   case sendMobileNotificationsChanged(Bool)
+/// }
+/// ```
+///
+/// And we're not even done yet. In the reducer we must now handle each action, which simply
+/// replaces the state at each field with a new value:
+///
+/// ```swift
+/// let settingsReducer = Reducer<
+///   SettingsState, SettingsAction, SettingsEnvironment
+/// > { state, action, environment in
+///   switch action {
+///   case let digestChanged(digest):
+///     state.digest = digest
+///     return .none
+///
+///   case let displayNameChanged(displayName):
+///     state.displayName = displayName
+///     return .none
+///
+///   case let enableNotificationsChanged(isOn):
+///     state.enableNotifications = isOn
+///     return .none
+///
+///   case let protectMyPostsChanged(isOn):
+///     state.protectMyPosts = isOn
+///     return .none
+///
+///   case let sendEmailNotificationsChanged(isOn):
+///     state.sendEmailNotifications = isOn
+///     return .none
+///
+///   case let sendMobileNotificationsChanged(isOn):
+///     state.sendMobileNotifications = isOn
+///     return .none
+///   }
+/// }
+/// ```
+///
+/// This is a _lot_ of boilerplate for something that should be simple. Luckily, we can
+/// dramatically eliminate this boilerplate using `BindableState` and ``BindableAction``.
+///
+/// First, we can annotate each bindable value of state with the `@BindableState` property
+/// wrapper:
+///
+/// ```swift
+/// struct SettingsState {
+///   @BindableState var digest = Digest.daily
+///   @BindableState var displayName = ""
+///   @BindableState var enableNotifications = false
+///   var isLoading = false
+///   @BindableState var protectMyPosts = false
+///   @BindableState var sendEmailNotifications = false
+///   @BindableState var sendMobileNotifications = false
+/// }
+/// ```
+///
+/// Each annotated field is directly to bindable to SwiftUI controls, like pickers, toggles, and
+/// text fields. Notably, the `isLoading` property is _not_ annotated as being bindable, which
+/// prevents the view from mutating this value directly.
+///
+/// Next, we can conform the action type to ``BindableAction`` by collapsing all of the
+/// individual, field-mutating actions into a single case that holds a ``BindingAction`` generic
+/// over the reducer's `SettingsState`:
+///
+/// ```swift
+/// enum SettingsAction: BindableAction {
+///   case binding(BindingAction<SettingsState>)
+/// }
+/// ```
+///
+/// And then, we can simplify the settings reducer by allowing the `binding` method to handle
+/// these field mutations for us:
+///
+/// ```swift
+/// let settingsReducer = Reducer<
+///   SettingsState, SettingsAction, SettingsEnvironment
+/// > {
+///   switch action {
+///   case .binding:
+///     return .none
+///   }
+/// }
+/// .binding()
+/// ```
+///
+/// Binding actions are constructed and sent to the store by calling ``ViewStore/binding(_:)``
+/// with a key path to the bindable state:
+///
+/// ```swift
+/// TextField("Display name", text: viewStore.binding(\.$displayName))
+/// ```
+///
+/// Should you need to layer additional functionality over these bindings, your reducer can
+/// pattern match the action for a given key path:
+///
+/// ```swift
+/// case .binding(\.$displayName):
+///   // Validate display name
+///
+/// case .binding(\.$enableNotifications):
+///   // Return an authorization request effect
+/// ```
+///
+/// Binding actions can also be tested in much the same way regular actions are tested. Rather
+/// than send a specific action describing how a binding changed, such as
+/// `.displayNameChanged("Blob")`, you will send a ``Reducer/binding(action:)`` action that
+/// describes which key path is being set to what value, such as `.set(\.$displayName, "Blob")`:
+///
+/// ```swift
+/// let store = TestStore(
+///   initialState: SettingsState(),
+///   reducer: settingsReducer,
+///   environment: SettingsEnvironment(...)
+/// )
+///
+/// store.send(.set(\.$displayName, "Blob")) {
+///   $0.displayName = "Blob"
+/// }
+/// store.send(.set(\.$protectMyPosts, true)) {
+///   $0.protectMyPosts = true
+/// )
+/// ```
+@dynamicMemberLookup
+@propertyWrapper
+public struct BindableState<Value> {
+  /// The underlying value wrapped by the bindable state.
+  public var wrappedValue: Value
+
+  /// Creates bindable state from the value of another bindable state.
+  public init(wrappedValue: Value) {
+    self.wrappedValue = wrappedValue
+  }
+
+  /// A projection that can be used to derive bindings from a view store.
   ///
-  /// Along with an action type that conforms to the ``BindableAction`` protocol, this type can be
-  /// used to safely eliminate the boilerplate that is typically incurred when working with multiple
-  /// mutable fields on state.
-  ///
-  /// For example, a settings screen may model its state with the following struct:
-  ///
-  /// ```swift
-  /// struct SettingsState {
-  ///   var digest = Digest.daily
-  ///   var displayName = ""
-  ///   var enableNotifications = false
-  ///   var isLoading = false
-  ///   var protectMyPosts = false
-  ///   var sendEmailNotifications = false
-  ///   var sendMobileNotifications = false
-  /// }
-  /// ```
-  ///
-  /// The majority of these fields should be editable by the view, and in the Composable
-  /// Architecture this means that each field requires a corresponding action that can be sent to
-  /// the store. Typically this comes in the form of an enum with a case per field:
-  ///
-  /// ```swift
-  /// enum SettingsAction {
-  ///   case digestChanged(Digest)
-  ///   case displayNameChanged(String)
-  ///   case enableNotificationsChanged(Bool)
-  ///   case protectMyPostsChanged(Bool)
-  ///   case sendEmailNotificationsChanged(Bool)
-  ///   case sendMobileNotificationsChanged(Bool)
-  /// }
-  /// ```
-  ///
-  /// And we're not even done yet. In the reducer we must now handle each action, which simply
-  /// replaces the state at each field with a new value:
-  ///
-  /// ```swift
-  /// let settingsReducer = Reducer<
-  ///   SettingsState, SettingsAction, SettingsEnvironment
-  /// > { state, action, environment in
-  ///   switch action {
-  ///   case let digestChanged(digest):
-  ///     state.digest = digest
-  ///     return .none
-  ///
-  ///   case let displayNameChanged(displayName):
-  ///     state.displayName = displayName
-  ///     return .none
-  ///
-  ///   case let enableNotificationsChanged(isOn):
-  ///     state.enableNotifications = isOn
-  ///     return .none
-  ///
-  ///   case let protectMyPostsChanged(isOn):
-  ///     state.protectMyPosts = isOn
-  ///     return .none
-  ///
-  ///   case let sendEmailNotificationsChanged(isOn):
-  ///     state.sendEmailNotifications = isOn
-  ///     return .none
-  ///
-  ///   case let sendMobileNotificationsChanged(isOn):
-  ///     state.sendMobileNotifications = isOn
-  ///     return .none
-  ///   }
-  /// }
-  /// ```
-  ///
-  /// This is a _lot_ of boilerplate for something that should be simple. Luckily, we can
-  /// dramatically eliminate this boilerplate using `BindableState` and ``BindableAction``.
-  ///
-  /// First, we can annotate each bindable value of state with the `@BindableState` property
-  /// wrapper:
-  ///
-  /// ```swift
-  /// struct SettingsState {
-  ///   @BindableState var digest = Digest.daily
-  ///   @BindableState var displayName = ""
-  ///   @BindableState var enableNotifications = false
-  ///   var isLoading = false
-  ///   @BindableState var protectMyPosts = false
-  ///   @BindableState var sendEmailNotifications = false
-  ///   @BindableState var sendMobileNotifications = false
-  /// }
-  /// ```
-  ///
-  /// Each annotated field is directly to bindable to SwiftUI controls, like pickers, toggles, and
-  /// text fields. Notably, the `isLoading` property is _not_ annotated as being bindable, which
-  /// prevents the view from mutating this value directly.
-  ///
-  /// Next, we can conform the action type to ``BindableAction`` by collapsing all of the
-  /// individual, field-mutating actions into a single case that holds a ``BindingAction`` generic
-  /// over the reducer's `SettingsState`:
-  ///
-  /// ```swift
-  /// enum SettingsAction: BindableAction {
-  ///   case binding(BindingAction<SettingsState>)
-  /// }
-  /// ```
-  ///
-  /// And then, we can simplify the settings reducer by allowing the `binding` method to handle
-  /// these field mutations for us:
-  ///
-  /// ```swift
-  /// let settingsReducer = Reducer<
-  ///   SettingsState, SettingsAction, SettingsEnvironment
-  /// > {
-  ///   switch action {
-  ///   case .binding:
-  ///     return .none
-  ///   }
-  /// }
-  /// .binding()
-  /// ```
-  ///
-  /// Binding actions are constructed and sent to the store by calling ``ViewStore/binding(_:)``
-  /// with a key path to the bindable state:
+  /// Use the projected value to derive bindings from a view store with properties annotated with
+  /// `@BindableState`. To get the `projectedValue`, prefix the property with `$`:
   ///
   /// ```swift
   /// TextField("Display name", text: viewStore.binding(\.$displayName))
   /// ```
   ///
-  /// Should you need to layer additional functionality over these bindings, your reducer can
-  /// pattern match the action for a given key path:
-  ///
-  /// ```swift
-  /// case .binding(\.$displayName):
-  ///   // Validate display name
-  ///
-  /// case .binding(\.$enableNotifications):
-  ///   // Return an authorization request effect
-  /// ```
-  ///
-  /// Binding actions can also be tested in much the same way regular actions are tested. Rather
-  /// than send a specific action describing how a binding changed, such as
-  /// `.displayNameChanged("Blob")`, you will send a ``Reducer/binding(action:)`` action that
-  /// describes which key path is being set to what value, such as `.set(\.$displayName, "Blob")`:
-  ///
-  /// ```swift
-  /// let store = TestStore(
-  ///   initialState: SettingsState(),
-  ///   reducer: settingsReducer,
-  ///   environment: SettingsEnvironment(...)
-  /// )
-  ///
-  /// store.send(.set(\.$displayName, "Blob")) {
-  ///   $0.displayName = "Blob"
-  /// }
-  /// store.send(.set(\.$protectMyPosts, true)) {
-  ///   $0.protectMyPosts = true
-  /// )
-  /// ```
-  @dynamicMemberLookup
-  @propertyWrapper
-  public struct BindableState<Value> {
-    /// The underlying value wrapped by the bindable state.
-    public var wrappedValue: Value
-
-    /// Creates bindable state from the value of another bindable state.
-    public init(wrappedValue: Value) {
-      self.wrappedValue = wrappedValue
-    }
-
-    /// A projection that can be used to derive bindings from a view store.
-    ///
-    /// Use the projected value to derive bindings from a view store with properties annotated with
-    /// `@BindableState`. To get the `projectedValue`, prefix the property with `$`:
-    ///
-    /// ```swift
-    /// TextField("Display name", text: viewStore.binding(\.$displayName))
-    /// ```
-    ///
-    /// See ``BindableState`` for more details.
-    public var projectedValue: Self {
-      get { self }
-      set { self = newValue }
-    }
-
-    /// Returns bindable state to the resulting value of a given key path.
-    ///
-    /// - Parameter keyPath: A key path to a specific resulting value.
-    /// - Returns: A new bindable state.
-    public subscript<Subject>(
-      dynamicMember keyPath: WritableKeyPath<Value, Subject>
-    ) -> BindableState<Subject> {
-      get { .init(wrappedValue: self.wrappedValue[keyPath: keyPath]) }
-      set { self.wrappedValue[keyPath: keyPath] = newValue.wrappedValue }
-    }
+  /// See ``BindableState`` for more details.
+  public var projectedValue: Self {
+    get { self }
+    set { self = newValue }
   }
 
-  extension BindableState: Equatable where Value: Equatable {}
+  /// Returns bindable state to the resulting value of a given key path.
+  ///
+  /// - Parameter keyPath: A key path to a specific resulting value.
+  /// - Returns: A new bindable state.
+  public subscript<Subject>(
+    dynamicMember keyPath: WritableKeyPath<Value, Subject>
+  ) -> BindableState<Subject> {
+    get { .init(wrappedValue: self.wrappedValue[keyPath: keyPath]) }
+    set { self.wrappedValue[keyPath: keyPath] = newValue.wrappedValue }
+  }
+}
 
-  extension BindableState: Hashable where Value: Hashable {}
+extension BindableState: Equatable where Value: Equatable {}
 
-  extension BindableState: Decodable where Value: Decodable {
-    public init(from decoder: Decoder) throws {
-      do {
-        let container = try decoder.singleValueContainer()
-        self.init(wrappedValue: try container.decode(Value.self))
-      } catch {
-        self.init(wrappedValue: try Value(from: decoder))
+extension BindableState: Hashable where Value: Hashable {}
+
+extension BindableState: Decodable where Value: Decodable {
+  public init(from decoder: Decoder) throws {
+    do {
+      let container = try decoder.singleValueContainer()
+      self.init(wrappedValue: try container.decode(Value.self))
+    } catch {
+      self.init(wrappedValue: try Value(from: decoder))
+    }
+  }
+}
+
+extension BindableState: Encodable where Value: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    do {
+      var container = encoder.singleValueContainer()
+      try container.encode(self.wrappedValue)
+    } catch {
+      try self.wrappedValue.encode(to: encoder)
+    }
+  }
+}
+
+extension BindableState: CustomReflectable {
+  public var customMirror: Mirror {
+    Mirror(reflecting: self.wrappedValue)
+  }
+}
+
+extension BindableState: CustomDumpRepresentable {
+  public var customDumpValue: Any {
+    self.wrappedValue
+  }
+}
+
+extension BindableState: CustomDebugStringConvertible where Value: CustomDebugStringConvertible {
+  public var debugDescription: String {
+    self.wrappedValue.debugDescription
+  }
+}
+
+/// An action type that exposes a `binding` case that holds a ``BindingAction``.
+///
+/// Used in conjunction with ``BindableState`` to safely eliminate the boilerplate typically
+/// associated with mutating multiple fields in state.
+///
+/// See the documentation for ``BindableState`` for more details.
+public protocol BindableAction {
+  /// The root state type that contains bindable fields.
+  associatedtype State
+
+  /// Embeds a binding action in this action type.
+  ///
+  /// - Returns: A binding action.
+  static func binding(_ action: BindingAction<State>) -> Self
+}
+
+extension BindableAction {
+  /// Constructs a binding action for the given key path and bindable value.
+  ///
+  /// Shorthand for `.binding(.set(\.$keyPath, value))`.
+  ///
+  /// - Returns: A binding action.
+  public static func set<Value: Equatable>(
+    _ keyPath: WritableKeyPath<State, BindableState<Value>>,
+    _ value: Value
+  ) -> Self {
+    self.binding(.set(keyPath, value))
+  }
+}
+
+extension ViewStore where Action: BindableAction, Action.State == State {
+  /// Returns a binding to the resulting bindable state of a given key path.
+  ///
+  /// - Parameter keyPath: A key path to a specific bindable state.
+  /// - Returns: A new binding.
+  public func binding<Value: Equatable>(
+    _ keyPath: WritableKeyPath<State, BindableState<Value>>,
+    file: StaticString = #fileID,
+    line: UInt = #line
+  ) -> Binding<Value> {
+    self.binding(
+      get: { $0[keyPath: keyPath].wrappedValue },
+      send: { value in
+        #if DEBUG
+          let debugger = BindableActionViewStoreDebugger(
+            value: value, bindableActionType: Action.self, file: file, line: line
+          )
+          let set: (inout State) -> Void = {
+            $0[keyPath: keyPath].wrappedValue = value
+            debugger.wasCalled = true
+          }
+        #else
+          let set: (inout State) -> Void = { $0[keyPath: keyPath].wrappedValue = value }
+        #endif
+        return .binding(.init(keyPath: keyPath, set: set, value: value))
       }
-    }
+    )
   }
-
-  extension BindableState: Encodable where Value: Encodable {
-    public func encode(to encoder: Encoder) throws {
-      do {
-        var container = encoder.singleValueContainer()
-        try container.encode(self.wrappedValue)
-      } catch {
-        try self.wrappedValue.encode(to: encoder)
-      }
-    }
-  }
-
-  extension BindableState: CustomReflectable {
-    public var customMirror: Mirror {
-      Mirror(reflecting: self.wrappedValue)
-    }
-  }
-
-  extension BindableState: CustomDumpRepresentable {
-    public var customDumpValue: Any {
-      self.wrappedValue
-    }
-  }
-
-  extension BindableState: CustomDebugStringConvertible where Value: CustomDebugStringConvertible {
-    public var debugDescription: String {
-      self.wrappedValue.debugDescription
-    }
-  }
-
-  /// An action type that exposes a `binding` case that holds a ``BindingAction``.
-  ///
-  /// Used in conjunction with ``BindableState`` to safely eliminate the boilerplate typically
-  /// associated with mutating multiple fields in state.
-  ///
-  /// See the documentation for ``BindableState`` for more details.
-  public protocol BindableAction {
-    /// The root state type that contains bindable fields.
-    associatedtype State
-
-    /// Embeds a binding action in this action type.
-    ///
-    /// - Returns: A binding action.
-    static func binding(_ action: BindingAction<State>) -> Self
-  }
-
-  extension BindableAction {
-    /// Constructs a binding action for the given key path and bindable value.
-    ///
-    /// Shorthand for `.binding(.set(\.$keyPath, value))`.
-    ///
-    /// - Returns: A binding action.
-    public static func set<Value: Equatable>(
-      _ keyPath: WritableKeyPath<State, BindableState<Value>>,
-      _ value: Value
-    ) -> Self {
-      self.binding(.set(keyPath, value))
-    }
-  }
-
-  extension ViewStore where Action: BindableAction, Action.State == State {
-    /// Returns a binding to the resulting bindable state of a given key path.
-    ///
-    /// - Parameter keyPath: A key path to a specific bindable state.
-    /// - Returns: A new binding.
-    public func binding<Value: Equatable>(
-      _ keyPath: WritableKeyPath<State, BindableState<Value>>,
-      file: StaticString = #fileID,
-      line: UInt = #line
-    ) -> Binding<Value> {
-      self.binding(
-        get: { $0[keyPath: keyPath].wrappedValue },
-        send: { value in
-          #if DEBUG
-            let debugger = BindableActionViewStoreDebugger(
-              value: value, bindableActionType: Action.self, file: file, line: line
-            )
-            let set: (inout State) -> Void = {
-              $0[keyPath: keyPath].wrappedValue = value
-              debugger.wasCalled = true
-            }
-          #else
-            let set: (inout State) -> Void = { $0[keyPath: keyPath].wrappedValue = value }
-          #endif
-          return .binding(.init(keyPath: keyPath, set: set, value: value))
-        }
-      )
-    }
-  }
-#endif
+}
 
 /// An action that describes simple mutations to some root state at a writable key path.
 ///
@@ -320,61 +316,59 @@ public struct BindingAction<Root>: Equatable {
   }
 }
 
-#if compiler(>=5.4)
-  extension BindingAction {
-    /// Returns an action that describes simple mutations to some root state at a writable key path
-    /// to bindable state.
-    ///
-    /// - Parameters:
-    ///   - keyPath: A key path to the property that should be mutated. This property must be
-    ///     annotated with the ``BindableState`` property wrapper.
-    ///   - value: A value to assign at the given key path.
-    /// - Returns: An action that describes simple mutations to some root state at a writable key
-    ///   path.
-    public static func set<Value: Equatable>(
-      _ keyPath: WritableKeyPath<Root, BindableState<Value>>,
-      _ value: Value
-    ) -> Self {
-      return .init(
-        keyPath: keyPath,
-        set: { $0[keyPath: keyPath].wrappedValue = value },
-        value: value
-      )
-    }
-
-    /// Matches a binding action by its key path.
-    ///
-    /// Implicitly invoked when switching on a reducer's action and pattern matching on a binding
-    /// action directly to do further work:
-    ///
-    /// ```swift
-    /// case .binding(\.$displayName): // Invokes the `~=` operator.
-    ///   // Validate display name
-    ///
-    /// case .binding(\.$enableNotifications):
-    ///   // Return an authorization request effect
-    /// ```
-    public static func ~= <Value>(
-      keyPath: WritableKeyPath<Root, BindableState<Value>>,
-      bindingAction: Self
-    ) -> Bool {
-      keyPath == bindingAction.keyPath
-    }
-
-    init<Value: Equatable>(
-      keyPath: WritableKeyPath<Root, BindableState<Value>>,
-      set: @escaping (inout Root) -> Void,
-      value: Value
-    ) {
-      self.init(
-        keyPath: keyPath,
-        set: set,
-        value: value,
-        valueIsEqualTo: { $0 as? Value == value }
-      )
-    }
+extension BindingAction {
+  /// Returns an action that describes simple mutations to some root state at a writable key path
+  /// to bindable state.
+  ///
+  /// - Parameters:
+  ///   - keyPath: A key path to the property that should be mutated. This property must be
+  ///     annotated with the ``BindableState`` property wrapper.
+  ///   - value: A value to assign at the given key path.
+  /// - Returns: An action that describes simple mutations to some root state at a writable key
+  ///   path.
+  public static func set<Value: Equatable>(
+    _ keyPath: WritableKeyPath<Root, BindableState<Value>>,
+    _ value: Value
+  ) -> Self {
+    return .init(
+      keyPath: keyPath,
+      set: { $0[keyPath: keyPath].wrappedValue = value },
+      value: value
+    )
   }
-#endif
+
+  /// Matches a binding action by its key path.
+  ///
+  /// Implicitly invoked when switching on a reducer's action and pattern matching on a binding
+  /// action directly to do further work:
+  ///
+  /// ```swift
+  /// case .binding(\.$displayName): // Invokes the `~=` operator.
+  ///   // Validate display name
+  ///
+  /// case .binding(\.$enableNotifications):
+  ///   // Return an authorization request effect
+  /// ```
+  public static func ~= <Value>(
+    keyPath: WritableKeyPath<Root, BindableState<Value>>,
+    bindingAction: Self
+  ) -> Bool {
+    keyPath == bindingAction.keyPath
+  }
+
+  init<Value: Equatable>(
+    keyPath: WritableKeyPath<Root, BindableState<Value>>,
+    set: @escaping (inout Root) -> Void,
+    value: Value
+  ) {
+    self.init(
+      keyPath: keyPath,
+      set: set,
+      value: value,
+      valueIsEqualTo: { $0 as? Value == value }
+    )
+  }
+}
 
 extension BindingAction {
   /// Transforms a binding action over some root state to some other type of root state given a
@@ -519,46 +513,44 @@ extension BindingAction: CustomDumpReflectable {
   }
 }
 
-#if compiler(>=5.4)
-  extension Reducer where Action: BindableAction, State == Action.State {
-    /// Returns a reducer that applies ``BindingAction`` mutations to `State` before running this
-    /// reducer's logic.
-    ///
-    /// For example, a settings screen may gather its binding actions into a single
-    /// ``BindingAction`` case by conforming to ``BindableAction``:
-    ///
-    /// ```swift
-    /// enum SettingsAction: BindableAction {
-    ///   ...
-    ///   case binding(BindingAction<SettingsState>)
-    /// }
-    /// ```
-    ///
-    /// The reducer can then be enhanced to automatically handle these mutations for you by tacking
-    /// on the ``binding()`` method:
-    ///
-    /// ```swift
-    /// let settingsReducer = Reducer<SettingsState, SettingsAction, SettingsEnvironment> {
-    ///   ...
-    /// }
-    /// .binding()
-    /// ```
-    ///
-    /// - Returns: A reducer that applies ``BindingAction`` mutations to `State` before running this
-    ///   reducer's logic.
-    public func binding() -> Self {
-      Self { state, action, environment in
-        guard let bindingAction = (/Action.binding).extract(from: action)
-        else {
-          return self.run(&state, action, environment)
-        }
-
-        bindingAction.set(&state)
+extension Reducer where Action: BindableAction, State == Action.State {
+  /// Returns a reducer that applies ``BindingAction`` mutations to `State` before running this
+  /// reducer's logic.
+  ///
+  /// For example, a settings screen may gather its binding actions into a single
+  /// ``BindingAction`` case by conforming to ``BindableAction``:
+  ///
+  /// ```swift
+  /// enum SettingsAction: BindableAction {
+  ///   ...
+  ///   case binding(BindingAction<SettingsState>)
+  /// }
+  /// ```
+  ///
+  /// The reducer can then be enhanced to automatically handle these mutations for you by tacking
+  /// on the ``binding()`` method:
+  ///
+  /// ```swift
+  /// let settingsReducer = Reducer<SettingsState, SettingsAction, SettingsEnvironment> {
+  ///   ...
+  /// }
+  /// .binding()
+  /// ```
+  ///
+  /// - Returns: A reducer that applies ``BindingAction`` mutations to `State` before running this
+  ///   reducer's logic.
+  public func binding() -> Self {
+    Self { state, action, environment in
+      guard let bindingAction = (/Action.binding).extract(from: action)
+      else {
         return self.run(&state, action, environment)
       }
+
+      bindingAction.set(&state)
+      return self.run(&state, action, environment)
     }
   }
-#endif
+}
 
 #if DEBUG
   private final class BindableActionViewStoreDebugger<Value> {

--- a/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
@@ -153,19 +153,17 @@ public struct ConfirmationDialogState<Action> {
     case hidden
     case visible
 
-    #if compiler(>=5.5)
-      @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
-      var toSwiftUI: SwiftUI.Visibility {
-        switch self {
-        case .automatic:
-          return .automatic
-        case .hidden:
-          return .hidden
-        case .visible:
-          return .visible
-        }
+    @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+    var toSwiftUI: SwiftUI.Visibility {
+      switch self {
+      case .automatic:
+        return .automatic
+      case .hidden:
+        return .hidden
+      case .visible:
+        return .visible
       }
-    #endif
+    }
   }
 }
 
@@ -234,54 +232,43 @@ extension View {
     _ store: Store<ConfirmationDialogState<Action>?, Action>,
     dismiss: Action
   ) -> some View {
-    #if compiler(>=5.5)
-      if #available(iOS 15, tvOS 15, watchOS 8, *) {
-        self.modifier(
-          NewConfirmationDialogModifier(
-            viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
-            dismiss: dismiss
-          )
-        )
-      } else {
-        #if !os(macOS)
-          self.modifier(
-            OldConfirmationDialogModifier(
-              viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
-              dismiss: dismiss
-            )
-          )
-        #endif
-      }
-    #elseif !os(macOS)
+    if #available(iOS 15, tvOS 15, watchOS 8, *) {
       self.modifier(
-        OldConfirmationDialogModifier(
+        NewConfirmationDialogModifier(
           viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
           dismiss: dismiss
         )
       )
-    #endif
+    } else {
+      #if !os(macOS)
+        self.modifier(
+          OldConfirmationDialogModifier(
+            viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
+            dismiss: dismiss
+          )
+        )
+      #endif
+    }
   }
 }
 
-#if compiler(>=5.5)
-  // NB: Workaround for iOS 14 runtime crashes during iOS 15 availability checks.
-  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
-  private struct NewConfirmationDialogModifier<Action>: ViewModifier {
-    @ObservedObject var viewStore: ViewStore<ConfirmationDialogState<Action>?, Action>
-    let dismiss: Action
+// NB: Workaround for iOS 14 runtime crashes during iOS 15 availability checks.
+@available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+private struct NewConfirmationDialogModifier<Action>: ViewModifier {
+  @ObservedObject var viewStore: ViewStore<ConfirmationDialogState<Action>?, Action>
+  let dismiss: Action
 
-    func body(content: Content) -> some View {
-      content.confirmationDialog(
-        (viewStore.state?.title).map { Text($0) } ?? Text(""),
-        isPresented: viewStore.binding(send: dismiss).isPresent(),
-        titleVisibility: viewStore.state?.titleVisibility.toSwiftUI ?? .automatic,
-        presenting: viewStore.state,
-        actions: { $0.toSwiftUIActions(send: viewStore.send) },
-        message: { $0.message.map { Text($0) } }
-      )
-    }
+  func body(content: Content) -> some View {
+    content.confirmationDialog(
+      (viewStore.state?.title).map { Text($0) } ?? Text(""),
+      isPresented: viewStore.binding(send: dismiss).isPresent(),
+      titleVisibility: viewStore.state?.titleVisibility.toSwiftUI ?? .automatic,
+      presenting: viewStore.state,
+      actions: { $0.toSwiftUIActions(send: viewStore.send) },
+      message: { $0.message.map { Text($0) } }
+    )
   }
-#endif
+}
 
 @available(iOS 13, *)
 @available(macOS 12, *)
@@ -307,15 +294,13 @@ private struct OldConfirmationDialogModifier<Action>: ViewModifier {
 @available(tvOS 13, *)
 @available(watchOS 6, *)
 extension ConfirmationDialogState {
-  #if compiler(>=5.5)
-    @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
-    @ViewBuilder
-    fileprivate func toSwiftUIActions(send: @escaping (Action) -> Void) -> some View {
-      ForEach(self.buttons.indices, id: \.self) {
-        self.buttons[$0].toSwiftUIButton(send: send)
-      }
+  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+  @ViewBuilder
+  fileprivate func toSwiftUIActions(send: @escaping (Action) -> Void) -> some View {
+    ForEach(self.buttons.indices, id: \.self) {
+      self.buttons[$0].toSwiftUIButton(send: send)
     }
-  #endif
+  }
 
   @available(macOS, unavailable)
   fileprivate func toSwiftUIActionSheet(send: @escaping (Action) -> Void) -> SwiftUI.ActionSheet {

--- a/Tests/ComposableArchitectureTests/BindingTests.swift
+++ b/Tests/ComposableArchitectureTests/BindingTests.swift
@@ -1,39 +1,37 @@
-#if compiler(>=5.4)
-  import ComposableArchitecture
-  import XCTest
+import ComposableArchitecture
+import XCTest
 
-  final class BindingTests: XCTestCase {
-    func testNestedBindableState() {
-      struct State: Equatable {
-        @BindableState var nested = Nested()
+final class BindingTests: XCTestCase {
+  func testNestedBindableState() {
+    struct State: Equatable {
+      @BindableState var nested = Nested()
 
-        struct Nested: Equatable {
-          var field = ""
-        }
+      struct Nested: Equatable {
+        var field = ""
       }
-
-      enum Action: BindableAction, Equatable {
-        case binding(BindingAction<State>)
-      }
-
-      let reducer = Reducer<State, Action, ()> { state, action, _ in
-        switch action {
-        case .binding(\.$nested.field):
-          state.nested.field += "!"
-          return .none
-        default:
-          return .none
-        }
-      }
-      .binding()
-
-      let store = Store(initialState: .init(), reducer: reducer, environment: ())
-
-      let viewStore = ViewStore(store)
-
-      viewStore.binding(\.$nested.field).wrappedValue = "Hello"
-
-      XCTAssertNoDifference(viewStore.state, .init(nested: .init(field: "Hello!")))
     }
+
+    enum Action: BindableAction, Equatable {
+      case binding(BindingAction<State>)
+    }
+
+    let reducer = Reducer<State, Action, ()> { state, action, _ in
+      switch action {
+      case .binding(\.$nested.field):
+        state.nested.field += "!"
+        return .none
+      default:
+        return .none
+      }
+    }
+    .binding()
+
+    let store = Store(initialState: .init(), reducer: reducer, environment: ())
+
+    let viewStore = ViewStore(store)
+
+    viewStore.binding(\.$nested.field).wrappedValue = "Hello"
+
+    XCTAssertNoDifference(viewStore.state, .init(nested: .init(field: "Hello!")))
   }
-#endif
+}

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -183,23 +183,21 @@ final class DebugTests: XCTestCase {
     )
   }
 
-  #if compiler(>=5.4)
-    func testBindingAction() {
-      struct State {
-        @BindableState var width = 0
-      }
-      let action = BindingAction.set(\State.$width, 50)
-      var dump = ""
-      customDump(action, to: &dump)
-      XCTAssertNoDifference(
-        dump,
-        #"""
-        BindingAction.set(
-          WritableKeyPath<State, BindableState<Int>>,
-          50
-        )
-        """#
-      )
+  func testBindingAction() {
+    struct State {
+      @BindableState var width = 0
     }
-  #endif
+    let action = BindingAction.set(\State.$width, 50)
+    var dump = ""
+    customDump(action, to: &dump)
+    XCTAssertNoDifference(
+      dump,
+      #"""
+      BindingAction.set(
+        WritableKeyPath<State, BindableState<Int>>,
+        50
+      )
+      """#
+    )
+  }
 }

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -211,18 +211,16 @@ final class EffectTests: XCTestCase {
     XCTAssertEqual(result, 42)
   }
 
-  #if compiler(>=5.4)
-    func testFailing() {
-      let effect = Effect<Never, Never>.failing("failing")
-      XCTExpectFailure {
-        effect
-          .sink(receiveValue: { _ in })
-          .store(in: &self.cancellables)
-      } issueMatcher: { issue in
-        issue.compactDescription == "failing - A failing effect ran."
-      }
+  func testFailing() {
+    let effect = Effect<Never, Never>.failing("failing")
+    XCTExpectFailure {
+      effect
+        .sink(receiveValue: { _ in })
+        .store(in: &self.cancellables)
+    } issueMatcher: { issue in
+      issue.compactDescription == "failing - A failing effect ran."
     }
-  #endif
+  }
 
   #if canImport(_Concurrency) && compiler(>=5.5.2)
     func testTask() {


### PR DESCRIPTION
The library requires Swift 5.5 because we have a bunch of compiler checks for 5.4 and 5.5. This PR removes all of those checks.

The diff is best viewed with whitespace off.