### PR TITLE
Rename enum Action cases to be consistent

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -78,7 +78,7 @@ let animationsReducer = Reducer<AnimationsState, AnimationsAction, AnimationsEnv
         .map { (output: .setColor($0), duration: 1) },
       scheduler: environment.mainQueue.animation(.linear)
     )
-    .cancellable(id: CancelId.self)
+    .cancellable(id: CancelID.self)
 
   case .resetButtonTapped:
     state.alert = AlertState(

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -46,8 +46,8 @@ struct AnimationsState: Equatable {
 }
 
 enum AnimationsAction: Equatable {
-  case circleScaleToggleChanged(Bool)
   case alertDismissed
+  case circleScaleToggleChanged(Bool)
   case rainbowButtonTapped
   case resetButtonTapped
   case resetConfirmationButtonTapped
@@ -64,12 +64,12 @@ let animationsReducer = Reducer<AnimationsState, AnimationsAction, AnimationsEnv
   enum CancelID {}
 
   switch action {
-  case let .circleScaleToggleChanged(isScaled):
-    state.isCircleScaled = isScaled
-    return .none
-
   case .alertDismissed:
     state.alert = nil
+    return .none
+
+  case let .circleScaleToggleChanged(isScaled):
+    state.isCircleScaled = isScaled
     return .none
 
   case .rainbowButtonTapped:

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -47,7 +47,7 @@ struct AnimationsState: Equatable {
 
 enum AnimationsAction: Equatable {
   case circleScaleToggleChanged(Bool)
-  case dismissAlert
+  case alertDismissed
   case rainbowButtonTapped
   case resetButtonTapped
   case resetConfirmationButtonTapped
@@ -61,14 +61,14 @@ struct AnimationsEnvironment {
 
 let animationsReducer = Reducer<AnimationsState, AnimationsAction, AnimationsEnvironment> {
   state, action, environment in
-  enum CancelID {}
+  enum CancelId {}
 
   switch action {
   case let .circleScaleToggleChanged(isScaled):
     state.isCircleScaled = isScaled
     return .none
 
-  case .dismissAlert:
+  case .alertDismissed:
     state.alert = nil
     return .none
 
@@ -78,7 +78,7 @@ let animationsReducer = Reducer<AnimationsState, AnimationsAction, AnimationsEnv
         .map { (output: .setColor($0), duration: 1) },
       scheduler: environment.mainQueue.animation(.linear)
     )
-    .cancellable(id: CancelID.self)
+    .cancellable(id: CancelId.self)
 
   case .resetButtonTapped:
     state.alert = AlertState(
@@ -93,7 +93,7 @@ let animationsReducer = Reducer<AnimationsState, AnimationsAction, AnimationsEnv
 
   case .resetConfirmationButtonTapped:
     state = AnimationsState()
-    return .cancel(id: CancelID.self)
+    return .cancel(id: CancelId.self)
 
   case let .setColor(color):
     state.circleColor = color
@@ -150,7 +150,7 @@ struct AnimationsView: View {
         Button("Reset") { viewStore.send(.resetButtonTapped) }
           .padding([.horizontal, .bottom])
       }
-      .alert(self.store.scope(state: \.alert), dismiss: .dismissAlert)
+      .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
       .navigationBarTitleDisplayMode(.inline)
     }
   }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -61,7 +61,7 @@ struct AnimationsEnvironment {
 
 let animationsReducer = Reducer<AnimationsState, AnimationsAction, AnimationsEnvironment> {
   state, action, environment in
-  enum CancelId {}
+  enum CancelID {}
 
   switch action {
   case let .circleScaleToggleChanged(isScaled):

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -93,7 +93,7 @@ let animationsReducer = Reducer<AnimationsState, AnimationsAction, AnimationsEnv
 
   case .resetConfirmationButtonTapped:
     state = AnimationsState()
-    return .cancel(id: CancelId.self)
+    return .cancel(id: CancelID.self)
 
   case let .setColor(color):
     state.circleColor = color

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
@@ -36,7 +36,7 @@ enum DownloadComponentAction: Equatable {
 
   enum AlertAction: Equatable {
     case deleteButtonTapped
-    case dismiss
+    case dismissed
     case nevermindButtonTapped
     case stopButtonTapped
   }
@@ -63,7 +63,7 @@ extension Reducer {
           return .none
 
         case .alert(.nevermindButtonTapped),
-          .alert(.dismiss):
+          .alert(.dismissed):
           state.alert = nil
           return .none
 
@@ -162,7 +162,7 @@ struct DownloadComponent<ID: Equatable>: View {
       .foregroundStyle(.primary)
       .alert(
         self.store.scope(state: \.alert, action: DownloadComponentAction.alert),
-        dismiss: .dismiss
+        dismiss: .dismissed
       )
     }
   }

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
@@ -16,7 +16,7 @@ struct AppState: Equatable {
 }
 
 enum AppAction: Equatable {
-  case dismissAuthorizationStateAlert
+  case authorizationStateAlertDismissed
   case recordButtonTapped
   case speech(Result<String, SpeechClient.Error>)
   case speechRecognizerAuthorizationStatusResponse(SFSpeechRecognizerAuthorizationStatus)
@@ -29,7 +29,7 @@ struct AppEnvironment {
 
 let appReducer = Reducer<AppState, AppAction, AppEnvironment> { state, action, environment in
   switch action {
-  case .dismissAuthorizationStateAlert:
+  case .authorizationStateAlertDismissed:
     state.alert = nil
     return .none
 
@@ -138,7 +138,7 @@ struct SpeechRecognitionView: View {
         }
       }
       .padding()
-      .alert(self.store.scope(state: \.alert), dismiss: .dismissAuthorizationStateAlert)
+      .alert(self.store.scope(state: \.alert), dismiss: .authorizationStateAlertDismissed)
     }
   }
 }


### PR DESCRIPTION
Hi, I found that some enum `Action` cases have different names compared to most others.
It would be nice to rename those for naming consistency.

```diff
// "dismissed" should be placed at the end of the case name.

- case dismissAlert
+ case alertDismissed

- case dismissAuthorizationStateAlert
+ case authorizationStateAlertDismissed


// also rename enum for cancellable id, like the others.

- enum CancelID {}
+ enum CancelId {}
```

Tests of the changed files have all passed.
Please let me know what you think. Thanks! 😃 