### PR TITLE
DocC Structure

### DIFF
--- a/ComposableArchitecture.xcworkspace/contents.xcworkspacedata
+++ b/ComposableArchitecture.xcworkspace/contents.xcworkspacedata
@@ -2,9 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Sources/ComposableArchitecture/Documentation.docc/Extensions/ViewStoreDeprecations.md">
-   </FileRef>
-   <FileRef
       location = "group:">
    </FileRef>
    <FileRef

--- a/ComposableArchitecture.xcworkspace/contents.xcworkspacedata
+++ b/ComposableArchitecture.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:Sources/ComposableArchitecture/Documentation.docc/Extensions/ViewStoreDeprecations.md">
+   </FileRef>
+   <FileRef
       location = "group:">
    </FileRef>
    <FileRef

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftUI.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftUI.md
@@ -1,0 +1,44 @@
+# SwiftUI Integration
+
+Integrating the Composable Architecture into a SwiftUI application.
+
+## Overview
+
+The Composable Architecture can be used to power applications built in many frameworks, but it was designed with SwiftUI in mind, and comes with many powerful tools to integrate into your SwiftUI applications.
+
+## Topics
+
+### View Containers
+
+- ``WithViewStore``
+- ``IfLetStore``
+- ``ForEachStore``
+- ``SwitchStore``
+
+### Bindings
+
+- ``ViewStore/binding(get:send:)-65xes``
+- ``ViewStore/binding(get:send:)-l66r``
+- ``ViewStore/binding(send:)-7nwak``
+- ``ViewStore/binding(send:)-705m7``
+
+### Bindable Domains
+
+- ``BindableState``
+- ``BindableAction``
+- ``BindingAction``
+- ``Reducer/binding()``
+- ``ViewStore/binding(_:file:line:)``
+
+### View State
+
+- ``AlertState``
+- ``ConfirmationDialogState``
+- ``TextState``
+
+### Deprecations
+
+- <doc:SwiftUIDeprecations>
+
+<!--TODO: Can't currently document `View` extensions-->
+<!--### View Modifiers-->

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftUI.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftUI.md
@@ -36,9 +36,9 @@ The Composable Architecture can be used to power applications built in many fram
 - ``ConfirmationDialogState``
 - ``TextState``
 
+<!--TODO: Can't currently document `View` extensions-->
+<!--### View Modifiers-->
+
 ### Deprecations
 
 - <doc:SwiftUIDeprecations>
-
-<!--TODO: Can't currently document `View` extensions-->
-<!--### View Modifiers-->

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftUIDeprecations.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftUIDeprecations.md
@@ -1,0 +1,16 @@
+# Deprecations
+
+Review unsupported SwiftUI APIs and their replacements.
+
+## Overview
+
+Avoid using deprecated APIs in your app. Select a method to see the replacement that you should use instead.
+
+## Topics
+
+### View State
+
+- ``ActionSheetState``
+
+<!--TODO: Can't currently document `View` extensions-->
+<!--### View Modifiers-->

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/UIKit.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/UIKit.md
@@ -1,0 +1,17 @@
+# UIKit Integration
+
+Integrating the Composable Architecture into a UIKit application.
+
+## Overview
+
+While the Composable Architecture was designed with SwiftUI in mind, it comes with tools to integrate into application code written in UIKit.
+
+## Topics
+
+### Store Scoping
+
+- ``Store/ifLet(then:else:)``
+
+### Subscribing to State Changes
+
+- ``ViewStore/publisher``

--- a/Sources/ComposableArchitecture/Documentation.docc/ComposableArchitecture.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/ComposableArchitecture.md
@@ -45,9 +45,25 @@ day-to-day when building applications, such as:
 
 ## Topics
 
-### Articles
+### Essentials
 
 - <doc:GettingStarted>
+
+### State Management
+
+- ``Reducer``
+- ``Effect``
+- ``Store``
+- ``ViewStore``
+
+### Integrations
+
+- <doc:SwiftUI>
+- <doc:UIKit>
+
+### Testing
+
+- ``TestStore``
 
 ## See Also
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
@@ -26,7 +26,7 @@
 
 ### Composition
 
-<!--NB: DocC has a bug that prevents `map` from being resolved-->
+<!--NB: DocC bug prevents the following from being resolved-->
 <!--- ``map(_:)``-->
 - ``merge(_:)-3al9f``
 - ``merge(_:)-4n451``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
