### PR TITLE
Cleanup: Global/Local -> Parent/Child

### DIFF
--- a/Examples/VoiceMemos/VoiceMemos/RecordingMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/RecordingMemo.swift
@@ -1,6 +1,8 @@
 import ComposableArchitecture
 import SwiftUI
 
+struct RecordingMemoFailed: Equatable, Error {}
+
 struct RecordingMemoState: Equatable {
   var date: Date
   var duration: TimeInterval = 0
@@ -11,8 +13,6 @@ struct RecordingMemoState: Equatable {
     case recording
     case encoding
   }
-
-  struct Failed: Equatable, Error {}
 }
 
 enum RecordingMemoAction: Equatable {
@@ -43,7 +43,7 @@ let recordingMemoReducer = Reducer<
     return .task { [state] in .delegate(.didFinish(.success(state))) }
 
   case .audioRecorderDidFinish(.success(false)):
-    return .task { .delegate(.didFinish(.failure(RecordingMemoState.Failed()))) }
+    return .task { .delegate(.didFinish(.failure(RecordingMemoFailed()))) }
 
   case let .audioRecorderDidFinish(.failure(error)):
     return .task { .delegate(.didFinish(.failure(error))) }

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
@@ -103,8 +103,7 @@ struct VoiceMemoView: View {
       HStack {
         TextField(
           "Untitled, \(viewStore.date.formatted(date: .numeric, time: .shortened))",
-          text: viewStore.binding(
-            get: \.title, send: VoiceMemoAction.titleTextFieldChanged)
+          text: viewStore.binding(get: \.title, send: { .titleTextFieldChanged($0) })
         )
 
         Spacer()

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -148,7 +148,7 @@ struct VoiceMemosView: View {
         VStack {
           List {
             ForEachStore(
-              self.store.scope(state: \.voiceMemos, action: VoiceMemosAction.voiceMemo(id:action:))
+              self.store.scope(state: \.voiceMemos, action: { .voiceMemo(id: $0, action: $1) })
             ) {
               VoiceMemoView(store: $0)
             }
@@ -160,7 +160,7 @@ struct VoiceMemosView: View {
           }
 
           IfLetStore(
-            self.store.scope(state: \.recordingMemo, action: VoiceMemosAction.recordingMemo)
+            self.store.scope(state: \.recordingMemo, action: { .recordingMemo($0) })
           ) { store in
             RecordingMemoView(store: store)
           } else: {

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemosApp.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemosApp.swift
@@ -14,8 +14,10 @@ struct VoiceMemosApp: App {
             audioPlayer: .live,
             audioRecorder: .live,
             mainRunLoop: .main,
-            openSettings: { @MainActor in
-              UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+            openSettings: {
+              await MainActor.run {
+                UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+              }
             },
             temporaryDirectory: { URL(fileURLWithPath: NSTemporaryDirectory()) },
             uuid: { UUID() }

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -19,13 +19,15 @@ extension CaseLet {
   public typealias LocalAction = CaseAction
 }
 
-extension TestStore {
-  @available(*, deprecated, renamed: "ScopedState")
-  public typealias LocalState = ScopedState
+#if DEBUG
+  extension TestStore {
+    @available(*, deprecated, renamed: "ScopedState")
+    public typealias LocalState = ScopedState
 
-  @available(*, deprecated, renamed: "ScopedAction")
-  public typealias LocalAction = ScopedAction
-}
+    @available(*, deprecated, renamed: "ScopedAction")
+    public typealias LocalAction = ScopedAction
+  }
+#endif
 
 // NB: Deprecated after 0.38.2:
 

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -3,6 +3,30 @@ import Combine
 import SwiftUI
 import XCTestDynamicOverlay
 
+// NB: Deprecated after 0.39.0:
+
+extension CaseLet {
+  @available(*, deprecated, renamed: "EnumState")
+  public typealias GlobalState = EnumState
+
+  @available(*, deprecated, renamed: "EnumAction")
+  public typealias GlobalAction = EnumAction
+
+  @available(*, deprecated, renamed: "CaseState")
+  public typealias LocalState = CaseState
+
+  @available(*, deprecated, renamed: "CaseAction")
+  public typealias LocalAction = CaseAction
+}
+
+extension TestStore {
+  @available(*, deprecated, renamed: "ScopedState")
+  public typealias LocalState = ScopedState
+
+  @available(*, deprecated, renamed: "ScopedAction")
+  public typealias LocalAction = ScopedAction
+}
+
 // NB: Deprecated after 0.38.2:
 
 extension Effect {
@@ -122,18 +146,18 @@ extension Reducer {
     deprecated,
     message: "'pullback' no longer takes a 'breakpointOnNil' argument"
   )
-  public func pullback<GlobalState, GlobalAction, GlobalEnvironment>(
-    state toLocalState: CasePath<GlobalState, State>,
-    action toLocalAction: CasePath<GlobalAction, Action>,
-    environment toLocalEnvironment: @escaping (GlobalEnvironment) -> Environment,
+  public func pullback<ParentState, ParentAction, ParentEnvironment>(
+    state toChildState: CasePath<ParentState, State>,
+    action toChildAction: CasePath<ParentAction, Action>,
+    environment toChildEnvironment: @escaping (ParentEnvironment) -> Environment,
     breakpointOnNil: Bool,
     file: StaticString = #fileID,
     line: UInt = #line
-  ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
+  ) -> Reducer<ParentState, ParentAction, ParentEnvironment> {
     self.pullback(
-      state: toLocalState,
-      action: toLocalAction,
-      environment: toLocalEnvironment,
+      state: toChildState,
+      action: toChildAction,
+      environment: toChildEnvironment,
       file: file,
       line: line
     )
@@ -159,18 +183,18 @@ extension Reducer {
     deprecated,
     message: "'forEach' no longer takes a 'breakpointOnNil' argument"
   )
-  public func forEach<GlobalState, GlobalAction, GlobalEnvironment, ID>(
-    state toLocalState: WritableKeyPath<GlobalState, IdentifiedArray<ID, State>>,
-    action toLocalAction: CasePath<GlobalAction, (ID, Action)>,
-    environment toLocalEnvironment: @escaping (GlobalEnvironment) -> Environment,
+  public func forEach<ParentState, ParentAction, ParentEnvironment, ID>(
+    state toElementsState: WritableKeyPath<ParentState, IdentifiedArray<ID, State>>,
+    action toElementAction: CasePath<ParentAction, (ID, Action)>,
+    environment toElementEnvironment: @escaping (ParentEnvironment) -> Environment,
     breakpointOnNil: Bool,
     file: StaticString = #fileID,
     line: UInt = #line
-  ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
+  ) -> Reducer<ParentState, ParentAction, ParentEnvironment> {
     self.forEach(
-      state: toLocalState,
-      action: toLocalAction,
-      environment: toLocalEnvironment,
+      state: toElementsState,
+      action: toElementAction,
+      environment: toElementEnvironment,
       file: file,
       line: line
     )
@@ -181,18 +205,18 @@ extension Reducer {
     deprecated,
     message: "'forEach' no longer takes a 'breakpointOnNil' argument"
   )
-  public func forEach<GlobalState, GlobalAction, GlobalEnvironment, Key>(
-    state toLocalState: WritableKeyPath<GlobalState, [Key: State]>,
-    action toLocalAction: CasePath<GlobalAction, (Key, Action)>,
-    environment toLocalEnvironment: @escaping (GlobalEnvironment) -> Environment,
+  public func forEach<ParentState, ParentAction, ParentEnvironment, Key>(
+    state toElementsState: WritableKeyPath<ParentState, [Key: State]>,
+    action toElementAction: CasePath<ParentAction, (Key, Action)>,
+    environment toElementEnvironment: @escaping (ParentEnvironment) -> Environment,
     breakpointOnNil: Bool,
     file: StaticString = #fileID,
     line: UInt = #line
-  ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
+  ) -> Reducer<ParentState, ParentAction, ParentEnvironment> {
     self.forEach(
-      state: toLocalState,
-      action: toLocalAction,
-      environment: toLocalEnvironment,
+      state: toElementsState,
+      action: toElementAction,
+      environment: toElementEnvironment,
       file: file,
       line: line
     )
@@ -202,7 +226,7 @@ extension Reducer {
 // NB: Deprecated after 0.29.0:
 
 #if DEBUG
-  extension TestStore where LocalState: Equatable, Action: Equatable {
+  extension TestStore where ScopedState: Equatable, Action: Equatable {
     @available(
       *, deprecated, message: "Use 'TestStore.send' and 'TestStore.receive' directly, instead."
     )
@@ -298,10 +322,10 @@ extension Reducer {
 
       @available(*, deprecated, message: "Call 'TestStore.send' directly, instead.")
       public static func send(
-        _ action: LocalAction,
+        _ action: ScopedAction,
         file: StaticString = #file,
         line: UInt = #line,
-        _ update: ((inout LocalState) throws -> Void)? = nil
+        _ update: ((inout ScopedState) throws -> Void)? = nil
       ) -> Step {
         Step(.send(action, update), file: file, line: line)
       }
@@ -311,7 +335,7 @@ extension Reducer {
         _ action: Action,
         file: StaticString = #file,
         line: UInt = #line,
-        _ update: ((inout LocalState) throws -> Void)? = nil
+        _ update: ((inout ScopedState) throws -> Void)? = nil
       ) -> Step {
         Step(.receive(action, update), file: file, line: line)
       }
@@ -353,8 +377,8 @@ extension Reducer {
       }
 
       fileprivate indirect enum StepType {
-        case send(LocalAction, ((inout LocalState) throws -> Void)?)
-        case receive(Action, ((inout LocalState) throws -> Void)?)
+        case send(ScopedAction, ((inout ScopedState) throws -> Void)?)
+        case receive(Action, ((inout ScopedState) throws -> Void)?)
         case environment((inout Environment) throws -> Void)
         case `do`(() throws -> Void)
         case sequence([Step])
@@ -404,26 +428,26 @@ extension Store {
       https://github.com/pointfreeco/swift-composable-architecture/discussions/new
       """
   )
-  public func publisherScope<P: Publisher, LocalState, LocalAction>(
-    state toLocalState: @escaping (AnyPublisher<State, Never>) -> P,
-    action fromLocalAction: @escaping (LocalAction) -> Action
-  ) -> AnyPublisher<Store<LocalState, LocalAction>, Never>
-  where P.Output == LocalState, P.Failure == Never {
+  public func publisherScope<P: Publisher, ChildState, ChildAction>(
+    state toChildState: @escaping (AnyPublisher<State, Never>) -> P,
+    action fromChildAction: @escaping (ChildAction) -> Action
+  ) -> AnyPublisher<Store<ChildState, ChildAction>, Never>
+  where P.Output == ChildState, P.Failure == Never {
 
-    func extractLocalState(_ state: State) -> LocalState? {
-      var localState: LocalState?
-      _ = toLocalState(Just(state).eraseToAnyPublisher())
-        .sink { localState = $0 }
-      return localState
+    func extractChildState(_ state: State) -> ChildState? {
+      var childState: ChildState?
+      _ = toChildState(Just(state).eraseToAnyPublisher())
+        .sink { childState = $0 }
+      return childState
     }
 
-    return toLocalState(self.state.eraseToAnyPublisher())
-      .map { localState in
-        let localStore = Store<LocalState, LocalAction>(
-          initialState: localState,
-          reducer: .init { localState, localAction, _ in
-            let task = self.send(fromLocalAction(localAction))
-            localState = extractLocalState(self.state.value) ?? localState
+    return toChildState(self.state.eraseToAnyPublisher())
+      .map { childState in
+        let childStore = Store<ChildState, ChildAction>(
+          initialState: childState,
+          reducer: .init { childState, childAction, _ in
+            let task = self.send(fromChildAction(childAction))
+            childState = extractChildState(self.state.value) ?? childState
             if let task = task {
               return .fireAndForget { await task.cancellableValue }
             } else {
@@ -433,12 +457,12 @@ extension Store {
           environment: ()
         )
 
-        localStore.parentCancellable = self.state
-          .sink { [weak localStore] state in
-            guard let localStore = localStore else { return }
-            localStore.state.value = extractLocalState(state) ?? localStore.state.value
+        childStore.parentCancellable = self.state
+          .sink { [weak childStore] state in
+            guard let childStore = childStore else { return }
+            childStore.state.value = extractChildState(state) ?? childStore.state.value
           }
-        return localStore
+        return childStore
       }
       .eraseToAnyPublisher()
   }
@@ -451,11 +475,11 @@ extension Store {
       https://github.com/pointfreeco/swift-composable-architecture/discussions/new
       """
   )
-  public func publisherScope<P: Publisher, LocalState>(
-    state toLocalState: @escaping (AnyPublisher<State, Never>) -> P
-  ) -> AnyPublisher<Store<LocalState, Action>, Never>
-  where P.Output == LocalState, P.Failure == Never {
-    self.publisherScope(state: toLocalState, action: { $0 })
+  public func publisherScope<P: Publisher, ChildState>(
+    state toChildState: @escaping (AnyPublisher<State, Never>) -> P
+  ) -> AnyPublisher<Store<ChildState, Action>, Never>
+  where P.Output == ChildState, P.Failure == Never {
+    self.publisherScope(state: toChildState, action: { $0 })
   }
 }
 
@@ -547,10 +571,10 @@ extension ViewStore {
       the view store's 'Action' type must also conform to 'BindableAction'.
       """
   )
-  public func binding<LocalState: Equatable>(
-    keyPath: WritableKeyPath<State, LocalState>,
+  public func binding<Value: Equatable>(
+    keyPath: WritableKeyPath<State, Value>,
     send action: @escaping (BindingAction<State>) -> Action
-  ) -> Binding<LocalState> {
+  ) -> Binding<Value> {
     self.binding(
       get: { $0[keyPath: keyPath] },
       send: { action(.set(keyPath, $0)) }
@@ -597,20 +621,20 @@ extension AlertState.Button {
 
 extension Reducer {
   @available(*, deprecated, message: "Use the 'IdentifiedArray'-based version, instead.")
-  public func forEach<GlobalState, GlobalAction, GlobalEnvironment>(
-    state toLocalState: WritableKeyPath<GlobalState, [State]>,
-    action toLocalAction: CasePath<GlobalAction, (Int, Action)>,
-    environment toLocalEnvironment: @escaping (GlobalEnvironment) -> Environment,
+  public func forEach<ParentState, ParentAction, ParentEnvironment>(
+    state toElementsState: WritableKeyPath<ParentState, [State]>,
+    action toElementAction: CasePath<ParentAction, (Int, Action)>,
+    environment toElementEnvironment: @escaping (ParentEnvironment) -> Environment,
     breakpointOnNil: Bool = true,
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
-  ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
-    .init { globalState, globalAction, globalEnvironment in
-      guard let (index, localAction) = toLocalAction.extract(from: globalAction) else {
+  ) -> Reducer<ParentState, ParentAction, ParentEnvironment> {
+    .init { parentState, parentAction, parentEnvironment in
+      guard let (index, action) = toElementAction.extract(from: parentAction) else {
         return .none
       }
-      if index >= globalState[keyPath: toLocalState].endIndex {
+      if index >= parentState[keyPath: toElementsState].endIndex {
         runtimeWarning(
           """
           A "forEach" reducer at "%@:%d" received an action when state contained no element at \
@@ -644,7 +668,7 @@ extension Reducer {
           [
             "\(fileID)",
             line,
-            debugCaseOutput(localAction),
+            debugCaseOutput(action),
             index,
           ],
           file: file,
@@ -653,11 +677,11 @@ extension Reducer {
         return .none
       }
       return self.run(
-        &globalState[keyPath: toLocalState][index],
-        localAction,
-        toLocalEnvironment(globalEnvironment)
+        &parentState[keyPath: toElementsState][index],
+        action,
+        toElementEnvironment(parentEnvironment)
       )
-      .map { toLocalAction.embed((index, $0)) }
+      .map { toElementAction.embed((index, $0)) }
     }
   }
 }

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -146,13 +146,13 @@ public struct Reducer<State, Action, Environment> {
     .combine(self, other)
   }
 
-  /// Transforms a reducer that works on local state, action, and environment into one that works on
-  /// global state, action and environment. It accomplishes this by providing 3 transformations to
+  /// Transforms a reducer that works on child state, action, and environment into one that works on
+  /// parent state, action and environment. It accomplishes this by providing 3 transformations to
   /// the method:
   ///
-  ///   * A writable key path that can get/set a piece of local state from the global state.
-  ///   * A case path that can extract/embed a local action into a global action.
-  ///   * A function that can transform the global environment into a local environment.
+  ///   * A writable key path that can get/set a piece of child state from the parent state.
+  ///   * A case path that can extract/embed a child action into a parent action.
+  ///   * A function that can transform the parent environment into a child environment.
   ///
   /// This operation is important for breaking down large reducers into small ones. When used with
   /// the ``combine(_:)-1ern2`` operator you can define many reducers that work on small pieces of
@@ -160,12 +160,12 @@ public struct Reducer<State, Action, Environment> {
   /// large domain.
   ///
   ///    ```swift
-  ///     // Global domain that holds a local domain:
+  ///     // Parent domain that holds a child domain:
   ///     struct AppState { var settings: SettingsState, /* rest of state */ }
   ///     enum AppAction { case settings(SettingsAction), /* other actions */ }
   ///     struct AppEnvironment { var settings: SettingsEnvironment, /* rest of dependencies */ }
   ///
-  ///     // A reducer that works on the local domain:
+  ///     // A reducer that works on the child domain:
   ///     let settingsReducer = Reducer<SettingsState, SettingsAction, SettingsEnvironment> { ... }
   ///
   ///     // Pullback the settings reducer so that it works on all of the app domain:
@@ -181,35 +181,35 @@ public struct Reducer<State, Action, Environment> {
   ///    ```
   ///
   /// - Parameters:
-  ///   - toLocalState: A key path that can get/set `State` inside `GlobalState`.
-  ///   - toLocalAction: A case path that can extract/embed `Action` from `GlobalAction`.
-  ///   - toLocalEnvironment: A function that transforms `GlobalEnvironment` into `Environment`.
-  /// - Returns: A reducer that works on `GlobalState`, `GlobalAction`, `GlobalEnvironment`.
-  public func pullback<GlobalState, GlobalAction, GlobalEnvironment>(
-    state toLocalState: WritableKeyPath<GlobalState, State>,
-    action toLocalAction: CasePath<GlobalAction, Action>,
-    environment toLocalEnvironment: @escaping (GlobalEnvironment) -> Environment
-  ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
-    .init { globalState, globalAction, globalEnvironment in
-      guard let localAction = toLocalAction.extract(from: globalAction) else { return .none }
+  ///   - toChildState: A key path that can get/set `State` inside `ParentState`.
+  ///   - toChildAction: A case path that can extract/embed `Action` from `ParentAction`.
+  ///   - toChildEnvironment: A function that transforms `ParentEnvironment` into `Environment`.
+  /// - Returns: A reducer that works on `ParentState`, `ParentAction`, `ParentEnvironment`.
+  public func pullback<ParentState, ParentAction, ParentEnvironment>(
+    state toChildState: WritableKeyPath<ParentState, State>,
+    action toChildAction: CasePath<ParentAction, Action>,
+    environment toChildEnvironment: @escaping (ParentEnvironment) -> Environment
+  ) -> Reducer<ParentState, ParentAction, ParentEnvironment> {
+    .init { parentState, parentAction, parentEnvironment in
+      guard let childAction = toChildAction.extract(from: parentAction) else { return .none }
       return self.reducer(
-        &globalState[keyPath: toLocalState],
-        localAction,
-        toLocalEnvironment(globalEnvironment)
+        &parentState[keyPath: toChildState],
+        childAction,
+        toChildEnvironment(parentEnvironment)
       )
-      .map(toLocalAction.embed)
+      .map(toChildAction.embed)
     }
   }
 
-  /// Transforms a reducer that works on local state, action, and environment into one that works on
-  /// global state, action and environment.
+  /// Transforms a reducer that works on child state, action, and environment into one that works on
+  /// parent state, action and environment.
   ///
   /// It accomplishes this by providing 3 transformations to the method:
   ///
-  ///   * A case path that can extract/embed a piece of local state from the global state, which is
+  ///   * A case path that can extract/embed a piece of child state from the parent state, which is
   ///     typically an enum.
-  ///   * A case path that can extract/embed a local action into a global action.
-  ///   * A function that can transform the global environment into a local environment.
+  ///   * A case path that can extract/embed a child action into a parent action.
+  ///   * A function that can transform the parent environment into a child environment.
   ///
   /// This overload of ``pullback(state:action:environment:)`` differs from the other in that it
   /// takes a `CasePath` transformation for the state instead of a `WritableKeyPath`. This makes it
@@ -222,12 +222,12 @@ public struct Reducer<State, Action, Environment> {
   /// works on a large domain.
   ///
   /// ```swift
-  /// // Global domain that holds a local domain:
+  /// // Parent domain that holds a child domain:
   /// enum AppState { case loggedIn(LoggedInState), /* rest of state */ }
   /// enum AppAction { case loggedIn(LoggedInAction), /* other actions */ }
   /// struct AppEnvironment { var loggedIn: LoggedInEnvironment, /* rest of dependencies */ }
   ///
-  /// // A reducer that works on the local domain:
+  /// // A reducer that works on the child domain:
   /// let loggedInReducer = Reducer<LoggedInState, LoggedInAction, LoggedInEnvironment> { ... }
   ///
   /// // Pullback the logged-in reducer so that it works on all of the app domain:
@@ -366,25 +366,25 @@ public struct Reducer<State, Action, Environment> {
   ///   stores on each case of the enum.
   ///
   /// - Parameters:
-  ///   - toLocalState: A case path that can extract/embed `State` from `GlobalState`.
-  ///   - toLocalAction: A case path that can extract/embed `Action` from `GlobalAction`.
-  ///   - toLocalEnvironment: A function that transforms `GlobalEnvironment` into `Environment`.
-  /// - Returns: A reducer that works on `GlobalState`, `GlobalAction`, `GlobalEnvironment`.
-  public func pullback<GlobalState, GlobalAction, GlobalEnvironment>(
-    state toLocalState: CasePath<GlobalState, State>,
-    action toLocalAction: CasePath<GlobalAction, Action>,
-    environment toLocalEnvironment: @escaping (GlobalEnvironment) -> Environment,
+  ///   - toChildState: A case path that can extract/embed `State` from `ParentState`.
+  ///   - toChildAction: A case path that can extract/embed `Action` from `ParentAction`.
+  ///   - toChildEnvironment: A function that transforms `ParentEnvironment` into `Environment`.
+  /// - Returns: A reducer that works on `ParentState`, `ParentAction`, `ParentEnvironment`.
+  public func pullback<ParentState, ParentAction, ParentEnvironment>(
+    state toChildState: CasePath<ParentState, State>,
+    action toChildAction: CasePath<ParentAction, Action>,
+    environment toChildEnvironment: @escaping (ParentEnvironment) -> Environment,
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
-  ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
-    .init { globalState, globalAction, globalEnvironment in
-      guard let localAction = toLocalAction.extract(from: globalAction) else { return .none }
+  ) -> Reducer<ParentState, ParentAction, ParentEnvironment> {
+    .init { parentState, parentAction, parentEnvironment in
+      guard let childAction = toChildAction.extract(from: parentAction) else { return .none }
 
-      guard var localState = toLocalState.extract(from: globalState) else {
+      guard var childState = toChildState.extract(from: parentState) else {
         runtimeWarning(
           """
-          A reducer pulled back from "%@:%d" received an action when local state was \
+          A reducer pulled back from "%@:%d" received an action when child state was \
           unavailable. …
 
             Action:
@@ -410,7 +410,7 @@ public struct Reducer<State, Action, Environment> {
           [
             "\(fileID)",
             line,
-            debugCaseOutput(localAction),
+            debugCaseOutput(childAction),
             "\(State.self)",
           ],
           file: file,
@@ -418,14 +418,14 @@ public struct Reducer<State, Action, Environment> {
         )
         return .none
       }
-      defer { globalState = toLocalState.embed(localState) }
+      defer { parentState = toChildState.embed(childState) }
 
       let effects = self.run(
-        &localState,
-        localAction,
-        toLocalEnvironment(globalEnvironment)
+        &childState,
+        childAction,
+        toChildEnvironment(parentEnvironment)
       )
-      .map(toLocalAction.embed)
+      .map(toChildAction.embed)
 
       return effects
     }
@@ -439,15 +439,15 @@ public struct Reducer<State, Action, Environment> {
   /// domain that contains some optional child domain:
   ///
   /// ```swift
-  /// // Global domain that holds an optional local domain:
+  /// // Parent domain that holds an optional child domain:
   /// struct AppState { var modal: ModalState? }
   /// enum AppAction { case modal(ModalAction) }
   /// struct AppEnvironment { var mainQueue: AnySchedulerOf<DispatchQueue> }
   ///
-  /// // A reducer that works on the non-optional local domain:
+  /// // A reducer that works on the non-optional child domain:
   /// let modalReducer = Reducer<ModalState, ModalAction, ModalEnvironment { ... }
   ///
-  /// // Pullback the local modal reducer so that it works on all of the app domain:
+  /// // Pullback the modal reducer so that it works on all of the app domain:
   /// let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
   ///   modalReducer.optional().pullback(
   ///     state: \.modal,
@@ -636,15 +636,15 @@ public struct Reducer<State, Action, Environment> {
   /// an element into one that works on an identified array of elements.
   ///
   /// ```swift
-  /// // Global domain that holds a collection of local domains:
+  /// // Parent domain that holds a collection of child domains:
   /// struct AppState { var todos: IdentifiedArrayOf<Todo> }
   /// enum AppAction { case todo(id: Todo.ID, action: TodoAction) }
   /// struct AppEnvironment { var mainQueue: AnySchedulerOf<DispatchQueue> }
   ///
-  /// // A reducer that works on a local domain:
+  /// // A reducer that works on an element's domain:
   /// let todoReducer = Reducer<Todo, TodoAction, TodoEnvironment> { ... }
   ///
-  /// // Pullback the local todo reducer so that it works on all of the app domain:
+  /// // Pullback the todo reducer so that it works on all of the app domain:
   /// let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
   ///   todoReducer.forEach(
   ///     state: \.todos,
@@ -661,23 +661,24 @@ public struct Reducer<State, Action, Environment> {
   /// combine `forEach` reducers _before_ parent reducers that can modify the collection.
   ///
   /// - Parameters:
-  ///   - toLocalState: A key path that can get/set a collection of `State` elements inside
-  ///     `GlobalState`.
-  ///   - toLocalAction: A case path that can extract/embed `(Collection.Index, Action)` from
-  ///     `GlobalAction`.
-  ///   - toLocalEnvironment: A function that transforms `GlobalEnvironment` into `Environment`.
-  /// - Returns: A reducer that works on `GlobalState`, `GlobalAction`, `GlobalEnvironment`.
-  public func forEach<GlobalState, GlobalAction, GlobalEnvironment, ID>(
-    state toLocalState: WritableKeyPath<GlobalState, IdentifiedArray<ID, State>>,
-    action toLocalAction: CasePath<GlobalAction, (ID, Action)>,
-    environment toLocalEnvironment: @escaping (GlobalEnvironment) -> Environment,
+  ///   - toElementsState: A key path that can get/set a collection of `State` elements inside
+  ///     `ParentState`.
+  ///   - toElementAction: A case path that can extract/embed `(ID, Action)` from `ParentAction`.
+  ///   - toElementEnvironment: A function that transforms `ParentEnvironment` into `Environment`.
+  /// - Returns: A reducer that works on `ParentState`, `ParentAction`, `ParentEnvironment`.
+  public func forEach<ParentState, ParentAction, ParentEnvironment, ID>(
+    state toElementsState: WritableKeyPath<ParentState, IdentifiedArray<ID, State>>,
+    action toElementAction: CasePath<ParentAction, (ID, Action)>,
+    environment toElementEnvironment: @escaping (ParentEnvironment) -> Environment,
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
-  ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
-    .init { globalState, globalAction, globalEnvironment in
-      guard let (id, localAction) = toLocalAction.extract(from: globalAction) else { return .none }
-      if globalState[keyPath: toLocalState][id: id] == nil {
+  ) -> Reducer<ParentState, ParentAction, ParentEnvironment> {
+    .init { parentState, parentAction, parentEnvironment in
+      guard let (id, elementAction) = toElementAction.extract(from: parentAction)
+      else { return .none }
+
+      if parentState[keyPath: toElementsState][id: id] == nil {
         runtimeWarning(
           """
           A "forEach" reducer at "%@:%d" received an action when state contained no element with \
@@ -710,7 +711,7 @@ public struct Reducer<State, Action, Environment> {
           [
             "\(fileID)",
             line,
-            debugCaseOutput(localAction),
+            debugCaseOutput(elementAction),
             "\(id)",
           ],
           file: file,
@@ -721,11 +722,11 @@ public struct Reducer<State, Action, Environment> {
       return
         self
         .reducer(
-          &globalState[keyPath: toLocalState][id: id]!,
-          localAction,
-          toLocalEnvironment(globalEnvironment)
+          &parentState[keyPath: toElementsState][id: id]!,
+          elementAction,
+          toElementEnvironment(parentEnvironment)
         )
-        .map { toLocalAction.embed((id, $0)) }
+        .map { toElementAction.embed((id, $0)) }
     }
   }
 
@@ -736,23 +737,23 @@ public struct Reducer<State, Action, Environment> {
   /// combine `forEach`` reducers _before_ parent reducers that can modify the dictionary.
   ///
   /// - Parameters:
-  ///   - toLocalState: A key path that can get/set a dictionary of `State` values inside
-  ///     `GlobalState`.
-  ///   - toLocalAction: A case path that can extract/embed `(Key, Action)` from `GlobalAction`.
-  ///   - toLocalEnvironment: A function that transforms `GlobalEnvironment` into `Environment`.
-  /// - Returns: A reducer that works on `GlobalState`, `GlobalAction`, `GlobalEnvironment`.
-  public func forEach<GlobalState, GlobalAction, GlobalEnvironment, Key>(
-    state toLocalState: WritableKeyPath<GlobalState, [Key: State]>,
-    action toLocalAction: CasePath<GlobalAction, (Key, Action)>,
-    environment toLocalEnvironment: @escaping (GlobalEnvironment) -> Environment,
+  ///   - toDictionaryState: A key path that can get/set a dictionary of `State` values inside
+  ///     `ParentState`.
+  ///   - toKeyedAction: A case path that can extract/embed `(Key, Action)` from `ParentAction`.
+  ///   - toValueEnvironment: A function that transforms `ParentEnvironment` into `Environment`.
+  /// - Returns: A reducer that works on `ParentState`, `ParentAction`, `ParentEnvironment`.
+  public func forEach<ParentState, ParentAction, ParentEnvironment, Key>(
+    state toDictionaryState: WritableKeyPath<ParentState, [Key: State]>,
+    action toKeyedAction: CasePath<ParentAction, (Key, Action)>,
+    environment toValueEnvironment: @escaping (ParentEnvironment) -> Environment,
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
-  ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
-    .init { globalState, globalAction, globalEnvironment in
-      guard let (key, localAction) = toLocalAction.extract(from: globalAction) else { return .none }
+  ) -> Reducer<ParentState, ParentAction, ParentEnvironment> {
+    .init { parentState, parentAction, parentEnvironment in
+      guard let (key, action) = toKeyedAction.extract(from: parentAction) else { return .none }
 
-      if globalState[keyPath: toLocalState][key] == nil {
+      if parentState[keyPath: toDictionaryState][key] == nil {
         runtimeWarning(
           """
           A "forEach" reducer at "%@:%d" received an action when state contained no value at \
@@ -784,7 +785,7 @@ public struct Reducer<State, Action, Environment> {
           [
             "\(fileID)",
             line,
-            debugCaseOutput(localAction),
+            debugCaseOutput(action),
             "\(key)",
           ],
           file: file,
@@ -793,11 +794,11 @@ public struct Reducer<State, Action, Environment> {
         return .none
       }
       return self.reducer(
-        &globalState[keyPath: toLocalState][key]!,
-        localAction,
-        toLocalEnvironment(globalEnvironment)
+        &parentState[keyPath: toDictionaryState][key]!,
+        action,
+        toValueEnvironment(parentEnvironment)
       )
-      .map { toLocalAction.embed((key, $0)) }
+      .map { toKeyedAction.embed((key, $0)) }
     }
   }
 

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -675,7 +675,7 @@ public struct Reducer<State, Action, Environment> {
     line: UInt = #line
   ) -> Reducer<ParentState, ParentAction, ParentEnvironment> {
     .init { parentState, parentAction, parentEnvironment in
-      guard let (id, elementAction) = toElementAction.extract(from: parentAction)
+      guard let (id, action) = toElementAction.extract(from: parentAction)
       else { return .none }
 
       if parentState[keyPath: toElementsState][id: id] == nil {
@@ -711,7 +711,7 @@ public struct Reducer<State, Action, Environment> {
           [
             "\(fileID)",
             line,
-            debugCaseOutput(elementAction),
+            debugCaseOutput(action),
             "\(id)",
           ],
           file: file,
@@ -723,7 +723,7 @@ public struct Reducer<State, Action, Environment> {
         self
         .reducer(
           &parentState[keyPath: toElementsState][id: id]!,
-          elementAction,
+          action,
           toElementEnvironment(parentEnvironment)
         )
         .map { toElementAction.embed((id, $0)) }

--- a/Sources/ComposableArchitecture/SwiftUI/Identified.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Identified.swift
@@ -43,9 +43,9 @@ public struct Identified<ID: Hashable, Value>: Identifiable {
     self.init(value, id: value[keyPath: id])
   }
 
-  public subscript<LocalValue>(
-    dynamicMember keyPath: WritableKeyPath<Value, LocalValue>
-  ) -> LocalValue {
+  public subscript<Subject>(
+    dynamicMember keyPath: WritableKeyPath<Value, Subject>
+  ) -> Subject {
     get { self.value[keyPath: keyPath] }
     set { self.value[keyPath: keyPath] = newValue }
   }

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -72,57 +72,57 @@ public struct SwitchStore<State, Action, Content: View>: View {
 }
 
 /// A view that handles a specific case of enum state in a ``SwitchStore``.
-public struct CaseLet<GlobalState, GlobalAction, LocalState, LocalAction, Content: View>: View {
-  @EnvironmentObject private var store: StoreObservableObject<GlobalState, GlobalAction>
-  public let toLocalState: (GlobalState) -> LocalState?
-  public let fromLocalAction: (LocalAction) -> GlobalAction
-  public let content: (Store<LocalState, LocalAction>) -> Content
+public struct CaseLet<EnumState, EnumAction, CaseState, CaseAction, Content: View>: View {
+  @EnvironmentObject private var store: StoreObservableObject<EnumState, EnumAction>
+  public let toCaseState: (EnumState) -> CaseState?
+  public let fromCaseAction: (CaseAction) -> EnumAction
+  public let content: (Store<CaseState, CaseAction>) -> Content
 
   /// Initializes a ``CaseLet`` view that computes content depending on if a store of enum state
   /// matches a particular case.
   ///
   /// - Parameters:
-  ///   - toLocalState: A function that can extract a case of switch store state, which can be
+  ///   - toCaseState: A function that can extract a case of switch store state, which can be
   ///     specified using case path literal syntax, _e.g._ `/State.case`.
-  ///   - fromLocalAction: A function that can embed a case action in a switch store action.
+  ///   - fromCaseAction: A function that can embed a case action in a switch store action.
   ///   - content: A function that is given a store of the given case's state and returns a view
   ///     that is visible only when the switch store's state matches.
   public init(
-    state toLocalState: @escaping (GlobalState) -> LocalState?,
-    action fromLocalAction: @escaping (LocalAction) -> GlobalAction,
-    @ViewBuilder then content: @escaping (Store<LocalState, LocalAction>) -> Content
+    state toCaseState: @escaping (EnumState) -> CaseState?,
+    action fromCaseAction: @escaping (CaseAction) -> EnumAction,
+    @ViewBuilder then content: @escaping (Store<CaseState, CaseAction>) -> Content
   ) {
-    self.toLocalState = toLocalState
-    self.fromLocalAction = fromLocalAction
+    self.toCaseState = toCaseState
+    self.fromCaseAction = fromCaseAction
     self.content = content
   }
 
   public var body: some View {
     IfLetStore(
       self.store.wrappedValue.scope(
-        state: self.toLocalState,
-        action: self.fromLocalAction
+        state: self.toCaseState,
+        action: self.fromCaseAction
       ),
       then: self.content
     )
   }
 }
 
-extension CaseLet where GlobalAction == LocalAction {
+extension CaseLet where EnumAction == CaseAction {
   /// Initializes a ``CaseLet`` view that computes content depending on if a store of enum state
   /// matches a particular case.
   ///
   /// - Parameters:
-  ///   - toLocalState: A function that can extract a case of switch store state, which can be
+  ///   - toCaseState: A function that can extract a case of switch store state, which can be
   ///     specified using case path literal syntax, _e.g._ `/State.case`.
   ///   - content: A function that is given a store of the given case's state and returns a view
   ///     that is visible only when the switch store's state matches.
   public init(
-    state toLocalState: @escaping (GlobalState) -> LocalState?,
-    @ViewBuilder then content: @escaping (Store<LocalState, LocalAction>) -> Content
+    state toCaseState: @escaping (EnumState) -> CaseState?,
+    @ViewBuilder then content: @escaping (Store<CaseState, CaseAction>) -> Content
   ) {
     self.init(
-      state: toLocalState,
+      state: toCaseState,
       action: { $0 },
       then: content
     )
@@ -174,7 +174,7 @@ extension SwitchStore {
     self.init(store: store) {
       let content = content().value
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
-        if content.0.toLocalState(viewStore.state) != nil {
+        if content.0.toCaseState(viewStore.state) != nil {
           content.0
         } else {
           content.1
@@ -232,9 +232,9 @@ extension SwitchStore {
     self.init(store: store) {
       let content = content().value
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
-        if content.0.toLocalState(viewStore.state) != nil {
+        if content.0.toCaseState(viewStore.state) != nil {
           content.0
-        } else if content.1.toLocalState(viewStore.state) != nil {
+        } else if content.1.toCaseState(viewStore.state) != nil {
           content.1
         } else {
           content.2
@@ -311,11 +311,11 @@ extension SwitchStore {
     self.init(store: store) {
       let content = content().value
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
-        if content.0.toLocalState(viewStore.state) != nil {
+        if content.0.toCaseState(viewStore.state) != nil {
           content.0
-        } else if content.1.toLocalState(viewStore.state) != nil {
+        } else if content.1.toCaseState(viewStore.state) != nil {
           content.1
-        } else if content.2.toLocalState(viewStore.state) != nil {
+        } else if content.2.toCaseState(viewStore.state) != nil {
           content.2
         } else {
           content.3
@@ -402,13 +402,13 @@ extension SwitchStore {
     self.init(store: store) {
       let content = content().value
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
-        if content.0.toLocalState(viewStore.state) != nil {
+        if content.0.toCaseState(viewStore.state) != nil {
           content.0
-        } else if content.1.toLocalState(viewStore.state) != nil {
+        } else if content.1.toCaseState(viewStore.state) != nil {
           content.1
-        } else if content.2.toLocalState(viewStore.state) != nil {
+        } else if content.2.toCaseState(viewStore.state) != nil {
           content.2
-        } else if content.3.toLocalState(viewStore.state) != nil {
+        } else if content.3.toCaseState(viewStore.state) != nil {
           content.3
         } else {
           content.4
@@ -510,15 +510,15 @@ extension SwitchStore {
     self.init(store: store) {
       let content = content().value
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
-        if content.0.toLocalState(viewStore.state) != nil {
+        if content.0.toCaseState(viewStore.state) != nil {
           content.0
-        } else if content.1.toLocalState(viewStore.state) != nil {
+        } else if content.1.toCaseState(viewStore.state) != nil {
           content.1
-        } else if content.2.toLocalState(viewStore.state) != nil {
+        } else if content.2.toCaseState(viewStore.state) != nil {
           content.2
-        } else if content.3.toLocalState(viewStore.state) != nil {
+        } else if content.3.toCaseState(viewStore.state) != nil {
           content.3
-        } else if content.4.toLocalState(viewStore.state) != nil {
+        } else if content.4.toCaseState(viewStore.state) != nil {
           content.4
         } else {
           content.5
@@ -631,17 +631,17 @@ extension SwitchStore {
     self.init(store: store) {
       let content = content().value
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
-        if content.0.toLocalState(viewStore.state) != nil {
+        if content.0.toCaseState(viewStore.state) != nil {
           content.0
-        } else if content.1.toLocalState(viewStore.state) != nil {
+        } else if content.1.toCaseState(viewStore.state) != nil {
           content.1
-        } else if content.2.toLocalState(viewStore.state) != nil {
+        } else if content.2.toCaseState(viewStore.state) != nil {
           content.2
-        } else if content.3.toLocalState(viewStore.state) != nil {
+        } else if content.3.toCaseState(viewStore.state) != nil {
           content.3
-        } else if content.4.toLocalState(viewStore.state) != nil {
+        } else if content.4.toCaseState(viewStore.state) != nil {
           content.4
-        } else if content.5.toLocalState(viewStore.state) != nil {
+        } else if content.5.toCaseState(viewStore.state) != nil {
           content.5
         } else {
           content.6
@@ -765,19 +765,19 @@ extension SwitchStore {
     self.init(store: store) {
       let content = content().value
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
-        if content.0.toLocalState(viewStore.state) != nil {
+        if content.0.toCaseState(viewStore.state) != nil {
           content.0
-        } else if content.1.toLocalState(viewStore.state) != nil {
+        } else if content.1.toCaseState(viewStore.state) != nil {
           content.1
-        } else if content.2.toLocalState(viewStore.state) != nil {
+        } else if content.2.toCaseState(viewStore.state) != nil {
           content.2
-        } else if content.3.toLocalState(viewStore.state) != nil {
+        } else if content.3.toCaseState(viewStore.state) != nil {
           content.3
-        } else if content.4.toLocalState(viewStore.state) != nil {
+        } else if content.4.toCaseState(viewStore.state) != nil {
           content.4
-        } else if content.5.toLocalState(viewStore.state) != nil {
+        } else if content.5.toCaseState(viewStore.state) != nil {
           content.5
-        } else if content.6.toLocalState(viewStore.state) != nil {
+        } else if content.6.toCaseState(viewStore.state) != nil {
           content.6
         } else {
           content.7
@@ -912,21 +912,21 @@ extension SwitchStore {
     self.init(store: store) {
       let content = content().value
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
-        if content.0.toLocalState(viewStore.state) != nil {
+        if content.0.toCaseState(viewStore.state) != nil {
           content.0
-        } else if content.1.toLocalState(viewStore.state) != nil {
+        } else if content.1.toCaseState(viewStore.state) != nil {
           content.1
-        } else if content.2.toLocalState(viewStore.state) != nil {
+        } else if content.2.toCaseState(viewStore.state) != nil {
           content.2
-        } else if content.3.toLocalState(viewStore.state) != nil {
+        } else if content.3.toCaseState(viewStore.state) != nil {
           content.3
-        } else if content.4.toLocalState(viewStore.state) != nil {
+        } else if content.4.toCaseState(viewStore.state) != nil {
           content.4
-        } else if content.5.toLocalState(viewStore.state) != nil {
+        } else if content.5.toCaseState(viewStore.state) != nil {
           content.5
-        } else if content.6.toLocalState(viewStore.state) != nil {
+        } else if content.6.toCaseState(viewStore.state) != nil {
           content.6
-        } else if content.7.toLocalState(viewStore.state) != nil {
+        } else if content.7.toCaseState(viewStore.state) != nil {
           content.7
         } else {
           content.8
@@ -1072,23 +1072,23 @@ extension SwitchStore {
     self.init(store: store) {
       let content = content().value
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
-        if content.0.toLocalState(viewStore.state) != nil {
+        if content.0.toCaseState(viewStore.state) != nil {
           content.0
-        } else if content.1.toLocalState(viewStore.state) != nil {
+        } else if content.1.toCaseState(viewStore.state) != nil {
           content.1
-        } else if content.2.toLocalState(viewStore.state) != nil {
+        } else if content.2.toCaseState(viewStore.state) != nil {
           content.2
-        } else if content.3.toLocalState(viewStore.state) != nil {
+        } else if content.3.toCaseState(viewStore.state) != nil {
           content.3
-        } else if content.4.toLocalState(viewStore.state) != nil {
+        } else if content.4.toCaseState(viewStore.state) != nil {
           content.4
-        } else if content.5.toLocalState(viewStore.state) != nil {
+        } else if content.5.toCaseState(viewStore.state) != nil {
           content.5
-        } else if content.6.toLocalState(viewStore.state) != nil {
+        } else if content.6.toCaseState(viewStore.state) != nil {
           content.6
-        } else if content.7.toLocalState(viewStore.state) != nil {
+        } else if content.7.toCaseState(viewStore.state) != nil {
           content.7
-        } else if content.8.toLocalState(viewStore.state) != nil {
+        } else if content.8.toCaseState(viewStore.state) != nil {
           content.8
         } else {
           content.9

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -170,7 +170,7 @@
   /// wait longer than the 0.5 seconds, because if it wasn't and it delivered an action when we did
   /// not expect it would cause a test failure.
   ///
-  public final class TestStore<State, LocalState, Action, LocalAction, Environment> {
+  public final class TestStore<State, ScopedState, Action, ScopedAction, Environment> {
     /// The current environment.
     ///
     /// The environment can be modified throughout a test store's lifecycle in order to influence
@@ -209,30 +209,30 @@
     public var timeout: UInt64
 
     private let file: StaticString
-    private let fromLocalAction: (LocalAction) -> Action
+    private let fromScopedAction: (ScopedAction) -> Action
     private var line: UInt
     private var inFlightEffects: Set<LongLivingEffect> = []
     var receivedActions: [(action: Action, state: State)] = []
     private let reducer: Reducer<State, Action, Environment>
     private var store: Store<State, TestAction>!
-    private let toLocalState: (State) -> LocalState
+    private let toScopedState: (State) -> ScopedState
 
     private init(
       environment: Environment,
       file: StaticString,
-      fromLocalAction: @escaping (LocalAction) -> Action,
+      fromScopedAction: @escaping (ScopedAction) -> Action,
       initialState: State,
       line: UInt,
       reducer: Reducer<State, Action, Environment>,
-      toLocalState: @escaping (State) -> LocalState
+      toScopedState: @escaping (State) -> ScopedState
     ) {
       self.environment = environment
       self.file = file
-      self.fromLocalAction = fromLocalAction
+      self.fromScopedAction = fromScopedAction
       self.line = line
       self.reducer = reducer
       self.state = initialState
-      self.toLocalState = toLocalState
+      self.toScopedState = toScopedState
       self.timeout = 100 * NSEC_PER_MSEC
 
       self.store = Store(
@@ -240,8 +240,8 @@
         reducer: Reducer<State, TestAction, Void> { [unowned self] state, action, _ in
           let effects: Effect<Action, Never>
           switch action.origin {
-          case let .send(localAction):
-            effects = self.reducer.run(&state, self.fromLocalAction(localAction), self.environment)
+          case let .send(scopedAction):
+            effects = self.reducer.run(&state, self.fromScopedAction(scopedAction), self.environment)
             self.state = state
 
           case let .receive(action):
@@ -395,7 +395,7 @@
       let line: UInt
 
       enum Origin {
-        case send(LocalAction)
+        case send(ScopedAction)
         case receive(Action)
       }
 
@@ -411,7 +411,7 @@
     }
   }
 
-  extension TestStore where State == LocalState, Action == LocalAction {
+  extension TestStore where State == ScopedState, Action == ScopedAction {
     /// Initializes a test store from an initial state, a reducer, and an initial environment.
     ///
     /// - Parameters:
@@ -428,16 +428,16 @@
       self.init(
         environment: environment,
         file: file,
-        fromLocalAction: { $0 },
+        fromScopedAction: { $0 },
         initialState: initialState,
         line: line,
         reducer: reducer,
-        toLocalState: { $0 }
+        toScopedState: { $0 }
       )
     }
   }
 
-  extension TestStore where LocalState: Equatable {
+  extension TestStore where ScopedState: Equatable {
     /// Sends an action to the store and asserts when state changes.
     ///
     /// This method suspends in order to allow any effects to start. For example, if you
@@ -503,8 +503,8 @@
     @MainActor
     @discardableResult
     public func send(
-      _ action: LocalAction,
-      _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil,
+      _ action: ScopedAction,
+      _ updateExpectingResult: ((inout ScopedState) throws -> Void)? = nil,
       file: StaticString = #file,
       line: UInt = #line
     ) async -> TestStoreTask {
@@ -521,7 +521,7 @@
           file: file, line: line
         )
       }
-      var expectedState = self.toLocalState(self.state)
+      var expectedState = self.toScopedState(self.state)
       let previousState = self.state
       let task = self.store.send(.init(origin: .send(action), file: file, line: line))
       await Task.megaYield()
@@ -532,7 +532,7 @@
 
         try self.expectedStateShouldMatch(
           expected: &expectedState,
-          actual: self.toLocalState(currentState),
+          actual: self.toScopedState(currentState),
           modify: updateExpectingResult,
           file: file,
           line: line
@@ -584,8 +584,8 @@
     @available(watchOS, deprecated: 9999.0, message: "Call the async-friendly 'send' instead.")
     @discardableResult
     public func send(
-      _ action: LocalAction,
-      _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil,
+      _ action: ScopedAction,
+      _ updateExpectingResult: ((inout ScopedState) throws -> Void)? = nil,
       file: StaticString = #file,
       line: UInt = #line
     ) -> TestStoreTask {
@@ -602,7 +602,7 @@
           file: file, line: line
         )
       }
-      var expectedState = self.toLocalState(self.state)
+      var expectedState = self.toScopedState(self.state)
       let previousState = self.state
       let task = self.store.send(.init(origin: .send(action), file: file, line: line))
       do {
@@ -612,7 +612,7 @@
 
         try self.expectedStateShouldMatch(
           expected: &expectedState,
-          actual: self.toLocalState(currentState),
+          actual: self.toScopedState(currentState),
           modify: updateExpectingResult,
           file: file,
           line: line
@@ -628,9 +628,9 @@
     }
 
     private func expectedStateShouldMatch(
-      expected: inout LocalState,
-      actual: LocalState,
-      modify: ((inout LocalState) throws -> Void)? = nil,
+      expected: inout ScopedState,
+      actual: ScopedState,
+      modify: ((inout ScopedState) throws -> Void)? = nil,
       file: StaticString,
       line: UInt
     ) throws {
@@ -678,7 +678,7 @@
     }
   }
 
-  extension TestStore where LocalState: Equatable, Action: Equatable {
+  extension TestStore where ScopedState: Equatable, Action: Equatable {
     /// Asserts an action was received from an effect and asserts when state changes.
     ///
     /// - Parameters:
@@ -693,7 +693,7 @@
     @available(watchOS, deprecated: 9999.0, message: "Call the async-friendly 'receive' instead.")
     public func receive(
       _ expectedAction: Action,
-      _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil,
+      _ updateExpectingResult: ((inout ScopedState) throws -> Void)? = nil,
       file: StaticString = #file,
       line: UInt = #line
     ) {
@@ -729,11 +729,11 @@
           file: file, line: line
         )
       }
-      var expectedState = self.toLocalState(self.state)
+      var expectedState = self.toScopedState(self.state)
       do {
         try expectedStateShouldMatch(
           expected: &expectedState,
-          actual: self.toLocalState(state),
+          actual: self.toScopedState(state),
           modify: updateExpectingResult,
           file: file,
           line: line
@@ -762,7 +762,7 @@
       public func receive(
         _ expectedAction: Action,
         timeout duration: Duration,
-        _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil,
+        _ updateExpectingResult: ((inout ScopedState) throws -> Void)? = nil,
         file: StaticString = #file,
         line: UInt = #line
       ) async {
@@ -789,7 +789,7 @@
     public func receive(
       _ expectedAction: Action,
       timeout nanoseconds: UInt64? = nil,
-      _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil,
+      _ updateExpectingResult: ((inout ScopedState) throws -> Void)? = nil,
       file: StaticString = #file,
       line: UInt = #line
     ) async {
@@ -855,43 +855,43 @@
   }
 
   extension TestStore {
-    /// Scopes a store to assert against more local state and actions.
+    /// Scopes a store to assert against scoped state and actions.
     ///
     /// Useful for testing view store-specific state and actions.
     ///
     /// - Parameters:
-    ///   - toLocalState: A function that transforms the reducer's state into more local state. This
+    ///   - toScopedState: A function that transforms the reducer's state into scoped state. This
     ///     state will be asserted against as it is mutated by the reducer. Useful for testing view
     ///     store state transformations.
-    ///   - fromLocalAction: A function that wraps a more local action in the reducer's action.
-    ///     Local actions can be "sent" to the store, while any reducer action may be received.
+    ///   - fromScopedAction: A function that wraps a more scoped action in the reducer's action.
+    ///     Scoped actions can be "sent" to the store, while any reducer action may be received.
     ///     Useful for testing view store action transformations.
     public func scope<S, A>(
-      state toLocalState: @escaping (LocalState) -> S,
-      action fromLocalAction: @escaping (A) -> LocalAction
+      state toScopedState: @escaping (ScopedState) -> S,
+      action fromScopedAction: @escaping (A) -> ScopedAction
     ) -> TestStore<State, S, Action, A, Environment> {
       .init(
         environment: self.environment,
         file: self.file,
-        fromLocalAction: { self.fromLocalAction(fromLocalAction($0)) },
+        fromScopedAction: { self.fromScopedAction(fromScopedAction($0)) },
         initialState: self.store.state.value,
         line: self.line,
         reducer: self.reducer,
-        toLocalState: { toLocalState(self.toLocalState($0)) }
+        toScopedState: { toScopedState(self.toScopedState($0)) }
       )
     }
 
-    /// Scopes a store to assert against more local state.
+    /// Scopes a store to assert against scoped state.
     ///
     /// Useful for testing view store-specific state.
     ///
-    /// - Parameter toLocalState: A function that transforms the reducer's state into more local
-    ///   state. This state will be asserted against as it is mutated by the reducer. Useful for
-    ///   testing view store state transformations.
+    /// - Parameter toScopedState: A function that transforms the reducer's state into scoped state.
+    ///   This state will be asserted against as it is mutated by the reducer. Useful for testing
+    ///   view store state transformations.
     public func scope<S>(
-      state toLocalState: @escaping (LocalState) -> S
-    ) -> TestStore<State, S, Action, LocalAction, Environment> {
-      self.scope(state: toLocalState, action: { $0 })
+      state toScopedState: @escaping (ScopedState) -> S
+    ) -> TestStore<State, S, Action, ScopedAction, Environment> {
+      self.scope(state: toScopedState, action: { $0 })
     }
   }
 

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -123,7 +123,7 @@ public final class ViewStore<State, Action>: ObservableObject {
   }
 
   /// Returns the resulting value of a given key path.
-  public subscript<LocalState>(dynamicMember keyPath: KeyPath<State, LocalState>) -> LocalState {
+  public subscript<Value>(dynamicMember keyPath: KeyPath<State, Value>) -> Value {
     self._state.value[keyPath: keyPath]
   }
 
@@ -328,17 +328,16 @@ public final class ViewStore<State, Action>: ObservableObject {
   /// ```
   ///
   /// - Parameters:
-  ///   - get: A function to get the state for the binding from the view
-  ///     store's full state.
-  ///   - localStateToViewAction: A function that transforms the binding's value
-  ///     into an action that can be sent to the store.
+  ///   - get: A function to get the state for the binding from the view store's full state.
+  ///   - valueToAction: A function that transforms the binding's value into an action that can be
+  ///     sent to the store.
   /// - Returns: A binding.
-  public func binding<LocalState>(
-    get: @escaping (State) -> LocalState,
-    send localStateToViewAction: @escaping (LocalState) -> Action
-  ) -> Binding<LocalState> {
+  public func binding<Value>(
+    get: @escaping (State) -> Value,
+    send valueToAction: @escaping (Value) -> Action
+  ) -> Binding<Value> {
     ObservedObject(wrappedValue: self)
-      .projectedValue[get: .init(rawValue: get), send: .init(rawValue: localStateToViewAction)]
+      .projectedValue[get: .init(rawValue: get), send: .init(rawValue: valueToAction)]
   }
 
   /// Derives a binding from the store that prevents direct writes to state and instead sends
@@ -366,10 +365,10 @@ public final class ViewStore<State, Action>: ObservableObject {
   ///   - get: A function to get the state for the binding from the view store's full state.
   ///   - action: The action to send when the binding is written to.
   /// - Returns: A binding.
-  public func binding<LocalState>(
-    get: @escaping (State) -> LocalState,
+  public func binding<Value>(
+    get: @escaping (State) -> Value,
     send action: Action
-  ) -> Binding<LocalState> {
+  ) -> Binding<Value> {
     self.binding(get: get, send: { _ in action })
   }
 
@@ -395,13 +394,13 @@ public final class ViewStore<State, Action>: ObservableObject {
   /// ```
   ///
   /// - Parameters:
-  ///   - localStateToViewAction: A function that transforms the binding's value
-  ///     into an action that can be sent to the store.
+  ///   - valueToAction: A function that transforms the binding's value into an action that can be
+  ///     sent to the store.
   /// - Returns: A binding.
   public func binding(
-    send localStateToViewAction: @escaping (State) -> Action
+    send valueToAction: @escaping (State) -> Action
   ) -> Binding<State> {
-    self.binding(get: { $0 }, send: localStateToViewAction)
+    self.binding(get: { $0 }, send: valueToAction)
   }
 
   /// Derives a binding from the store that prevents direct writes to state and instead sends
@@ -431,10 +430,10 @@ public final class ViewStore<State, Action>: ObservableObject {
     self.binding(send: { _ in action })
   }
 
-  private subscript<LocalState>(
-    get state: HashableWrapper<(State) -> LocalState>,
-    send action: HashableWrapper<(LocalState) -> Action>
-  ) -> LocalState {
+  private subscript<Value>(
+    get state: HashableWrapper<(State) -> Value>,
+    send action: HashableWrapper<(Value) -> Action>
+  ) -> Value {
     get { state.rawValue(self.state) }
     set { self.send(action.rawValue(newValue)) }
   }
@@ -525,9 +524,9 @@ public struct StorePublisher<State>: Publisher {
   }
 
   /// Returns the resulting publisher of a given key path.
-  public subscript<LocalState: Equatable>(
-    dynamicMember keyPath: KeyPath<State, LocalState>
-  ) -> StorePublisher<LocalState> {
+  public subscript<Value: Equatable>(
+    dynamicMember keyPath: KeyPath<State, Value>
+  ) -> StorePublisher<Value> {
     .init(upstream: self.upstream.map(keyPath).removeDuplicates(), viewStore: self.viewStore)
   }
 }


### PR DESCRIPTION
We use "Global" and "Local" to describe transformations between domains, but it can be confusing because "global" doesn't feel very relative without a "more [global]" qualifying it. Let's instead adopt more relative terminology. For the most part this means global-local becomes parent-child, and in other cases I've updated the terminology to be more domain-specific.

Also snuck a few small cleanup fixes in this PR.
