### PR TITLE
Bump timeout on flakey tests

### DIFF
--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -127,7 +127,7 @@ final class ReducerTests: XCTestCase {
     store.send(.incr) { $0.count = 1 }
     store.send(.noop)
 
-    self.wait(for: [logsExpectation], timeout: 2)
+    self.wait(for: [logsExpectation], timeout: 5)
 
     XCTAssertNoDifference(
       logs,
@@ -180,7 +180,7 @@ final class ReducerTests: XCTestCase {
     )
     viewStore.send(.incrWithBool(true))
 
-    self.wait(for: [logsExpectation], timeout: 2)
+    self.wait(for: [logsExpectation], timeout: 5)
 
     XCTAssertNoDifference(
       logs,


### PR DESCRIPTION
We have a few flakey tests that occasionally fail on CI due to expectation timeouts. We've seen that some failures take awhile for XCTest to process, so let's see if bumping this will help...