### PR TITLE
Fixed broken other versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ The documentation for releases and `main` are available here:
   <summary>
   Other versions
   </summary>
+
   * [0.37.0](https://pointfreeco.github.io/swift-composable-architecture/0.37.0/documentation/composablearchitecture)
   * [0.36.0](https://pointfreeco.github.io/swift-composable-architecture/0.36.0/documentation/composablearchitecture)
   * [0.35.0](https://pointfreeco.github.io/swift-composable-architecture/0.35.0/documentation/composablearchitecture)


### PR DESCRIPTION
"Other versions" in README is not marked up.
↓
![sccreenshot 2022-07-27 0 47 27](https://user-images.githubusercontent.com/1137860/181051306-408378e5-8df7-4032-b91b-76f584f015ba.png)

Can be fixed by inserting a blank line after  `</summary>`.