### PR TITLE
Require sendable cancel ID.

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -205,7 +205,7 @@ extension Task where Success == Never, Failure == Never {
   /// Cancel any currently in-flight operation with the given identifier.
   ///
   /// - Parameter id: An identifier.
-  public static func cancel(id: AnyHashable) async {
+  public static func cancel<ID: Hashable & Sendable>(id: ID) async {
     await MainActor.run {
       cancellablesLock.sync { cancellationCancellables[.init(id: id)]?.forEach { $0.cancel() } }
     }


### PR DESCRIPTION
Fixes a concurrency warning in Cancellation.swift. There's a lot more work to do in this file before it's ready for Swift 6, but this was an easy one.