### PR TITLE
Add multiple functions to merge/concatenate effects and/or its outputs

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -340,6 +340,105 @@ extension Effect {
     .merge(effects)
   }
 
+  /// Merges a variadic list of effects together into a single effect, which runs the effects at the
+  /// same time.
+  ///
+  /// - Parameter effects: A list of effects.
+  /// - Returns: A new effect
+  public func merge(_ effects: Self...) -> Self {
+    self.merge(effects)
+  }
+
+  /// Merges another effect together into a single effect, which runs the effects at the
+  /// same time.
+  ///
+  /// - Parameter effect: An effect.
+  /// - Returns: A new effect
+  public func merge(_ effect: Effect) -> Effect {
+    .merge(self, effect)
+  }
+
+  /// Merges an effect array together into a single effect, which runs the effects at the
+  /// same time.
+  ///
+  /// - Parameter effects: An array of effects.
+  /// - Returns: A new effect
+  public func merge(_ effects: [Effect]) -> Effect {
+    self.merge(Effect.merge(effects))
+  }
+
+  /// Merges an effect array returned by a closure together into a single effect,
+  /// which runs the effects at the same time.
+  ///
+  /// - Parameter effects: A closure returns an effect array.
+  /// - Returns: A new effect
+  public func merge(_ effects: @escaping () -> [Effect]) -> Effect {
+    self.merge(Effect.merge(effects()))
+  }
+
+  /// Merges an effect array returned by a closure together into a single effect,
+  /// which runs the effects at the same time.
+  ///
+  /// - Parameter effects: A closure returns an effect array.
+  /// - Returns: A new effect
+  public static func merge(_ effects: @escaping () -> [Effect]) -> Effect {
+    .merge(effects())
+  }
+
+  /// Transfers a variadic list of outputs into effects and merges together into a single effect,
+  /// which runs the effects at the same time.
+  ///
+  /// - Parameter outputs: A list of outputs.
+  /// - Returns: A new effect
+  public func mergeOutputs(_ outputs: Output...) -> Effect {
+    self.merge(outputs.map(Effect.init(value:)))
+  }
+
+  /// Transfers a variadic list of outputs into effects and merges together into a single effect,
+  /// which runs the effects at the same time.
+  ///
+  /// - Parameter outputs: A list of outputs.
+  /// - Returns: A new effect
+  public static func mergeOutputs(_ outputs: Output...) -> Effect {
+    .merge(outputs.map(Effect.init(value:)))
+  }
+
+  /// Transfers an output array into effects and merges together into a single effect,
+  /// which runs the effects at the same time.
+  ///
+  /// - Parameter outputs: An array of outputs.
+  /// - Returns: A new effect
+  public func mergeOutputs(_ outputs: [Output]) -> Effect {
+    self.merge(outputs.map(Effect.init(value:)))
+  }
+
+  /// Transfers an output array into effects and merges together into a single effect,
+  /// which runs the effects at the same time.
+  ///
+  /// - Parameter outputs: An array of outputs.
+  /// - Returns: A new effect
+  public static func mergeOutputs(_ outputs: [Output]) -> Effect {
+    .merge(outputs.map(Effect.init(value:)))
+  }
+
+  /// Transfers an output array returned by a closure into effects and merges together into a single effect,
+  /// which runs the effects at the same time.
+  ///
+  /// - Parameter outputs: A closure returns an output array.
+  /// - Returns: A new effect
+  public func mergeOutputs(_ outputs: @escaping () -> [Output]) -> Effect {
+    self.merge(outputs().map(Effect.init(value:)))
+  }
+
+  /// Transfers an output array returned by a closure into effects and merges together into a single effect,
+  /// which runs the effects at the same time.
+  ///
+  /// - Parameter outputs: A closure returns an output array.
+  /// - Returns: A new effect
+  public static func mergeOutputs(_ outputs: @escaping () -> [Output]) -> Effect {
+    .merge(outputs().map(Effect.init(value:)))
+  }
+
   /// Merges a sequence of effects together into a single effect, which runs the effects at the same
   /// time.
   ///

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -463,6 +463,153 @@ extension Effect {
     .concatenate(effects)
   }
 
