### PR TITLE
[SwiftUI Case Studies] Revise initialState and layout in Animations

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -39,7 +39,7 @@ extension Effect where Failure == Never {
 }
 
 struct AnimationsState: Equatable {
-  var alert: AlertState<AnimationsAction>? = nil
+  var alert: AlertState<AnimationsAction>?
   var circleCenter = CGPoint(x: 50, y: 50)
   var circleColor = Color.white
   var isCircleScaled = false

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -40,8 +40,8 @@ extension Effect where Failure == Never {
 
 struct AnimationsState: Equatable {
   var alert: AlertState<AnimationsAction>?
-  var circleCenter = CGPoint(x: 50, y: 50)
-  var circleColor = Color.white
+  var circleCenter = CGPoint(x: UIScreen.main.bounds.width / 2, y: UIScreen.main.bounds.height / 2)
+  var circleColor = Color.black
   var isCircleScaled = false
 }
 
@@ -73,7 +73,7 @@ let animationsReducer = Reducer<AnimationsState, AnimationsAction, AnimationsEnv
 
   case .rainbowButtonTapped:
     return .keyFrames(
-      values: [Color.red, .blue, .green, .orange, .pink, .purple, .yellow, .white]
+      values: [Color.red, .blue, .green, .orange, .pink, .purple, .yellow, .black]
         .map { (output: .setColor($0), duration: 1) },
       scheduler: environment.mainQueue.animation(.linear)
     )
@@ -117,6 +117,7 @@ struct AnimationsView: View {
 
             Circle()
               .fill(viewStore.circleColor)
+              .colorInvert()
               .blendMode(.difference)
               .frame(width: 50, height: 50)
               .scaleEffect(viewStore.isCircleScaled ? 2 : 1)
@@ -150,6 +151,7 @@ struct AnimationsView: View {
         }
         .alert(self.store.scope(state: \.alert), dismiss: .dismissAlert)
       }
+      .navigationBarTitleDisplayMode(.inline)
     }
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -7,7 +7,7 @@ private let readMe = """
   """
 
 struct FocusDemoState: Equatable {
-  @BindableState var focusedField: Field? = nil
+  @BindableState var focusedField: Field?
   @BindableState var password: String = ""
   @BindableState var username: String = ""
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
@@ -53,8 +53,8 @@ class AnimationTests: XCTestCase {
     }
 
     mainQueue.advance(by: .seconds(1))
-    store.receive(.setColor(.white)) {
-      $0.circleColor = .white
+    store.receive(.setColor(.black)) {
+      $0.circleColor = .black
     }
 
     mainQueue.run()


### PR DESCRIPTION
Hi, thank you making this cool library.
While studying [SwiftUI Case Studies], I found a couple things to suggest.

I made 2 commits:
- https://github.com/pointfreeco/swift-composable-architecture/commit/aabc8299db91935e527a5653beb168a869f79c7c
  - remove two unnecessary `nil` literals in `AnimationsState` and `FocusDemoState`
- https://github.com/pointfreeco/swift-composable-architecture/commit/9668ac5ee0d446134d18de781ada9014bd60c6a6
  - In 01-GettingStarted-Animations.swift
  - move Circle's initial location to center of the screen for better visibility.
  - align 'circleColor' property's value with actual color using `colorInvert()` so that rainbow keyFrames colors match the circle's actual color, not inverted.
  ```swift
    case .rainbowButtonTapped:
      return .keyFrames(
        values: [Color.red, .blue, .green, .orange, .pink, .purple, .yellow, .black]
          .map { (output: .setColor($0), duration: 1) },
        scheduler: environment.mainQueue.animation(.linear)
      )
  ```
  - remove top margin to display more text because we cannot apply ScrollView in this case.
  - please check out gif examples below. (1.5x speed)

Let me know what you think. Thank you! 😄 

<br>

|before|after|
|:-:|:-:|
|<img src="https://user-images.githubusercontent.com/71127966/178098556-6377de4f-dd7b-460a-85e3-92a292ab33bb.gif" width="250">|<img src="https://user-images.githubusercontent.com/71127966/178098572-62697bd6-57bb-4530-9784-133ea3a374a3.gif" width="250">|