### PR TITLE
XCTFail -> Unimplemented and fix test

### DIFF
--- a/Sources/ComposableArchitecture/TestSupport/UnimplementedEffect.swift
+++ b/Sources/ComposableArchitecture/TestSupport/UnimplementedEffect.swift
@@ -82,8 +82,8 @@ extension Effect {
   ///   messages.
   /// - Returns: An effect that causes a test to fail if it runs.
   public static func unimplemented(_ prefix: String) -> Self {
-    .fireAndForget {
-      XCTFail("\(prefix.isEmpty ? "" : "\(prefix) - ")An unimplemented effect ran.")
-    }
+    .fireAndForget(
+      XCTUnimplemented("\(prefix.isEmpty ? "" : "\(prefix) - ")An unimplemented effect ran.")
+    )
   }
 }

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -218,7 +218,7 @@ final class EffectTests: XCTestCase {
         .sink(receiveValue: { _ in })
         .store(in: &self.cancellables)
     } issueMatcher: { issue in
-      issue.compactDescription == "unimplemented - An unimplemented effect ran."
+      issue.compactDescription == "Unimplemented: unimplemented - An unimplemented effect ran."
     }
   }
 


### PR DESCRIPTION
Hi, thanks for the great library.

I thought XCTUnimplemented should be used for the UnimplementedEffect included in the new release.
So, fix XCTFail to Unimplemented in UnimplementedEffect.

Sorry if I'm wrong.