### PR TITLE
"Failing" -> "Unimplemented"

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
@@ -206,17 +206,11 @@ struct SystemEnvironment<Environment> {
   import XCTestDynamicOverlay
 
   extension SystemEnvironment {
-    static func failing(
-      date: @escaping () -> Date = {
-        XCTFail("date dependency is unimplemented.")
-        return Date()
-      },
+    static func unimplemented(
+      date: @escaping () -> Date = XCTUnimplemented("\(Self.self).date", placeholder: Date()),
       environment: Environment,
-      mainQueue: AnySchedulerOf<DispatchQueue> = .failing,
-      uuid: @escaping () -> UUID = {
-        XCTFail("UUID dependency is unimplemented.")
-        return UUID()
-      }
+      mainQueue: AnySchedulerOf<DispatchQueue> = .unimplemented,
+      uuid: @escaping () -> UUID = XCTUnimplemented("\(Self.self).uuid", placeholder: UUID())
     ) -> Self {
       Self(
         date: date,

--- a/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
@@ -51,10 +51,10 @@ extension FactClient {
 
 #if DEBUG
   extension FactClient {
-    // This is the "failing" fact dependency that is useful to plug into tests that you want
+    // This is the "unimplemented" fact dependency that is useful to plug into tests that you want
     // to prove do not need the dependency.
-    static let failing = Self(
-      fetch: { _ in .failing("\(Self.self).fact is unimplemented.") }
+    static let unimplemented = Self(
+      fetch: { _ in .unimplemented("\(Self.self).fact") }
     )
   }
 #endif

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-BasicsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-BasicsTests.swift
@@ -9,7 +9,7 @@ class EffectsBasicsTests: XCTestCase {
       initialState: EffectsBasicsState(),
       reducer: effectsBasicsReducer,
       environment: EffectsBasicsEnvironment(
-        fact: .failing,
+        fact: .unimplemented,
         mainQueue: .immediate
       )
     )
@@ -26,7 +26,7 @@ class EffectsBasicsTests: XCTestCase {
     let store = TestStore(
       initialState: EffectsBasicsState(),
       reducer: effectsBasicsReducer,
-      environment: .failing
+      environment: .unimplemented
     )
 
     store.environment.fact.fetch = { Effect(value: "\($0) is a good number Brent") }
@@ -48,7 +48,7 @@ class EffectsBasicsTests: XCTestCase {
     let store = TestStore(
       initialState: EffectsBasicsState(),
       reducer: effectsBasicsReducer,
-      environment: .failing
+      environment: .unimplemented
     )
 
     store.environment.fact.fetch = { _ in Effect(error: FactClient.Error()) }
@@ -67,8 +67,8 @@ class EffectsBasicsTests: XCTestCase {
 }
 
 extension EffectsBasicsEnvironment {
-  static let failing = Self(
-    fact: .failing,
-    mainQueue: .failing
+  static let unimplemented = Self(
+    fact: .unimplemented,
+    mainQueue: .unimplemented
   )
 }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
@@ -9,7 +9,7 @@ class WebSocketTests: XCTestCase {
     let socketSubject = PassthroughSubject<WebSocketClient.Action, Never>()
     let receiveSubject = PassthroughSubject<WebSocketClient.Message, NSError>()
 
-    var webSocket = WebSocketClient.failing
+    var webSocket = WebSocketClient.unimplemented
     webSocket.open = { _, _, _ in socketSubject.eraseToEffect() }
     webSocket.receive = { _ in receiveSubject.eraseToEffect() }
     webSocket.send = { _, _ in Effect(value: nil) }
@@ -58,7 +58,7 @@ class WebSocketTests: XCTestCase {
     let socketSubject = PassthroughSubject<WebSocketClient.Action, Never>()
     let receiveSubject = PassthroughSubject<WebSocketClient.Message, NSError>()
 
-    var webSocket = WebSocketClient.failing
+    var webSocket = WebSocketClient.unimplemented
     webSocket.open = { _, _, _ in socketSubject.eraseToEffect() }
     webSocket.receive = { _ in receiveSubject.eraseToEffect() }
     webSocket.send = { _, _ in Effect(value: NSError(domain: "", code: 1)) }
@@ -103,7 +103,7 @@ class WebSocketTests: XCTestCase {
     let socketSubject = PassthroughSubject<WebSocketClient.Action, Never>()
     let pingSubject = PassthroughSubject<NSError?, Never>()
 
-    var webSocket = WebSocketClient.failing
+    var webSocket = WebSocketClient.unimplemented
     webSocket.open = { _, _, _ in socketSubject.eraseToEffect() }
     webSocket.receive = { _ in .none }
     webSocket.sendPing = { _ in pingSubject.eraseToEffect() }
@@ -141,7 +141,7 @@ class WebSocketTests: XCTestCase {
   func testWebSocketConnectError() {
     let socketSubject = PassthroughSubject<WebSocketClient.Action, Never>()
 
-    var webSocket = WebSocketClient.failing
+    var webSocket = WebSocketClient.unimplemented
     webSocket.cancel = { _, _, _ in .fireAndForget { socketSubject.send(completion: .finished) } }
     webSocket.open = { _, _, _ in socketSubject.eraseToEffect() }
     webSocket.receive = { _ in .none }
@@ -168,11 +168,11 @@ class WebSocketTests: XCTestCase {
 }
 
 extension WebSocketClient {
-  static let failing = Self(
-    cancel: { _, _, _ in .failing("WebSocketClient.cancel") },
-    open: { _, _, _ in .failing("WebSocketClient.open") },
-    receive: { _ in .failing("WebSocketClient.receive") },
-    send: { _, _ in .failing("WebSocketClient.send") },
-    sendPing: { _ in .failing("WebSocketClient.sendPing") }
+  static let unimplemented = Self(
+    cancel: { _, _, _ in .unimplemented("\(Self.self).cancel") },
+    open: { _, _, _ in .unimplemented("\(Self.self).open") },
+    receive: { _ in .unimplemented("\(Self.self).receive") },
+    send: { _, _ in .unimplemented("\(Self.self).send") },
+    sendPing: { _ in .unimplemented("\(Self.self).sendPing") }
   )
 }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
@@ -18,7 +18,7 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
   let scheduler = DispatchQueue.test
 
   func testDownloadFlow() {
-    var downloadClient = DownloadClient.failing
+    var downloadClient = DownloadClient.unimplemented
     downloadClient.download = { _ in self.downloadSubject.eraseToEffect() }
 
     let store = TestStore(
@@ -53,7 +53,7 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
   }
 
   func testDownloadThrottling() {
-    var downloadClient = DownloadClient.failing
+    var downloadClient = DownloadClient.unimplemented
     downloadClient.download = { _ in self.downloadSubject.eraseToEffect() }
 
     let store = TestStore(
@@ -93,7 +93,7 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
   }
 
   func testCancelDownloadFlow() {
-    var downloadClient = DownloadClient.failing
+    var downloadClient = DownloadClient.unimplemented
     downloadClient.download = { _ in self.downloadSubject.eraseToEffect() }
 
     let store = TestStore(
@@ -130,7 +130,7 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
   }
 
   func testDownloadFinishesWhileTryingToCancel() {
-    var downloadClient = DownloadClient.failing
+    var downloadClient = DownloadClient.unimplemented
     downloadClient.download = { _ in self.downloadSubject.eraseToEffect() }
 
     let store = TestStore(
@@ -168,7 +168,7 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
   }
 
   func testDeleteDownloadFlow() {
-    var downloadClient = DownloadClient.failing
+    var downloadClient = DownloadClient.unimplemented
     downloadClient.download = { _ in self.downloadSubject.eraseToEffect() }
 
     let store = TestStore(
@@ -200,7 +200,7 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
 }
 
 extension DownloadClient {
-  static let failing = Self(
-    download: { _ in .failing("DownloadClient.download") }
+  static let unimplemented = Self(
+    download: { _ in .unimplemented("\(Self.self).download") }
   )
 }

--- a/Examples/Search/Search/WeatherClient.swift
+++ b/Examples/Search/Search/WeatherClient.swift
@@ -79,9 +79,9 @@ extension WeatherClient {
 // MARK: - Mock API implementations
 
 extension WeatherClient {
-  static let failing = Self(
-    forecast: { _ in .failing("\(Self.self).forecast") },
-    search: { _ in .failing("\(Self.self).search") }
+  static let unimplemented = Self(
+    forecast: { _ in .unimplemented("\(Self.self).forecast") },
+    search: { _ in .unimplemented("\(Self.self).search") }
   )
 }
 

--- a/Examples/Search/SearchTests/SearchTests.swift
+++ b/Examples/Search/SearchTests/SearchTests.swift
@@ -12,7 +12,7 @@ class SearchTests: XCTestCase {
       initialState: SearchState(),
       reducer: searchReducer,
       environment: SearchEnvironment(
-        weatherClient: .failing,
+        weatherClient: .unimplemented,
         mainQueue: self.scheduler.eraseToAnyScheduler()
       )
     )
@@ -36,7 +36,7 @@ class SearchTests: XCTestCase {
       initialState: SearchState(),
       reducer: searchReducer,
       environment: SearchEnvironment(
-        weatherClient: .failing,
+        weatherClient: .unimplemented,
         mainQueue: self.scheduler.eraseToAnyScheduler()
       )
     )
@@ -50,7 +50,7 @@ class SearchTests: XCTestCase {
   }
 
   func testClearQueryCancelsInFlightSearchRequest() {
-    var weatherClient = WeatherClient.failing
+    var weatherClient = WeatherClient.unimplemented
     weatherClient.search = { _ in Effect(value: .mock) }
 
     let store = TestStore(
@@ -84,7 +84,7 @@ class SearchTests: XCTestCase {
     var results = Search.mock.results
     results.append(specialResult)
 
-    var weatherClient = WeatherClient.failing
+    var weatherClient = WeatherClient.unimplemented
     weatherClient.forecast = { _ in Effect(value: .mock) }
 
     let store = TestStore(
@@ -143,7 +143,7 @@ class SearchTests: XCTestCase {
     var results = Search.mock.results
     results.append(specialResult)
 
-    var weatherClient = WeatherClient.failing
+    var weatherClient = WeatherClient.unimplemented
     weatherClient.forecast = { _ in Effect(value: .mock) }
 
     let store = TestStore(
@@ -194,7 +194,7 @@ class SearchTests: XCTestCase {
   }
 
   func testTapOnLocationFailure() {
-    var weatherClient = WeatherClient.failing
+    var weatherClient = WeatherClient.unimplemented
     weatherClient.forecast = { _ in Effect(error: WeatherClient.Failure()) }
 
     let results = Search.mock.results

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Failing.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Failing.swift
@@ -4,10 +4,10 @@ import Speech
 
 #if DEBUG
   extension SpeechClient {
-    static let failing = Self(
-      finishTask: { .failing("SpeechClient.finishTask") },
-      recognitionTask: { _ in .failing("SpeechClient.recognitionTask") },
-      requestAuthorization: { .failing("SpeechClient.requestAuthorization") }
+    static let unimplemented = Self(
+      finishTask: { .unimplemented("\(Self.self).finishTask") },
+      recognitionTask: { _ in .unimplemented("\(Self.self).recognitionTask") },
+      requestAuthorization: { .unimplemented("\(Self.self).requestAuthorization") }
     )
   }
 #endif

--- a/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
+++ b/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
@@ -8,7 +8,7 @@ class SpeechRecognitionTests: XCTestCase {
   let recognitionTaskSubject = PassthroughSubject<SpeechClient.Action, SpeechClient.Error>()
 
   func testDenyAuthorization() {
-    var speechClient = SpeechClient.failing
+    var speechClient = SpeechClient.unimplemented
     speechClient.requestAuthorization = { Effect(value: .denied) }
 
     let store = TestStore(
@@ -37,7 +37,7 @@ class SpeechRecognitionTests: XCTestCase {
   }
 
   func testRestrictedAuthorization() {
-    var speechClient = SpeechClient.failing
+    var speechClient = SpeechClient.unimplemented
     speechClient.requestAuthorization = { Effect(value: .restricted) }
 
     let store = TestStore(
@@ -60,7 +60,7 @@ class SpeechRecognitionTests: XCTestCase {
   }
 
   func testAllowAndRecord() {
-    var speechClient = SpeechClient.failing
+    var speechClient = SpeechClient.unimplemented
     speechClient.finishTask = {
       .fireAndForget { self.recognitionTaskSubject.send(completion: .finished) }
     }
@@ -108,7 +108,7 @@ class SpeechRecognitionTests: XCTestCase {
   }
 
   func testAudioSessionFailure() {
-    var speechClient = SpeechClient.failing
+    var speechClient = SpeechClient.unimplemented
     speechClient.recognitionTask = { _ in self.recognitionTaskSubject.eraseToEffect() }
     speechClient.requestAuthorization = { Effect(value: .authorized) }
 
@@ -138,7 +138,7 @@ class SpeechRecognitionTests: XCTestCase {
   }
 
   func testAudioEngineFailure() {
-    var speechClient = SpeechClient.failing
+    var speechClient = SpeechClient.unimplemented
     speechClient.recognitionTask = { _ in self.recognitionTaskSubject.eraseToEffect() }
     speechClient.requestAuthorization = { Effect(value: .authorized) }
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/AuthenticationClient/AuthenticationClient.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/AuthenticationClient/AuthenticationClient.swift
@@ -72,9 +72,9 @@ public struct AuthenticationClient {
 
 #if DEBUG
   extension AuthenticationClient {
-    public static let failing = Self(
-      login: { _ in .failing("AuthenticationClient.login") },
-      twoFactor: { _ in .failing("AuthenticationClient.twoFactor") }
+    public static let unimplemented = Self(
+      login: { _ in .unimplemented("\(Self.self).login") },
+      twoFactor: { _ in .unimplemented("\(Self.self).twoFactor") }
     )
   }
 #endif

--- a/Examples/TicTacToe/tic-tac-toe/Tests/AppCoreTests/AppCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/AppCoreTests/AppCoreTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 class AppCoreTests: XCTestCase {
   func testIntegration() {
-    var authenticationClient = AuthenticationClient.failing
+    var authenticationClient = AuthenticationClient.unimplemented
     authenticationClient.login = { _ in
       Effect(value: AuthenticationResponse(token: "deadbeef", twoFactorRequired: false))
     }
@@ -57,7 +57,7 @@ class AppCoreTests: XCTestCase {
   }
 
   func testIntegration_TwoFactor() {
-    var authenticationClient = AuthenticationClient.failing
+    var authenticationClient = AuthenticationClient.unimplemented
     authenticationClient.login = { _ in
       Effect(value: AuthenticationResponse(token: "deadbeef", twoFactorRequired: true))
     }

--- a/Examples/TicTacToe/tic-tac-toe/Tests/LoginCoreTests/LoginCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/LoginCoreTests/LoginCoreTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 class LoginCoreTests: XCTestCase {
   func testFlow_Success_TwoFactor_Integration() {
-    var authenticationClient = AuthenticationClient.failing
+    var authenticationClient = AuthenticationClient.unimplemented
     authenticationClient.login = { _ in
       Effect(value: AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: true))
     }
@@ -60,7 +60,7 @@ class LoginCoreTests: XCTestCase {
   }
 
   func testFlow_DismissEarly_TwoFactor_Integration() {
-    var authenticationClient = AuthenticationClient.failing
+    var authenticationClient = AuthenticationClient.unimplemented
     authenticationClient.login = { _ in
       Effect(value: AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: true))
     }

--- a/Examples/TicTacToe/tic-tac-toe/Tests/LoginSwiftUITests/LoginSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/LoginSwiftUITests/LoginSwiftUITests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 class LoginSwiftUITests: XCTestCase {
   func testFlow_Success() {
-    var authenticationClient = AuthenticationClient.failing
+    var authenticationClient = AuthenticationClient.unimplemented
     authenticationClient.login = { _ in
       Effect(value: AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false))
     }
@@ -45,7 +45,7 @@ class LoginSwiftUITests: XCTestCase {
   }
 
   func testFlow_Success_TwoFactor() {
-    var authenticationClient = AuthenticationClient.failing
+    var authenticationClient = AuthenticationClient.unimplemented
     authenticationClient.login = { _ in
       Effect(value: AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: true))
     }
@@ -86,7 +86,7 @@ class LoginSwiftUITests: XCTestCase {
   }
 
   func testFlow_Failure() {
-    var authenticationClient = AuthenticationClient.failing
+    var authenticationClient = AuthenticationClient.unimplemented
     authenticationClient.login = { _ in Effect(error: .invalidUserPassword) }
 
     let store = TestStore(

--- a/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorCoreTests/TwoFactorCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorCoreTests/TwoFactorCoreTests.swift
@@ -9,7 +9,7 @@ class TwoFactorCoreTests: XCTestCase {
       initialState: TwoFactorState(token: "deadbeefdeadbeef"),
       reducer: twoFactorReducer,
       environment: TwoFactorEnvironment(
-        authenticationClient: .failing,
+        authenticationClient: .unimplemented,
         mainQueue: .immediate
       )
     )
@@ -47,7 +47,7 @@ class TwoFactorCoreTests: XCTestCase {
       initialState: TwoFactorState(token: "deadbeefdeadbeef"),
       reducer: twoFactorReducer,
       environment: TwoFactorEnvironment(
-        authenticationClient: .failing,
+        authenticationClient: .unimplemented,
         mainQueue: .immediate
       )
     )

--- a/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorSwiftUITests/TwoFactorSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorSwiftUITests/TwoFactorSwiftUITests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 class TwoFactorSwiftUITests: XCTestCase {
   func testFlow_Success() {
-    var authenticationClient = AuthenticationClient.failing
+    var authenticationClient = AuthenticationClient.unimplemented
     authenticationClient.twoFactor = { _ in
       Effect(value: AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false))
     }
@@ -56,7 +56,7 @@ class TwoFactorSwiftUITests: XCTestCase {
   }
 
   func testFlow_Failure() {
-    var authenticationClient = AuthenticationClient.failing
+    var authenticationClient = AuthenticationClient.unimplemented
     authenticationClient.twoFactor = { _ in Effect(error: .invalidTwoFactor) }
 
     let store = TestStore(

--- a/Examples/VoiceMemos/VoiceMemos/AudioPlayerClient/FailingAudioPlayerClient.swift
+++ b/Examples/VoiceMemos/VoiceMemos/AudioPlayerClient/FailingAudioPlayerClient.swift
@@ -3,9 +3,9 @@ import Foundation
 
 #if DEBUG
   extension AudioPlayerClient {
-    static let failing = Self(
-      play: { _ in .failing("AudioPlayerClient.play") },
-      stop: { .failing("AudioPlayerClient.stop") }
+    static let unimplemented = Self(
+      play: { _ in .unimplemented("\(Self.self).play") },
+      stop: { .unimplemented("\(Self.self).stop") }
     )
   }
 #endif

--- a/Examples/VoiceMemos/VoiceMemos/AudioRecorderClient/FailingAudioRecorderClient.swift
+++ b/Examples/VoiceMemos/VoiceMemos/AudioRecorderClient/FailingAudioRecorderClient.swift
@@ -3,11 +3,11 @@ import Foundation
 
 #if DEBUG
   extension AudioRecorderClient {
-    static let failing = Self(
-      currentTime: { .failing("AudioRecorderClient.currentTime") },
-      requestRecordPermission: { .failing("AudioRecorderClient.requestRecordPermission") },
-      startRecording: { _ in .failing("AudioRecorderClient.startRecording") },
-      stopRecording: { .failing("AudioRecorderClient.stopRecording") }
+    static let unimplemented = Self(
+      currentTime: { .unimplemented("\(Self.self).currentTime") },
+      requestRecordPermission: { .unimplemented("\(Self.self).requestRecordPermission") },
+      startRecording: { _ in .unimplemented("\(Self.self).startRecording") },
+      stopRecording: { .unimplemented("\(Self.self).stopRecording") }
     )
   }
 #endif

--- a/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
+++ b/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
@@ -1,6 +1,7 @@
 import Combine
 import ComposableArchitecture
 import XCTest
+import XCTestDynamicOverlay
 
 @testable import VoiceMemos
 
@@ -15,7 +16,7 @@ class VoiceMemosTests: XCTestCase {
       AudioRecorderClient.Action, AudioRecorderClient.Failure
     >()
 
-    var environment = VoiceMemosEnvironment.failing
+    var environment = VoiceMemosEnvironment.unimplemented
     environment.audioRecorder.currentTime = { Effect(value: 2.5) }
     environment.audioRecorder.requestRecordPermission = { Effect(value: true) }
     environment.audioRecorder.startRecording = { _ in
@@ -79,7 +80,7 @@ class VoiceMemosTests: XCTestCase {
   func testPermissionDenied() {
     var didOpenSettings = false
 
-    var environment = VoiceMemosEnvironment.failing
+    var environment = VoiceMemosEnvironment.unimplemented
     environment.audioRecorder.requestRecordPermission = { Effect(value: false) }
     environment.mainRunLoop = .immediate
     environment.openSettings = .fireAndForget { didOpenSettings = true }
@@ -107,7 +108,7 @@ class VoiceMemosTests: XCTestCase {
       AudioRecorderClient.Action, AudioRecorderClient.Failure
     >()
 
-    var environment = VoiceMemosEnvironment.failing
+    var environment = VoiceMemosEnvironment.unimplemented
     environment.audioRecorder.currentTime = { Effect(value: 2.5) }
     environment.audioRecorder.requestRecordPermission = { Effect(value: true) }
     environment.audioRecorder.startRecording = { _ in
@@ -142,7 +143,7 @@ class VoiceMemosTests: XCTestCase {
   }
 
   func testPlayMemoHappyPath() {
-    var environment = VoiceMemosEnvironment.failing
+    var environment = VoiceMemosEnvironment.unimplemented
     environment.audioPlayer.play = { _ in
       Effect(value: .didFinishPlaying(successfully: true))
         .delay(for: 1, scheduler: self.mainRunLoop)
@@ -189,7 +190,7 @@ class VoiceMemosTests: XCTestCase {
   }
 
   func testPlayMemoFailure() {
-    var environment = VoiceMemosEnvironment.failing
+    var environment = VoiceMemosEnvironment.unimplemented
     environment.audioPlayer.play = { _ in Effect(error: .decodeErrorDidOccur) }
     environment.mainRunLoop = self.mainRunLoop.eraseToAnyScheduler()
 
@@ -221,7 +222,7 @@ class VoiceMemosTests: XCTestCase {
 
   func testStopMemo() {
     var didStopAudioPlayerClient = false
-    var environment = VoiceMemosEnvironment.failing
+    var environment = VoiceMemosEnvironment.unimplemented
     environment.audioPlayer.stop = { .fireAndForget { didStopAudioPlayerClient = true } }
 
     let url = URL(string: "https://www.pointfree.co/functions")!
@@ -249,7 +250,7 @@ class VoiceMemosTests: XCTestCase {
 
   func testDeleteMemo() {
     var didStopAudioPlayerClient = false
-    var environment = VoiceMemosEnvironment.failing
+    var environment = VoiceMemosEnvironment.unimplemented
     environment.audioPlayer.stop = { .fireAndForget { didStopAudioPlayerClient = true } }
 
     let url = URL(string: "https://www.pointfree.co/functions")!
@@ -277,7 +278,7 @@ class VoiceMemosTests: XCTestCase {
 
   func testDeleteMemoWhilePlaying() {
     let url = URL(string: "https://www.pointfree.co/functions")!
-    var environment = VoiceMemosEnvironment.failing
+    var environment = VoiceMemosEnvironment.unimplemented
     environment.audioPlayer.play = { _ in .none }
     environment.audioPlayer.stop = { .none }
     environment.mainRunLoop = self.mainRunLoop.eraseToAnyScheduler()
@@ -308,18 +309,14 @@ class VoiceMemosTests: XCTestCase {
 }
 
 extension VoiceMemosEnvironment {
-  static let failing = Self(
-    audioPlayer: .failing,
-    audioRecorder: .failing,
-    mainRunLoop: .failing,
-    openSettings: .failing("VoiceMemosEnvironment.openSettings"),
-    temporaryDirectory: {
-      XCTFail("VoiceMemosEnvironment.temporaryDirectory is unimplemented")
-      return URL(fileURLWithPath: NSTemporaryDirectory())
-    },
-    uuid: {
-      XCTFail("VoiceMemosEnvironment.uuid is unimplemented")
-      return UUID()
-    }
+  static let unimplemented = Self(
+    audioPlayer: .unimplemented,
+    audioRecorder: .unimplemented,
+    mainRunLoop: .unimplemented,
+    openSettings: .unimplemented("\(Self.self).openSettings"),
+    temporaryDirectory: XCTUnimplemented(
+      "\(Self.self).temporaryDirectory", placeholder: URL(fileURLWithPath: NSTemporaryDirectory())
+    ),
+    uuid: XCTUnimplemented("\(Self.self).uuid", placeholder: UUID())
   )
 }

--- a/Package.swift
+++ b/Package.swift
@@ -18,11 +18,11 @@ let package = Package(
   ],
   dependencies: [
     .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
-    .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "0.5.3"),
+    .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "0.6.0"),
     .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.8.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.3.0"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "0.3.2"),
-    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.2.1"),
+    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.3.0"),
   ],
   targets: [
     .target(

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -3,6 +3,18 @@ import Combine
 import SwiftUI
 import XCTestDynamicOverlay
 
+// NB: Deprecated after 0.38.0:
+
+extension Effect {
+  @available(iOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(macOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(tvOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(watchOS, deprecated: 9999.0, renamed: "unimplemented")
+  public static func failing(_ prefix: String) -> Self {
+    self.unimplemented(prefix)
+  }
+}
+
 // NB: Deprecated after 0.36.0:
 
 extension ViewStore {

--- a/Sources/ComposableArchitecture/TestSupport/UnimplementedEffect.swift
+++ b/Sources/ComposableArchitecture/TestSupport/UnimplementedEffect.swift
@@ -64,7 +64,7 @@ extension Effect {
   ///     initialState: CounterState(count: 0)
   ///     reducer: counterReducer,
   ///     environment: CounterEnvironment(
-  ///       playSound: .failing("playSound")
+  ///       playSound: .unimplemented("playSound")
   ///     )
   ///   )
   ///
@@ -74,16 +74,16 @@ extension Effect {
   /// }
   /// ```
   ///
-  /// By using a `.failing` effect in our environment we have strengthened the assertion and made
-  /// the test easier to understand at the same time. We can see, without consulting the reducer
-  /// itself, that this particular action should not access this effect.
+  /// By using an `.unimplemented` effect in our environment we have strengthened the assertion and
+  /// made the test easier to understand at the same time. We can see, without consulting the
+  /// reducer itself, that this particular action should not access this effect.
   ///
   /// - Parameter prefix: A string that identifies this scheduler and will prefix all failure
   ///   messages.
   /// - Returns: An effect that causes a test to fail if it runs.
-  public static func failing(_ prefix: String) -> Self {
+  public static func unimplemented(_ prefix: String) -> Self {
     .fireAndForget {
-      XCTFail("\(prefix.isEmpty ? "" : "\(prefix) - ")A failing effect ran.")
+      XCTFail("\(prefix.isEmpty ? "" : "\(prefix) - ")An unimplemented effect ran.")
     }
   }
 }

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -212,14 +212,14 @@ final class EffectTests: XCTestCase {
   }
 
   #if compiler(>=5.4)
-    func testFailing() {
-      let effect = Effect<Never, Never>.failing("failing")
+    func testUnimplemented() {
+      let effect = Effect<Never, Never>.unimplemented("unimplemented")
       XCTExpectFailure {
         effect
           .sink(receiveValue: { _ in })
           .store(in: &self.cancellables)
       } issueMatcher: { issue in
-        issue.compactDescription == "failing - A failing effect ran."
+        issue.compactDescription == "unimplemented - An unimplemented effect ran."
       }
     }
   #endif


### PR DESCRIPTION
We've found that the "failing" naming of dependencies can be confusing. While it's accurate in isolation, when you're writing tests, "failure" is already a loaded term. We'd like to move in the direction of the "unimplemented" terminology (which is funnily enough where we started, when we had some preexisting dependencies that would `fatalError`).

This PR:

- Renames `Effect.failing` to `Effect.unimplemented`, soft-deprecating `Effect.failing` in the process. We can warn in a future version.
- Uses `XCTUnimplemented` and `UnimplementedScheduler` in examples