### PR TITLE
Add `final` keyword to every test class by default

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndConfirmationDialogsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndConfirmationDialogsTests.swift
@@ -6,7 +6,7 @@ import XCTest
 @testable import SwiftUICaseStudies
 
 @MainActor
-class AlertsAndConfirmationDialogsTests: XCTestCase {
+final class AlertsAndConfirmationDialogsTests: XCTestCase {
   func testAlert() async {
     let store = TestStore(
       initialState: AlertAndConfirmationDialogState(),

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import SwiftUICaseStudies
 
 @MainActor
-class AnimationTests: XCTestCase {
+final class AnimationTests: XCTestCase {
   func testRainbow() async {
     let mainQueue = DispatchQueue.test
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-BindingBasicsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-BindingBasicsTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import SwiftUICaseStudies
 
 @MainActor
-class BindingFormTests: XCTestCase {
+final class BindingFormTests: XCTestCase {
   func testBasics() async {
     let store = TestStore(
       initialState: BindingFormState(),

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-SharedStateTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-SharedStateTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import SwiftUICaseStudies
 
 @MainActor
-class SharedStateTests: XCTestCase {
+final class SharedStateTests: XCTestCase {
   func testTabRestoredOnReset() async {
     let store = TestStore(
       initialState: SharedState(),

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-BasicsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-BasicsTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import SwiftUICaseStudies
 
 @MainActor
-class EffectsBasicsTests: XCTestCase {
+final class EffectsBasicsTests: XCTestCase {
   func testCountDown() async {
     let store = TestStore(
       initialState: EffectsBasicsState(),

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-CancellationTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-CancellationTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import SwiftUICaseStudies
 
 @MainActor
-class EffectsCancellationTests: XCTestCase {
+final class EffectsCancellationTests: XCTestCase {
   func testTrivia_SuccessfulRequest() async {
     let store = TestStore(
       initialState: EffectsCancellationState(),

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import SwiftUICaseStudies
 
 @MainActor
-class LongLivingEffectsTests: XCTestCase {
+final class LongLivingEffectsTests: XCTestCase {
   func testReducer() async {
     let (screenshots, takeScreenshot) = AsyncStream<Void>.streamWithContinuation()
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-RefreshableTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-RefreshableTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import SwiftUICaseStudies
 
 @MainActor
-class RefreshableTests: XCTestCase {
+final class RefreshableTests: XCTestCase {
   func testHappyPath() async {
     let store = TestStore(
       initialState: RefreshableState(),

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-TimersTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-TimersTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import SwiftUICaseStudies
 
 @MainActor
-class TimersTests: XCTestCase {
+final class TimersTests: XCTestCase {
   func testStart() async {
     let mainQueue = DispatchQueue.test
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import SwiftUICaseStudies
 
 @MainActor
-class WebSocketTests: XCTestCase {
+final class WebSocketTests: XCTestCase {
   func testWebSocketHappyPath() async {
     let actions = AsyncStream<WebSocketClient.Action>.streamWithContinuation()
     let messages = AsyncStream<TaskResult<WebSocketClient.Message>>.streamWithContinuation()

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-LifecycleTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-LifecycleTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import SwiftUICaseStudies
 
 @MainActor
-class LifecycleTests: XCTestCase {
+final class LifecycleTests: XCTestCase {
   func testLifecycle() async {
     let mainQueue = DispatchQueue.test
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import SwiftUICaseStudies
 
 @MainActor
-class ReusableComponentsFavoritingTests: XCTestCase {
+final class ReusableComponentsFavoritingTests: XCTestCase {
   func testFavoriteButton() async {
     let scheduler = DispatchQueue.test
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
@@ -6,7 +6,7 @@ import XCTestDynamicOverlay
 @testable import SwiftUICaseStudies
 
 @MainActor
-class ReusableComponentsDownloadComponentTests: XCTestCase {
+final class ReusableComponentsDownloadComponentTests: XCTestCase {
   let download = AsyncThrowingStream<DownloadClient.Event, Error>.streamWithContinuation()
   let reducer = Reducer<
     DownloadComponentState<Int>,

--- a/Examples/CaseStudies/tvOSCaseStudiesTests/tvOSCaseStudiesTests.swift
+++ b/Examples/CaseStudies/tvOSCaseStudiesTests/tvOSCaseStudiesTests.swift
@@ -2,5 +2,5 @@ import XCTest
 
 @testable import tvOSCaseStudies
 
-class tvOSCaseStudiesTests: XCTestCase {
+final class tvOSCaseStudiesTests: XCTestCase {
 }

--- a/Examples/Search/SearchTests/SearchTests.swift
+++ b/Examples/Search/SearchTests/SearchTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import Search
 
 @MainActor
-class SearchTests: XCTestCase {
+final class SearchTests: XCTestCase {
   func testSearchAndClearQuery() async {
     let store = TestStore(
       initialState: SearchState(),

--- a/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
+++ b/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import SpeechRecognition
 
 @MainActor
-class SpeechRecognitionTests: XCTestCase {
+final class SpeechRecognitionTests: XCTestCase {
   let recognitionTask = AsyncThrowingStream<SpeechRecognitionResult, Error>.streamWithContinuation()
 
   func testDenyAuthorization() async {

--- a/Examples/TicTacToe/tic-tac-toe/Tests/AppCoreTests/AppCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/AppCoreTests/AppCoreTests.swift
@@ -7,7 +7,7 @@ import TwoFactorCore
 import XCTest
 
 @MainActor
-class AppCoreTests: XCTestCase {
+final class AppCoreTests: XCTestCase {
   func testIntegration() async {
     var authenticationClient = AuthenticationClient.unimplemented
     authenticationClient.login = { _ in

--- a/Examples/TicTacToe/tic-tac-toe/Tests/GameCoreTests/GameCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/GameCoreTests/GameCoreTests.swift
@@ -3,7 +3,7 @@ import GameCore
 import XCTest
 
 @MainActor
-class GameCoreTests: XCTestCase {
+final class GameCoreTests: XCTestCase {
   let store = TestStore(
     initialState: GameState(
       oPlayerName: "Blob Jr.",

--- a/Examples/TicTacToe/tic-tac-toe/Tests/GameSwiftUITests/GameSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/GameSwiftUITests/GameSwiftUITests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import GameSwiftUI
 
 @MainActor
-class GameSwiftUITests: XCTestCase {
+final class GameSwiftUITests: XCTestCase {
   let store = TestStore(
     initialState: GameState(
       oPlayerName: "Blob Jr.",

--- a/Examples/TicTacToe/tic-tac-toe/Tests/LoginCoreTests/LoginCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/LoginCoreTests/LoginCoreTests.swift
@@ -5,7 +5,7 @@ import TwoFactorCore
 import XCTest
 
 @MainActor
-class LoginCoreTests: XCTestCase {
+final class LoginCoreTests: XCTestCase {
   func testFlow_Success_TwoFactor_Integration() async {
     var authenticationClient = AuthenticationClient.unimplemented
     authenticationClient.login = { _ in

--- a/Examples/TicTacToe/tic-tac-toe/Tests/LoginSwiftUITests/LoginSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/LoginSwiftUITests/LoginSwiftUITests.swift
@@ -7,7 +7,7 @@ import XCTest
 @testable import LoginSwiftUI
 
 @MainActor
-class LoginSwiftUITests: XCTestCase {
+final class LoginSwiftUITests: XCTestCase {
   func testFlow_Success() async {
     var authenticationClient = AuthenticationClient.unimplemented
     authenticationClient.login = { _ in

--- a/Examples/TicTacToe/tic-tac-toe/Tests/NewGameCoreTests/NewGameCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/NewGameCoreTests/NewGameCoreTests.swift
@@ -4,7 +4,7 @@ import NewGameCore
 import XCTest
 
 @MainActor
-class NewGameCoreTests: XCTestCase {
+final class NewGameCoreTests: XCTestCase {
   let store = TestStore(
     initialState: NewGameState(),
     reducer: newGameReducer,

--- a/Examples/TicTacToe/tic-tac-toe/Tests/NewGameSwiftUITests/NewGameSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/NewGameSwiftUITests/NewGameSwiftUITests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import NewGameSwiftUI
 
 @MainActor
-class NewGameSwiftUITests: XCTestCase {
+final class NewGameSwiftUITests: XCTestCase {
   let store = TestStore(
     initialState: NewGameState(),
     reducer: newGameReducer,

--- a/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorCoreTests/TwoFactorCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorCoreTests/TwoFactorCoreTests.swift
@@ -4,7 +4,7 @@ import TwoFactorCore
 import XCTest
 
 @MainActor
-class TwoFactorCoreTests: XCTestCase {
+final class TwoFactorCoreTests: XCTestCase {
   func testFlow_Success() async {
     let store = TestStore(
       initialState: TwoFactorState(token: "deadbeefdeadbeef"),

--- a/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorSwiftUITests/TwoFactorSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorSwiftUITests/TwoFactorSwiftUITests.swift
@@ -7,7 +7,7 @@ import XCTest
 @testable import TwoFactorSwiftUI
 
 @MainActor
-class TwoFactorSwiftUITests: XCTestCase {
+final class TwoFactorSwiftUITests: XCTestCase {
   func testFlow_Success() async {
     var authenticationClient = AuthenticationClient.unimplemented
     authenticationClient.twoFactor = { _ in

--- a/Examples/Todos/TodosTests/TodosTests.swift
+++ b/Examples/Todos/TodosTests/TodosTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import Todos
 
 @MainActor
-class TodosTests: XCTestCase {
+final class TodosTests: XCTestCase {
   let mainQueue = DispatchQueue.test
 
   func testAddTodo() async {

--- a/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
+++ b/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
@@ -6,7 +6,7 @@ import XCTestDynamicOverlay
 @testable import VoiceMemos
 
 @MainActor
-class VoiceMemosTests: XCTestCase {
+final class VoiceMemosTests: XCTestCase {
   let mainRunLoop = RunLoop.test
 
   func testRecordMemoHappyPath() async {

--- a/Tests/ComposableArchitectureTests/TaskResultTests.swift
+++ b/Tests/ComposableArchitectureTests/TaskResultTests.swift
@@ -1,7 +1,7 @@
 import ComposableArchitecture
 import XCTest
 
-class TaskResultTests: XCTestCase {
+final class TaskResultTests: XCTestCase {
   func testEqualityNonEquatableError() {
     struct Failure: Error {
       let message: String

--- a/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import XCTest
 
 @MainActor
-class TestStoreFailureTests: XCTestCase {
+final class TestStoreFailureTests: XCTestCase {
   func testNoStateChangeFailure() {
     enum Action { case first, second }
     let store = TestStore(

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 import XCTest
 
 @MainActor
-class TestStoreTests: XCTestCase {
+final class TestStoreTests: XCTestCase {
   func testEffectConcatenation() async {
     struct State: Equatable {}
 


### PR DESCRIPTION
Hi everyone!
In my opinion, the test class (which inherits from the [XCTestCase](https://developer.apple.com/documentation/xctest/xctestcase) class) doesn't need to be overridden.
And I found that some test classes already have `final`, but some don't.

So I want to add `final` keyword to every test class by default.
Please comment if there are cases where it should not be `final class` intentionally, or if you have other opinions.
Thanks!

(ref.) Airbnb Swift Style Guide - [Default classes to `final`.](https://github.com/airbnb/swift#final-classes-by-default)