### PR TITLE
Add `now` convenience property to date dependency

### DIFF
--- a/Sources/Dependencies/Dependencies/Date.swift
+++ b/Sources/Dependencies/Dependencies/Date.swift
@@ -4,19 +4,31 @@ import XCTestDynamicOverlay
 #if swift(>=5.6)
   extension DependencyValues {
     /// A dependency that returns the current date.
-  ///
-  /// By default, a ``DateGenerator/live`` generator is supplied. When used from a `TestStore`, an
-  /// ``DateGenerator/unimplemented`` generator is supplied, unless explicitly overridden, for
-  /// example using a ``DateGenerator/constant(_:)`` generator:
-  ///
-  /// ```swift
-  /// let store = TestStore(
-  ///   initialState: MyFeature.State()
-  ///   reducer: My.Feature()
-  /// )
-  ///
-  /// store.dependencies.date = .constant(Date(timeIntervalSince1970: 0))
-  /// ```
+    ///
+    /// By default, a ``DateGenerator/live`` generator is supplied. When used from a `TestStore`, an
+    /// ``DateGenerator/unimplemented`` generator is supplied, unless explicitly overridden.
+    ///
+    /// You can access the current date from a reducer by introducing a `Dependency` property
+    /// wrapper to the generator's ``DateGenerator/now`` property:
+    ///
+    /// ```swift
+    /// struct MyFeature: ReducerProtocol {
+    ///   @Dependency(\.date.now) var now
+    ///   // ...
+    /// }
+    /// ```
+    ///
+    /// To override the current date in tests, you can assign the generator's ``DateGenerator/now``
+    /// property:
+    ///
+    /// ```swift
+    /// let store = TestStore(
+    ///   initialState: MyFeature.State()
+    ///   reducer: My.Feature()
+    /// )
+    ///
+    /// store.dependencies.date.now = Date(timeIntervalSince1970: 0)
+    /// ```
     public var date: DateGenerator {
       get { self[DateGeneratorKey.self] }
       set { self[DateGeneratorKey.self] = newValue }
@@ -28,27 +40,33 @@ import XCTestDynamicOverlay
     }
   }
 
-/// A dependency that generates a date.
-///
-/// See ``DependencyValues/date`` for more information.
-  public struct DateGenerator: Sendable {
-    private let generate: @Sendable () -> Date
-
-  /// A generator that returns a constant date.
+  /// A dependency that generates a date.
   ///
-  /// - Parameter now: A date to return.
-  /// - Returns: A generator that always returns the given date.
+  /// See ``DependencyValues/date`` for more information.
+  public struct DateGenerator: Sendable {
+    private var generate: @Sendable () -> Date
+
+    /// A generator that returns a constant date.
+    ///
+    /// - Parameter now: A date to return.
+    /// - Returns: A generator that always returns the given date.
     public static func constant(_ now: Date) -> Self {
       Self { now }
     }
 
-  /// A generator that calls `Date()` under the hood.
+    /// A generator that calls `Date()` under the hood.
     public static let live = Self { Date() }
 
-  /// A generator that calls `XCTFail` when it is invoked.
+    /// A generator that calls `XCTFail` when it is invoked.
     public static let unimplemented = Self {
       XCTFail(#"Unimplemented: @Dependency(\.date)"#)
       return Date()
+    }
+
+    /// The current date.
+    public var now: Date {
+      get { self.generate() }
+      set { self.generate = { newValue } }
     }
 
     public func callAsFunction() -> Date {


### PR DESCRIPTION
Inspired by @Jeehut's https://github.com/pointfreeco/swift-composable-architecture/discussions/1282#discussioncomment-3456006, this PR adds a convenience `now` property to the date generator dependency.

This means you can use the friendlier, more modern `now` verbiage in your features and tests:

```swift
// In your reducer type:
@Dependency(\.date.now) var now

// In your reducer method/body:
self.now  // Date

// In your tests:
store.dependencies.date.now = Date(timeIntervalSince1970: 0)
```