### PR TITLE
Relax AlertState.init(title: TextState, message: TextState? = nil, buttons: [Button])

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -105,7 +105,7 @@ public struct AlertState<Action> {
   public var message: TextState?
   public var title: TextState
 
-  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+  @available(iOS 15, macOS 11, tvOS 15, watchOS 8, *)
   public init(
     title: TextState,
     message: TextState? = nil,


### PR DESCRIPTION
We are working on a macOS app supporting BigSur.

``` 
 public init(
    title: TextState,
    message: TextState? = nil,
    buttons: [Button]
  ) {

  // is very similar to

  public init(
    title: TextState,
    message: TextState? = nil,
    dismissButton: Button? = nil
  ) {
```

I want to relax the macOS requirements to 11.