@@ -1,0 +1,64 @@
+# ``ComposableArchitecture/Effect``
+
+## Topics
+
+### Creating an Effect
+
+- ``none``
+- ``init(value:)``
+- ``init(error:)``
+- ``run(_:)``
+- ``future(_:)``
+- ``catching(_:)``
+- ``result(_:)``
+- ``fireAndForget(_:)``
+- ``fireAndForget(priority:_:)``
+- ``task(priority:operation:)-7lrdd``
+
+### Cancellation
+
+- ``cancellable(id:cancelInFlight:)-499iv``
+- ``cancel(id:)-7vmd9``
+- ``cancel(ids:)-8gan2``
+- ``cancellable(id:cancelInFlight:)-17skv``
+- ``cancel(id:)-iun1``
+- ``cancel(ids:)-dmwy``
+
+### Composition
+
+<!--NB: DocC has a bug that prevents `map` from being resolved-->
+<!--- ``map(_:)``-->
+- ``merge(_:)-3al9f``
+- ``merge(_:)-4n451``
+- ``concatenate(_:)-3awnj``
+- ``concatenate(_:)-8x6rz``
+
+### Timing
+
+- ``deferred(for:scheduler:options:)``
+- ``debounce(id:for:scheduler:options:)-8x633``
+- ``debounce(id:for:scheduler:options:)-76yye``
+- ``throttle(id:for:scheduler:latest:)-9kwd5``
+- ``throttle(id:for:scheduler:latest:)-5jfpx``
+- ``timer(id:every:tolerance:on:options:)-4exe6``
+- ``timer(id:every:tolerance:on:options:)-7po0d``
+
+### Testing
+
+- ``unimplemented(_:)``
+
+### SwiftUI Integration
+
+- ``animation(_:)``
+
+### Combine Integration
+
+- ``receive(subscriber:)``
+- ``init(_:)``
+- ``upstream``
+- ``Subscriber``
+<!--TODO: Can't currently document `Publisher` extensions-->
+
+### Deprecations
+
+- <doc:EffectDeprecations>

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectDeprecations.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectDeprecations.md
@@ -1,0 +1,21 @@
+# Deprecations
+
+Review unsupported effect APIs and their replacements.
+
+## Overview
+
+Avoid using deprecated APIs in your app. Select a method to see the replacement that you should use instead.
+
+## Topics
+
+### Creating an Effect
+
+- ``Effect/task(priority:operation:)-2czg0``
+
+### Cancellation
+
+- ``Effect/cancel(ids:)-9tnmm``
+
+### Testing
+
+- ``Effect/failing(_:)``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Reducer.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Reducer.md
@@ -1,0 +1,42 @@
+# ``ComposableArchitecture/Reducer``
+
+## Topics
+
+### Creating a Reducer
+
+- ``init(_:)``
+- ``empty``
+
+### Invoking Reducers
+
+- ``run(_:_:_:)``
+- ``callAsFunction(_:_:_:)``
+
+### Composing Reducers
+
+- ``combine(_:)-994ak``
+- ``combine(_:)-1ern2``
+- ``combined(with:)``
+- ``pullback(state:action:environment:)``
+- ``pullback(state:action:environment:file:line:)``
+- ``optional(file:line:)``
+- ``forEach(state:action:environment:file:line:)-gvte``
+- ``forEach(state:action:environment:file:line:)-21wow``
+- ``Identified``
+
+### SwiftUI Integration
+
+- ``binding()``
+
+### Debugging Reducers
+
+- ``debug(_:state:action:actionFormat:environment:)``
+- ``debug(_:actionFormat:environment:)``
+- ``debugActions(_:actionFormat:environment:)``
+- ``signpost(_:log:)``
+- ``ActionFormat``
+- ``DebugEnvironment``
+
+### Deprecations
+
+- <doc:ReducerDeprecations>

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerDeprecations.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerDeprecations.md
@@ -1,0 +1,21 @@
+# Deprecations
+
+Review unsupported reducer APIs and their replacements.
+
+## Overview
+
+Avoid using deprecated APIs in your app. Select a method to see the replacement that you should use instead.
+
+## Topics
+
+### Composition
+
+- ``Reducer/pullback(state:action:environment:breakpointOnNil:file:line:)``
+- ``Reducer/optional(breakpointOnNil:file:line:)``
+- ``Reducer/forEach(state:action:environment:breakpointOnNil:file:line:)-7h573``
+- ``Reducer/forEach(state:action:environment:breakpointOnNil:file:line:)-1h7qx``
+- ``Reducer/forEach(state:action:environment:breakpointOnNil:file:line:)-8iy04``
+
+### SwiftUI Integration
+
+- ``Reducer/binding(action:)``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Store.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Store.md
@@ -1,0 +1,27 @@
+# ``ComposableArchitecture/Store``
+
+## Topics
+
+### Creating a Store
+
+- ``init(initialState:reducer:environment:)``
+- ``unchecked(initialState:reducer:environment:)``
+
+### Scoping Stores
+
+- ``scope(state:action:)``
+- ``scope(state:)``
+- ``stateless``
+- ``actionless``
+
+### Combine Integration
+
+- ``StorePublisher``
+
+### UIKit Integration
+
+- ``ifLet(then:else:)``
+
+### Deprecations
+
+- <doc:StoreDeprecations>

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/StoreDeprecations.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/StoreDeprecations.md
@@ -1,0 +1,14 @@
+# Deprecations
+
+Review unsupported store APIs and their replacements.
+
+## Overview
+
+Avoid using deprecated APIs in your app. Select a method to see the replacement that you should use instead.
+
+## Topics
+
+### Scoping Stores
+
+- ``Store/publisherScope(state:action:)``
+- ``Store/publisherScope(state:)``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwitchStore.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwitchStore.md
@@ -1,0 +1,8 @@
+# ``ComposableArchitecture/SwitchStore``
+
+## Topics
+
+### Building Content
+
+- ``CaseLet``
+- ``Default``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStore.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStore.md
@@ -1,0 +1,33 @@
+# ``ComposableArchitecture/TestStore``
+
+## Topics
+
+### Creating a Test Store
+
+- ``init(initialState:reducer:environment:file:line:)``
+
+### Testing a Reducer
+
+- ``send(_:_:file:line:)``
+- ``receive(_:_:file:line:)``
+
+### Controlling Dependencies
+
+Controlling a reducer's dependencies are a crucial part of building a reliable test suite. Mutating the environment provides a means of influencing a reducer's dependencies over the course of a test.
+
+- ``environment``
+
+### Accessing State
+
+While the most common way of interacting with a test store's state is via its ``send(_:_:file:line:)`` and ``receive(_:_:file:line:)`` methods, you may also access it directly throughout a test.
+
+- ``state``
+
+### Scoping a Test Store
+
+- ``scope(state:action:)``
+- ``scope(state:)``
+
+### Deprecations
+
+- <doc:TestStoreDeprecations>

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStoreDeprecations.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStoreDeprecations.md
@@ -1,0 +1,15 @@
+# Deprecations
+
+Review unsupported test store APIs and their replacements.
+
+## Overview
+
+Avoid using deprecated APIs in your app. Select a method to see the replacement that you should use instead.
+
+## Topics
+
+### Testing a Reducer
+
+- ``TestStore/assert(_:file:line:)-707lb``
+- ``TestStore/assert(_:file:line:)-4gff7``
+- ``TestStore/Step``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/ViewStore.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/ViewStore.md
@@ -16,10 +16,10 @@
 ### Sending Actions
 
 - ``send(_:)``
