### PR TITLE
Clean up deprecation formatting

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -31,7 +31,10 @@ extension Effect {
     *,
     deprecated,
     message:
-      "Using a variadic list is no longer supported. Use an array of identifiers instead. For more on this change, see: https://github.com/pointfreeco/swift-composable-architecture/pull/1041"
+      """
+      Using a variadic list is no longer supported. Use an array of identifiers instead. For more \
+      on this change, see: https://github.com/pointfreeco/swift-composable-architecture/pull/1041
+      """
   )
   @_disfavoredOverload
   public static func cancel(ids: AnyHashable...) -> Self {
@@ -324,7 +327,10 @@ extension Store {
   @available(
     *, deprecated,
     message:
-      "If you use this method, please open a discussion on GitHub and let us know how: https://github.com/pointfreeco/swift-composable-architecture/discussions/new"
+      """
+      If you use this method, please open a discussion on GitHub and let us know how: \
+      https://github.com/pointfreeco/swift-composable-architecture/discussions/new
+      """
   )
   public func publisherScope<P: Publisher, LocalState, LocalAction>(
     state toLocalState: @escaping (AnyPublisher<State, Never>) -> P,
@@ -364,7 +370,10 @@ extension Store {
   @available(
     *, deprecated,
     message:
-      "If you use this method, please open a discussion on GitHub and let us know how: https://github.com/pointfreeco/swift-composable-architecture/discussions/new"
+      """
+      If you use this method, please open a discussion on GitHub and let us know how: \
+      https://github.com/pointfreeco/swift-composable-architecture/discussions/new
+      """
   )
   public func publisherScope<P: Publisher, LocalState>(
     state toLocalState: @escaping (AnyPublisher<State, Never>) -> P
@@ -378,7 +387,12 @@ extension ViewStore where Action: BindableAction, Action.State == State {
   @available(
     *, deprecated,
     message:
-      "Dynamic member lookup is no longer supported for bindable state. Instead of dot-chaining on the view store, e.g. 'viewStore.$value', invoke the 'binding' method on view store with a key path to the value, e.g. 'viewStore.binding(\\.$value)'. For more on this change, see: https://github.com/pointfreeco/swift-composable-architecture/pull/810"
+      """
+      Dynamic member lookup is no longer supported for bindable state. Instead of dot-chaining on \
+      the view store, e.g. 'viewStore.$value', invoke the 'binding' method on view store with a \
+      key path to the value, e.g. 'viewStore.binding(\\.$value)'. For more on this change, see: \
+      https://github.com/pointfreeco/swift-composable-architecture/pull/810
+      """
   )
   public subscript<Value: Equatable>(
     dynamicMember keyPath: WritableKeyPath<State, BindableState<Value>>
@@ -396,7 +410,10 @@ extension BindingAction {
   @available(
     *, deprecated,
     message:
-      "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\\.$value'"
+      """
+      For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', \
+      and accessed via key paths to that 'BindableState', like '\\.$value'
+      """
   )
   public static func set<Value: Equatable>(
     _ keyPath: WritableKeyPath<Root, Value>,
@@ -413,7 +430,10 @@ extension BindingAction {
   @available(
     *, deprecated,
     message:
-      "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', and accessed via key paths to that 'BindableState', like '\\.$value'"
+      """
+      For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', \
+      and accessed via key paths to that 'BindableState', like '\\.$value'
+      """
   )
   public static func ~= <Value>(
     keyPath: WritableKeyPath<Root, Value>,
@@ -427,7 +447,10 @@ extension Reducer {
   @available(
     *, deprecated,
     message:
-      "'Reducer.binding()' no longer takes an explicit extract function and instead the reducer's 'Action' type must conform to 'BindableAction'"
+      """
+      "'Reducer.binding()' no longer takes an explicit extract function and instead the reducer's \
+      'Action' type must conform to 'BindableAction'
+      """
   )
   public func binding(action toBindingAction: @escaping (Action) -> BindingAction<State>?) -> Self {
     Self { state, action, environment in
@@ -441,7 +464,12 @@ extension ViewStore {
   @available(
     *, deprecated,
     message:
-      "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState'. Bindings are now derived via 'ViewStore.binding' with a key path to that 'BindableState' (for example, 'viewStore.binding(\\.$value)'). For dynamic member lookup to be available, the view store's 'Action' type must also conform to 'BindableAction'."
+      """
+      "For improved safety, bindable properties must now be wrapped explicitly in 'BindableState'. \
+      Bindings are now derived via 'ViewStore.binding' with a key path to that 'BindableState' \
+      (for example, 'viewStore.binding(\\.$value)'). For dynamic member lookup to be available, \
+      the view store's 'Action' type must also conform to 'BindableAction'.
+      """
   )
   public func binding<LocalState: Equatable>(
     keyPath: WritableKeyPath<State, LocalState>,


### PR DESCRIPTION
Didn't realize multiline worked here, but should make it easier to read without word wrap
