### PR TITLE
Clean up Todos sort debouncing

### DIFF
--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -90,15 +90,18 @@ let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
 
     case .todo(id: _, action: .checkBoxToggled):
       enum TodoCompletionID {}
-      return .task { .sortCompletedTodos }
-        .debounce(id: TodoCompletionID.self, for: 1, scheduler: environment.mainQueue.animation())
+      return .task {
+        try await environment.mainQueue.sleep(for: .seconds(1))
+        return .sortCompletedTodos
+      }
+      .animation()
+      .cancellable(id: TodoCompletionID.self, cancelInFlight: true)
 
     case .todo:
       return .none
     }
   }
 )
-.debug()
 
 struct AppView: View {
   let store: Store<AppState, AppAction>

--- a/Examples/Todos/Todos/TodosApp.swift
+++ b/Examples/Todos/Todos/TodosApp.swift
@@ -8,7 +8,7 @@ struct TodosApp: App {
       AppView(
         store: Store(
           initialState: AppState(),
-          reducer: appReducer,
+          reducer: appReducer.debug(),
           environment: AppEnvironment(
             mainQueue: .main,
             uuid: { UUID() }


### PR DESCRIPTION
Slightly more code, but uses simple Swift concurrency instead of relying on an operator.