### PR TITLE
Make TestStore.send async

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -52,7 +52,7 @@ let effectsBasicsReducer = Reducer<
     state.numberFact = nil
     // Return an effect that re-increments the count after 1 second.
     return .task {
-      try? await environment.mainQueue.sleep(for: 1)
+      try await environment.mainQueue.sleep(for: 1)
       return .incrementButtonTapped
     }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -65,7 +65,7 @@ let refreshableReducer = Reducer<
     state.fact = nil
     state.isLoading = true
     return .task { [count = state.count] in
-      try? await environment.mainQueue.sleep(for: .seconds(1))
+      try await environment.mainQueue.sleep(for: .seconds(1))
       return await .factResponse(TaskResult { try await environment.fact.fetch(count) })
     }
     .animation()

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
@@ -46,7 +46,7 @@ let multipleDependenciesReducer = Reducer<
   switch action {
   case .alertButtonTapped:
     return .task {
-      try? await environment.mainQueue.sleep(for: 1)
+      try await environment.mainQueue.sleep(for: 1)
       return .alertDelayReceived
     }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -68,7 +68,7 @@ let loadThenNavigateListReducer =
           state.rows[id: row.id]?.isActivityIndicatorVisible = row.id == navigatedId
         }
         return .task {
-          try? await environment.mainQueue.sleep(for: 1)
+          try await environment.mainQueue.sleep(for: 1)
           return .setNavigationSelectionDelayCompleted(navigatedId)
         }
         .cancellable(id: CancelId.self, cancelInFlight: true)

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -56,7 +56,7 @@ let navigateAndLoadListReducer =
       case let .setNavigation(selection: .some(id)):
         state.selection = Identified(nil, id: id)
         return .task {
-          try? await environment.mainQueue.sleep(for: 1)
+          try await environment.mainQueue.sleep(for: 1)
           return .setNavigationSelectionDelayCompleted
         }
         .cancellable(id: CancelId.self, cancelInFlight: true)

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -49,7 +49,7 @@ let loadThenNavigateReducer =
       case .setNavigation(isActive: true):
         state.isActivityIndicatorVisible = true
         return .task {
-          try? await environment.mainQueue.sleep(for: 1)
+          try await environment.mainQueue.sleep(for: 1)
           return .setNavigationIsActiveDelayCompleted
         }
         .cancellable(id: CancelId.self)

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -44,7 +44,7 @@ let navigateAndLoadReducer =
       case .setNavigation(isActive: true):
         state.isNavigationActive = true
         return .task {
-          try? await environment.mainQueue.sleep(for: 1)
+          try await environment.mainQueue.sleep(for: 1)
           return .setNavigationIsActiveDelayCompleted
         }
         .cancellable(id: CancelId.self)

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -49,7 +49,7 @@ let loadThenPresentReducer =
       case .setSheet(isPresented: true):
         state.isActivityIndicatorVisible = true
         return .task {
-          try? await environment.mainQueue.sleep(for: 1)
+          try await environment.mainQueue.sleep(for: 1)
           return .setSheetIsPresentedDelayCompleted
         }
         .cancellable(id: CancelId.self)

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -42,7 +42,7 @@ let presentAndLoadReducer =
       case .setSheet(isPresented: true):
         state.isSheetPresented = true
         return .task {
-          try? await environment.mainQueue.sleep(for: 1)
+          try await environment.mainQueue.sleep(for: 1)
           return .setSheetIsPresentedDelayCompleted
         }
         .cancellable(id: CancelId.self)

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndConfirmationDialogsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndConfirmationDialogsTests.swift
@@ -5,15 +5,16 @@ import XCTest
 
 @testable import SwiftUICaseStudies
 