-- ``send(_:while:)``
 
 ### Interacting with Concurrency
 
+- ``send(_:while:)``
 - ``yield(while:)``
 
 ### SwiftUI Integration

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/ViewStore.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/ViewStore.md
@@ -1,0 +1,38 @@
+# ``ComposableArchitecture/ViewStore``
+
+## Topics
+
+### Creating a View Store
+
+<!--NB: DocC bug prevents the following from being resolved-->
+<!--- ``init(_:)``-->
+- ``init(_:removeDuplicates:)``
+
+### Accessing State
+
+- ``state``
+- ``subscript(dynamicMember:)-kwxk``
+
+### Sending Actions
+
+- ``send(_:)``
+- ``send(_:while:)``
+
+### Interacting with Concurrency
+
+- ``yield(while:)``
+
+### SwiftUI Integration
+
+- ``send(_:animation:)``
+- ``send(_:animation:while:)``
+- ``binding(get:send:)-65xes``
+- ``binding(get:send:)-l66r``
+- ``binding(send:)-7nwak``
+- ``binding(send:)-705m7``
+<!--NB: DocC bug prevents the following from being resolved-->
+<!--- ``objectWillChange``-->
+
+### Deprecations
+
+- <doc:ViewStoreDeprecations>

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/ViewStoreDeprecations.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/ViewStoreDeprecations.md
@@ -1,0 +1,18 @@
+# Deprecations
+
+Review unsupported view store APIs and their replacements.
+
+## Overview
+
+Avoid using deprecated APIs in your app. Select a method to see the replacement that you should use instead.
+
+## Topics
+
+### Interacting with Concurrency
+
+- ``ViewStore/suspend(while:)``
+
+### SwiftUI Integration
+
+- ``ViewStore/subscript(dynamicMember:)-7xjrv``
+- ``ViewStore/binding(keyPath:send:)``

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -119,8 +119,8 @@ import SwiftUI
 /// .binding()
 /// ```
 ///
-/// Binding actions are constructed and sent to the store by calling ``ViewStore/binding(_:)``
-/// with a key path to the bindable state:
+/// Binding actions are constructed and sent to the store by calling
+/// ``ViewStore/binding(_:file:line:)`` with a key path to the bindable state:
 ///
 /// ```swift
 /// TextField("Display name", text: viewStore.binding(\.$displayName))


### PR DESCRIPTION
This PR takes a first stab at introducing some structure to TCA's documentation. It's minimal organization for a better Table of Contents experience:

<img width="247" alt="image" src="https://user-images.githubusercontent.com/658/176934945-ae7c4a17-8eb7-44db-8aac-97b61d9847d9.png">

It does its best to hide away deprecated APIs and surface most import APIs first and in a progressive manner. We have a lot more to do, but it's a start!