### PR TITLE
Collapse case study readmes behind disclosure groups

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -89,14 +89,18 @@ struct AlertAndConfirmationDialogView: View {
   var body: some View {
     WithViewStore(self.store) { viewStore in
       Form {
-        Section(header: Text(template: readMe, .caption)) {
-          Text("Count: \(viewStore.count)")
-          Button("Alert") { viewStore.send(.alertButtonTapped) }
-          Button("Confirmation Dialog") { viewStore.send(.confirmationDialogButtonTapped) }
+        Section {
+          DisclosureGroup("About this case study") {
+            Text(template: readMe)
+          }
         }
+
+        Text("Count: \(viewStore.count)")
+        Button("Alert") { viewStore.send(.alertButtonTapped) }
+        Button("Confirmation Dialog") { viewStore.send(.confirmationDialogButtonTapped) }
       }
     }
-    .navigationBarTitle("Alerts & Confirmation Dialogs")
+    .navigationBarTitle("Alerts & Dialogs")
     .alert(
       self.store.scope(state: \.alert),
       dismiss: .alertDismissed

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -65,48 +65,52 @@ struct BindingBasicsView: View {
   var body: some View {
     WithViewStore(self.store) { viewStore in
       Form {
-        Section(header: Text(template: readMe, .caption)) {
-          HStack {
-            TextField(
-              "Type here",
-              text: viewStore.binding(get: \.text, send: BindingBasicsAction.textChanged)
-            )
-            .disableAutocorrection(true)
-            .foregroundColor(viewStore.toggleIsOn ? .gray : .primary)
-            Text(alternate(viewStore.text))
+        Section {
+          DisclosureGroup("About this case study") {
+            Text(template: readMe)
           }
-          .disabled(viewStore.toggleIsOn)
-
-          Toggle(
-            isOn: viewStore.binding(get: \.toggleIsOn, send: BindingBasicsAction.toggleChanged)
-              .resignFirstResponder()
-          ) {
-            Text("Disable other controls")
-          }
-
-          Stepper(
-            value: viewStore.binding(
-              get: \.stepCount, send: BindingBasicsAction.stepCountChanged),
-            in: 0...100
-          ) {
-            Text("Max slider value: \(viewStore.stepCount)")
-              .font(.body.monospacedDigit())
-          }
-          .disabled(viewStore.toggleIsOn)
-
-          HStack {
-            Text("Slider value: \(Int(viewStore.sliderValue))")
-              .font(.body.monospacedDigit())
-            Slider(
-              value: viewStore.binding(
-                get: \.sliderValue,
-                send: BindingBasicsAction.sliderValueChanged
-              ),
-              in: 0...Double(viewStore.stepCount)
-            )
-          }
-          .disabled(viewStore.toggleIsOn)
         }
+
+        HStack {
+          TextField(
+            "Type here",
+            text: viewStore.binding(get: \.text, send: BindingBasicsAction.textChanged)
+          )
+          .disableAutocorrection(true)
+          .foregroundColor(viewStore.toggleIsOn ? .gray : .primary)
+          Text(alternate(viewStore.text))
+        }
+        .disabled(viewStore.toggleIsOn)
+
+        Toggle(
+          isOn: viewStore.binding(get: \.toggleIsOn, send: BindingBasicsAction.toggleChanged)
+            .resignFirstResponder()
+        ) {
+          Text("Disable other controls")
+        }
+
+        Stepper(
+          value: viewStore.binding(
+            get: \.stepCount, send: BindingBasicsAction.stepCountChanged),
+          in: 0...100
+        ) {
+          Text("Max slider value: \(viewStore.stepCount)")
+            .font(.body.monospacedDigit())
+        }
+        .disabled(viewStore.toggleIsOn)
+
+        HStack {
+          Text("Slider value: \(Int(viewStore.sliderValue))")
+            .font(.body.monospacedDigit())
+          Slider(
+            value: viewStore.binding(
+              get: \.sliderValue,
+              send: BindingBasicsAction.sliderValueChanged
+            ),
+            in: 0...Double(viewStore.stepCount)
+          )
+        }
+        .disabled(viewStore.toggleIsOn)
       }
     }
     .navigationBarTitle("Bindings basics")

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -53,41 +53,45 @@ struct BindingFormView: View {
   var body: some View {
     WithViewStore(self.store) { viewStore in
       Form {
-        Section(header: Text(template: readMe, .caption)) {
-          HStack {
-            TextField("Type here", text: viewStore.binding(\.$text))
-              .disableAutocorrection(true)
-              .foregroundColor(viewStore.toggleIsOn ? .gray : .primary)
-
-            Text(alternate(viewStore.text))
+        Section {
+          DisclosureGroup("About this case study") {
+            Text(template: readMe)
           }
-          .disabled(viewStore.toggleIsOn)
-
-          Toggle(
-            "Disable other controls",
-            isOn: viewStore.binding(\.$toggleIsOn)
-              .resignFirstResponder()
-          )
-
-          Stepper(value: viewStore.binding(\.$stepCount), in: 0...100) {
-            Text("Max slider value: \(viewStore.stepCount)")
-              .font(.body.monospacedDigit())
-          }
-          .disabled(viewStore.toggleIsOn)
-
-          HStack {
-            Text("Slider value: \(Int(viewStore.sliderValue))")
-              .font(.body.monospacedDigit())
-
-            Slider(value: viewStore.binding(\.$sliderValue), in: 0...Double(viewStore.stepCount))
-          }
-          .disabled(viewStore.toggleIsOn)
-
-          Button("Reset") {
-            viewStore.send(.resetButtonTapped)
-          }
-          .foregroundColor(.red)
         }
+
+        HStack {
+          TextField("Type here", text: viewStore.binding(\.$text))
+            .disableAutocorrection(true)
+            .foregroundColor(viewStore.toggleIsOn ? .gray : .primary)
+
+          Text(alternate(viewStore.text))
+        }
+        .disabled(viewStore.toggleIsOn)
+
+        Toggle(
+          "Disable other controls",
+          isOn: viewStore.binding(\.$toggleIsOn)
+            .resignFirstResponder()
+        )
+
+        Stepper(value: viewStore.binding(\.$stepCount), in: 0...100) {
+          Text("Max slider value: \(viewStore.stepCount)")
+            .font(.body.monospacedDigit())
+        }
+        .disabled(viewStore.toggleIsOn)
+
+        HStack {
+          Text("Slider value: \(Int(viewStore.sliderValue))")
+            .font(.body.monospacedDigit())
+
+          Slider(value: viewStore.binding(\.$sliderValue), in: 0...Double(viewStore.stepCount))
+        }
+        .disabled(viewStore.toggleIsOn)
+
+        Button("Reset") {
+          viewStore.send(.resetButtonTapped)
+        }
+        .foregroundColor(.red)
       }
     }
     .navigationBarTitle("Bindings form")

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -39,25 +39,29 @@ struct TwoCountersView: View {
 
   var body: some View {
     Form {
-      Section(header: Text(template: readMe, .caption)) {
-        HStack {
-          Text("Counter 1")
-
-          CounterView(
-            store: self.store.scope(state: \.counter1, action: TwoCountersAction.counter1)
-          )
-          .buttonStyle(.borderless)
-          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
+      Section {
+        DisclosureGroup("About this case study") {
+          Text(template: readMe)
         }
-        HStack {
-          Text("Counter 2")
+      }
+      HStack {
+        Text("Counter 1")
 
-          CounterView(
-            store: self.store.scope(state: \.counter2, action: TwoCountersAction.counter2)
-          )
-          .buttonStyle(.borderless)
-          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
-        }
+        CounterView(
+          store: self.store.scope(state: \.counter1, action: TwoCountersAction.counter1)
+        )
+        .buttonStyle(.borderless)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
+      }
+      HStack {
+        Text("Counter 2")
+
+        CounterView(
+          store: self.store.scope(state: \.counter2, action: TwoCountersAction.counter2)
+        )
+        .buttonStyle(.borderless)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
+
       }
     }
     .navigationBarTitle("Two counter demo")

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -51,7 +51,13 @@ struct CounterDemoView: View {
 
   var body: some View {
     Form {
-      Section(header: Text(readMe)) {
+      Section {
+        DisclosureGroup("About this case study") {
+          Text(readMe)
+        }
+      }
+
+      Section {
         CounterView(store: self.store)
           .buttonStyle(.borderless)
           .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -54,28 +54,32 @@ struct OptionalBasicsView: View {
   var body: some View {
     WithViewStore(self.store) { viewStore in
       Form {
-        Section(header: Text(template: readMe, .caption)) {
-          Button("Toggle counter state") {
-            viewStore.send(.toggleCounterButtonTapped)
+        Section {
+          DisclosureGroup("About this case study") {
+            Text(template: readMe)
           }
-
-          IfLetStore(
-            self.store.scope(
-              state: \.optionalCounter,
-              action: OptionalBasicsAction.optionalCounter
-            ),
-            then: { store in
-              VStack(alignment: .leading, spacing: 16) {
-                Text(template: "`CounterState` is non-`nil`", .body)
-                CounterView(store: store)
-                  .buttonStyle(.borderless)
-              }
-            },
-            else: {
-              Text(template: "`CounterState` is `nil`", .body)
-            }
-          )
         }
+
+        Button("Toggle counter state") {
+          viewStore.send(.toggleCounterButtonTapped)
+        }
+
+        IfLetStore(
+          self.store.scope(
+            state: \.optionalCounter,
+            action: OptionalBasicsAction.optionalCounter
+          ),
+          then: { store in
+            VStack(alignment: .leading, spacing: 16) {
+              Text(template: "`CounterState` is non-`nil`")
+              CounterView(store: store)
+                .buttonStyle(.borderless)
+            }
+          },
+          else: {
+            Text(template: "`CounterState` is `nil`")
+          }
+        )
       }
     }
     .navigationBarTitle("Optional state")

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -87,7 +87,9 @@ struct EffectsBasicsView: View {
     WithViewStore(self.store) { viewStore in
       Form {
         Section {
-          Text(readMe)
+          DisclosureGroup("About this case study") {
+            Text(readMe)
+          }
         }
 
         Section {
@@ -122,6 +124,7 @@ struct EffectsBasicsView: View {
             UIApplication.shared.open(URL(string: "http://numbersapi.com")!)
           }
           .foregroundColor(.gray)
+          .frame(maxWidth: .infinity)
         }
       }
       .buttonStyle(.borderless)

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -81,7 +81,9 @@ struct EffectsCancellationView: View {
     WithViewStore(self.store) { viewStore in
       Form {
         Section {
-          Text(readMe)
+          DisclosureGroup("About this case study") {
+            Text(readMe)
+          }
         }
 
         Section {
@@ -116,6 +118,7 @@ struct EffectsCancellationView: View {
             UIApplication.shared.open(URL(string: "http://numbersapi.com")!)
           }
           .foregroundColor(.gray)
+          .frame(maxWidth: .infinity)
         }
       }
       .buttonStyle(.borderless)

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -64,10 +64,14 @@ struct LongLivingEffectsView: View {
   var body: some View {
     WithViewStore(self.store) { viewStore in
       Form {
-        Section(header: Text(template: readMe, .body)) {
-          Text("A screenshot of this screen has been taken \(viewStore.screenshotCount) times.")
-            .font(.headline)
+        Section {
+          DisclosureGroup("About this case study") {
+            Text(template: readMe)
+          }
         }
+
+        Text("A screenshot of this screen has been taken \(viewStore.screenshotCount) times.")
+          .font(.headline)
 
         Section {
           NavigationLink(destination: self.detailView) {

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -77,7 +77,11 @@ struct RefreshableView: View {
   var body: some View {
     WithViewStore(self.store) { viewStore in
       List {
-        Text(template: readMe, .body)
+        Section {
+          DisclosureGroup("About this case study") {
+            Text(template: readMe)
+          }
+        }
 
         HStack {
           Button("-") { viewStore.send(.decrementButtonTapped) }

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -142,8 +142,10 @@ struct WebSocketView: View {
   var body: some View {
     WithViewStore(self.store) { viewStore in
       VStack(alignment: .leading) {
-        Text(template: readMe, .body)
-          .padding(.bottom)
+        DisclosureGroup("About this case study") {
+          Text(template: readMe)
+        }
+        .padding(.bottom)
 
         HStack {
           TextField(

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -96,29 +96,32 @@ struct LoadThenNavigateListView: View {
   var body: some View {
     WithViewStore(self.store) { viewStore in
       Form {
-        Section(header: Text(readMe)) {
-          ForEach(viewStore.rows) { row in
-            NavigationLink(
-              destination: IfLetStore(
-                self.store.scope(
-                  state: \.selection?.value,
-                  action: LoadThenNavigateListAction.counter
-                )
-              ) {
-                CounterView(store: $0)
-              },
-              tag: row.id,
-              selection: viewStore.binding(
-                get: \.selection?.id,
-                send: LoadThenNavigateListAction.setNavigation(selection:)
+        Section {
+          DisclosureGroup("About this case study") {
+            Text(readMe)
+          }
+        }
+        ForEach(viewStore.rows) { row in
+          NavigationLink(
+            destination: IfLetStore(
+              self.store.scope(
+                state: \.selection?.value,
+                action: LoadThenNavigateListAction.counter
               )
             ) {
-              HStack {
-                Text("Load optional counter that starts from \(row.count)")
-                if row.isActivityIndicatorVisible {
-                  Spacer()
-                  ProgressView()
-                }
+              CounterView(store: $0)
+            },
+            tag: row.id,
+            selection: viewStore.binding(
+              get: \.selection?.id,
+              send: LoadThenNavigateListAction.setNavigation(selection:)
+            )
+          ) {
+            HStack {
+              Text("Load optional counter that starts from \(row.count)")
+              if row.isActivityIndicatorVisible {
+                Spacer()
+                ProgressView()
               }
             }
           }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -82,27 +82,30 @@ struct NavigateAndLoadListView: View {
   var body: some View {
     WithViewStore(self.store) { viewStore in
       Form {
-        Section(header: Text(readMe)) {
-          ForEach(viewStore.rows) { row in
-            NavigationLink(
-              destination: IfLetStore(
-                self.store.scope(
-                  state: \.selection?.value,
-                  action: NavigateAndLoadListAction.counter
-                )
-              ) {
-                CounterView(store: $0)
-              } else: {
-                ProgressView()
-              },
-              tag: row.id,
-              selection: viewStore.binding(
-                get: \.selection?.id,
-                send: NavigateAndLoadListAction.setNavigation(selection:)
+        Section {
+          DisclosureGroup("About this case study") {
+            Text(readMe)
+          }
+        }
+        ForEach(viewStore.rows) { row in
+          NavigationLink(
+            destination: IfLetStore(
+              self.store.scope(
+                state: \.selection?.value,
+                action: NavigateAndLoadListAction.counter
               )
             ) {
-              Text("Load optional counter that starts from \(row.count)")
-            }
+              CounterView(store: $0)
+            } else: {
+              ProgressView()
+            },
+            tag: row.id,
+            selection: viewStore.binding(
+              get: \.selection?.id,
+              send: NavigateAndLoadListAction.setNavigation(selection:)
+            )
+          ) {
+            Text("Load optional counter that starts from \(row.count)")
           }
         }
       }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -74,27 +74,30 @@ struct LoadThenNavigateView: View {
   var body: some View {
     WithViewStore(self.store) { viewStore in
       Form {
-        Section(header: Text(readMe)) {
-          NavigationLink(
-            destination: IfLetStore(
-              self.store.scope(
-                state: \.optionalCounter,
-                action: LoadThenNavigateAction.optionalCounter
-              )
-            ) {
-              CounterView(store: $0)
-            },
-            isActive: viewStore.binding(
-              get: \.isNavigationActive,
-              send: LoadThenNavigateAction.setNavigation(isActive:)
+        Section {
+          DisclosureGroup("About this case study") {
+            Text(readMe)
+          }
+        }
+        NavigationLink(
+          destination: IfLetStore(
+            self.store.scope(
+              state: \.optionalCounter,
+              action: LoadThenNavigateAction.optionalCounter
             )
           ) {
-            HStack {
-              Text("Load optional counter")
-              if viewStore.isActivityIndicatorVisible {
-                Spacer()
-                ProgressView()
-              }
+            CounterView(store: $0)
+          },
+          isActive: viewStore.binding(
+            get: \.isNavigationActive,
+            send: LoadThenNavigateAction.setNavigation(isActive:)
+          )
+        ) {
+          HStack {
+            Text("Load optional counter")
+            if viewStore.isActivityIndicatorVisible {
+              Spacer()
+              ProgressView()
             }
           }
         }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -69,26 +69,29 @@ struct NavigateAndLoadView: View {
   var body: some View {
     WithViewStore(self.store) { viewStore in
       Form {
-        Section(header: Text(readMe)) {
-          NavigationLink(
-            destination: IfLetStore(
-              self.store.scope(
-                state: \.optionalCounter,
-                action: NavigateAndLoadAction.optionalCounter
-              )
-            ) {
-              CounterView(store: $0)
-            } else: {
-              ProgressView()
-            },
-            isActive: viewStore.binding(
-              get: \.isNavigationActive,
-              send: NavigateAndLoadAction.setNavigation(isActive:)
+        Section {
+          DisclosureGroup("About this case study") {
+            Text(readMe)
+          }
+        }
+        NavigationLink(
+          destination: IfLetStore(
+            self.store.scope(
+              state: \.optionalCounter,
+              action: NavigateAndLoadAction.optionalCounter
             )
           ) {
-            HStack {
-              Text("Load optional counter")
-            }
+            CounterView(store: $0)
+          } else: {
+            ProgressView()
+          },
+          isActive: viewStore.binding(
+            get: \.isNavigationActive,
+            send: NavigateAndLoadAction.setNavigation(isActive:)
+          )
+        ) {
+          HStack {
+            Text("Load optional counter")
           }
         }
       }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -74,14 +74,17 @@ struct LoadThenPresentView: View {
   var body: some View {
     WithViewStore(self.store) { viewStore in
       Form {
-        Section(header: Text(readMe)) {
-          Button(action: { viewStore.send(.setSheet(isPresented: true)) }) {
-            HStack {
-              Text("Load optional counter")
-              if viewStore.isActivityIndicatorVisible {
-                Spacer()
-                ProgressView()
-              }
+        Section {
+          DisclosureGroup("About this case study") {
+            Text(readMe)
+          }
+        }
+        Button(action: { viewStore.send(.setSheet(isPresented: true)) }) {
+          HStack {
+            Text("Load optional counter")
+            if viewStore.isActivityIndicatorVisible {
+              Spacer()
+              ProgressView()
             }
           }
         }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -67,10 +67,13 @@ struct PresentAndLoadView: View {
   var body: some View {
     WithViewStore(self.store) { viewStore in
       Form {
-        Section(header: Text(readMe)) {
-          Button("Load optional counter") {
-            viewStore.send(.setSheet(isPresented: true))
+        Section {
+          DisclosureGroup("About this case study") {
+            Text(readMe)
           }
+        }
+        Button("Load optional counter") {
+          viewStore.send(.setSheet(isPresented: true))
         }
       }
       .sheet(

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -79,17 +79,21 @@ struct LifecycleDemoView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      VStack {
+      Form {
+        Section {
+          DisclosureGroup("About this case study") {
+            Text(template: readMe)
+          }
+        }
+
         Button("Toggle Timer") { viewStore.send(.toggleTimerButtonTapped) }
 
         IfLetStore(self.store.scope(state: \.count, action: LifecycleDemoAction.timer)) {
           TimerView(store: $0)
         }
-
-        Spacer()
       }
-      .navigationBarTitle("Lifecycle")
     }
+    .navigationBarTitle("Lifecycle")
   }
 }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -75,30 +75,33 @@ struct NestedView: View {
   var body: some View {
     WithViewStore(self.store.scope(state: \.description)) { viewStore in
       Form {
-        Section(header: Text(template: readMe, .caption)) {
+        Section {
+          DisclosureGroup("About this case study") {
+            Text(template: readMe)
+          }
+        }
 
-          ForEachStore(
-            self.store.scope(state: \.children, action: NestedAction.node(id:action:))
-          ) { childStore in
-            WithViewStore(childStore) { childViewStore in
-              HStack {
-                TextField(
-                  "Untitled",
-                  text: childViewStore.binding(get: \.description, send: NestedAction.rename)
-                )
+        ForEachStore(
+          self.store.scope(state: \.children, action: NestedAction.node(id:action:))
+        ) { childStore in
+          WithViewStore(childStore) { childViewStore in
+            HStack {
+              TextField(
+                "Untitled",
+                text: childViewStore.binding(get: \.description, send: NestedAction.rename)
+              )
 
-                Spacer()
+              Spacer()
 
-                NavigationLink(
-                  destination: NestedView(store: childStore)
-                ) {
-                  Text("")
-                }
+              NavigationLink(
+                destination: NestedView(store: childStore)
+              ) {
+                Text("")
               }
             }
           }
-          .onDelete { viewStore.send(.remove($0)) }
         }
+        .onDelete { viewStore.send(.remove($0)) }
       }
       .navigationBarTitle(viewStore.state.isEmpty ? "Untitled" : viewStore.state)
       .navigationBarItems(

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -174,15 +174,16 @@ struct CitiesView: View {
 
   var body: some View {
     Form {
-      Section(
-        header: Text(readMe)
-      ) {
-        ForEachStore(
-          self.store.scope(state: \.cityMaps, action: MapAppAction.cityMaps(id:action:))
-        ) { cityMapStore in
-          CityMapRowView(store: cityMapStore)
-            .buttonStyle(.borderless)
+      Section {
+        DisclosureGroup("About this case study") {
+          Text(readMe)
         }
+      }
+      ForEachStore(
+        self.store.scope(state: \.cityMaps, action: MapAppAction.cityMaps(id:action:))
+      ) { cityMapStore in
+        CityMapRowView(store: cityMapStore)
+          .buttonStyle(.borderless)
       }
     }
     .navigationBarTitle("Offline Downloads")

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -174,13 +174,16 @@ struct EpisodesView: View {
 
   var body: some View {
     Form {
-      Section(header: Text(template: readMe, .caption)) {
-        ForEachStore(
-          self.store.scope(state: \.episodes, action: EpisodesAction.episode(id:action:))
-        ) { rowStore in
-          EpisodeView(store: rowStore)
-            .buttonStyle(.borderless)
+      Section {
+        DisclosureGroup("About this case study") {
+          Text(template: readMe)
         }
+      }
+      ForEachStore(
+        self.store.scope(state: \.episodes, action: EpisodesAction.episode(id:action:))
+      ) { rowStore in
+        EpisodeView(store: rowStore)
+          .buttonStyle(.borderless)
       }
     }
     .navigationBarTitle("Favoriting")

--- a/Examples/CaseStudies/SwiftUICaseStudies/Internal/TemplateText.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/Internal/TemplateText.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 extension Text {
-  init(template: String, _ style: Font.TextStyle) {
+  init(template: String, _ style: Font.TextStyle = .body) {
     enum Style: Hashable {
       case code
       case emphasis


### PR DESCRIPTION
These READMEs can be quite a lot all at once, and on smaller devices can even completely hide the content.