### PR TITLE
Add previewValue to DependencyKey, and fixed build errors on Xcode 13.

### DIFF
--- a/Examples/SpeechRecognition/SpeechRecognition.xcodeproj/project.pbxproj
+++ b/Examples/SpeechRecognition/SpeechRecognition.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		CA2332122447ACFA00B818EB /* SpeechRecognition.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2332112447ACFA00B818EB /* SpeechRecognition.swift */; };
 		CA2332142447ACFB00B818EB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CA2332132447ACFB00B818EB /* Assets.xcassets */; };
 		CA2332252447ACFC00B818EB /* SpeechRecognitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2332242447ACFC00B818EB /* SpeechRecognitionTests.swift */; };
+		CA98A19028B3FB0B00F9CBC9 /* Lorem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA98A18F28B3FB0B00F9CBC9 /* Lorem.swift */; };
 		CACC04222447C66C000C5725 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACC04212447C66C000C5725 /* Client.swift */; };
 		CACC04242447D96D000C5725 /* Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACC04232447D96D000C5725 /* Live.swift */; };
 		CACC04272447DBAF000C5725 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACC04262447DBAF000C5725 /* Models.swift */; };
@@ -60,6 +61,7 @@
 		CA2332202447ACFC00B818EB /* SpeechRecognitionTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SpeechRecognitionTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA2332242447ACFC00B818EB /* SpeechRecognitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognitionTests.swift; sourceTree = "<group>"; };
 		CA23322F2447AE0300B818EB /* swift-composable-architecture */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "swift-composable-architecture"; path = ../..; sourceTree = "<group>"; };
+		CA98A18F28B3FB0B00F9CBC9 /* Lorem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lorem.swift; sourceTree = "<group>"; };
 		CACC04212447C66C000C5725 /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
 		CACC04232447D96D000C5725 /* Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Live.swift; sourceTree = "<group>"; };
 		CACC04262447DBAF000C5725 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
@@ -131,6 +133,7 @@
 			children = (
 				CACC04212447C66C000C5725 /* Client.swift */,
 				CACC04232447D96D000C5725 /* Live.swift */,
+				CA98A18F28B3FB0B00F9CBC9 /* Lorem.swift */,
 				CACC04262447DBAF000C5725 /* Models.swift */,
 				CACC04282447DF0B000C5725 /* Unimplemented.swift */,
 			);
@@ -247,6 +250,7 @@
 				CACC04292447DF0B000C5725 /* Unimplemented.swift in Sources */,
 				CA2332102447ACFA00B818EB /* SpeechRecognitionApp.swift in Sources */,
 				CA2332122447ACFA00B818EB /* SpeechRecognition.swift in Sources */,
+				CA98A19028B3FB0B00F9CBC9 /* Lorem.swift in Sources */,
 				CACC04222447C66C000C5725 /* Client.swift in Sources */,
 				CACC04272447DBAF000C5725 /* Models.swift in Sources */,
 			);

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Client.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Client.swift
@@ -1,4 +1,5 @@
 import Combine
+import Dependencies
 import Speech
 
 struct SpeechClient {
@@ -14,4 +15,16 @@ struct SpeechClient {
     case couldntStartAudioEngine
     case couldntConfigureAudioSession
   }
+}
+
+extension DependencyValues {
+  var speechClient: SpeechClient {
+    get { self[SpeechClientKey.self] }
+    set { self[SpeechClientKey.self] = newValue }
+  }
+}
+
+enum SpeechClientKey: LiveDependencyKey {
+  static let previewValue = SpeechClient.lorem
+  static let testValue = SpeechClient.unimplemented
 }

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Live.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Live.swift
@@ -2,16 +2,8 @@ import Combine
 import ComposableArchitecture
 import Speech
 
