### PR TITLE
Small updates to animations case study.

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -40,7 +40,7 @@ extension Effect where Failure == Never {
 
 struct AnimationsState: Equatable {
   var alert: AlertState<AnimationsAction>?
-  var circleCenter = CGPoint(x: UIScreen.main.bounds.width / 2, y: UIScreen.main.bounds.height / 2)
+  var circleCenter = CGPoint(x: 175, y: 300)
   var circleColor = Color.black
   var isCircleScaled = false
 }
@@ -61,6 +61,7 @@ struct AnimationsEnvironment {
 
 let animationsReducer = Reducer<AnimationsState, AnimationsAction, AnimationsEnvironment> {
   state, action, environment in
+  enum CancelID {}
 
   switch action {
   case let .circleScaleToggleChanged(isScaled):
@@ -77,6 +78,7 @@ let animationsReducer = Reducer<AnimationsState, AnimationsAction, AnimationsEnv
         .map { (output: .setColor($0), duration: 1) },
       scheduler: environment.mainQueue.animation(.linear)
     )
+    .cancellable(id: CancelID.self)
 
   case .resetButtonTapped:
     state.alert = AlertState(
@@ -91,7 +93,7 @@ let animationsReducer = Reducer<AnimationsState, AnimationsAction, AnimationsEnv
 
   case .resetConfirmationButtonTapped:
     state = AnimationsState()
-    return .none
+    return .cancel(id: CancelID.self)
 
   case let .setColor(color):
     state.circleColor = color

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
@@ -59,4 +59,44 @@ class AnimationTests: XCTestCase {
 
     mainQueue.run()
   }
+
+  func testReset() {
+    let mainQueue = DispatchQueue.test
+
+    let store = TestStore(
+      initialState: AnimationsState(),
+      reducer: animationsReducer,
+      environment: AnimationsEnvironment(
+        mainQueue: mainQueue.eraseToAnyScheduler()
+      )
+    )
+
+    store.send(.rainbowButtonTapped)
+
+    store.receive(.setColor(.red)) {
+      $0.circleColor = .red
+    }
+
+    mainQueue.advance(by: .seconds(1))
+    store.receive(.setColor(.blue)) {
+      $0.circleColor = .blue
+    }
+
+    store.send(.resetButtonTapped) {
+      $0.alert = AlertState(
+        title: TextState("Reset state?"),
+        primaryButton: .destructive(
+          TextState("Reset"),
+          action: .send(.resetConfirmationButtonTapped, animation: .default)
+        ),
+        secondaryButton: .cancel(TextState("Cancel"))
+      )
+    }
+    
+    store.send(.resetConfirmationButtonTapped) {
+      $0 = AnimationsState()
+    }
+
+    mainQueue.run()
+  }
 }


### PR DESCRIPTION
Backports the cancellation logic from #1189 and writes a test.