+@MainActor
 class AlertsAndConfirmationDialogsTests: XCTestCase {
-  func testAlert() {
+  func testAlert() async {
     let store = TestStore(
       initialState: AlertAndConfirmationDialogState(),
       reducer: alertAndConfirmationDialogReducer,
       environment: AlertAndConfirmationDialogEnvironment()
     )
 
-    store.send(.alertButtonTapped) {
+    await store.send(.alertButtonTapped) {
       $0.alert = AlertState(
         title: TextState("Alert!"),
         message: TextState("This is an alert"),
@@ -21,23 +22,23 @@ class AlertsAndConfirmationDialogsTests: XCTestCase {
         secondaryButton: .default(TextState("Increment"), action: .send(.incrementButtonTapped))
       )
     }
-    store.send(.incrementButtonTapped) {
+    await store.send(.incrementButtonTapped) {
       $0.alert = AlertState(title: TextState("Incremented!"))
       $0.count = 1
     }
-    store.send(.alertDismissed) {
+    await store.send(.alertDismissed) {
       $0.alert = nil
     }
   }
 
-  func testConfirmationDialog() {
+  func testConfirmationDialog() async {
     let store = TestStore(
       initialState: AlertAndConfirmationDialogState(),
       reducer: alertAndConfirmationDialogReducer,
       environment: AlertAndConfirmationDialogEnvironment()
     )
 
-    store.send(.confirmationDialogButtonTapped) {
+    await store.send(.confirmationDialogButtonTapped) {
       $0.confirmationDialog = ConfirmationDialogState(
         title: TextState("Confirmation dialog"),
         message: TextState("This is a confirmation dialog."),
@@ -48,11 +49,11 @@ class AlertsAndConfirmationDialogsTests: XCTestCase {
         ]
       )
     }
-    store.send(.incrementButtonTapped) {
+    await store.send(.incrementButtonTapped) {
       $0.alert = AlertState(title: TextState("Incremented!"))
       $0.count = 1
     }
-    store.send(.confirmationDialogDismissed) {
+    await store.send(.confirmationDialogDismissed) {
       $0.confirmationDialog = nil
     }
   }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
@@ -17,7 +17,7 @@ class AnimationTests: XCTestCase {
       )
     )
 
-    store.send(.rainbowButtonTapped)
+    await store.send(.rainbowButtonTapped)
 
     await store.receive(.setColor(.red)) {
       $0.circleColor = .red

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-BindingBasicsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-BindingBasicsTests.swift
@@ -4,28 +4,29 @@ import XCTest
 
 @testable import SwiftUICaseStudies
 
+@MainActor
 class BindingFormTests: XCTestCase {
-  func testBasics() {
+  func testBasics() async {
     let store = TestStore(
       initialState: BindingFormState(),
       reducer: bindingFormReducer,
       environment: BindingFormEnvironment()
     )
 
-    store.send(.set(\.$sliderValue, 2)) {
+    await store.send(.set(\.$sliderValue, 2)) {
       $0.sliderValue = 2
     }
-    store.send(.set(\.$stepCount, 1)) {
+    await store.send(.set(\.$stepCount, 1)) {
       $0.sliderValue = 1
       $0.stepCount = 1
     }
-    store.send(.set(\.$text, "Blob")) {
+    await store.send(.set(\.$text, "Blob")) {
       $0.text = "Blob"
     }
-    store.send(.set(\.$toggleIsOn, true)) {
+    await store.send(.set(\.$toggleIsOn, true)) {
       $0.toggleIsOn = true
     }
-    store.send(.resetButtonTapped) {
+    await store.send(.resetButtonTapped) {
       $0 = BindingFormState(sliderValue: 5, stepCount: 10, text: "", toggleIsOn: false)
     }
   }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-SharedStateTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-SharedStateTests.swift
@@ -4,21 +4,22 @@ import XCTest
 
 @testable import SwiftUICaseStudies
 
+@MainActor
 class SharedStateTests: XCTestCase {
-  func testTabRestoredOnReset() {
+  func testTabRestoredOnReset() async {
     let store = TestStore(
       initialState: SharedState(),
       reducer: sharedStateReducer,
       environment: ()
     )
 
-    store.send(.selectTab(.profile)) {
+    await store.send(.selectTab(.profile)) {
       $0.currentTab = .profile
       $0.profile = SharedState.ProfileState(
         currentTab: .profile, count: 0, maxCount: 0, minCount: 0, numberOfCounts: 0
       )
     }
-    store.send(.profile(.resetCounterButtonTapped)) {
+    await store.send(.profile(.resetCounterButtonTapped)) {
       $0.currentTab = .counter
       $0.profile = SharedState.ProfileState(
         currentTab: .counter, count: 0, maxCount: 0, minCount: 0, numberOfCounts: 0
@@ -26,20 +27,20 @@ class SharedStateTests: XCTestCase {
     }
   }
 
-  func testTabSelection() {
+  func testTabSelection() async {
     let store = TestStore(
       initialState: SharedState(),
       reducer: sharedStateReducer,
       environment: ()
     )
 
-    store.send(.selectTab(.profile)) {
+    await store.send(.selectTab(.profile)) {
       $0.currentTab = .profile
       $0.profile = SharedState.ProfileState(
         currentTab: .profile, count: 0, maxCount: 0, minCount: 0, numberOfCounts: 0
       )
     }
-    store.send(.selectTab(.counter)) {
+    await store.send(.selectTab(.counter)) {
       $0.currentTab = .counter
       $0.profile = SharedState.ProfileState(
         currentTab: .counter, count: 0, maxCount: 0, minCount: 0, numberOfCounts: 0
@@ -47,30 +48,30 @@ class SharedStateTests: XCTestCase {
     }
   }
 
-  func testSharedCounts() {
+  func testSharedCounts() async {
     let store = TestStore(
       initialState: SharedState(),
       reducer: sharedStateReducer,
       environment: ()
     )
 
-    store.send(.counter(.incrementButtonTapped)) {
+    await store.send(.counter(.incrementButtonTapped)) {
       $0.counter.count = 1
       $0.counter.maxCount = 1
       $0.counter.numberOfCounts = 1
     }
-    store.send(.counter(.decrementButtonTapped)) {
+    await store.send(.counter(.decrementButtonTapped)) {
       $0.counter.count = 0
       $0.counter.numberOfCounts = 2
     }
-    store.send(.counter(.decrementButtonTapped)) {
+    await store.send(.counter(.decrementButtonTapped)) {
       $0.counter.count = -1
       $0.counter.minCount = -1
       $0.counter.numberOfCounts = 3
     }
   }
 
-  func testIsPrimeWhenPrime() {
+  func testIsPrimeWhenPrime() async {
     let store = TestStore(
       initialState: SharedState.CounterState(
         alert: nil, count: 3, maxCount: 0, minCount: 0, numberOfCounts: 0
@@ -79,17 +80,17 @@ class SharedStateTests: XCTestCase {
       environment: ()
     )
 
-    store.send(.isPrimeButtonTapped) {
+    await store.send(.isPrimeButtonTapped) {
       $0.alert = AlertState(
         title: TextState("👍 The number \($0.count) is prime!")
       )
     }
-    store.send(.alertDismissed) {
+    await store.send(.alertDismissed) {
       $0.alert = nil
     }
   }
 
-  func testIsPrimeWhenNotPrime() {
+  func testIsPrimeWhenNotPrime() async {
     let store = TestStore(
       initialState: SharedState.CounterState(
         alert: nil, count: 6, maxCount: 0, minCount: 0, numberOfCounts: 0
@@ -98,12 +99,12 @@ class SharedStateTests: XCTestCase {
       environment: ()
     )
 
-    store.send(.isPrimeButtonTapped) {
+    await store.send(.isPrimeButtonTapped) {
       $0.alert = AlertState(
         title: TextState("👎 The number \($0.count) is not prime :(")
       )
     }
-    store.send(.alertDismissed) {
+    await store.send(.alertDismissed) {
       $0.alert = nil
     }
   }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-BasicsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-BasicsTests.swift
@@ -14,10 +14,10 @@ class EffectsBasicsTests: XCTestCase {
 
     store.environment.mainQueue = .immediate
 
-    store.send(.incrementButtonTapped) {
+    await store.send(.incrementButtonTapped) {
       $0.count = 1
     }
-    store.send(.decrementButtonTapped) {
+    await store.send(.decrementButtonTapped) {
       $0.count = 0
     }
     await store.receive(.incrementButtonTapped) {
@@ -35,10 +35,10 @@ class EffectsBasicsTests: XCTestCase {
     store.environment.fact.fetch = { "\($0) is a good number Brent" }
     store.environment.mainQueue = .immediate
 
-    store.send(.incrementButtonTapped) {
+    await store.send(.incrementButtonTapped) {
       $0.count = 1
     }
-    store.send(.numberFactButtonTapped) {
+    await store.send(.numberFactButtonTapped) {
       $0.isNumberFactRequestInFlight = true
     }
     await store.receive(.numberFactResponse(.success("1 is a good number Brent"))) {

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-CancellationTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-CancellationTests.swift
@@ -54,36 +54,42 @@ class EffectsCancellationTests: XCTestCase {
   // in the `.cancelButtonTapped` action of the `effectsCancellationReducer`. This will cause the
   // test to fail, showing that we are exhaustively asserting that the effect truly is canceled and
   // will never emit.
-  func testTrivia_CancelButtonCancelsRequest() {
+  func testTrivia_CancelButtonCancelsRequest() async {
     let store = TestStore(
       initialState: EffectsCancellationState(),
       reducer: effectsCancellationReducer,
       environment: .unimplemented
     )
 
-    store.environment.fact.fetch = { "\($0) is a good number Brent" }
+    store.environment.fact.fetch = {
+      try await Task.sleep(nanoseconds: NSEC_PER_SEC)
+      return "\($0) is a good number Brent"
+    }
 
-    store.send(.triviaButtonTapped) {
+    await store.send(.triviaButtonTapped) {
       $0.isTriviaRequestInFlight = true
     }
-    store.send(.cancelButtonTapped) {
+    await store.send(.cancelButtonTapped) {
       $0.isTriviaRequestInFlight = false
     }
   }
 
-  func testTrivia_PlusMinusButtonsCancelsRequest() {
+  func testTrivia_PlusMinusButtonsCancelsRequest() async {
     let store = TestStore(
       initialState: EffectsCancellationState(),
       reducer: effectsCancellationReducer,
       environment: .unimplemented
     )
 
-    store.environment.fact.fetch = { "\($0) is a good number Brent" }
+    store.environment.fact.fetch = {
+      try await Task.sleep(nanoseconds: NSEC_PER_SEC)
+      return "\($0) is a good number Brent"
+    }
 
-    store.send(.triviaButtonTapped) {
+    await store.send(.triviaButtonTapped) {
       $0.isTriviaRequestInFlight = true
     }
-    store.send(.stepperChanged(1)) {
+    await store.send(.stepperChanged(1)) {
       $0.count = 1
       $0.isTriviaRequestInFlight = false
     }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-CancellationTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-CancellationTests.swift
@@ -15,13 +15,13 @@ class EffectsCancellationTests: XCTestCase {
 
     store.environment.fact.fetch = { "\($0) is a good number Brent" }
 
-    store.send(.stepperChanged(1)) {
+    await store.send(.stepperChanged(1)) {
       $0.count = 1
     }
-    store.send(.stepperChanged(0)) {
+    await store.send(.stepperChanged(0)) {
       $0.count = 0
     }
-    store.send(.triviaButtonTapped) {
+    await store.send(.triviaButtonTapped) {
       $0.isTriviaRequestInFlight = true
     }
     await store.receive(.triviaResponse(.success("0 is a good number Brent"))) {
@@ -40,7 +40,7 @@ class EffectsCancellationTests: XCTestCase {
 
     store.environment.fact.fetch = { _ in throw FactError() }
 
-    store.send(.triviaButtonTapped) {
+    await store.send(.triviaButtonTapped) {
       $0.isTriviaRequestInFlight = true
     }
     await store.receive(.triviaResponse(.failure(FactError()))) {

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
@@ -17,7 +17,7 @@ class LongLivingEffectsTests: XCTestCase {
       )
     )
 
-    let task = store.send(.task)
+    let task = await store.send(.task)
 
     // Simulate a screenshot being taken
     takeScreenshot.yield()

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-RefreshableTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-RefreshableTests.swift
@@ -49,22 +49,27 @@ class RefreshableTests: XCTestCase {
     }
   }
 
-  func testCancellation() {
+  func testCancellation() async {
     let store = TestStore(
       initialState: RefreshableState(),
       reducer: refreshableReducer,
       environment: .unimplemented
     )
 
-    store.environment.fact.fetch = { "\($0) is a good number." }
+    store.environment.mainQueue = .immediate
 
-    store.send(.incrementButtonTapped) {
+    store.environment.fact.fetch = {
+      try await Task.sleep(nanoseconds: NSEC_PER_SEC)
+      return "\($0) is a good number."
+    }
+
+    await store.send(.incrementButtonTapped) {
       $0.count = 1
     }
-    store.send(.refresh) {
+    await store.send(.refresh) {
       $0.isLoading = true
     }
-    store.send(.cancelButtonTapped) {
+    await store.send(.cancelButtonTapped) {
       $0.isLoading = false
     }
   }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-RefreshableTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-RefreshableTests.swift
@@ -15,10 +15,10 @@ class RefreshableTests: XCTestCase {
     store.environment.fact.fetch = { "\($0) is a good number." }
     store.environment.mainQueue = .immediate
 
-    store.send(.incrementButtonTapped) {
+    await store.send(.incrementButtonTapped) {
       $0.count = 1
     }
-    store.send(.refresh) {
+    await store.send(.refresh) {
       $0.isLoading = true
     }
     await store.receive(.factResponse(.success("1 is a good number."))) {
@@ -38,10 +38,10 @@ class RefreshableTests: XCTestCase {
     store.environment.fact.fetch = { _ in throw FactError() }
     store.environment.mainQueue = .immediate
 
-    store.send(.incrementButtonTapped) {
+    await store.send(.incrementButtonTapped) {
       $0.count = 1
     }
-    store.send(.refresh) {
+    await store.send(.refresh) {
       $0.isLoading = true
     }
     await store.receive(.factResponse(.failure(FactError()))) {

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-TimersTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-TimersTests.swift
@@ -16,7 +16,7 @@ class TimersTests: XCTestCase {
       )
     )
 
-    store.send(.toggleTimerButtonTapped) {
+    await store.send(.toggleTimerButtonTapped) {
       $0.isTimerActive = true
     }
     await mainQueue.advance(by: 1)
@@ -39,7 +39,7 @@ class TimersTests: XCTestCase {
     await store.receive(.timerTicked) {
       $0.secondsElapsed = 6
     }
-    store.send(.toggleTimerButtonTapped) {
+    await store.send(.toggleTimerButtonTapped) {
       $0.isTimerActive = false
     }
     await store.finish()

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-TimersTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-TimersTests.swift
@@ -42,6 +42,5 @@ class TimersTests: XCTestCase {
     await store.send(.toggleTimerButtonTapped) {
       $0.isTimerActive = false
     }
-    await store.finish()
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
@@ -26,7 +26,7 @@ class WebSocketTests: XCTestCase {
     )
 
     // Connect to the socket
-    store.send(.connectButtonTapped) {
+    await store.send(.connectButtonTapped) {
       $0.connectivityState = .connecting
     }
     actions.continuation.yield(.didOpen(protocol: nil))
@@ -41,10 +41,10 @@ class WebSocketTests: XCTestCase {
     }
 
     // Send a message
-    store.send(.messageToSendChanged("Hi")) {
+    await store.send(.messageToSendChanged("Hi")) {
       $0.messageToSend = "Hi"
     }
-    store.send(.sendButtonTapped) {
+    await store.send(.sendButtonTapped) {
       $0.messageToSend = ""
     }
     await store.receive(.sendResponse(didSucceed: true))
@@ -56,7 +56,7 @@ class WebSocketTests: XCTestCase {
     }
 
     // Disconnect from the socket
-    store.send(.connectButtonTapped) {
+    await store.send(.connectButtonTapped) {
       $0.connectivityState = .disconnected
     }
   }
@@ -84,7 +84,7 @@ class WebSocketTests: XCTestCase {
     )
 
     // Connect to the socket
-    store.send(.connectButtonTapped) {
+    await store.send(.connectButtonTapped) {
       $0.connectivityState = .connecting
     }
     actions.continuation.yield(.didOpen(protocol: nil))
@@ -93,10 +93,10 @@ class WebSocketTests: XCTestCase {
     }
 
     // Send a message
-    store.send(.messageToSendChanged("Hi")) {
+    await store.send(.messageToSendChanged("Hi")) {
       $0.messageToSend = "Hi"
     }
-    store.send(.sendButtonTapped) {
+    await store.send(.sendButtonTapped) {
       $0.messageToSend = ""
     }
     await store.receive(.sendResponse(didSucceed: false)) {
@@ -104,7 +104,7 @@ class WebSocketTests: XCTestCase {
     }
 
     // Disconnect from the socket
-    store.send(.connectButtonTapped) {
+    await store.send(.connectButtonTapped) {
       $0.connectivityState = .disconnected
     }
   }
@@ -129,7 +129,7 @@ class WebSocketTests: XCTestCase {
     )
 
     // Connect to the socket
-    store.send(.connectButtonTapped) {
+    await store.send(.connectButtonTapped) {
       $0.connectivityState = .connecting
     }
     actions.continuation.yield(.didOpen(protocol: nil))
@@ -145,7 +145,7 @@ class WebSocketTests: XCTestCase {
     XCTAssertEqual(after, 1)
 
     // Disconnect from the socket
-    store.send(.connectButtonTapped) {
+    await store.send(.connectButtonTapped) {
       $0.connectivityState = .disconnected
     }
   }
@@ -168,7 +168,7 @@ class WebSocketTests: XCTestCase {
     )
 
     // Attempt to connect to the socket
-    store.send(.connectButtonTapped) {
+    await store.send(.connectButtonTapped) {
       $0.connectivityState = .connecting
     }
     actions.continuation.yield(.didClose(code: .internalServerError, reason: nil))

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-LifecycleTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-LifecycleTests.swift
@@ -17,11 +17,11 @@ class LifecycleTests: XCTestCase {
       )
     )
 
-    store.send(.toggleTimerButtonTapped) {
+    await store.send(.toggleTimerButtonTapped) {
       $0.count = 0
     }
 
-    store.send(.timer(.onAppear))
+    await store.send(.timer(.onAppear))
 
     await mainQueue.advance(by: .seconds(1))
     await store.receive(.timer(.action(.tick))) {
@@ -33,18 +33,18 @@ class LifecycleTests: XCTestCase {
       $0.count = 2
     }
 
-    store.send(.timer(.action(.incrementButtonTapped))) {
+    await store.send(.timer(.action(.incrementButtonTapped))) {
       $0.count = 3
     }
 
-    store.send(.timer(.action(.decrementButtonTapped))) {
+    await store.send(.timer(.action(.decrementButtonTapped))) {
       $0.count = 2
     }
 
-    store.send(.toggleTimerButtonTapped) {
+    await store.send(.toggleTimerButtonTapped) {
       $0.count = nil
     }
 
-    store.send(.timer(.onDisappear))
+    await store.send(.timer(.onDisappear))
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
@@ -35,7 +35,7 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
       environment: DownloadComponentEnvironment(downloadClient: downloadClient)
     )
 
-    store.send(.buttonTapped) {
+    await store.send(.buttonTapped) {
       $0.mode = .startingToDownload
     }
 
@@ -65,7 +65,7 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
       environment: DownloadComponentEnvironment(downloadClient: downloadClient)
     )
 
-    store.send(.buttonTapped) {
+    await store.send(.buttonTapped) {
       $0.mode = .startingToDownload
     }
 
@@ -74,7 +74,7 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
       $0.mode = .downloading(progress: 0.2)
     }
 
-    store.send(.buttonTapped) {
+    await store.send(.buttonTapped) {
       $0.alert = AlertState(
         title: TextState("Do you want to stop downloading this map?"),
         primaryButton: .destructive(
@@ -85,7 +85,7 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
       )
     }
 
-    store.send(.alert(.stopButtonTapped)) {
+    await store.send(.alert(.stopButtonTapped)) {
       $0.alert = nil
       $0.mode = .notDownloaded
     }
@@ -105,11 +105,11 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
       environment: DownloadComponentEnvironment(downloadClient: downloadClient)
     )
 
-    let task = store.send(.buttonTapped) {
+    let task = await store.send(.buttonTapped) {
       $0.mode = .startingToDownload
     }
 
-    store.send(.buttonTapped) {
+    await store.send(.buttonTapped) {
       $0.alert = AlertState(
         title: TextState("Do you want to stop downloading this map?"),
         primaryButton: .destructive(

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
@@ -130,7 +130,7 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
     await task.finish()
   }
 
-  func testDeleteDownloadFlow() {
+  func testDeleteDownloadFlow() async {
     var downloadClient = DownloadClient.unimplemented
     downloadClient.download = { _ in self.download.stream }
 
@@ -144,7 +144,7 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
       environment: DownloadComponentEnvironment(downloadClient: downloadClient)
     )
 
-    store.send(.buttonTapped) {
+    await store.send(.buttonTapped) {
       $0.alert = AlertState(
         title: TextState("Do you want to delete this map from your offline storage?"),
         primaryButton: .destructive(
@@ -155,7 +155,7 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
       )
     }
 
-    store.send(.alert(.deleteButtonTapped)) {
+    await store.send(.alert(.deleteButtonTapped)) {
       $0.alert = nil
       $0.mode = .notDownloaded
     }

--- a/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
@@ -41,7 +41,7 @@ let lazyNavigationReducer =
       case .setNavigation(isActive: true):
         state.isActivityIndicatorHidden = false
         return .task {
-          try? await environment.mainQueue.sleep(for: 1)
+          try await environment.mainQueue.sleep(for: 1)
           return .setNavigationIsActiveDelayCompleted
         }
         .cancellable(id: CancelId.self)

--- a/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
@@ -37,7 +37,7 @@ let eagerNavigationReducer =
       case .setNavigation(isActive: true):
         state.isNavigationActive = true
         return .task {
-          try? await environment.mainQueue.sleep(for: 1)
+          try await environment.mainQueue.sleep(for: 1)
           return .setNavigationIsActiveDelayCompleted
         }
         .cancellable(id: CancelId.self)

--- a/Examples/CaseStudies/UIKitCaseStudies/SceneDelegate.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/SceneDelegate.swift
@@ -9,7 +9,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     willConnectTo session: UISceneSession,
     options connectionOptions: UIScene.ConnectionOptions
   ) {
-    self.window = (scene as? UIWindowScene).map(UIWindow.init(windowScene:))
+    self.window = (scene as? UIWindowScene).map { UIWindow(windowScene: $0) }
     self.window?.rootViewController = UINavigationController(
       rootViewController: RootViewController())
     self.window?.makeKeyAndVisible()

--- a/Examples/CaseStudies/UIKitCaseStudiesTests/UIKitCaseStudiesTests.swift
+++ b/Examples/CaseStudies/UIKitCaseStudiesTests/UIKitCaseStudiesTests.swift
@@ -3,23 +3,24 @@ import XCTest
 
 @testable import UIKitCaseStudies
 
+@MainActor
 final class UIKitCaseStudiesTests: XCTestCase {
-  func testCountDown() {
+  func testCountDown() async {
     let store = TestStore(
       initialState: CounterState(),
       reducer: counterReducer,
       environment: CounterEnvironment()
     )
 
-    store.send(.incrementButtonTapped) {
+    await store.send(.incrementButtonTapped) {
       $0.count = 1
     }
-    store.send(.decrementButtonTapped) {
+    await store.send(.decrementButtonTapped) {
       $0.count = 0
     }
   }
 
-  func testCountDownList() {
+  func testCountDownList() async {
     let firstState = CounterState()
     let secondState = CounterState()
     let thirdState = CounterState()
@@ -32,24 +33,24 @@ final class UIKitCaseStudiesTests: XCTestCase {
       environment: CounterListEnvironment()
     )
 
-    store.send(.counter(id: firstState.id, action: .incrementButtonTapped)) {
+    await store.send(.counter(id: firstState.id, action: .incrementButtonTapped)) {
       $0.counters[id: firstState.id]?.count = 1
     }
-    store.send(.counter(id: firstState.id, action: .decrementButtonTapped)) {
+    await store.send(.counter(id: firstState.id, action: .decrementButtonTapped)) {
       $0.counters[id: firstState.id]?.count = 0
     }
 
-    store.send(.counter(id: secondState.id, action: .incrementButtonTapped)) {
+    await store.send(.counter(id: secondState.id, action: .incrementButtonTapped)) {
       $0.counters[id: secondState.id]?.count = 1
     }
-    store.send(.counter(id: secondState.id, action: .decrementButtonTapped)) {
+    await store.send(.counter(id: secondState.id, action: .decrementButtonTapped)) {
       $0.counters[id: secondState.id]?.count = 0
     }
 
-    store.send(.counter(id: thirdState.id, action: .incrementButtonTapped)) {
+    await store.send(.counter(id: thirdState.id, action: .incrementButtonTapped)) {
       $0.counters[id: thirdState.id]?.count = 1
     }
-    store.send(.counter(id: thirdState.id, action: .decrementButtonTapped)) {
+    await store.send(.counter(id: thirdState.id, action: .decrementButtonTapped)) {
       $0.counters[id: thirdState.id]?.count = 0
     }
   }

--- a/Examples/CaseStudies/UIKitCaseStudiesTests/UIKitCaseStudiesTests.swift
+++ b/Examples/CaseStudies/UIKitCaseStudiesTests/UIKitCaseStudiesTests.swift
@@ -11,10 +11,10 @@ final class UIKitCaseStudiesTests: XCTestCase {
       environment: CounterEnvironment()
     )
 
-    await store.send(.incrementButtonTapped) {
+    store.send(.incrementButtonTapped) {
       $0.count = 1
     }
-    await store.send(.decrementButtonTapped) {
+    store.send(.decrementButtonTapped) {
       $0.count = 0
     }
   }
@@ -32,24 +32,24 @@ final class UIKitCaseStudiesTests: XCTestCase {
       environment: CounterListEnvironment()
     )
 
-    await store.send(.counter(id: firstState.id, action: .incrementButtonTapped)) {
+    store.send(.counter(id: firstState.id, action: .incrementButtonTapped)) {
       $0.counters[id: firstState.id]?.count = 1
     }
-    await store.send(.counter(id: firstState.id, action: .decrementButtonTapped)) {
+    store.send(.counter(id: firstState.id, action: .decrementButtonTapped)) {
       $0.counters[id: firstState.id]?.count = 0
     }
 
-    await store.send(.counter(id: secondState.id, action: .incrementButtonTapped)) {
+    store.send(.counter(id: secondState.id, action: .incrementButtonTapped)) {
       $0.counters[id: secondState.id]?.count = 1
     }
-    await store.send(.counter(id: secondState.id, action: .decrementButtonTapped)) {
+    store.send(.counter(id: secondState.id, action: .decrementButtonTapped)) {
       $0.counters[id: secondState.id]?.count = 0
     }
 
-    await store.send(.counter(id: thirdState.id, action: .incrementButtonTapped)) {
+    store.send(.counter(id: thirdState.id, action: .incrementButtonTapped)) {
       $0.counters[id: thirdState.id]?.count = 1
     }
-    await store.send(.counter(id: thirdState.id, action: .decrementButtonTapped)) {
+    store.send(.counter(id: thirdState.id, action: .decrementButtonTapped)) {
       $0.counters[id: thirdState.id]?.count = 0
     }
   }

--- a/Examples/CaseStudies/UIKitCaseStudiesTests/UIKitCaseStudiesTests.swift
+++ b/Examples/CaseStudies/UIKitCaseStudiesTests/UIKitCaseStudiesTests.swift
@@ -11,10 +11,10 @@ final class UIKitCaseStudiesTests: XCTestCase {
       environment: CounterEnvironment()
     )
 
-    store.send(.incrementButtonTapped) {
+    await store.send(.incrementButtonTapped) {
       $0.count = 1
     }
-    store.send(.decrementButtonTapped) {
+    await store.send(.decrementButtonTapped) {
       $0.count = 0
     }
   }
@@ -32,24 +32,24 @@ final class UIKitCaseStudiesTests: XCTestCase {
       environment: CounterListEnvironment()
     )
 
-    store.send(.counter(id: firstState.id, action: .incrementButtonTapped)) {
+    await store.send(.counter(id: firstState.id, action: .incrementButtonTapped)) {
       $0.counters[id: firstState.id]?.count = 1
     }
-    store.send(.counter(id: firstState.id, action: .decrementButtonTapped)) {
+    await store.send(.counter(id: firstState.id, action: .decrementButtonTapped)) {
       $0.counters[id: firstState.id]?.count = 0
     }
 
-    store.send(.counter(id: secondState.id, action: .incrementButtonTapped)) {
+    await store.send(.counter(id: secondState.id, action: .incrementButtonTapped)) {
       $0.counters[id: secondState.id]?.count = 1
     }
-    store.send(.counter(id: secondState.id, action: .decrementButtonTapped)) {
+    await store.send(.counter(id: secondState.id, action: .decrementButtonTapped)) {
       $0.counters[id: secondState.id]?.count = 0
     }
 
-    store.send(.counter(id: thirdState.id, action: .incrementButtonTapped)) {
+    await store.send(.counter(id: thirdState.id, action: .incrementButtonTapped)) {
       $0.counters[id: thirdState.id]?.count = 1
     }
-    store.send(.counter(id: thirdState.id, action: .decrementButtonTapped)) {
+    await store.send(.counter(id: thirdState.id, action: .decrementButtonTapped)) {
       $0.counters[id: thirdState.id]?.count = 0
     }
   }

--- a/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
+++ b/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
@@ -18,7 +18,7 @@ class SpeechRecognitionTests: XCTestCase {
       )
     )
 
-    store.send(.recordButtonTapped) {
+    await store.send(.recordButtonTapped) {
       $0.isRecording = true
     }
     await store.receive(.speechRecognizerAuthorizationStatusResponse(.denied)) {
@@ -45,7 +45,7 @@ class SpeechRecognitionTests: XCTestCase {
       )
     )
 
-    store.send(.recordButtonTapped) {
+    await store.send(.recordButtonTapped) {
       $0.isRecording = true
     }
     await store.receive(.speechRecognizerAuthorizationStatusResponse(.restricted)) {
@@ -81,7 +81,7 @@ class SpeechRecognitionTests: XCTestCase {
     finalResult.bestTranscription.formattedString = "Hello world"
     finalResult.isFinal = true
 
-    let task = store.send(.recordButtonTapped) {
+    let task = await store.send(.recordButtonTapped) {
       $0.isRecording = true
     }
 
@@ -114,7 +114,7 @@ class SpeechRecognitionTests: XCTestCase {
       )
     )
 
-    store.send(.recordButtonTapped) {
+    await store.send(.recordButtonTapped) {
       $0.isRecording = true
     }
 
@@ -141,7 +141,7 @@ class SpeechRecognitionTests: XCTestCase {
       )
     )
 
-    store.send(.recordButtonTapped) {
+    await store.send(.recordButtonTapped) {
       $0.isRecording = true
     }
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/AuthenticationClient/AuthenticationClient.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/AuthenticationClient/AuthenticationClient.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import Foundation
 import XCTestDynamicOverlay
 
-public struct LoginRequest {
+public struct LoginRequest: Sendable {
   public var email: String
   public var password: String
 
@@ -28,7 +28,7 @@ public struct TwoFactorRequest {
   }
 }
 
-public struct AuthenticationResponse: Equatable {
+public struct AuthenticationResponse: Equatable, Sendable {
   public var token: String
   public var twoFactorRequired: Bool
 
@@ -41,7 +41,7 @@ public struct AuthenticationResponse: Equatable {
   }
 }
 
-public enum AuthenticationError: Equatable, LocalizedError {
+public enum AuthenticationError: Equatable, LocalizedError, Sendable {
   case invalidUserPassword
   case invalidTwoFactor
   case invalidIntermediateToken

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameCore/GameCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameCore/GameCore.swift
@@ -39,7 +39,7 @@ public struct GameState: Equatable {
   }
 }
 
-public enum GameAction: Equatable {
+public enum GameAction: Equatable, Sendable {
   case cellTapped(row: Int, column: Int)
   case playAgainButtonTapped
   case quitButtonTapped

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 public struct GameView: View {
   let store: Store<GameState, GameAction>
 
-  struct ViewState: Equatable {
+  struct ViewState: Equatable, Sendable {
     var board: [[String]]
     var isGameDisabled: Bool
     var isPlayAgainButtonVisible: Bool

--- a/Examples/TicTacToe/tic-tac-toe/Tests/AppCoreTests/AppCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/AppCoreTests/AppCoreTests.swift
@@ -21,18 +21,18 @@ class AppCoreTests: XCTestCase {
       )
     )
 
-    store.send(.login(.emailChanged("blob@pointfree.co"))) {
+    await store.send(.login(.emailChanged("blob@pointfree.co"))) {
       try (/AppState.login).modify(&$0) {
         $0.email = "blob@pointfree.co"
       }
     }
-    store.send(.login(.passwordChanged("bl0bbl0b"))) {
+    await store.send(.login(.passwordChanged("bl0bbl0b"))) {
       try (/AppState.login).modify(&$0) {
         $0.password = "bl0bbl0b"
         $0.isFormValid = true
       }
     }
-    store.send(.login(.loginButtonTapped)) {
+    await store.send(.login(.loginButtonTapped)) {
       try (/AppState.login).modify(&$0) {
         $0.isLoginRequestInFlight = true
       }
@@ -46,12 +46,12 @@ class AppCoreTests: XCTestCase {
     ) {
       $0 = .newGame(NewGameState())
     }
-    store.send(.newGame(.oPlayerNameChanged("Blob Sr."))) {
+    await store.send(.newGame(.oPlayerNameChanged("Blob Sr."))) {
       try (/AppState.newGame).modify(&$0) {
         $0.oPlayerName = "Blob Sr."
       }
     }
-    store.send(.newGame(.logoutButtonTapped)) {
+    await store.send(.newGame(.logoutButtonTapped)) {
       $0 = .login(LoginState())
     }
   }
@@ -72,20 +72,20 @@ class AppCoreTests: XCTestCase {
       )
     )
 
-    store.send(.login(.emailChanged("blob@pointfree.co"))) {
+    await store.send(.login(.emailChanged("blob@pointfree.co"))) {
       try (/AppState.login).modify(&$0) {
         $0.email = "blob@pointfree.co"
       }
     }
 
-    store.send(.login(.passwordChanged("bl0bbl0b"))) {
+    await store.send(.login(.passwordChanged("bl0bbl0b"))) {
       try (/AppState.login).modify(&$0) {
         $0.password = "bl0bbl0b"
         $0.isFormValid = true
       }
     }
 
-    store.send(.login(.loginButtonTapped)) {
+    await store.send(.login(.loginButtonTapped)) {
       try (/AppState.login).modify(&$0) {
         $0.isLoginRequestInFlight = true
       }
@@ -101,14 +101,14 @@ class AppCoreTests: XCTestCase {
       }
     }
 
-    store.send(.login(.twoFactor(.codeChanged("1234")))) {
+    await store.send(.login(.twoFactor(.codeChanged("1234")))) {
       try (/AppState.login).modify(&$0) {
         $0.twoFactor?.code = "1234"
         $0.twoFactor?.isFormValid = true
       }
     }
 
-    store.send(.login(.twoFactor(.submitButtonTapped))) {
+    await store.send(.login(.twoFactor(.submitButtonTapped))) {
       try (/AppState.login).modify(&$0) {
         $0.twoFactor?.isTwoFactorRequestInFlight = true
       }

--- a/Examples/TicTacToe/tic-tac-toe/Tests/GameCoreTests/GameCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/GameCoreTests/GameCoreTests.swift
@@ -2,6 +2,7 @@ import ComposableArchitecture
 import GameCore
 import XCTest
 
+@MainActor
 class GameCoreTests: XCTestCase {
   let store = TestStore(
     initialState: GameState(
@@ -12,67 +13,67 @@ class GameCoreTests: XCTestCase {
     environment: GameEnvironment()
   )
 
-  func testFlow_Winner_Quit() {
-    self.store.send(.cellTapped(row: 0, column: 0)) {
+  func testFlow_Winner_Quit() async {
+    await self.store.send(.cellTapped(row: 0, column: 0)) {
       $0.board[0][0] = .x
       $0.currentPlayer = .o
     }
-    self.store.send(.cellTapped(row: 2, column: 1)) {
+    await self.store.send(.cellTapped(row: 2, column: 1)) {
       $0.board[2][1] = .o
       $0.currentPlayer = .x
     }
-    self.store.send(.cellTapped(row: 1, column: 0)) {
+    await self.store.send(.cellTapped(row: 1, column: 0)) {
       $0.board[1][0] = .x
       $0.currentPlayer = .o
     }
-    self.store.send(.cellTapped(row: 1, column: 1)) {
+    await self.store.send(.cellTapped(row: 1, column: 1)) {
       $0.board[1][1] = .o
       $0.currentPlayer = .x
     }
-    self.store.send(.cellTapped(row: 2, column: 0)) {
+    await self.store.send(.cellTapped(row: 2, column: 0)) {
       $0.board[2][0] = .x
     }
-    self.store.send(.quitButtonTapped)
+    await self.store.send(.quitButtonTapped)
   }
 
-  func testFlow_Tie() {
-    self.store.send(.cellTapped(row: 0, column: 0)) {
+  func testFlow_Tie() async {
+    await self.store.send(.cellTapped(row: 0, column: 0)) {
       $0.board[0][0] = .x
       $0.currentPlayer = .o
     }
-    self.store.send(.cellTapped(row: 2, column: 2)) {
+    await self.store.send(.cellTapped(row: 2, column: 2)) {
       $0.board[2][2] = .o
       $0.currentPlayer = .x
     }
-    self.store.send(.cellTapped(row: 1, column: 0)) {
+    await self.store.send(.cellTapped(row: 1, column: 0)) {
       $0.board[1][0] = .x
       $0.currentPlayer = .o
     }
-    self.store.send(.cellTapped(row: 2, column: 0)) {
+    await self.store.send(.cellTapped(row: 2, column: 0)) {
       $0.board[2][0] = .o
       $0.currentPlayer = .x
     }
-    self.store.send(.cellTapped(row: 2, column: 1)) {
+    await self.store.send(.cellTapped(row: 2, column: 1)) {
       $0.board[2][1] = .x
       $0.currentPlayer = .o
     }
-    self.store.send(.cellTapped(row: 1, column: 2)) {
+    await self.store.send(.cellTapped(row: 1, column: 2)) {
       $0.board[1][2] = .o
       $0.currentPlayer = .x
     }
-    self.store.send(.cellTapped(row: 0, column: 2)) {
+    await self.store.send(.cellTapped(row: 0, column: 2)) {
       $0.board[0][2] = .x
       $0.currentPlayer = .o
     }
-    self.store.send(.cellTapped(row: 0, column: 1)) {
+    await self.store.send(.cellTapped(row: 0, column: 1)) {
       $0.board[0][1] = .o
       $0.currentPlayer = .x
     }
-    self.store.send(.cellTapped(row: 1, column: 1)) {
+    await self.store.send(.cellTapped(row: 1, column: 1)) {
       $0.board[1][1] = .x
       $0.currentPlayer = .o
     }
-    self.store.send(.playAgainButtonTapped) {
+    await self.store.send(.playAgainButtonTapped) {
       $0 = GameState(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr.")
     }
   }

--- a/Examples/TicTacToe/tic-tac-toe/Tests/GameSwiftUITests/GameSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/GameSwiftUITests/GameSwiftUITests.swift
@@ -4,6 +4,7 @@ import XCTest
 
 @testable import GameSwiftUI
 
+@MainActor
 class GameSwiftUITests: XCTestCase {
   let store = TestStore(
     initialState: GameState(
@@ -15,72 +16,72 @@ class GameSwiftUITests: XCTestCase {
   )
   .scope(state: GameView.ViewState.init)
 
-  func testFlow_Winner_Quit() {
-    self.store.send(.cellTapped(row: 0, column: 0)) {
+  func testFlow_Winner_Quit() async {
+    await self.store.send(.cellTapped(row: 0, column: 0)) {
       $0.board[0][0] = "❌"
       $0.title = "Blob Jr., place your ⭕️"
     }
-    self.store.send(.cellTapped(row: 2, column: 1)) {
+    await self.store.send(.cellTapped(row: 2, column: 1)) {
       $0.board[2][1] = "⭕️"
       $0.title = "Blob Sr., place your ❌"
     }
-    self.store.send(.cellTapped(row: 1, column: 0)) {
+    await self.store.send(.cellTapped(row: 1, column: 0)) {
       $0.board[1][0] = "❌"
       $0.title = "Blob Jr., place your ⭕️"
     }
-    self.store.send(.cellTapped(row: 1, column: 1)) {
+    await self.store.send(.cellTapped(row: 1, column: 1)) {
       $0.board[1][1] = "⭕️"
       $0.title = "Blob Sr., place your ❌"
     }
-    self.store.send(.cellTapped(row: 2, column: 0)) {
+    await self.store.send(.cellTapped(row: 2, column: 0)) {
       $0.board[2][0] = "❌"
       $0.isGameDisabled = true
       $0.isPlayAgainButtonVisible = true
       $0.title = "Winner! Congrats Blob Sr.!"
     }
-    self.store.send(.quitButtonTapped)
+    await self.store.send(.quitButtonTapped)
   }
 
-  func testFlow_Tie() {
-    self.store.send(.cellTapped(row: 0, column: 0)) {
+  func testFlow_Tie() async {
+    await self.store.send(.cellTapped(row: 0, column: 0)) {
       $0.board[0][0] = "❌"
       $0.title = "Blob Jr., place your ⭕️"
     }
-    self.store.send(.cellTapped(row: 2, column: 2)) {
+    await self.store.send(.cellTapped(row: 2, column: 2)) {
       $0.board[2][2] = "⭕️"
       $0.title = "Blob Sr., place your ❌"
     }
-    self.store.send(.cellTapped(row: 1, column: 0)) {
+    await self.store.send(.cellTapped(row: 1, column: 0)) {
       $0.board[1][0] = "❌"
       $0.title = "Blob Jr., place your ⭕️"
     }
-    self.store.send(.cellTapped(row: 2, column: 0)) {
+    await self.store.send(.cellTapped(row: 2, column: 0)) {
       $0.board[2][0] = "⭕️"
       $0.title = "Blob Sr., place your ❌"
     }
-    self.store.send(.cellTapped(row: 2, column: 1)) {
+    await self.store.send(.cellTapped(row: 2, column: 1)) {
       $0.board[2][1] = "❌"
       $0.title = "Blob Jr., place your ⭕️"
     }
-    self.store.send(.cellTapped(row: 1, column: 2)) {
+    await self.store.send(.cellTapped(row: 1, column: 2)) {
       $0.board[1][2] = "⭕️"
       $0.title = "Blob Sr., place your ❌"
     }
-    self.store.send(.cellTapped(row: 0, column: 2)) {
+    await self.store.send(.cellTapped(row: 0, column: 2)) {
       $0.board[0][2] = "❌"
       $0.title = "Blob Jr., place your ⭕️"
     }
-    self.store.send(.cellTapped(row: 0, column: 1)) {
+    await self.store.send(.cellTapped(row: 0, column: 1)) {
       $0.board[0][1] = "⭕️"
       $0.title = "Blob Sr., place your ❌"
     }
-    self.store.send(.cellTapped(row: 1, column: 1)) {
+    await self.store.send(.cellTapped(row: 1, column: 1)) {
       $0.board[1][1] = "❌"
       $0.isGameDisabled = true
       $0.isPlayAgainButtonVisible = true
       $0.title = "Tied game!"
     }
-    self.store.send(.playAgainButtonTapped) {
+    await self.store.send(.playAgainButtonTapped) {
       $0 = GameView.ViewState(state: GameState(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr."))
     }
   }

--- a/Examples/TicTacToe/tic-tac-toe/Tests/LoginCoreTests/LoginCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/LoginCoreTests/LoginCoreTests.swift
@@ -23,14 +23,14 @@ class LoginCoreTests: XCTestCase {
       )
     )
 
-    store.send(.emailChanged("2fa@pointfree.co")) {
+    await store.send(.emailChanged("2fa@pointfree.co")) {
       $0.email = "2fa@pointfree.co"
     }
-    store.send(.passwordChanged("password")) {
+    await store.send(.passwordChanged("password")) {
       $0.password = "password"
       $0.isFormValid = true
     }
-    store.send(.loginButtonTapped) {
+    await store.send(.loginButtonTapped) {
       $0.isLoginRequestInFlight = true
     }
     await store.receive(
@@ -41,11 +41,11 @@ class LoginCoreTests: XCTestCase {
       $0.isLoginRequestInFlight = false
       $0.twoFactor = TwoFactorState(token: "deadbeefdeadbeef")
     }
-    store.send(.twoFactor(.codeChanged("1234"))) {
+    await store.send(.twoFactor(.codeChanged("1234"))) {
       $0.twoFactor?.code = "1234"
       $0.twoFactor?.isFormValid = true
     }
-    store.send(.twoFactor(.submitButtonTapped)) {
+    await store.send(.twoFactor(.submitButtonTapped)) {
       $0.twoFactor?.isTwoFactorRequestInFlight = true
     }
     await store.receive(
@@ -65,7 +65,8 @@ class LoginCoreTests: XCTestCase {
       AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: true)
     }
     authenticationClient.twoFactor = { _ in
-      AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false)
+      try await Task.sleep(nanoseconds: NSEC_PER_SEC)
+      return AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false)
     }
 
     let store = TestStore(
@@ -76,14 +77,14 @@ class LoginCoreTests: XCTestCase {
       )
     )
 
-    store.send(.emailChanged("2fa@pointfree.co")) {
+    await store.send(.emailChanged("2fa@pointfree.co")) {
       $0.email = "2fa@pointfree.co"
     }
-    store.send(.passwordChanged("password")) {
+    await store.send(.passwordChanged("password")) {
       $0.password = "password"
       $0.isFormValid = true
     }
-    store.send(.loginButtonTapped) {
+    await store.send(.loginButtonTapped) {
       $0.isLoginRequestInFlight = true
     }
     await store.receive(
@@ -94,14 +95,14 @@ class LoginCoreTests: XCTestCase {
       $0.isLoginRequestInFlight = false
       $0.twoFactor = TwoFactorState(token: "deadbeefdeadbeef")
     }
-    store.send(.twoFactor(.codeChanged("1234"))) {
+    await store.send(.twoFactor(.codeChanged("1234"))) {
       $0.twoFactor?.code = "1234"
       $0.twoFactor?.isFormValid = true
     }
-    store.send(.twoFactor(.submitButtonTapped)) {
+    await store.send(.twoFactor(.submitButtonTapped)) {
       $0.twoFactor?.isTwoFactorRequestInFlight = true
     }
-    store.send(.twoFactorDismissed) {
+    await store.send(.twoFactorDismissed) {
       $0.twoFactor = nil
     }
   }

--- a/Examples/TicTacToe/tic-tac-toe/Tests/LoginSwiftUITests/LoginSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/LoginSwiftUITests/LoginSwiftUITests.swift
@@ -23,14 +23,14 @@ class LoginSwiftUITests: XCTestCase {
     )
     .scope(state: LoginView.ViewState.init, action: LoginAction.init)
 
-    store.send(.emailChanged("blob@pointfree.co")) {
+    await store.send(.emailChanged("blob@pointfree.co")) {
       $0.email = "blob@pointfree.co"
     }
-    store.send(.passwordChanged("password")) {
+    await store.send(.passwordChanged("password")) {
       $0.password = "password"
       $0.isLoginButtonDisabled = false
     }
-    store.send(.loginButtonTapped) {
+    await store.send(.loginButtonTapped) {
       $0.isActivityIndicatorVisible = true
       $0.isFormDisabled = true
     }
@@ -59,14 +59,14 @@ class LoginSwiftUITests: XCTestCase {
     )
     .scope(state: LoginView.ViewState.init, action: LoginAction.init)
 
-    store.send(.emailChanged("2fa@pointfree.co")) {
+    await store.send(.emailChanged("2fa@pointfree.co")) {
       $0.email = "2fa@pointfree.co"
     }
-    store.send(.passwordChanged("password")) {
+    await store.send(.passwordChanged("password")) {
       $0.password = "password"
       $0.isLoginButtonDisabled = false
     }
-    store.send(.loginButtonTapped) {
+    await store.send(.loginButtonTapped) {
       $0.isActivityIndicatorVisible = true
       $0.isFormDisabled = true
     }
@@ -79,7 +79,7 @@ class LoginSwiftUITests: XCTestCase {
       $0.isFormDisabled = false
       $0.isTwoFactorActive = true
     }
-    store.send(.twoFactorDismissed) {
+    await store.send(.twoFactorDismissed) {
       $0.isTwoFactorActive = false
     }
   }
@@ -97,14 +97,14 @@ class LoginSwiftUITests: XCTestCase {
     )
     .scope(state: LoginView.ViewState.init, action: LoginAction.init)
 
-    store.send(.emailChanged("blob")) {
+    await store.send(.emailChanged("blob")) {
       $0.email = "blob"
     }
-    store.send(.passwordChanged("password")) {
+    await store.send(.passwordChanged("password")) {
       $0.password = "password"
       $0.isLoginButtonDisabled = false
     }
-    store.send(.loginButtonTapped) {
+    await store.send(.loginButtonTapped) {
       $0.isActivityIndicatorVisible = true
       $0.isFormDisabled = true
     }
@@ -115,7 +115,7 @@ class LoginSwiftUITests: XCTestCase {
       $0.isActivityIndicatorVisible = false
       $0.isFormDisabled = false
     }
-    store.send(.alertDismissed) {
+    await store.send(.alertDismissed) {
       $0.alert = nil
     }
   }

--- a/Examples/TicTacToe/tic-tac-toe/Tests/NewGameCoreTests/NewGameCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/NewGameCoreTests/NewGameCoreTests.swift
@@ -3,6 +3,7 @@ import GameCore
 import NewGameCore
 import XCTest
 
+@MainActor
 class NewGameCoreTests: XCTestCase {
   let store = TestStore(
     initialState: NewGameState(),
@@ -10,29 +11,29 @@ class NewGameCoreTests: XCTestCase {
     environment: NewGameEnvironment()
   )
 
-  func testFlow_NewGame_Integration() {
-    self.store.send(.oPlayerNameChanged("Blob Sr.")) {
+  func testFlow_NewGame_Integration() async {
+    await self.store.send(.oPlayerNameChanged("Blob Sr.")) {
       $0.oPlayerName = "Blob Sr."
     }
-    self.store.send(.xPlayerNameChanged("Blob Jr.")) {
+    await self.store.send(.xPlayerNameChanged("Blob Jr.")) {
       $0.xPlayerName = "Blob Jr."
     }
-    self.store.send(.letsPlayButtonTapped) {
+    await self.store.send(.letsPlayButtonTapped) {
       $0.game = GameState(oPlayerName: "Blob Sr.", xPlayerName: "Blob Jr.")
     }
-    self.store.send(.game(.cellTapped(row: 0, column: 0))) {
+    await self.store.send(.game(.cellTapped(row: 0, column: 0))) {
       $0.game!.board[0][0] = .x
       $0.game!.currentPlayer = .o
     }
-    self.store.send(.game(.quitButtonTapped)) {
+    await self.store.send(.game(.quitButtonTapped)) {
       $0.game = nil
     }
-    self.store.send(.letsPlayButtonTapped) {
+    await self.store.send(.letsPlayButtonTapped) {
       $0.game = GameState(oPlayerName: "Blob Sr.", xPlayerName: "Blob Jr.")
     }
-    self.store.send(.gameDismissed) {
+    await self.store.send(.gameDismissed) {
       $0.game = nil
     }
-    self.store.send(.logoutButtonTapped)
+    await self.store.send(.logoutButtonTapped)
   }
 }

--- a/Examples/TicTacToe/tic-tac-toe/Tests/NewGameSwiftUITests/NewGameSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/NewGameSwiftUITests/NewGameSwiftUITests.swift
@@ -4,6 +4,7 @@ import XCTest
 
 @testable import NewGameSwiftUI
 
+@MainActor
 class NewGameSwiftUITests: XCTestCase {
   let store = TestStore(
     initialState: NewGameState(),
@@ -12,20 +13,20 @@ class NewGameSwiftUITests: XCTestCase {
   )
   .scope(state: NewGameView.ViewState.init, action: NewGameAction.init)
 
-  func testNewGame() {
-    self.store.send(.xPlayerNameChanged("Blob Sr.")) {
+  func testNewGame() async {
+    await self.store.send(.xPlayerNameChanged("Blob Sr.")) {
       $0.xPlayerName = "Blob Sr."
     }
-    self.store.send(.oPlayerNameChanged("Blob Jr.")) {
+    await self.store.send(.oPlayerNameChanged("Blob Jr.")) {
       $0.oPlayerName = "Blob Jr."
       $0.isLetsPlayButtonDisabled = false
     }
-    self.store.send(.letsPlayButtonTapped) {
+    await self.store.send(.letsPlayButtonTapped) {
       $0.isGameActive = true
     }
-    self.store.send(.gameDismissed) {
+    await self.store.send(.gameDismissed) {
       $0.isGameActive = false
     }
-    self.store.send(.logoutButtonTapped)
+    await self.store.send(.logoutButtonTapped)
   }
 }

--- a/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorCoreTests/TwoFactorCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorCoreTests/TwoFactorCoreTests.swift
@@ -17,20 +17,20 @@ class TwoFactorCoreTests: XCTestCase {
     store.environment.authenticationClient.twoFactor = { _ in
       AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false)
     }
-    store.send(.codeChanged("1")) {
+    await store.send(.codeChanged("1")) {
       $0.code = "1"
     }
-    store.send(.codeChanged("12")) {
+    await store.send(.codeChanged("12")) {
       $0.code = "12"
     }
-    store.send(.codeChanged("123")) {
+    await store.send(.codeChanged("123")) {
       $0.code = "123"
     }
-    store.send(.codeChanged("1234")) {
+    await store.send(.codeChanged("1234")) {
       $0.code = "1234"
       $0.isFormValid = true
     }
-    store.send(.submitButtonTapped) {
+    await store.send(.submitButtonTapped) {
       $0.isTwoFactorRequestInFlight = true
     }
     await store.receive(
@@ -55,11 +55,11 @@ class TwoFactorCoreTests: XCTestCase {
       throw AuthenticationError.invalidTwoFactor
     }
 
-    store.send(.codeChanged("1234")) {
+    await store.send(.codeChanged("1234")) {
       $0.code = "1234"
       $0.isFormValid = true
     }
-    store.send(.submitButtonTapped) {
+    await store.send(.submitButtonTapped) {
       $0.isTwoFactorRequestInFlight = true
     }
     await store.receive(.twoFactorResponse(.failure(AuthenticationError.invalidTwoFactor))) {
@@ -68,7 +68,7 @@ class TwoFactorCoreTests: XCTestCase {
       )
       $0.isTwoFactorRequestInFlight = false
     }
-    store.send(.alertDismissed) {
+    await store.send(.alertDismissed) {
       $0.alert = nil
     }
   }

--- a/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorSwiftUITests/TwoFactorSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorSwiftUITests/TwoFactorSwiftUITests.swift
@@ -26,20 +26,20 @@ class TwoFactorSwiftUITests: XCTestCase {
     store.environment.authenticationClient.twoFactor = { _ in
       AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false)
     }
-    store.send(.codeChanged("1")) {
+    await store.send(.codeChanged("1")) {
       $0.code = "1"
     }
-    store.send(.codeChanged("12")) {
+    await store.send(.codeChanged("12")) {
       $0.code = "12"
     }
-    store.send(.codeChanged("123")) {
+    await store.send(.codeChanged("123")) {
       $0.code = "123"
     }
-    store.send(.codeChanged("1234")) {
+    await store.send(.codeChanged("1234")) {
       $0.code = "1234"
       $0.isSubmitButtonDisabled = false
     }
-    store.send(.submitButtonTapped) {
+    await store.send(.submitButtonTapped) {
       $0.isActivityIndicatorVisible = true
       $0.isFormDisabled = true
     }
@@ -68,11 +68,11 @@ class TwoFactorSwiftUITests: XCTestCase {
     )
     .scope(state: TwoFactorView.ViewState.init, action: TwoFactorAction.init)
 
-    store.send(.codeChanged("1234")) {
+    await store.send(.codeChanged("1234")) {
       $0.code = "1234"
       $0.isSubmitButtonDisabled = false
     }
-    store.send(.submitButtonTapped) {
+    await store.send(.submitButtonTapped) {
       $0.isActivityIndicatorVisible = true
       $0.isFormDisabled = true
     }
@@ -83,7 +83,7 @@ class TwoFactorSwiftUITests: XCTestCase {
       $0.isActivityIndicatorVisible = false
       $0.isFormDisabled = false
     }
-    store.send(.alertDismissed) {
+    await store.send(.alertDismissed) {
       $0.alert = nil
     }
   }

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -80,7 +80,7 @@ let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
       state.todos.move(fromOffsets: source, toOffset: destination)
 
       return .task {
-        try? await environment.mainQueue.sleep(for: .milliseconds(100))
+        try await environment.mainQueue.sleep(for: .milliseconds(100))
         return .sortCompletedTodos
       }
 

--- a/Examples/Todos/TodosTests/TodosTests.swift
+++ b/Examples/Todos/TodosTests/TodosTests.swift
@@ -79,7 +79,7 @@ class TodosTests: XCTestCase {
       )
     )
 
-    store.send(.todo(id: state.todos[0].id, action: .checkBoxToggled)) {
+    await store.send(.todo(id: state.todos[0].id, action: .checkBoxToggled)) {
       $0.todos[id: state.todos[0].id]?.isComplete = true
     }
     await self.mainQueue.advance(by: 1)
@@ -115,11 +115,11 @@ class TodosTests: XCTestCase {
       )
     )
 
-    store.send(.todo(id: state.todos[0].id, action: .checkBoxToggled)) {
+    await store.send(.todo(id: state.todos[0].id, action: .checkBoxToggled)) {
       $0.todos[id: state.todos[0].id]?.isComplete = true
     }
     await self.mainQueue.advance(by: 0.5)
-    store.send(.todo(id: state.todos[0].id, action: .checkBoxToggled)) {
+    await store.send(.todo(id: state.todos[0].id, action: .checkBoxToggled)) {
       $0.todos[id: state.todos[0].id]?.isComplete = false
     }
     await self.mainQueue.advance(by: 1)
@@ -223,10 +223,10 @@ class TodosTests: XCTestCase {
       )
     )
 
-    store.send(.editModeChanged(.active)) {
+    await store.send(.editModeChanged(.active)) {
       $0.editMode = .active
     }
-    store.send(.move([0], 2)) {
+    await store.send(.move([0], 2)) {
       $0.todos = [
         $0.todos[1],
         $0.todos[0],
@@ -271,13 +271,13 @@ class TodosTests: XCTestCase {
       )
     )
 
-    store.send(.editModeChanged(.active)) {
+    await store.send(.editModeChanged(.active)) {
       $0.editMode = .active
     }
-    store.send(.filterPicked(.completed)) {
+    await store.send(.filterPicked(.completed)) {
       $0.filter = .completed
     }
-    store.send(.move([0], 1)) {
+    await store.send(.move([0], 1)) {
       $0.todos = [
         $0.todos[0],
         $0.todos[2],

--- a/Examples/Todos/TodosTests/TodosTests.swift
+++ b/Examples/Todos/TodosTests/TodosTests.swift
@@ -7,7 +7,7 @@ import XCTest
 class TodosTests: XCTestCase {
   let mainQueue = DispatchQueue.test
 
-  func testAddTodo() {
+  func testAddTodo() async {
     let store = TestStore(
       initialState: AppState(),
       reducer: appReducer,
@@ -17,7 +17,7 @@ class TodosTests: XCTestCase {
       )
     )
 
-    store.send(.addTodoButtonTapped) {
+    await store.send(.addTodoButtonTapped) {
       $0.todos.insert(
         Todo(
           description: "",
@@ -29,7 +29,7 @@ class TodosTests: XCTestCase {
     }
   }
 
-  func testEditTodo() {
+  func testEditTodo() async {
     let state = AppState(
       todos: [
         Todo(
@@ -48,7 +48,7 @@ class TodosTests: XCTestCase {
       )
     )
 
-    store.send(
+    await store.send(
       .todo(id: state.todos[0].id, action: .textFieldChanged("Learn Composable Architecture"))
     ) {
       $0.todos[id: state.todos[0].id]?.description = "Learn Composable Architecture"
@@ -126,7 +126,7 @@ class TodosTests: XCTestCase {
     await store.receive(.sortCompletedTodos)
   }
 
-  func testClearCompleted() {
+  func testClearCompleted() async {
     let state = AppState(
       todos: [
         Todo(
@@ -150,14 +150,14 @@ class TodosTests: XCTestCase {
       )
     )
 
-    store.send(.clearCompletedButtonTapped) {
+    await store.send(.clearCompletedButtonTapped) {
       $0.todos = [
         $0.todos[0]
       ]
     }
   }
 
-  func testDelete() {
+  func testDelete() async {
     let state = AppState(
       todos: [
         Todo(
@@ -186,7 +186,7 @@ class TodosTests: XCTestCase {
       )
     )
 
-    store.send(.delete([1])) {
+    await store.send(.delete([1])) {
       $0.todos = [
         $0.todos[0],
         $0.todos[2],
@@ -289,7 +289,7 @@ class TodosTests: XCTestCase {
     await store.receive(.sortCompletedTodos)
   }
 
-  func testFilteredEdit() {
+  func testFilteredEdit() async {
     let state = AppState(
       todos: [
         Todo(
@@ -313,10 +313,10 @@ class TodosTests: XCTestCase {
       )
     )
 
-    store.send(.filterPicked(.completed)) {
+    await store.send(.filterPicked(.completed)) {
       $0.filter = .completed
     }
-    store.send(.todo(id: state.todos[1].id, action: .textFieldChanged("Did this already"))) {
+    await store.send(.todo(id: state.todos[1].id, action: .textFieldChanged("Did this already"))) {
       $0.todos[id: state.todos[1].id]?.description = "Did this already"
     }
   }

--- a/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
+++ b/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
@@ -36,7 +36,7 @@ class VoiceMemosTests: XCTestCase {
       environment: environment
     )
 
-    let recordButtonTappedTask = store.send(.recordButtonTapped)
+    let recordButtonTappedTask = await store.send(.recordButtonTapped)
     await self.mainRunLoop.advance()
     await store.receive(.recordPermissionResponse(true)) {
       $0.audioRecorderPermission = .allowed
@@ -55,7 +55,7 @@ class VoiceMemosTests: XCTestCase {
       $0.currentRecording?.duration = 2
     }
     await self.mainRunLoop.advance(by: 0.5)
-    store.send(.recordButtonTapped) {
+    await store.send(.recordButtonTapped) {
       $0.currentRecording?.mode = .encoding
     }
     await store.receive(.finalRecordingTime(2.5)) {
@@ -90,12 +90,12 @@ class VoiceMemosTests: XCTestCase {
       environment: environment
     )
 
-    store.send(.recordButtonTapped)
+    await store.send(.recordButtonTapped)
     await store.receive(.recordPermissionResponse(false)) {
       $0.alert = AlertState(title: TextState("Permission is required to record voice memos."))
       $0.audioRecorderPermission = .denied
     }
-    store.send(.alertDismissed) {
+    await store.send(.alertDismissed) {
       $0.alert = nil
     }
     await store.send(.openSettingsButtonTapped).finish()
@@ -123,7 +123,7 @@ class VoiceMemosTests: XCTestCase {
       environment: environment
     )
 
-    store.send(.recordButtonTapped)
+    await store.send(.recordButtonTapped)
     await self.mainRunLoop.advance(by: 0.5)
     await store.receive(.recordPermissionResponse(true)) {
       $0.audioRecorderPermission = .allowed
@@ -167,7 +167,7 @@ class VoiceMemosTests: XCTestCase {
       environment: environment
     )
 
-    let task = store.send(.voiceMemo(id: url, action: .playButtonTapped)) {
+    let task = await store.send(.voiceMemo(id: url, action: .playButtonTapped)) {
       $0.voiceMemos[id: url]?.mode = .playing(progress: 0)
     }
     await self.mainRunLoop.advance(by: 0.5)
@@ -208,7 +208,7 @@ class VoiceMemosTests: XCTestCase {
       environment: environment
     )
 
-    let task = store.send(.voiceMemo(id: url, action: .playButtonTapped)) {
+    let task = await store.send(.voiceMemo(id: url, action: .playButtonTapped)) {
       $0.voiceMemos[id: url]?.mode = .playing(progress: 0)
     }
     await store.receive(.voiceMemo(id: url, action: .audioPlayerClient(.failure(SomeError())))) {
@@ -218,7 +218,7 @@ class VoiceMemosTests: XCTestCase {
     await task.cancel()
   }
 
-  func testStopMemo() {
+  func testStopMemo() async {
     let url = URL(fileURLWithPath: "pointfreeco/functions.m4a")
     let store = TestStore(
       initialState: VoiceMemosState(
@@ -236,12 +236,12 @@ class VoiceMemosTests: XCTestCase {
       environment: .unimplemented
     )
 
-    store.send(.voiceMemo(id: url, action: .playButtonTapped)) {
+    await store.send(.voiceMemo(id: url, action: .playButtonTapped)) {
       $0.voiceMemos[id: url]?.mode = .notPlaying
     }
   }
 
-  func testDeleteMemo() {
+  func testDeleteMemo() async {
     let url = URL(fileURLWithPath: "pointfreeco/functions.m4a")
     let store = TestStore(
       initialState: VoiceMemosState(
@@ -259,12 +259,12 @@ class VoiceMemosTests: XCTestCase {
       environment: .unimplemented
     )
 
-    store.send(.voiceMemo(id: url, action: .delete)) {
+    await store.send(.voiceMemo(id: url, action: .delete)) {
       $0.voiceMemos = []
     }
   }
 
-  func testDeleteMemoWhilePlaying() {
+  func testDeleteMemoWhilePlaying() async {
     let url = URL(fileURLWithPath: "pointfreeco/functions.m4a")
     var environment = VoiceMemosEnvironment.unimplemented
     environment.audioPlayer.play = { _ in try await Task.never() }
@@ -286,10 +286,10 @@ class VoiceMemosTests: XCTestCase {
       environment: environment
     )
 
-    store.send(.voiceMemo(id: url, action: .playButtonTapped)) {
+    await store.send(.voiceMemo(id: url, action: .playButtonTapped)) {
       $0.voiceMemos[id: url]?.mode = .playing(progress: 0)
     }
-    store.send(.voiceMemo(id: url, action: .delete)) {
+    await store.send(.voiceMemo(id: url, action: .delete)) {
       $0.voiceMemos = []
     }
   }

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ The test below has the user increment and decrement the count, then they ask for
 
 ```swift
 // Test that tapping on the increment/decrement buttons changes the count
-awaitnstore.send(.incrementButtonTapped) {
+await store.send(.incrementButtonTapped) {
   $0.count = 1
 }
 await store.send(.decrementButtonTapped) {

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ And that is enough to get something on the screen to play around with. It's defi
 To test, you first create a `TestStore` with the same information that you would to create a regular `Store`, except this time we can supply test-friendly dependencies. In particular, we can now use a `numberFact` implementation that immediately returns a value we control rather than reaching out into the real world:
 
 ```swift
+@MainActor
 func testFeature() async {
   let store = TestStore(
     initialState: AppState(),
@@ -293,24 +294,24 @@ The test below has the user increment and decrement the count, then they ask for
 
 ```swift
 // Test that tapping on the increment/decrement buttons changes the count
-store.send(.incrementButtonTapped) {
+awaitnstore.send(.incrementButtonTapped) {
   $0.count = 1
 }
-store.send(.decrementButtonTapped) {
+await store.send(.decrementButtonTapped) {
   $0.count = 0
 }
 
 // Test that tapping the fact button causes us to receive a response from the effect. Note
 // that we have to await the receive because the effect is asynchronous and so takes a small
 // amount of time to emit.
-store.send(.numberFactButtonTapped)
+await store.send(.numberFactButtonTapped)
 
 await store.receive(.numberFactResponse(.success("0 is a good number Brent"))) {
   $0.numberFactAlert = "0 is a good number Brent"
 }
 
 // And finally dismiss the alert
-store.send(.factAlertDismissed) {
+await store.send(.factAlertDismissed) {
   $0.numberFactAlert = nil
 }
 ```

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -403,7 +403,7 @@ extension Effect where Failure == Never {
     priority: TaskPriority? = nil,
     _ work: @escaping @Sendable () async throws -> Void
   ) -> Self {
-    Effect<Void, Never>.task(priority: priority) { try? await work() }
+    Effect<Void, Never>.task(priority: priority) { try await work() }
       .fireAndForget()
   }
 }

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -144,7 +144,8 @@ public struct Effect<Output, Failure: Error> {
   /// fail if it ever executes:
   ///
   /// ```swift
-  /// func testIncrement() {
+  /// @MainActor
+  /// func testIncrement() async {
   ///   let store = TestStore(
   ///     initialState: CounterState(count: 0)
   ///     reducer: counterReducer,
@@ -153,7 +154,7 @@ public struct Effect<Output, Failure: Error> {
   ///     )
   ///   )
   ///
-  ///   store.send(.increment) {
+  ///   await store.send(.increment) {
   ///     $0.count = 1
   ///   }
   /// }

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -463,3 +463,4 @@ public struct Send<Action> {
 }
 
 extension Send: Sendable where Action: Sendable {}
+

--- a/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift
+++ b/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift
@@ -32,7 +32,7 @@
 ///     environment: Environment(analytics: analytics)
 ///   )
 ///
-///   store.send(.buttonTapped)
+///   await store.send(.buttonTapped)
 ///
 ///   let trackedEvents = await events.value
 ///   XCTAssertEqual(trackedEvents, ["Button Tapped"])

--- a/Sources/ComposableArchitecture/Effects/Timer.swift
+++ b/Sources/ComposableArchitecture/Effects/Timer.swift
@@ -55,7 +55,8 @@ extension Effect where Failure == Never {
   /// Then to test the timer in this feature you can use a test scheduler to advance time:
   ///
   /// ```swift
-  /// func testTimer() {
+  /// @MainActor
+  /// func testTimer() async {
   ///   let mainQueue = DispatchQueue.test
   ///
   ///   let store = TestStore(
@@ -66,19 +67,19 @@ extension Effect where Failure == Never {
   ///     )
   ///   )
   ///
-  ///   store.send(.startButtonTapped)
+  ///   await store.send(.startButtonTapped)
   ///
-  ///   mainQueue.advance(by: .seconds(1))
-  ///   store.receive(.timerTicked) { $0.count = 1 }
+  ///   await mainQueue.advance(by: .seconds(1))
+  ///   await store.receive(.timerTicked) { $0.count = 1 }
   ///
-  ///   mainQueue.advance(by: .seconds(5))
-  ///   store.receive(.timerTicked) { $0.count = 2 }
-  ///   store.receive(.timerTicked) { $0.count = 3 }
-  ///   store.receive(.timerTicked) { $0.count = 4 }
-  ///   store.receive(.timerTicked) { $0.count = 5 }
-  ///   store.receive(.timerTicked) { $0.count = 6 }
+  ///   await mainQueue.advance(by: .seconds(5))
+  ///   await store.receive(.timerTicked) { $0.count = 2 }
+  ///   await store.receive(.timerTicked) { $0.count = 3 }
+  ///   await store.receive(.timerTicked) { $0.count = 4 }
+  ///   await store.receive(.timerTicked) { $0.count = 5 }
+  ///   await store.receive(.timerTicked) { $0.count = 6 }
   ///
-  ///   store.send(.stopButtonTapped)
+  ///   await store.send(.stopButtonTapped)
   /// }
   /// ```
   ///

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -395,6 +395,7 @@ public final class Store<State, Action> {
       effectCancellable.wrappedValue =
         effect
         .handleEvents(
+//          receiveSubscription: <#T##((Subscription) -> Void)?##((Subscription) -> Void)?##(Subscription) -> Void#>
           receiveCancel: { [weak self] in
             self?.threadCheck(status: .effectCompletion(action))
             self?.effectCancellables[uuid] = nil

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -395,7 +395,6 @@ public final class Store<State, Action> {
       effectCancellable.wrappedValue =
         effect
         .handleEvents(
-//          receiveSubscription: <#T##((Subscription) -> Void)?##((Subscription) -> Void)?##(Subscription) -> Void#>
           receiveCancel: { [weak self] in
             self?.threadCheck(status: .effectCompletion(action))
             self?.effectCancellables[uuid] = nil

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -534,7 +534,7 @@
     ///     store after processing the given action. Do not provide a closure if no change is
     ///     expected.
     /// - Returns: A ``TestStoreTask`` that represents the lifecycle of the effect executed when
-    ///            sending the action.
+    ///   sending the action.
     @MainActor
     @discardableResult
     public func send(

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -429,6 +429,10 @@
     ///     expected.
     /// - Returns: A ``TestStoreTask`` that represents the lifecycle of the effect executed when
     ///            sending the action.
+    @available(iOS, deprecated: 9999.0, message: "Call the async-friendly 'send' instead.")
+    @available(macOS, deprecated: 9999.0, message: "Call the async-friendly 'send' instead.")
+    @available(tvOS, deprecated: 9999.0, message: "Call the async-friendly 'send' instead.")
+    @available(watchOS, deprecated: 9999.0, message: "Call the async-friendly 'send' instead.")
     @discardableResult
     public func send(
       _ action: LocalAction,
@@ -472,6 +476,19 @@
       }
 
       return .init(rawValue: task, timeout: self.timeout)
+    }
+
+    @MainActor
+    @discardableResult
+    public func send(
+      _ action: LocalAction,
+      _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil,
+      file: StaticString = #file,
+      line: UInt = #line
+    ) async -> TestStoreTask {
+      let task = { self.send(action, updateExpectingResult, file: file, line: line) }()
+      await Task.megaYield()
+      return task
     }
 
     private func expectedStateShouldMatch(
@@ -668,6 +685,7 @@
       else { return }
 
       { self.receive(expectedAction, updateExpectingResult, file: file, line: line) }()
+      await Task.megaYield()
     }
   }
 

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -519,7 +519,7 @@
     /// let store = TestStore(...)
     ///
     /// // emulate the view appearing
-    /// let task = store.send(.task)
+    /// let task = await store.send(.task)
     ///
     /// // assertions
     ///

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -64,15 +64,16 @@
   /// One can assert against its behavior over time:
   ///
   /// ```swift
+  /// @MainActor
   /// class CounterTests: XCTestCase {
-  ///   func testCounter() {
+  ///   func testCounter() async {
   ///     let store = TestStore(
-  ///       initialState: CounterState(count: 0),  // Given a counter state of 0
+  ///       initialState: CounterState(count: 0),    // Given a counter state of 0
   ///       reducer: counterReducer,
   ///       environment: ()
   ///     )
-  ///     store.send(.incrementButtonTapped) {     // When the increment button is tapped
-  ///       $0.count = 1                           // Then the count should be 1
+  ///     await store.send(.incrementButtonTapped) { // When the increment button is tapped
+  ///       $0.count = 1                             // Then the count should be 1
   ///     }
   ///   }
   /// }
@@ -400,86 +401,6 @@
   extension TestStore where LocalState: Equatable {
     /// Sends an action to the store and asserts when state changes.
     ///
-    /// This method returns a ``TestStoreTask``, which represents the lifecycle of the effect
-    /// started from sending an action. You can use this value to force the cancellation of the
-    /// effect, which is helpful for effects that are tied to a view's lifecycle and not torn
-    /// down when an action is sent, such as actions sent in SwiftUI's `task` view modifier.
-    ///
-    /// For example, if your feature kicks off a long-living effect when the view appears by using
-    /// SwiftUI's `task` view modifier, then you can write a test for such a feature by explicitly
-    /// canceling the effect's task after you make all assertions:
-    ///
-    /// ```swift
-    /// let store = TestStore(...)
-    ///
-    /// // emulate the view appearing
-    /// let task = store.send(.task)
-    ///
-    /// // assertions
-    ///
-    /// // emulate the view disappearing
-    /// await task.cancel()
-    /// ```
-    ///
-    /// - Parameters:
-    ///   - action: An action.
-    ///   - updateExpectingResult: A closure that asserts state changed by sending the action to the
-    ///     store. The mutable state sent to this closure must be modified to match the state of the
-    ///     store after processing the given action. Do not provide a closure if no change is
-    ///     expected.
-    /// - Returns: A ``TestStoreTask`` that represents the lifecycle of the effect executed when
-    ///            sending the action.
-    @available(iOS, deprecated: 9999.0, message: "Call the async-friendly 'send' instead.")
-    @available(macOS, deprecated: 9999.0, message: "Call the async-friendly 'send' instead.")
-    @available(tvOS, deprecated: 9999.0, message: "Call the async-friendly 'send' instead.")
-    @available(watchOS, deprecated: 9999.0, message: "Call the async-friendly 'send' instead.")
-    @discardableResult
-    public func send(
-      _ action: LocalAction,
-      _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil,
-      file: StaticString = #file,
-      line: UInt = #line
-    ) -> TestStoreTask {
-      if !self.receivedActions.isEmpty {
-        var actions = ""
-        customDump(self.receivedActions.map(\.action), to: &actions)
-        XCTFail(
-          """
-          Must handle \(self.receivedActions.count) received \
-          action\(self.receivedActions.count == 1 ? "" : "s") before sending an action: …
-
-          Unhandled actions: \(actions)
-          """,
-          file: file, line: line
-        )
-      }
-      var expectedState = self.toLocalState(self.state)
-      let previousState = self.state
-      let task = self.store.send(.init(origin: .send(action), file: file, line: line))
-      do {
-        let currentState = self.state
-        self.state = previousState
-        defer { self.state = currentState }
-
-        try self.expectedStateShouldMatch(
-          expected: &expectedState,
-          actual: self.toLocalState(currentState),
-          modify: updateExpectingResult,
-          file: file,
-          line: line
-        )
-      } catch {
-        XCTFail("Threw error: \(error)", file: file, line: line)
-      }
-      if "\(self.file)" == "\(file)" {
-        self.line = line
-      }
-
-      return .init(rawValue: task, timeout: self.timeout)
-    }
-
-    /// Sends an action to the store and asserts when state changes.
-    ///
     /// This method suspends briefly in order to allow any effects to start. For example, if you
     /// track some analytics in a ``Effect/fireAndForget(priority:_:)`` when an action is sent,
     /// you can assert on that behavior immediately after awaiting `store.send`:
@@ -519,7 +440,7 @@
     /// let store = TestStore(...)
     ///
     /// // emulate the view appearing
-    /// let task = await store.send(.task)
+    /// let task = store.send(.task)
     ///
     /// // assertions
     ///
@@ -534,7 +455,7 @@
     ///     store after processing the given action. Do not provide a closure if no change is
     ///     expected.
     /// - Returns: A ``TestStoreTask`` that represents the lifecycle of the effect executed when
-    ///   sending the action.
+    ///            sending the action.
     @MainActor
     @discardableResult
     public func send(
@@ -560,6 +481,86 @@
       let previousState = self.state
       let task = self.store.send(.init(origin: .send(action), file: file, line: line))
       await Task.megaYield()
+      do {
+        let currentState = self.state
+        self.state = previousState
+        defer { self.state = currentState }
+
+        try self.expectedStateShouldMatch(
+          expected: &expectedState,
+          actual: self.toLocalState(currentState),
+          modify: updateExpectingResult,
+          file: file,
+          line: line
+        )
+      } catch {
+        XCTFail("Threw error: \(error)", file: file, line: line)
+      }
+      if "\(self.file)" == "\(file)" {
+        self.line = line
+      }
+
+      return .init(rawValue: task, timeout: self.timeout)
+    }
+
+    /// Sends an action to the store and asserts when state changes.
+    ///
+    /// This method returns a ``TestStoreTask``, which represents the lifecycle of the effect
+    /// started from sending an action. You can use this value to force the cancellation of the
+    /// effect, which is helpful for effects that are tied to a view's lifecycle and not torn
+    /// down when an action is sent, such as actions sent in SwiftUI's `task` view modifier.
+    ///
+    /// For example, if your feature kicks off a long-living effect when the view appears by using
+    /// SwiftUI's `task` view modifier, then you can write a test for such a feature by explicitly
+    /// canceling the effect's task after you make all assertions:
+    ///
+    /// ```swift
+    /// let store = TestStore(...)
+    ///
+    /// // emulate the view appearing
+    /// let task = await store.send(.task)
+    ///
+    /// // assertions
+    ///
+    /// // emulate the view disappearing
+    /// await task.cancel()
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - action: An action.
+    ///   - updateExpectingResult: A closure that asserts state changed by sending the action to the
+    ///     store. The mutable state sent to this closure must be modified to match the state of the
+    ///     store after processing the given action. Do not provide a closure if no change is
+    ///     expected.
+    /// - Returns: A ``TestStoreTask`` that represents the lifecycle of the effect executed when
+    ///   sending the action.
+    @available(iOS, deprecated: 9999.0, message: "Call the async-friendly 'send' instead.")
+    @available(macOS, deprecated: 9999.0, message: "Call the async-friendly 'send' instead.")
+    @available(tvOS, deprecated: 9999.0, message: "Call the async-friendly 'send' instead.")
+    @available(watchOS, deprecated: 9999.0, message: "Call the async-friendly 'send' instead.")
+    @discardableResult
+    public func send(
+      _ action: LocalAction,
+      _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil,
+      file: StaticString = #file,
+      line: UInt = #line
+    ) -> TestStoreTask {
+      if !self.receivedActions.isEmpty {
+        var actions = ""
+        customDump(self.receivedActions.map(\.action), to: &actions)
+        XCTFail(
+          """
+          Must handle \(self.receivedActions.count) received \
+          action\(self.receivedActions.count == 1 ? "" : "s") before sending an action: …
+
+          Unhandled actions: \(actions)
+          """,
+          file: file, line: line
+        )
+      }
+      var expectedState = self.toLocalState(self.state)
+      let previousState = self.state
+      let task = self.store.send(.init(origin: .send(action), file: file, line: line))
       do {
         let currentState = self.state
         self.state = previousState

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -406,6 +406,7 @@
     /// you can assert on that behavior immediately after awaiting `store.send`:
     ///
     /// ```swift
+    /// @MainActor
     /// func testAnalytics() async {
     ///   let events = SendableState<[String]>([])
     ///   let analytics = AnalyticsClient(

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -499,7 +499,7 @@
       if "\(self.file)" == "\(file)" {
         self.line = line
       }
-
+      await Task.megaYield()
       return .init(rawValue: task, timeout: self.timeout)
     }
 

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -455,7 +455,7 @@
     ///     store after processing the given action. Do not provide a closure if no change is
     ///     expected.
     /// - Returns: A ``TestStoreTask`` that represents the lifecycle of the effect executed when
-    ///            sending the action.
+    ///   sending the action.
     @MainActor
     @discardableResult
     public func send(

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -440,7 +440,7 @@
     /// let store = TestStore(...)
     ///
     /// // emulate the view appearing
-    /// let task = store.send(.task)
+    /// let task = await store.send(.task)
     ///
     /// // assertions
     ///

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -759,7 +759,7 @@
   /// See ``TestStore/finish(timeout:file:line:)`` for the ability to await all in-flight effects.
   ///
   /// See ``ViewStoreTask`` for the analog provided to ``ViewStore``.
-  public struct TestStoreTask {
+  public struct TestStoreTask: Sendable {
     /// The underlying task.
     public let rawValue: Task<Void, Never>
 

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -7,7 +7,7 @@ import XCTest
 final class ComposableArchitectureTests: XCTestCase {
   var cancellables: Set<AnyCancellable> = []
 
-  func testScheduling() {
+  func testScheduling() async {
     enum CounterAction: Equatable {
       case incrAndSquareLater
       case incrNow
@@ -46,18 +46,18 @@ final class ComposableArchitectureTests: XCTestCase {
       environment: mainQueue.eraseToAnyScheduler()
     )
 
-    store.send(.incrAndSquareLater)
-    mainQueue.advance(by: 1)
-    store.receive(.squareNow) { $0 = 4 }
-    mainQueue.advance(by: 1)
-    store.receive(.incrNow) { $0 = 5 }
-    store.receive(.squareNow) { $0 = 25 }
+    await store.send(.incrAndSquareLater)
+    await mainQueue.advance(by: 1)
+    await store.receive(.squareNow) { $0 = 4 }
+    await mainQueue.advance(by: 1)
+    await store.receive(.incrNow) { $0 = 5 }
+    await store.receive(.squareNow) { $0 = 25 }
 
-    store.send(.incrAndSquareLater)
-    mainQueue.advance(by: 2)
-    store.receive(.squareNow) { $0 = 625 }
-    store.receive(.incrNow) { $0 = 626 }
-    store.receive(.squareNow) { $0 = 391876 }
+    await store.send(.incrAndSquareLater)
+    await mainQueue.advance(by: 2)
+    await store.receive(.squareNow) { $0 = 625 }
+    await store.receive(.incrNow) { $0 = 626 }
+    await store.receive(.squareNow) { $0 = 391876 }
   }
 
   func testSimultaneousWorkOrdering() {
@@ -76,7 +76,7 @@ final class ComposableArchitectureTests: XCTestCase {
     XCTAssertNoDifference(values, [1, 42, 1, 1, 42])
   }
 
-  func testLongLivingEffects() {
+  func testLongLivingEffects() async {
     typealias Environment = (
       startEffect: Effect<Void, Never>,
       stopEffect: Effect<Never, Never>
@@ -107,11 +107,11 @@ final class ComposableArchitectureTests: XCTestCase {
       )
     )
 
-    store.send(.start)
-    store.send(.incr) { $0 = 1 }
+    await store.send(.start)
+    await store.send(.incr) { $0 = 1 }
     subject.send()
-    store.receive(.incr) { $0 = 2 }
-    store.send(.end)
+    await store.receive(.incr) { $0 = 2 }
+    await store.send(.end)
   }
 
   func testCancellation() async {

--- a/Tests/ComposableArchitectureTests/EffectRunTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectRunTests.swift
@@ -17,7 +17,7 @@ final class EffectRunTests: XCTestCase {
       }
     }
     let store = TestStore(initialState: State(), reducer: reducer, environment: ())
-    store.send(.tapped)
+    await store.send(.tapped)
     await store.receive(.response)
   }
 
@@ -38,7 +38,7 @@ final class EffectRunTests: XCTestCase {
       }
     }
     let store = TestStore(initialState: State(), reducer: reducer, environment: ())
-    store.send(.tapped)
+    await store.send(.tapped)
     await store.receive(.response)
   }
 

--- a/Tests/ComposableArchitectureTests/EffectTaskTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTaskTests.swift
@@ -17,7 +17,7 @@ final class EffectTaskTests: XCTestCase {
       }
     }
     let store = TestStore(initialState: State(), reducer: reducer, environment: ())
-    store.send(.tapped)
+    await store.send(.tapped)
     await store.receive(.response)
   }
 
@@ -38,7 +38,7 @@ final class EffectTaskTests: XCTestCase {
       }
     }
     let store = TestStore(initialState: State(), reducer: reducer, environment: ())
-    store.send(.tapped)
+    await store.send(.tapped)
     await store.receive(.response)
   }
 

--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -5,6 +5,7 @@ import CustomDump
 import XCTest
 import os.signpost
 
+@MainActor
 final class ReducerTests: XCTestCase {
   var cancellables: Set<AnyCancellable> = []
 
@@ -19,7 +20,7 @@ final class ReducerTests: XCTestCase {
     XCTAssertNoDifference(state, 1)
   }
 
-  func testCombine_EffectsAreMerged() {
+  func testCombine_EffectsAreMerged() async {
     typealias Scheduler = AnySchedulerOf<DispatchQueue>
     enum Action: Equatable {
       case increment
@@ -48,19 +49,19 @@ final class ReducerTests: XCTestCase {
       environment: mainQueue.eraseToAnyScheduler()
     )
 
-    store.send(.increment) {
+    await store.send(.increment) {
       $0 = 2
     }
     // Waiting a second causes the fast effect to fire.
-    mainQueue.advance(by: 1)
+    await mainQueue.advance(by: 1)
     XCTAssertNoDifference(fastValue, 42)
     // Waiting one more second causes the slow effect to fire. This proves that the effects
     // are merged together, as opposed to concatenated.
-    mainQueue.advance(by: 1)
+    await mainQueue.advance(by: 1)
     XCTAssertNoDifference(slowValue, 1729)
   }
 
-  func testCombine() {
+  func testCombine() async {
     enum Action: Equatable {
       case increment
     }
@@ -86,7 +87,7 @@ final class ReducerTests: XCTestCase {
       environment: ()
     )
 
-    store.send(.increment) {
+    await store.send(.increment) {
       $0 = 2
     }
 
@@ -94,7 +95,7 @@ final class ReducerTests: XCTestCase {
     XCTAssertTrue(mainEffectExecuted)
   }
 
-  func testDebug() {
+  func testDebug() async {
     var logs: [String] = []
     let logsExpectation = self.expectation(description: "logs")
     logsExpectation.expectedFulfillmentCount = 2
@@ -124,8 +125,8 @@ final class ReducerTests: XCTestCase {
       reducer: reducer,
       environment: ()
     )
-    store.send(.incr) { $0.count = 1 }
-    store.send(.noop)
+    await store.send(.incr) { $0.count = 1 }
+    await store.send(.noop)
 
     self.wait(for: [logsExpectation], timeout: 2)
 

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -306,7 +306,7 @@ final class StoreTests: XCTestCase {
       .store(in: &self.cancellables)
   }
 
-  func testActionQueuing() {
+  func testActionQueuing() async {
     let subject = PassthroughSubject<Void, Never>()
 
     enum Action: Equatable {
@@ -334,13 +334,13 @@ final class StoreTests: XCTestCase {
       environment: ()
     )
 
-    store.send(.`init`)
-    store.send(.incrementTapped)
-    store.receive(.doIncrement) {
+    await store.send(.`init`)
+    await store.send(.incrementTapped)
+    await store.receive(.doIncrement) {
       $0 = 1
     }
-    store.send(.incrementTapped)
-    store.receive(.doIncrement) {
+    await store.send(.incrementTapped)
+    await store.receive(.doIncrement) {
       $0 = 2
     }
     subject.send(completion: .finished)

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -505,7 +505,7 @@ final class StoreTests: XCTestCase {
       environment: ()
     )
 
-    let task = store.send(.task)
+    let task = await store.send(.task)
     await store.receive(.response)
     await store.receive(.response1)
     await store.receive(.response2)
@@ -527,7 +527,7 @@ final class StoreTests: XCTestCase {
       environment: ()
     )
 
-    let task = store.send(.task)
+    let task = await store.send(.task)
     await task.cancel()
   }
   

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -527,8 +527,7 @@ final class StoreTests: XCTestCase {
       environment: ()
     )
 
-    let task = await store.send(.task)
-    await task.cancel()
+    await store.send(.task).cancel()
   }
   
   func testScopeCancellation() async throws {

--- a/Tests/ComposableArchitectureTests/TaskCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/TaskCancellationTests.swift
@@ -18,6 +18,10 @@ final class TaskCancellationTests: XCTestCase {
     await stream.first(where: { true })
     await Task.cancel(id: ID.self)
     XCTAssertEqual(cancellationCancellables, [:])
-    try? await task.cancellableValue
+    do {
+      try await task.cancellableValue
+      XCTFail()
+    } catch {
+    }
   }
 }

--- a/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
@@ -151,7 +151,7 @@ class TestStoreFailureTests: XCTestCase {
         let store = TestStore(
           initialState: 0,
           reducer: Reducer<Int, Void, Void> { state, action, _ in
-            .task { try? await Task.sleep(nanoseconds: NSEC_PER_SEC) }
+            .task { try await Task.sleep(nanoseconds: NSEC_PER_SEC) }
           },
           environment: ()
         )

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -72,7 +72,7 @@ class TestStoreTests: XCTestCase {
         switch action {
         case .tap:
           return .task {
-            try? await Task.sleep(nanoseconds: 1_000_000)
+            try await Task.sleep(nanoseconds: 1_000_000)
             return .response(42)
           }
         case let .response(number):

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -46,7 +46,7 @@ class TestStoreTests: XCTestCase {
       environment: mainQueue.eraseToAnyScheduler()
     )
 
-    store.send(.a)
+    await store.send(.a)
 
     await mainQueue.advance(by: 1)
 
@@ -58,7 +58,7 @@ class TestStoreTests: XCTestCase {
     await store.receive(.c2)
     await store.receive(.c3)
 
-    store.send(.d)
+    await store.send(.d)
   }
 
   func testAsync() async {
@@ -83,7 +83,7 @@ class TestStoreTests: XCTestCase {
       environment: ()
     )
 
-    store.send(.tap)
+    await store.send(.tap)
     await store.receive(.response(42), timeout: 2_000_000) {
       $0 = 42
     }

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -89,7 +89,7 @@ class TestStoreTests: XCTestCase {
     }
   }
 
-  func testExpectedStateEquality() {
+  func testExpectedStateEquality() async {
     struct State: Equatable {
       var count: Int = 0
       var isChanging: Bool = false
@@ -120,10 +120,10 @@ class TestStoreTests: XCTestCase {
       environment: ()
     )
 
-    store.send(.increment) {
+    await store.send(.increment) {
       $0.isChanging = true
     }
-    store.receive(.changed(from: 0, to: 1)) {
+    await store.receive(.changed(from: 0, to: 1)) {
       $0.isChanging = false
       $0.count = 1
     }
@@ -141,7 +141,7 @@ class TestStoreTests: XCTestCase {
     }
   }
 
-  func testExpectedStateEqualityMustModify() {
+  func testExpectedStateEqualityMustModify() async {
     struct State: Equatable {
       var count: Int = 0
     }
@@ -165,8 +165,8 @@ class TestStoreTests: XCTestCase {
       environment: ()
     )
 
-    store.send(.noop)
-    store.receive(.finished)
+    await store.send(.noop)
+    await store.receive(.finished)
 
     XCTExpectFailure {
       _ = store.send(.noop) {
@@ -180,7 +180,7 @@ class TestStoreTests: XCTestCase {
     }
   }
 
-  func testStateAccess() {
+  func testStateAccess() async {
     enum Action { case a, b, c, d }
     let store = TestStore(
       initialState: 0,
@@ -197,22 +197,22 @@ class TestStoreTests: XCTestCase {
       environment: ()
     )
 
-    store.send(.a) {
+    await store.send(.a) {
       $0 = 1
       XCTAssertEqual(store.state, 0)
     }
     XCTAssertEqual(store.state, 1)
-    store.receive(.b) {
+    await store.receive(.b) {
       $0 = 2
       XCTAssertEqual(store.state, 1)
     }
     XCTAssertEqual(store.state, 2)
-    store.receive(.c) {
+    await store.receive(.c) {
       $0 = 3
       XCTAssertEqual(store.state, 2)
     }
     XCTAssertEqual(store.state, 3)
-    store.receive(.d) {
+    await store.receive(.d) {
       $0 = 4
       XCTAssertEqual(store.state, 3)
     }


### PR DESCRIPTION
We are now making `TestStore.send` async where it suspends long enough for the effect to officially start. This makes it easier to send actions in tests and then immediately assert on how `fireAndForget` effects behaved.

This PR also contains some miscellaneous clean up.