-extension DependencyValues {
-  var speechClient: SpeechClient {
-    get { self[SpeechClientKey.self] }
-    set { self[SpeechClientKey.self] = newValue }
-  }
-
-  private enum SpeechClientKey: LiveDependencyKey {
-    static let liveValue = SpeechClient.live
-    static let testValue = SpeechClient.unimplemented
-  }
+extension SpeechClientKey {
+  static let liveValue = SpeechClient.live
 }
 
 extension SpeechClient {

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Lorem.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Lorem.swift
@@ -1,0 +1,50 @@
+import ComposableArchitecture
+
+extension SpeechClient {
+  static var lorem: Self {
+    let isRecording = ActorIsolated(false)
+
+    return Self(
+      finishTask: { await isRecording.setValue(false) },
+      requestAuthorization: { .authorized },
+      startTask: { _ in
+          .init { c in
+            Task {
+              await isRecording.setValue(true)
+              var finalText = """
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor \
+              incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud \
+              exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute \
+              irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla \
+              pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui \
+              officia deserunt mollit anim id est laborum.
+              """
+              var text = ""
+              while await isRecording.value {
+                let word = finalText.prefix { $0 != " " }
+                try await Task.sleep(
+                  nanoseconds: UInt64(word.count) * NSEC_PER_MSEC * 50
+                  + .random(in: 0...(NSEC_PER_MSEC * 200))
+                )
+                finalText.removeFirst(word.count)
+                if finalText.first == " " {
+                  finalText.removeFirst()
+                }
+                text += word + " "
+                c.yield(
+                  .init(
+                    bestTranscription: .init(
+                      formattedString: text,
+                      segments: []
+                    ),
+                    isFinal: false,
+                    transcriptions: []
+                  )
+                )
+              }
+            }
+          }
+      }
+    )
+  }
+}

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
@@ -153,57 +153,7 @@ struct SpeechRecognitionView_Previews: PreviewProvider {
       store: Store(
         initialState: SpeechRecognition.State(transcribedText: "Test test 123"),
         reducer: SpeechRecognition()
-          .dependency(\.speechClient, .lorem)
       )
-    )
-  }
-}
-
-extension SpeechClient {
-  static var lorem: Self {
-    let isRecording = ActorIsolated(false)
-
-    return Self(
-      finishTask: { await isRecording.setValue(false) },
-      requestAuthorization: { .authorized },
-      startTask: { _ in
-        .init { c in
-          Task {
-            await isRecording.setValue(true)
-            var finalText = """
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor \
-              incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud \
-              exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute \
-              irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla \
-              pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui \
-              officia deserunt mollit anim id est laborum.
-              """
-            var text = ""
-            while await isRecording.value {
-              let word = finalText.prefix { $0 != " " }
-              try await Task.sleep(
-                nanoseconds: UInt64(word.count) * NSEC_PER_MSEC * 50
-                  + .random(in: 0...(NSEC_PER_MSEC * 200))
-              )
-              finalText.removeFirst(word.count)
-              if finalText.first == " " {
-                finalText.removeFirst()
-              }
-              text += word + " "
-              c.yield(
-                .init(
-                  bestTranscription: .init(
-                    formattedString: text,
-                    segments: []
-                  ),
-                  isFinal: false,
-                  transcriptions: []
-                )
-              )
-            }
-          }
-        }
-      }
     )
   }
 }

--- a/Examples/VoiceMemos/VoiceMemos.xcodeproj/project.pbxproj
+++ b/Examples/VoiceMemos/VoiceMemos.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CA8A72EB28B402CD00074C85 /* MockAudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8A72EA28B402CD00074C85 /* MockAudioPlayer.swift */; };
+		CA8A72ED28B402E700074C85 /* MockAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8A72EC28B402E700074C85 /* MockAudioRecorder.swift */; };
 		CA93D05C249BF42500A6F65D /* VoiceMemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA93D05B249BF42500A6F65D /* VoiceMemo.swift */; };
 		CA93D05E249BF46E00A6F65D /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA93D05D249BF46E00A6F65D /* Helpers.swift */; };
 		CABAB49028A2B5F900122307 /* RecordingMemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABAB48F28A2B5F900122307 /* RecordingMemo.swift */; };
