### PR TITLE
Another flakey test fix

### DIFF
--- a/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift
@@ -165,5 +165,5 @@ public struct DebugEnvironment {
 
 private let _queue = DispatchQueue(
   label: "co.pointfree.ComposableArchitecture.DebugEnvironment",
-  qos: .background
+  qos: .default
 )


### PR DESCRIPTION
Solution #1193 was probably not correct (though probably helps in its own right). I think `.background` priority, especially on a CI box, made scheduling of this logging easy to miss.