+  /// Concatenates a variadic list of effects together into a single effect, which runs the effects
+  /// one after the other.
+  ///
+  /// - Warning: Combine's `Publishers.Concatenate` operator, which this function uses, can leak
+  ///   when its suffix is a `Publishers.MergeMany` operator, which is used throughout the
+  ///   Composable Architecture in functions like ``Reducer/combine(_:)-1ern2``.
+  ///
+  ///   Feedback filed: <https://gist.github.com/mbrandonw/611c8352e1bd1c22461bd505e320ab58>
+  ///
+  /// - Parameter effects: A variadic list of effects.
+  /// - Returns: A new effect
+  public func concatenate(_ effects: Self...) -> Self {
+    self.concatenate(effects)
+  }
+
+  /// Concatenates another effect together into a single effect, which runs the effects
+  /// one after the other.
+  ///
+  /// - Parameter effect: Another effect.
+  /// - Returns: A new effect
+  public func concatenate(_ effect: Effect) -> Effect {
+    Effect.concatenate(self, effect)
+  }
+
+  /// Concatenates an effect array together into a single effect, which runs the effects
+  /// one after the other.
+  ///
+  /// - Warning: Combine's `Publishers.Concatenate` operator, which this function uses, can leak
+  ///   when its suffix is a `Publishers.MergeMany` operator, which is used throughout the
+  ///   Composable Architecture in functions like ``Reducer/combine(_:)-1ern2``.
+  ///
+  ///   Feedback filed: <https://gist.github.com/mbrandonw/611c8352e1bd1c22461bd505e320ab58>
+  ///
+  /// - Parameter effects: An array of effects.
+  /// - Returns: A new effect
+  public func concatenate(_ effects: [Effect]) -> Effect {
+    self.concatenate(Effect.concatenate(effects))
+  }
+
+  /// Concatenates an effect array returned by a closure together into a single effect, which runs the effects
+  /// one after the other.
+  ///
+  /// - Warning: Combine's `Publishers.Concatenate` operator, which this function uses, can leak
+  ///   when its suffix is a `Publishers.MergeMany` operator, which is used throughout the
+  ///   Composable Architecture in functions like ``Reducer/combine(_:)-1ern2``.
+  ///
+  ///   Feedback filed: <https://gist.github.com/mbrandonw/611c8352e1bd1c22461bd505e320ab58>
+  ///
+  /// - Parameter effects: A closure returns an effect array.
+  /// - Returns: A new effect
+  public func concatenate(_ effects: @escaping () -> [Effect]) -> Effect {
+    self.concatenate(Effect.concatenate(effects()))
+  }
+
+  /// Concatenates an effect array returned by a closure together into a single effect, which runs the effects
+  /// one after the other.
+  ///
+  /// - Warning: Combine's `Publishers.Concatenate` operator, which this function uses, can leak
+  ///   when its suffix is a `Publishers.MergeMany` operator, which is used throughout the
+  ///   Composable Architecture in functions like ``Reducer/combine(_:)-1ern2``.
+  ///
+  ///   Feedback filed: <https://gist.github.com/mbrandonw/611c8352e1bd1c22461bd505e320ab58>
+  ///
+  /// - Parameter effects: A closure returns an effect array.
+  /// - Returns: A new effect
+  public static func concatenate(_ effects: @escaping () -> [Effect]) -> Effect {
+    Effect.concatenate(effects())
+  }
+
+  /// Transfers a variadic list of outputs into effects and concatenates together into a single effect,
+  /// which runs the effects one after the other.
+  ///
+  /// - Parameter effects: A list of outputs.
+  /// - Returns: A new effect
+  public func concatenateOutputs(_ outputs: Output...) -> Effect {
+    self.concatenate(outputs.map(Effect.init(value:)))
+  }
+
+  /// Transfers a variadic list of outputs into effects and concatenates together into a single effect,
+  /// which runs the effects one after the other.
+  ///
+  /// - Warning: Combine's `Publishers.Concatenate` operator, which this function uses, can leak
+  ///   when its suffix is a `Publishers.MergeMany` operator, which is used throughout the
+  ///   Composable Architecture in functions like ``Reducer/combine(_:)-1ern2``.
+  ///
+  ///   Feedback filed: <https://gist.github.com/mbrandonw/611c8352e1bd1c22461bd505e320ab58>
+  ///
+  /// - Parameter effects: A list of outputs.
+  /// - Returns: A new effect
+  public static func concatenateOutputs(_ outputs: Output...) -> Effect {
+    .concatenate(outputs.map(Effect.init(value:)))
+  }
+
+  /// Transfers an output array into effects and concatenates together into a single effect,
+  /// which runs the effects one after the other.
+  ///
+  /// - Warning: Combine's `Publishers.Concatenate` operator, which this function uses, can leak
+  ///   when its suffix is a `Publishers.MergeMany` operator, which is used throughout the
+  ///   Composable Architecture in functions like ``Reducer/combine(_:)-1ern2``.
+  ///
+  ///   Feedback filed: <https://gist.github.com/mbrandonw/611c8352e1bd1c22461bd505e320ab58>
+  ///
+  /// - Parameter effects: An array of outputs.
+  /// - Returns: A new effect
+  public func concatenateOutputs(_ outputs: [Output]) -> Effect {
+    self.concatenate(outputs.map(Effect.init(value:)))
+  }
+
+  /// Transfers an output array into effects and concatenates together into a single effect,
+  /// which runs the effects one after the other.
+  ///
+  /// - Warning: Combine's `Publishers.Concatenate` operator, which this function uses, can leak
+  ///   when its suffix is a `Publishers.MergeMany` operator, which is used throughout the
+  ///   Composable Architecture in functions like ``Reducer/combine(_:)-1ern2``.
+  ///
+  ///   Feedback filed: <https://gist.github.com/mbrandonw/611c8352e1bd1c22461bd505e320ab58>
+  ///
+  /// - Parameter effects: An array of outputs.
+  /// - Returns: A new effect
+  public static func concatenateOutputs(_ outputs: [Output]) -> Effect {
+    .concatenate(outputs.map(Effect.init(value:)))
+  }
+
+  /// Transfers an output array returned by a closure into effects and concatenates together into a single effect,
+  /// which runs the effects one after the other.
+  ///
+  /// - Warning: Combine's `Publishers.Concatenate` operator, which this function uses, can leak
+  ///   when its suffix is a `Publishers.MergeMany` operator, which is used throughout the
+  ///   Composable Architecture in functions like ``Reducer/combine(_:)-1ern2``.
+  ///
+  ///   Feedback filed: <https://gist.github.com/mbrandonw/611c8352e1bd1c22461bd505e320ab58>
+  ///
+  /// - Parameter effects: A closure returns an output array.
+  /// - Returns: A new effect
+  public func concatenateOutputs(_ outputs: @escaping () -> [Output]) -> Effect {
+    self.concatenate(outputs().map(Effect.init(value:)))
+  }
+
+  /// Transfers an output array returned by a closure into effects and concatenates together into a single effect,
+  /// which runs the effects one after the other.
+  ///
+  /// - Parameter effects: A closure returns an output array.
+  /// - Returns: A new effect
+  public static func concatenateOutputs(_ outputs: @escaping () -> [Output]) -> Effect {
+    .merge(outputs().map(Effect.init(value:)))
+  }
+
   /// Concatenates a collection of effects together into a single effect, which runs the effects one
   /// after the other.
   ///

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -80,7 +80,7 @@ final class EffectTests: XCTestCase {
   func testConcatenateOneEffect() {
     var values: [Int] = []
 
-    let effect = Effect<Int, Never>.concatenate(
+    let effect: Effect<Int, Never> = Effect.concatenate(
       Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect()
     )
 
@@ -93,6 +93,216 @@ final class EffectTests: XCTestCase {
 
     self.mainQueue.run()
     XCTAssertNoDifference(values, [1])
+  }
+
+  func testConcatenateWithChainingList() {
+    let effect: Effect<Int, Never> = Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect()
+      .concatenate(
+        Effect(value: 2).delay(for: 2, scheduler: mainQueue).eraseToEffect(),
+        Effect(value: 3).delay(for: 3, scheduler: mainQueue).eraseToEffect()
+      )
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1])
+
+    self.mainQueue.advance(by: 2)
+    XCTAssertNoDifference(values, [1, 2])
+
+    self.mainQueue.advance(by: 3)
+    XCTAssertNoDifference(values, [1, 2, 3])
+
+    self.mainQueue.run()
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testConcatenateByChaining() {
+    let effect: Effect<Int, Never> = Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect()
+      .concatenate(Effect(value: 2).delay(for: 2, scheduler: mainQueue).eraseToEffect())
+      .concatenate(Effect(value: 3).delay(for: 3, scheduler: mainQueue).eraseToEffect())
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1])
+
+    self.mainQueue.advance(by: 2)
+    XCTAssertNoDifference(values, [1, 2])
+
+    self.mainQueue.advance(by: 3)
+    XCTAssertNoDifference(values, [1, 2, 3])
+
+    self.mainQueue.run()
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testConcatenateWithArray() {
+    let effect = Effect<Int, Never>.concatenate(
+      [
+        Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect(),
+        Effect(value: 2).delay(for: 2, scheduler: mainQueue).eraseToEffect(),
+        Effect(value: 3).delay(for: 3, scheduler: mainQueue).eraseToEffect()
+      ]
+    )
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1])
+
+    self.mainQueue.advance(by: 2)
+    XCTAssertNoDifference(values, [1, 2])
+
+    self.mainQueue.advance(by: 3)
+    XCTAssertNoDifference(values, [1, 2, 3])
+
+    self.mainQueue.run()
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testConcatenateWithClosure() {
+    let effect = Effect<Int, Never>.concatenate {
+      [
+        Effect(value: 1).delay(for: 1, scheduler: self.mainQueue).eraseToEffect(),
+        Effect(value: 2).delay(for: 2, scheduler: self.mainQueue).eraseToEffect(),
+        Effect(value: 3).delay(for: 3, scheduler: self.mainQueue).eraseToEffect()
+      ]
+    }
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1])
+
+    self.mainQueue.advance(by: 2)
+    XCTAssertNoDifference(values, [1, 2])
+
+    self.mainQueue.advance(by: 3)
+    XCTAssertNoDifference(values, [1, 2, 3])
+
+    self.mainQueue.run()
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testConcatenateWithChainingArray() {
+    let effect: Effect<Int, Never> = Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect()
+      .concatenate(
+        [
+          Effect(value: 2).delay(for: 2, scheduler: mainQueue).eraseToEffect(),
+          Effect(value: 3).delay(for: 3, scheduler: mainQueue).eraseToEffect()
+        ]
+      )
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1])
+
+    self.mainQueue.advance(by: 2)
+    XCTAssertNoDifference(values, [1, 2])
+
+    self.mainQueue.advance(by: 3)
+    XCTAssertNoDifference(values, [1, 2, 3])
+
+    self.mainQueue.run()
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testConcatenateWithChainingClosure() {
+    let effect: Effect<Int, Never> = Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect()
+      .concatenate {
+        [
+          Effect(value: 2).delay(for: 2, scheduler: self.mainQueue).eraseToEffect(),
+          Effect(value: 3).delay(for: 3, scheduler: self.mainQueue).eraseToEffect()
+        ]
+      }
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1])
+
+    self.mainQueue.advance(by: 2)
+    XCTAssertNoDifference(values, [1, 2])
+
+    self.mainQueue.advance(by: 3)
+    XCTAssertNoDifference(values, [1, 2, 3])
+
+    self.mainQueue.run()
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testConcatenateOutputs() {
+    let effect = Effect<Int, Never>.concatenateOutputs(1, 2, 3)
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testConcatenateChainingOutputs() {
+    let effect: Effect<Int, Never> = Effect(value: 1).concatenateOutputs(2, 3)
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testConcatenateWithOutputArray() {
+    let effect: Effect<Int, Never> = Effect.concatenateOutputs([1, 2, 3])
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testConcatenateWithChainingOutputArray() {
+    let effect: Effect<Int, Never> = Effect(value: 1).concatenateOutputs([2, 3])
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testConcatenateWithOutputClosure() {
+    let effect: Effect<Int, Never> = Effect.concatenateOutputs { [1, 2, 3] }
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testConcatenateWithChainingOutputClosure() {
+    let effect: Effect<Int, Never> = Effect(value: 1).concatenateOutputs { [2, 3] }
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [1, 2, 3])
   }
 
   func testMerge() {

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -117,6 +117,216 @@ final class EffectTests: XCTestCase {
     XCTAssertNoDifference(values, [1, 2, 3])
   }
 
+  func testMergeOneEffect() {
+    var values: [Int] = []
+
+    let effect: Effect<Int, Never> = Effect.merge(
+      Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect()
+    )
+
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1])
+
+    self.mainQueue.run()
+    XCTAssertNoDifference(values, [1])
+  }
+
+  func testMergeWithChainingList() {
+    let effect: Effect<Int, Never> = Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect()
+      .merge(
+        Effect(value: 2).delay(for: 2, scheduler: mainQueue).eraseToEffect(),
+        Effect(value: 3).delay(for: 3, scheduler: mainQueue).eraseToEffect()
+      )
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1, 2])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testMergeByChaining() {
+    let effect: Effect<Int, Never> = Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect()
+      .merge(Effect(value: 2).delay(for: 2, scheduler: mainQueue).eraseToEffect())
+      .merge(Effect(value: 3).delay(for: 3, scheduler: mainQueue).eraseToEffect())
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1, 2])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testMergeWithArray() {
+    let effect = Effect<Int, Never>.merge(
+      [
+        Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect(),
+        Effect(value: 2).delay(for: 2, scheduler: mainQueue).eraseToEffect(),
+        Effect(value: 3).delay(for: 3, scheduler: mainQueue).eraseToEffect()
+      ]
+    )
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1, 2])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testMergeWithClosure() {
+    let effect = Effect<Int, Never>.merge {
+      [
+        Effect(value: 1).delay(for: 1, scheduler: self.mainQueue).eraseToEffect(),
+        Effect(value: 2).delay(for: 2, scheduler: self.mainQueue).eraseToEffect(),
+        Effect(value: 3).delay(for: 3, scheduler: self.mainQueue).eraseToEffect()
+      ]
+    }
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1, 2])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testMergeWithChainingArray() {
+    let effect: Effect<Int, Never> = Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect()
+      .merge(
+        [
+          Effect(value: 2).delay(for: 2, scheduler: mainQueue).eraseToEffect(),
+          Effect(value: 3).delay(for: 3, scheduler: mainQueue).eraseToEffect()
+        ]
+      )
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1, 2])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testMergeWithChainingClosure() {
+    let effect: Effect<Int, Never> = Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect()
+      .merge {
+        [
+          Effect(value: 2).delay(for: 2, scheduler: self.mainQueue).eraseToEffect(),
+          Effect(value: 3).delay(for: 3, scheduler: self.mainQueue).eraseToEffect()
+        ]
+      }
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1, 2])
+
+    self.mainQueue.advance(by: 1)
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testMergeOutputs() {
+    let effect = Effect<Int, Never>.mergeOutputs(1, 2, 3)
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testMergeChainingOutputs() {
+    let effect: Effect<Int, Never> = Effect(value: 1).mergeOutputs(2, 3)
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testMergeWithOutputArray() {
+    let effect: Effect<Int, Never> = Effect.mergeOutputs([1, 2, 3])
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testMergeWithChainingOutputArray() {
+    let effect: Effect<Int, Never> = Effect(value: 1).mergeOutputs([2, 3])
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testMergeWithOutputClosure() {
+    let effect: Effect<Int, Never> = Effect.mergeOutputs { [1, 2, 3] }
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
+  func testMergeWithChainingOutputClosure() {
+    let effect: Effect<Int, Never> = Effect(value: 1).mergeOutputs { [2, 3] }
+
+    var values: [Int] = []
+    effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
+
+    XCTAssertNoDifference(values, [1, 2, 3])
+  }
+
   func testEffectSubscriberInitializer() {
     let effect = Effect<Int, Never>.run { subscriber in
       subscriber.send(1)


### PR DESCRIPTION
Enhance the ways (array/closure) to merge/concatenate effects and/or its outputs and add instance functions for chaining.

with array/closure, we can merge different effects/outputs by the conditions:

```Swift
let effect: Effect<Int, Never> = Effect.merge {
  if condition {
    return [Effect(value: 1)]
  } else {
    return [Effect(value: 1), Effect(value: 2)]
  }
}
```

merge the effects with its outputs:

```Swift
enum ExampleAction {
    case action1
    case action2
    case action3
  }

// Instead of:
let mergedEffect: Effect<ExampleAction, Never> = Effect.merge(
  Effect(value: .action1),
  Effect(value: .action2),
  Effect(value: .action3),
)

// We can:
let mergedEffectWithActions: Effect<ExampleAction, Never> = Effect.mergeOutputs(.action1, .action2, .action3)
```

and we can chain the effects/outputs in different ways:

```Swift
let mergedEffect: Effect<ExampleAction, Never> = Effect.mergeOutputs(.action1, .action2).concatenateOutputs(.action3)
```