@@ -59,10 +61,12 @@
 
 /* Begin PBXFileReference section */
 		23EDBE6B271CD8DD004F7430 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		CA8A72EA28B402CD00074C85 /* MockAudioPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAudioPlayer.swift; sourceTree = "<group>"; };
+		CA8A72EC28B402E700074C85 /* MockAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAudioRecorder.swift; sourceTree = "<group>"; };
 		CA93D05B249BF42500A6F65D /* VoiceMemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMemo.swift; sourceTree = "<group>"; };
 		CA93D05D249BF46E00A6F65D /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
-		DC52A00F288F01B30092F7DB /* Dependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dependencies.swift; sourceTree = "<group>"; };
 		CABAB48F28A2B5F900122307 /* RecordingMemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingMemo.swift; sourceTree = "<group>"; };
+		DC52A00F288F01B30092F7DB /* Dependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dependencies.swift; sourceTree = "<group>"; };
 		DC5BDCAA24589177009C65A3 /* VoiceMemos.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VoiceMemos.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC5BDCAF24589177009C65A3 /* VoiceMemosApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMemosApp.swift; sourceTree = "<group>"; };
 		DC5BDCB124589177009C65A3 /* VoiceMemos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMemos.swift; sourceTree = "<group>"; };
@@ -148,6 +152,7 @@
 			children = (
 				DC5BDF352458939C009C65A3 /* AudioRecorderClient.swift */,
 				DC5BDF39245893C1009C65A3 /* LiveAudioRecorderClient.swift */,
+				CA8A72EC28B402E700074C85 /* MockAudioRecorder.swift */,
 				DC94F0112458E0AA00082DE9 /* UnimplementedAudioRecorderClient.swift */,
 			);
 			path = AudioRecorderClient;
@@ -158,6 +163,7 @@
 			children = (
 				DC5BDF3C245893E6009C65A3 /* AudioPlayerClient.swift */,
 				DC5BDF3E24589406009C65A3 /* LiveAudioPlayerClient.swift */,
+				CA8A72EA28B402CD00074C85 /* MockAudioPlayer.swift */,
 				DC94F00F2458E09900082DE9 /* UnimplementedAudioPlayerClient.swift */,
 			);
 			path = AudioPlayerClient;
@@ -271,12 +277,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				DC5BDF362458939C009C65A3 /* AudioRecorderClient.swift in Sources */,
+				CA8A72EB28B402CD00074C85 /* MockAudioPlayer.swift in Sources */,
 				DC94F0122458E0AA00082DE9 /* UnimplementedAudioRecorderClient.swift in Sources */,
 				DC5BDF3D245893E6009C65A3 /* AudioPlayerClient.swift in Sources */,
 				CA93D05E249BF46E00A6F65D /* Helpers.swift in Sources */,
 				DC5BDF3A245893C1009C65A3 /* LiveAudioRecorderClient.swift in Sources */,
 				DC5BDF3F24589406009C65A3 /* LiveAudioPlayerClient.swift in Sources */,
 				DC52A010288F01B30092F7DB /* Dependencies.swift in Sources */,
+				CA8A72ED28B402E700074C85 /* MockAudioRecorder.swift in Sources */,
 				DC94F0102458E09900082DE9 /* UnimplementedAudioPlayerClient.swift in Sources */,
 				CA93D05C249BF42500A6F65D /* VoiceMemo.swift in Sources */,
 				DC5BDCB024589177009C65A3 /* VoiceMemosApp.swift in Sources */,

--- a/Examples/VoiceMemos/VoiceMemos/AudioPlayerClient/AudioPlayerClient.swift
+++ b/Examples/VoiceMemos/VoiceMemos/AudioPlayerClient/AudioPlayerClient.swift
@@ -1,18 +1,18 @@
 import Dependencies
 import Foundation
 
+struct AudioPlayerClient {
+  var play: @Sendable (URL) async throws -> Bool
+}
+
+enum AudioPlayerClientKey: DependencyKey {
+  static var previewValue = AudioPlayerClient.mock
+  static let testValue = AudioPlayerClient.unimplemented
+}
+
 extension DependencyValues {
   var audioPlayer: AudioPlayerClient {
     get { self[AudioPlayerClientKey.self] }
     set { self[AudioPlayerClientKey.self] = newValue }
   }
-
-  private enum AudioPlayerClientKey: LiveDependencyKey {
-    static let liveValue = AudioPlayerClient.live
-    static let testValue = AudioPlayerClient.unimplemented
-  }
-}
-
-struct AudioPlayerClient {
-  var play: @Sendable (URL) async throws -> Bool
 }

--- a/Examples/VoiceMemos/VoiceMemos/AudioPlayerClient/LiveAudioPlayerClient.swift
+++ b/Examples/VoiceMemos/VoiceMemos/AudioPlayerClient/LiveAudioPlayerClient.swift
@@ -1,4 +1,9 @@
 @preconcurrency import AVFoundation
+import Dependencies
+
+extension AudioPlayerClientKey: LiveDependencyKey {
+  static let liveValue = AudioPlayerClient.live
+}
 
 extension AudioPlayerClient {
   static let live = Self { url in

--- a/Examples/VoiceMemos/VoiceMemos/AudioPlayerClient/MockAudioPlayer.swift
+++ b/Examples/VoiceMemos/VoiceMemos/AudioPlayerClient/MockAudioPlayer.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension AudioPlayerClient {
+  static let mock = Self(
+    play: { _ in
+      try await Task.sleep(nanoseconds: NSEC_PER_SEC * 5)
+      return true
+    }
+  )
+}

--- a/Examples/VoiceMemos/VoiceMemos/AudioRecorderClient/AudioRecorderClient.swift
+++ b/Examples/VoiceMemos/VoiceMemos/AudioRecorderClient/AudioRecorderClient.swift
@@ -1,21 +1,21 @@
 import Dependencies
 import Foundation
 
-extension DependencyValues {
-  var audioRecorder: AudioRecorderClient {
-    get { self[AudioRecorderClientKey.self] }
-    set { self[AudioRecorderClientKey.self] = newValue }
-  }
-
-  private enum AudioRecorderClientKey: LiveDependencyKey {
-    static let liveValue = AudioRecorderClient.live
-    static let testValue = AudioRecorderClient.unimplemented
-  }
-}
-
 struct AudioRecorderClient {
   var currentTime: @Sendable () async -> TimeInterval?
   var requestRecordPermission: @Sendable () async -> Bool
   var startRecording: @Sendable (URL) async throws -> Bool
   var stopRecording: @Sendable () async -> Void
+}
+
+enum AudioRecorderClientKey: DependencyKey {
+  static var previewValue = AudioRecorderClient.mock
+  static let testValue = AudioRecorderClient.unimplemented
+}
+
+extension DependencyValues {
+  var audioRecorder: AudioRecorderClient {
+    get { self[AudioRecorderClientKey.self] }
+    set { self[AudioRecorderClientKey.self] = newValue }
+  }
 }

--- a/Examples/VoiceMemos/VoiceMemos/AudioRecorderClient/LiveAudioRecorderClient.swift
+++ b/Examples/VoiceMemos/VoiceMemos/AudioRecorderClient/LiveAudioRecorderClient.swift
@@ -2,6 +2,10 @@ import AVFoundation
 import ComposableArchitecture  // TODO: Should `UncheckedSendable` live in `Dependencies`?
 import Foundation
 
+extension AudioRecorderClientKey: LiveDependencyKey {
+  static let liveValue = AudioRecorderClient.live
+}
+
 extension AudioRecorderClient {
   static var live: Self {
     let audioRecorder = AudioRecorder()

--- a/Examples/VoiceMemos/VoiceMemos/AudioRecorderClient/MockAudioRecorder.swift
+++ b/Examples/VoiceMemos/VoiceMemos/AudioRecorderClient/MockAudioRecorder.swift
@@ -1,0 +1,26 @@
+import ComposableArchitecture
+import Foundation
+
+extension AudioRecorderClient {
+  static var mock: Self {
+    let isRecording = ActorIsolated(false)
+    let currentTime = ActorIsolated(0.0)
+
+    return Self(
+      currentTime: { await currentTime.value },
+      requestRecordPermission: { true },
+      startRecording: { _ in
+        await isRecording.setValue(true)
+        while await isRecording.value {
+          try await Task.sleep(nanoseconds: NSEC_PER_SEC)
+          await currentTime.withValue { $0 += 1 }
+        }
+        return true
+      },
+      stopRecording: {
+        await isRecording.setValue(false)
+        await currentTime.setValue(0)
+      }
+    )
+  }
+}

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -233,44 +233,7 @@ struct VoiceMemos_Previews: PreviewProvider {
           ]
         ),
         reducer: VoiceMemos()
-          .dependency(\.audioPlayer, .mock)
-          .dependency(\.audioRecorder, .mock)
-          .dependency(\.openSettings) {}
       )
     )
-    .environment(\.colorScheme, .dark)
   }
-}
-
-extension AudioRecorderClient {
-  static var mock: Self {
-    let isRecording = ActorIsolated(false)
-    let currentTime = ActorIsolated(0.0)
-
-    return Self(
-      currentTime: { await currentTime.value },
-      requestRecordPermission: { true },
-      startRecording: { _ in
-        await isRecording.setValue(true)
-        while await isRecording.value {
-          try await Task.sleep(nanoseconds: NSEC_PER_SEC)
-          await currentTime.withValue { $0 += 1 }
-        }
-        return true
-      },
-      stopRecording: {
-        await isRecording.setValue(false)
-        await currentTime.setValue(0)
-      }
-    )
-  }
-}
-
-extension AudioPlayerClient {
-  static let mock = Self(
-    play: { _ in
-      try await Task.sleep(nanoseconds: NSEC_PER_SEC * 5)
-      return true
-    }
-  )
 }

--- a/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
+++ b/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
@@ -9,7 +9,7 @@ import XCTestDynamicOverlay
 final class VoiceMemosTests: XCTestCase {
   let mainRunLoop = RunLoop.test
 
-  func testRecordMemoHappyPath() async {
+  func testRecordMemoHappyPath() async throws {
     // NB: Combine's concatenation behavior is different in 13.3
     guard #available(iOS 13.4, *) else { return }
 
@@ -59,7 +59,9 @@ final class VoiceMemosTests: XCTestCase {
       $0.recordingMemo?.duration = 2.5
     }
     await store.receive(.recordingMemo(.audioRecorderDidFinish(.success(true))))
-    await store.receive(.recordingMemo(.delegate(.didFinish(.success(store.state.recordingMemo!)))))
+    try await store.receive(
+      .recordingMemo(.delegate(.didFinish(.success(XCTUnwrap(store.state.recordingMemo)))))
+    )
     {
       $0.recordingMemo = nil
       $0.voiceMemos = [

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1003,7 +1003,11 @@
 
   class TestReducer<Base: ReducerProtocol>: ReducerProtocol {
     let base: Base
-    var dependencies = DependencyValues(isTesting: true)
+    var dependencies = { () -> DependencyValues in
+      var dependencies = DependencyValues()
+      dependencies.environment = .test
+      return dependencies
+    }()
     var inFlightEffects: Set<LongLivingEffect> = []
     var receivedActions: [(action: Base.Action, state: Base.State)] = []
     var state: Base.State

--- a/Sources/Dependencies/Dependencies/Calendar.swift
+++ b/Sources/Dependencies/Dependencies/Calendar.swift
@@ -1,7 +1,7 @@
 import Foundation
 import XCTestDynamicOverlay
 
-#if swift(>=5.7)
+#if swift(>=5.6)
   extension DependencyValues {
     /// The current calendar that reducers should use when handling dates.
     public var calendar: Calendar {

--- a/Sources/Dependencies/Dependencies/Calendar.swift
+++ b/Sources/Dependencies/Dependencies/Calendar.swift
@@ -1,18 +1,20 @@
 import Foundation
 import XCTestDynamicOverlay
 
-extension DependencyValues {
-  /// The current calendar that reducers should use when handling dates.
-  public var calendar: Calendar {
-    get { self[CalendarKey.self] }
-    set { self[CalendarKey.self] = newValue }
-  }
+#if swift(>=5.7)
+  extension DependencyValues {
+    /// The current calendar that reducers should use when handling dates.
+    public var calendar: Calendar {
+      get { self[CalendarKey.self] }
+      set { self[CalendarKey.self] = newValue }
+    }
 
-  private enum CalendarKey: LiveDependencyKey {
-    static let liveValue = Calendar.autoupdatingCurrent
-    static var testValue: Calendar {
-      XCTFail(#"Unimplemented: @Dependency(\.calendar)"#)
-      return .autoupdatingCurrent
+    private enum CalendarKey: LiveDependencyKey {
+      static let liveValue = Calendar.autoupdatingCurrent
+      static var testValue: Calendar {
+        XCTFail(#"Unimplemented: @Dependency(\.calendar)"#)
+        return .autoupdatingCurrent
+      }
     }
   }
-}
+#endif

--- a/Sources/Dependencies/Dependencies/Date.swift
+++ b/Sources/Dependencies/Dependencies/Date.swift
@@ -1,59 +1,61 @@
 import Foundation
 import XCTestDynamicOverlay
 
-extension DependencyValues {
-  /// A dependency that returns the current date.
-  public var date: any DateGenerator {
-    get { self[DateGeneratorKey.self] }
-    set { self[DateGeneratorKey.self] = newValue }
+#if swift(>=5.7)
+  extension DependencyValues {
+    /// A dependency that returns the current date.
+    public var date: any DateGenerator {
+      get { self[DateGeneratorKey.self] }
+      set { self[DateGeneratorKey.self] = newValue }
+    }
+
+    private enum DateGeneratorKey: LiveDependencyKey {
+      // TODO: Benchmark difference between existential overhead vs. struct with non-inlined closures.
+      static let liveValue: any DateGenerator = LiveDateGenerator()
+      static let testValue: any DateGenerator = UnimplementedDateGenerator()
+    }
   }
 
-  private enum DateGeneratorKey: LiveDependencyKey {
-    // TODO: Benchmark difference between existential overhead vs. struct with non-inlined closures.
-    static let liveValue: any DateGenerator = LiveDateGenerator()
-    static let testValue: any DateGenerator = UnimplementedDateGenerator()
+  // TODO: use struct instead, and same for UUID
+  public protocol DateGenerator: Sendable {
+    func callAsFunction() -> Date
   }
-}
 
-// TODO: use struct instead, and same for UUID
-public protocol DateGenerator: Sendable {
-  func callAsFunction() -> Date
-}
-
-extension DateGenerator where Self == LiveDateGenerator {
-  public static var live: Self { Self() }
-}
-
-public struct LiveDateGenerator: DateGenerator {
-  @inlinable
-  public func callAsFunction() -> Date {
-    Date()
+  extension DateGenerator where Self == LiveDateGenerator {
+    public static var live: Self { Self() }
   }
-}
 
-public struct ConstantDateGenerator: DateGenerator {
-  public let constant: Date
-  public init(_ constant: Date) {
-    self.constant = constant
+  public struct LiveDateGenerator: DateGenerator {
+    @inlinable
+    public func callAsFunction() -> Date {
+      Date()
+    }
   }
-  @inlinable
-  public func callAsFunction() -> Date {
-    self.constant
+
+  public struct ConstantDateGenerator: DateGenerator {
+    public let constant: Date
+    public init(_ constant: Date) {
+      self.constant = constant
+    }
+    @inlinable
+    public func callAsFunction() -> Date {
+      self.constant
+    }
   }
-}
 
-extension DateGenerator where Self == ConstantDateGenerator {
-  public static func constant(_ date: Date) -> Self { .init(date) }
-}
-
-extension DateGenerator where Self == UnimplementedDateGenerator {
-  public static var unimplemented: Self { Self() }
-}
-
-public struct UnimplementedDateGenerator: DateGenerator {
-  @inlinable
-  public func callAsFunction() -> Date {
-    XCTFail(#"Unimplemented: @Dependency(\.date)"#)
-    return Date()
+  extension DateGenerator where Self == ConstantDateGenerator {
+    public static func constant(_ date: Date) -> Self { .init(date) }
   }
-}
+
+  extension DateGenerator where Self == UnimplementedDateGenerator {
+    public static var unimplemented: Self { Self() }
+  }
+
+  public struct UnimplementedDateGenerator: DateGenerator {
+    @inlinable
+    public func callAsFunction() -> Date {
+      XCTFail(#"Unimplemented: @Dependency(\.date)"#)
+      return Date()
+    }
+  }
+#endif

--- a/Sources/Dependencies/Dependencies/Date.swift
+++ b/Sources/Dependencies/Dependencies/Date.swift
@@ -1,7 +1,7 @@
 import Foundation
 import XCTestDynamicOverlay
 
-#if swift(>=5.7)
+#if swift(>=5.6)
   extension DependencyValues {
     /// A dependency that returns the current date.
     public var date: any DateGenerator {

--- a/Sources/Dependencies/Dependencies/Locale.swift
+++ b/Sources/Dependencies/Dependencies/Locale.swift
@@ -1,18 +1,20 @@
 import Foundation
 import XCTestDynamicOverlay
 
-extension DependencyValues {
-  /// The current locale that reducers should use.
-  public var locale: Locale {
-    get { self[LocaleKey.self] }
-    set { self[LocaleKey.self] = newValue }
-  }
+#if swift(>=5.6)
+  extension DependencyValues {
+    /// The current locale that reducers should use.
+    public var locale: Locale {
+      get { self[LocaleKey.self] }
+      set { self[LocaleKey.self] = newValue }
+    }
 
-  private enum LocaleKey: LiveDependencyKey {
-    static let liveValue = Locale.autoupdatingCurrent
-    static var testValue: Locale {
-      XCTFail(#"Unimplemented: @Dependency(\.locale)"#)
-      return .autoupdatingCurrent
+    private enum LocaleKey: LiveDependencyKey {
+      static let liveValue = Locale.autoupdatingCurrent
+      static var testValue: Locale {
+        XCTFail(#"Unimplemented: @Dependency(\.locale)"#)
+        return .autoupdatingCurrent
+      }
     }
   }
-}
+#endif

--- a/Sources/Dependencies/Dependencies/TimeZone.swift
+++ b/Sources/Dependencies/Dependencies/TimeZone.swift
@@ -1,18 +1,20 @@
 import Foundation
 import XCTestDynamicOverlay
 
-extension DependencyValues {
-  /// The current time zone that reducers should use when handling dates.
-  public var timeZone: TimeZone {
-    get { self[TimeZoneKey.self] }
-    set { self[TimeZoneKey.self] = newValue }
-  }
+#if swift(>=5.6)
+  extension DependencyValues {
+    /// The current time zone that reducers should use when handling dates.
+    public var timeZone: TimeZone {
+      get { self[TimeZoneKey.self] }
+      set { self[TimeZoneKey.self] = newValue }
+    }
 
-  private enum TimeZoneKey: LiveDependencyKey {
-    static let liveValue = TimeZone.autoupdatingCurrent
-    static var testValue: TimeZone {
-      XCTFail(#"Unimplemented: @Dependency(\.timeZone)"#)
-      return .autoupdatingCurrent
+    private enum TimeZoneKey: LiveDependencyKey {
+      static let liveValue = TimeZone.autoupdatingCurrent
+      static var testValue: TimeZone {
+        XCTFail(#"Unimplemented: @Dependency(\.timeZone)"#)
+        return .autoupdatingCurrent
+      }
     }
   }
-}
+#endif

--- a/Sources/Dependencies/DependencyKey.swift
+++ b/Sources/Dependencies/DependencyKey.swift
@@ -3,7 +3,12 @@ public protocol DependencyKey {
   // NB: This associated type should be constrained to `Sendable` when this bug is fixed:
   //     https://github.com/apple/swift/issues/60649
 
+  static var previewValue: Value { get }
   static var testValue: Value { get }
+}
+
+extension DependencyKey {
+  public static var previewValue: Value { Self.testValue }
 }
 
 public protocol LiveDependencyKey: DependencyKey {

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -33,12 +33,11 @@ public struct DependencyValues: Sendable {
         let mode =
           self.storage[ObjectIdentifier(EnvironmentKey.self)]?.base as? Environment
           ?? {
-            #if DEBUG
-              if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" {
-                return Environment.preview
-              }
+            if isPreview {
+              return Environment.preview
+            } else {
               return Environment.live
-            #endif
+            }
           }()
 
         switch mode {
@@ -90,3 +89,14 @@ extension DependencyValues {
     set { self[EnvironmentKey.self] = newValue }
   }
 }
+
+private var isPreview = { () -> Bool in
+  #if DEBUG
+    if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" {
+      return true
+    }
+    return false
+  #else
+    return false
+  #endif
+}()

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -90,13 +90,8 @@ extension DependencyValues {
   }
 }
 
-private var isPreview = { () -> Bool in
-  #if DEBUG
-    if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" {
-      return true
-    }
-    return false
-  #else
-    return false
-  #endif
-}()
+#if DEBUG
+  private let isPreview = ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
+#else
+  private let isPreview = false
+#endif

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -15,7 +15,7 @@ import Foundation
 /// @Dependency(\.date) var date
 /// ```
 public struct DependencyValues: Sendable {
-  public enum Environment {
+  public enum Environment: Sendable {
     case live, preview, test
   }
 


### PR DESCRIPTION
Based on a [conversation](https://github.com/pointfreeco/swift-composable-architecture/discussions/1282#discussioncomment-3449849) in #1282, we now allow people to also supply a `previewValue` when conforming to `DependencyKey` which will be used in Xcode previews only. If no `previewValue` is provided it will default to the `testValue`.

I also fixed some errors that prevented TCA from compiling in Xcode 13. This is for the core library only. The case studies and some demo apps will only compile on Xcode 14 since we want to only show the most modern way of interacting with the library in those projects.