### PR TITLE
LiveDependencyKey: DependencyKey -> DependencyKey: TestDependencyKey

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -53,7 +53,7 @@ extension DependencyValues {
     set { self[ScreenshotsKeys.self] = newValue }
   }
 
-  private enum ScreenshotsKeys: LiveDependencyKey {
+  private enum ScreenshotsKeys: DependencyKey {
     static let liveValue: @Sendable () async -> AsyncStream<Void> = {
       await AsyncStream(
         NotificationCenter.default

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -181,7 +181,7 @@ extension DependencyValues {
     set { self[WebSocketKey.self] = newValue }
   }
 
-  private enum WebSocketKey: LiveDependencyKey {
+  private enum WebSocketKey: DependencyKey {
     static let liveValue = WebSocketClient.live
     static let testValue = WebSocketClient.unimplemented
   }

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadClient.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadClient.swift
@@ -18,7 +18,7 @@ extension DependencyValues {
     set { self[DownloadClientKey.self] = newValue }
   }
 
-  private enum DownloadClientKey: LiveDependencyKey {
+  private enum DownloadClientKey: DependencyKey {
     static let liveValue = DownloadClient.live
     static let testValue = DownloadClient.unimplemented
   }

--- a/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
@@ -12,7 +12,7 @@ extension DependencyValues {
     set { self[FactClientKey.self] = newValue }
   }
 
-  private enum FactClientKey: LiveDependencyKey {
+  private enum FactClientKey: DependencyKey {
     static let liveValue = FactClient.live
     static let testValue = FactClient.unimplemented
   }

--- a/Examples/Search/Search/WeatherClient.swift
+++ b/Examples/Search/Search/WeatherClient.swift
@@ -49,7 +49,7 @@ extension DependencyValues {
     set { self[WeatherClientKey.self] = newValue }
   }
 
-  private enum WeatherClientKey: LiveDependencyKey {
+  private enum WeatherClientKey: DependencyKey {
     static let liveValue = WeatherClient.live
     static let testValue = WeatherClient.unimplemented
   }

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Client.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Client.swift
@@ -24,7 +24,7 @@ extension DependencyValues {
   }
 }
 
-enum SpeechClientKey: DependencyKey {
+enum SpeechClientKey: TestDependencyKey {
   static let previewValue = SpeechClient.lorem
   static let testValue = SpeechClient.unimplemented
 }

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Live.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Live.swift
@@ -2,7 +2,7 @@ import Combine
 import ComposableArchitecture
 import Speech
 
-extension SpeechClientKey: LiveDependencyKey {
+extension SpeechClientKey: DependencyKey {
   static let liveValue = SpeechClient.live
 }
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/AuthenticationClient/AuthenticationClient.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/AuthenticationClient/AuthenticationClient.swift
@@ -7,7 +7,8 @@ extension DependencyValues {
     get { self[AuthenticationClientKey.self] }
     set { self[AuthenticationClientKey.self] = newValue }
   }
-  public enum AuthenticationClientKey: DependencyKey {
+
+  public enum AuthenticationClientKey: TestDependencyKey {
     public static var testValue = AuthenticationClient.unimplemented
   }
 }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/AuthenticationClientLive/LiveAuthenticationClient.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/AuthenticationClientLive/LiveAuthenticationClient.swift
@@ -2,7 +2,7 @@ import AuthenticationClient
 import Dependencies
 import Foundation
 
-extension DependencyValues.AuthenticationClientKey: LiveDependencyKey {
+extension DependencyValues.AuthenticationClientKey: DependencyKey {
   public static let liveValue = AuthenticationClient.live
 }
 

--- a/Examples/VoiceMemos/VoiceMemos/AudioPlayerClient/AudioPlayerClient.swift
+++ b/Examples/VoiceMemos/VoiceMemos/AudioPlayerClient/AudioPlayerClient.swift
@@ -5,7 +5,7 @@ struct AudioPlayerClient {
   var play: @Sendable (URL) async throws -> Bool
 }
 
-enum AudioPlayerClientKey: DependencyKey {
+enum AudioPlayerClientKey: TestDependencyKey {
   static var previewValue = AudioPlayerClient.mock
   static let testValue = AudioPlayerClient.unimplemented
 }

--- a/Examples/VoiceMemos/VoiceMemos/AudioPlayerClient/LiveAudioPlayerClient.swift
+++ b/Examples/VoiceMemos/VoiceMemos/AudioPlayerClient/LiveAudioPlayerClient.swift
@@ -1,7 +1,7 @@
 @preconcurrency import AVFoundation
 import Dependencies
 
-extension AudioPlayerClientKey: LiveDependencyKey {
+extension AudioPlayerClientKey: DependencyKey {
   static let liveValue = AudioPlayerClient.live
 }
 

--- a/Examples/VoiceMemos/VoiceMemos/AudioRecorderClient/AudioRecorderClient.swift
+++ b/Examples/VoiceMemos/VoiceMemos/AudioRecorderClient/AudioRecorderClient.swift
@@ -8,7 +8,7 @@ struct AudioRecorderClient {
   var stopRecording: @Sendable () async -> Void
 }
 
-enum AudioRecorderClientKey: DependencyKey {
+enum AudioRecorderClientKey: TestDependencyKey {
   static var previewValue = AudioRecorderClient.mock
   static let testValue = AudioRecorderClient.unimplemented
 }

--- a/Examples/VoiceMemos/VoiceMemos/AudioRecorderClient/LiveAudioRecorderClient.swift
+++ b/Examples/VoiceMemos/VoiceMemos/AudioRecorderClient/LiveAudioRecorderClient.swift
@@ -2,7 +2,7 @@ import AVFoundation
 import ComposableArchitecture  // TODO: Should `UncheckedSendable` live in `Dependencies`?
 import Foundation
 
-extension AudioRecorderClientKey: LiveDependencyKey {
+extension AudioRecorderClientKey: DependencyKey {
   static let liveValue = AudioRecorderClient.live
 }
 

--- a/Examples/VoiceMemos/VoiceMemos/Dependencies.swift
+++ b/Examples/VoiceMemos/VoiceMemos/Dependencies.swift
@@ -8,7 +8,7 @@ extension DependencyValues {
     set { self[OpenSettingsKey.self] = newValue }
   }
 
-  private enum OpenSettingsKey: LiveDependencyKey {
+  private enum OpenSettingsKey: DependencyKey {
     typealias Value = @Sendable () async -> Void
 
     static let liveValue: @Sendable () async -> Void = {
@@ -26,7 +26,7 @@ extension DependencyValues {
     set { self[TemporaryDirectoryKey.self] = newValue }
   }
 
-  private enum TemporaryDirectoryKey: LiveDependencyKey {
+  private enum TemporaryDirectoryKey: DependencyKey {
     static let liveValue: @Sendable () -> URL = { URL(fileURLWithPath: NSTemporaryDirectory()) }
     static let testValue: @Sendable () -> URL = XCTUnimplemented(
       #"@Dependency(\.temporaryDirectory"#,

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Dependencies.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Dependencies.md
@@ -190,12 +190,12 @@ times when you want to register your own dependencies with the library so that y
 `@Dependency` property wrapper. Doing this is quite similar to registering an environment value
 in SwiftUI (see [docs][environment-values-docs]).
 
-First you create a type that conforms to the [`DependencyKey`][dependency-key-docs] protocol.
-The only requirement is that you provide a `testValue`, which will be the version of the dependency
-used when your feature is run in a ``TestStore``:
+First you create a type that conforms to the [`TestDependencyKey`][test-dependency-key-docs]
+protocol. The only requirement is that you provide a `testValue`, which will be the version of the
+dependency used when your feature is run in a ``TestStore``:
 
 ```swift
-private enum APIClientKey: DependencyKey {
+private enum APIClientKey: TestDependencyKey {
   static let testValue = APIClient.unimplemented
 }
 ```
@@ -205,15 +205,17 @@ that triggers an `XCTFail` anytime one of its endpoints is invoked. This makes i
 stub the bare minimum of the dependency's interface, allowing you to prove that your test flow
 doesn't interact with any other endpoints.
 
-Next you extend the key to also conform to the [`LiveDependencyKey`][live-dependency-key-docs] 
-protocol, which will be the version of the dependency used when your feature is run in an Xcode
-preview, in the simulator, or on a device:
+Next you extend the key to also conform to the [`DependencyKey`][dependency-key-docs] protocol,
+which will be the version of the dependency used when your feature is run in an Xcode preview, in
+the simulator, or on a device:
 
 ```swift
-extension APIClientKey: LiveDependencyKey {
+extension APIClientKey: DependencyKey {
   static let liveValue = APIClient.live
 }
 ```
+
+<!-- TODO: Document `previewValue` -->
 
 This is the version of the dependency that can actually interact with outside systems. In this
 case it means the API client can actually make network requests to an external server.
@@ -270,5 +272,5 @@ func testFetchUser() async {
 [swift-identified-collections]: https://github.com/pointfreeco/swift-identified-collections
 [dependency-property-wrapper-docs]: todo: get url
 [environment-values-docs]: https://developer.apple.com/documentation/swiftui/environmentvalues
+[test-dependency-key-docs]: todo: get url
 [dependency-key-docs]: todo: get url
-[live-dependency-key-docs]: todo: get url

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToReducerProtocols.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToReducerProtocols.md
@@ -292,7 +292,7 @@ dependency with the system, and then it will be automatically available to every
 application:
 
 ```swift
-private enum APIClientKey: LiveDependencyKey {
+private enum APIClientKey: DependencyKey {
   static let liveValue = APIClient.live
   static let testValue = APIClient.unimplemented
 }

--- a/Sources/ComposableArchitecture/Internal/TypeName.swift
+++ b/Sources/ComposableArchitecture/Internal/TypeName.swift
@@ -4,11 +4,12 @@ func typeName(_ type: Any.Type) -> String {
   if let index = name.firstIndex(of: ".") {
     name.removeSubrange(...index)
   }
-  return
+  let sanitizedName =
     name
     .replacingOccurrences(
       of: #"<.+>|\(unknown context at \$[[:xdigit:]]+\)\."#,
       with: "",
       options: .regularExpression
     )
+  return sanitizedName
 }

--- a/Sources/Dependencies/Dependencies/Calendar.swift
+++ b/Sources/Dependencies/Dependencies/Calendar.swift
@@ -6,7 +6,7 @@ import XCTestDynamicOverlay
     /// The current calendar that reducers should use when handling dates.
     ///
     /// By default, the calendar returned from `Calendar.autoupdatingCurrent` is supplied. When used
-    /// from a ``TestStore``, access will call to `XCTFail` when invoked, unless explicitly
+    /// from a `TestStore`, access will call to `XCTFail` when invoked, unless explicitly
     /// overridden:
     ///
     /// ```swift
@@ -22,7 +22,7 @@ import XCTestDynamicOverlay
       set { self[CalendarKey.self] = newValue }
     }
 
-    private enum CalendarKey: LiveDependencyKey {
+    private enum CalendarKey: DependencyKey {
       static let liveValue = Calendar.autoupdatingCurrent
       static var testValue: Calendar {
         XCTFail(#"Unimplemented: @Dependency(\.calendar)"#)

--- a/Sources/Dependencies/Dependencies/Date.swift
+++ b/Sources/Dependencies/Dependencies/Date.swift
@@ -34,7 +34,7 @@ import XCTestDynamicOverlay
       set { self[DateGeneratorKey.self] = newValue }
     }
 
-    private enum DateGeneratorKey: LiveDependencyKey {
+    private enum DateGeneratorKey: DependencyKey {
       static let liveValue: DateGenerator = .live
       static let testValue: DateGenerator = .unimplemented
     }

--- a/Sources/Dependencies/Dependencies/Locale.swift
+++ b/Sources/Dependencies/Dependencies/Locale.swift
@@ -6,7 +6,7 @@ import XCTestDynamicOverlay
     /// The current locale that reducers should use.
     ///
     /// By default, the locale returned from `Locale.autoupdatingCurrent` is supplied. When used
-    /// from a ``TestStore``, access will call to `XCTFail` when invoked, unless explicitly
+    /// from a `TestStore`, access will call to `XCTFail` when invoked, unless explicitly
     /// overridden:
     ///
     /// ```swift
@@ -22,7 +22,7 @@ import XCTestDynamicOverlay
       set { self[LocaleKey.self] = newValue }
     }
 
-    private enum LocaleKey: LiveDependencyKey {
+    private enum LocaleKey: DependencyKey {
       static let liveValue = Locale.autoupdatingCurrent
       static var testValue: Locale {
         XCTFail(#"Unimplemented: @Dependency(\.locale)"#)

--- a/Sources/Dependencies/Dependencies/MainQueue.swift
+++ b/Sources/Dependencies/Dependencies/MainQueue.swift
@@ -70,7 +70,7 @@
       set { self[MainQueueKey.self] = newValue }
     }
 
-    private enum MainQueueKey: LiveDependencyKey {
+    private enum MainQueueKey: DependencyKey {
       static let liveValue = AnySchedulerOf<DispatchQueue>.main
       static let testValue = AnySchedulerOf<DispatchQueue>
         .unimplemented(#"@Dependency(\.mainQueue)"#)

--- a/Sources/Dependencies/Dependencies/MainRunLoop.swift
+++ b/Sources/Dependencies/Dependencies/MainRunLoop.swift
@@ -70,7 +70,7 @@
       set { self[MainRunLoopKey.self] = newValue }
     }
 
-    private enum MainRunLoopKey: LiveDependencyKey {
+    private enum MainRunLoopKey: DependencyKey {
       static let liveValue = AnySchedulerOf<RunLoop>.main
       static let testValue = AnySchedulerOf<RunLoop>.unimplemented(#"@Dependency(\.mainRunLoop)"#)
     }

--- a/Sources/Dependencies/Dependencies/RandomNumberGenerator.swift
+++ b/Sources/Dependencies/Dependencies/RandomNumberGenerator.swift
@@ -67,7 +67,7 @@ extension DependencyValues {
     set { self[WithRandomNumberGeneratorKey.self] = newValue }
   }
 
-  private enum WithRandomNumberGeneratorKey: LiveDependencyKey {
+  private enum WithRandomNumberGeneratorKey: DependencyKey {
     static let liveValue = WithRandomNumberGenerator(SystemRandomNumberGenerator())
     static let testValue = WithRandomNumberGenerator(UnimplementedRandomNumberGenerator())
   }

--- a/Sources/Dependencies/Dependencies/TimeZone.swift
+++ b/Sources/Dependencies/Dependencies/TimeZone.swift
@@ -6,7 +6,7 @@ import XCTestDynamicOverlay
     /// The current time zone that reducers should use when handling dates.
     ///
     /// By default, the time zone returned from `TimeZone.autoupdatingCurrent` is supplied. When
-    /// used from a ``TestStore``, access will call to `XCTFail` when invoked, unless explicitly
+    /// used from a `TestStore`, access will call to `XCTFail` when invoked, unless explicitly
     /// overridden:
     ///
     /// ```swift
@@ -22,7 +22,7 @@ import XCTestDynamicOverlay
       set { self[TimeZoneKey.self] = newValue }
     }
 
-    private enum TimeZoneKey: LiveDependencyKey {
+    private enum TimeZoneKey: DependencyKey {
       static let liveValue = TimeZone.autoupdatingCurrent
       static var testValue: TimeZone {
         XCTFail(#"Unimplemented: @Dependency(\.timeZone)"#)

--- a/Sources/Dependencies/Dependencies/UUID.swift
+++ b/Sources/Dependencies/Dependencies/UUID.swift
@@ -75,7 +75,7 @@ extension DependencyValues {
     set { self[UUIDGeneratorKey.self] = newValue }
   }
 
-  private enum UUIDGeneratorKey: LiveDependencyKey {
+  private enum UUIDGeneratorKey: DependencyKey {
     static let liveValue: UUIDGenerator = .live
     static let testValue: UUIDGenerator = .unimplemented
   }

--- a/Sources/Dependencies/DependencyKey.swift
+++ b/Sources/Dependencies/DependencyKey.swift
@@ -3,14 +3,42 @@
 /// Similar to SwiftUI's `EnvironmentKey` protocol, which is used to extend `EnvironmentValues` with
 /// custom dependencies, `DependencyKey` can be used to extend ``DependencyValues``.
 ///
+/// `DependencyKey` has one main requirement, ``liveValue``, which must return a default value for
+/// use in your live application.
+///
+/// `DependencyKey` inherits two overridable requirements from ``TestDependencyKey``:
+/// ``TestDependencyKey/testValue``, which should return a default value for the purpose of
+/// testing, and ``TestDependencyKey/previewValue-416hu``, which can return a default value suitable
+/// for Xcode previews. When left unimplemented, these endpoints will return the ``liveValue``,
+/// instead.
+///
+/// If you plan on separating your interface from your live implementation, conform to
+/// ``TestDependencyKey`` in your interface module, and extend this conformance to `DependencyKey`
+/// in your implementation module.
+public protocol DependencyKey: TestDependencyKey {
+  /// The live value for the dependency key.
+  static var liveValue: Value { get }
+}
+
+extension DependencyKey {
+  /// A default implementation that provides the ``liveValue`` to Xcode previews.
+  public static var previewValue: Value { Self.liveValue }
+
+  /// A default implementation that provides the ``liveValue`` to tests.
+  public static var testValue: Value { Self.liveValue }
+}
+
+/// A "test" key for accessing dependencies.
+///
+/// This protocol lives one layer below ``DependencyKey`` and allows you to separate a dependency's
+/// interface from its live implementation.
+///
 /// `DependencyKey` has one main requirement, ``testValue``, which must return a default value for
-/// the purposes of testing, and one optional requirement, ``previewValue``, which can return a
-/// default value suitable for Xcode previews.
+/// the purposes of testing, and one optional requirement, ``previewValue-416hu``, which can return
+/// a default value suitable for Xcode previews, or the ``testValue``, if left unimplemented.
 ///
-/// See ``LiveDependencyKey`` to define a static, default value for the live application.
-///
-/// TODO: rename to TestDependencyKey
-public protocol DependencyKey {
+/// See ``DependencyKey`` to define a static, default value for the live application.
+public protocol TestDependencyKey {
   /// The associated type representing the type of the dependency key's value.
   associatedtype Value
   // NB: This associated type should be constrained to `Sendable` when this bug is fixed:
@@ -39,13 +67,7 @@ public protocol DependencyKey {
   static var testValue: Value { get }
 }
 
-extension DependencyKey {
+extension TestDependencyKey {
+  /// A default implementation that provides the ``testValue`` to Xcode previews.
   public static var previewValue: Value { Self.testValue }
-}
-
-/// A key for accessing live dependencies.
-///
-/// TODO: rename DependencyKey
-public protocol LiveDependencyKey: DependencyKey {
-  static var liveValue: Value { get }
 }

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -56,7 +56,7 @@ public struct DependencyValues: Sendable {
   /// You use custom dependency values the same way you use system-provided values, setting a value
   /// with the `ReducerProtocol/dependency(_:_:)` modifier, and reading values with the
   /// ``Dependency`` property wrapper.
-  public subscript<Key: DependencyKey>(
+  public subscript<Key: TestDependencyKey>(
     key: Key.Type,
     file: StaticString = #file,
     fileID: StaticString = #fileID,
@@ -83,10 +83,10 @@ public struct DependencyValues: Sendable {
                 Dependency:
                   %4$@
 
-              Every dependency registered with the library must conform to 'LiveDependencyKey', \
+              Every dependency registered with the library must conform to 'DependencyKey', \
               and that conformance must be visible to the running application.
 
-              To fix, make sure that '%3$@' conforms to 'LiveDependencyKey' by providing a live \
+              To fix, make sure that '%3$@' conforms to 'DependencyKey' by providing a live \
               implementation of your dependency, and make sure that the conformance is linked \
               with this current application.
               """,
@@ -123,7 +123,7 @@ extension DependencyValues {
     _modify { yield &self[IsTestingKey.self] }
   }
 
-  private enum IsTestingKey: LiveDependencyKey {
+  private enum IsTestingKey: DependencyKey {
     static let liveValue = false
     static var previewValue = false
     static let testValue = true
@@ -138,7 +138,7 @@ private struct AnySendable: @unchecked Sendable {
   }
 }
 
-private enum EnvironmentKey: LiveDependencyKey {
+private enum EnvironmentKey: DependencyKey {
   static var liveValue = DependencyValues.Environment.live
   static var previewValue = DependencyValues.Environment.preview
   static var testValue = DependencyValues.Environment.test

--- a/Sources/Dependencies/Internal/OpenExistential.swift
+++ b/Sources/Dependencies/Internal/OpenExistential.swift
@@ -2,10 +2,10 @@
   // MARK: swift(>=5.7)
   // MARK: Equatable
 
-  // MARK: LiveDependencyKey
+  // MARK: DependencyKey
 
   func _liveValue(_ key: Any.Type) -> Any? {
-    (key as? any LiveDependencyKey.Type)?.liveValue
+    (key as? any DependencyKey.Type)?.liveValue
   }
 #else
   // MARK: -
@@ -13,20 +13,20 @@
 
   private enum Witness<T> {}
 
-  // MARK: LiveDependencyKey
+  // MARK: DependencyKey
 
   func _liveValue(_ key: Any.Type) -> Any? {
     func open<T>(_: T.Type) -> Any? {
-      (Witness<T>.self as? AnyLiveDependencyKey.Type)?.liveValue
+      (Witness<T>.self as? AnyDependencyKey.Type)?.liveValue
     }
     return _openExistential(key, do: open)
   }
 
-  protocol AnyLiveDependencyKey {
+  protocol AnyDependencyKey {
     static var liveValue: Any { get }
   }
 
-  extension Witness: AnyLiveDependencyKey where T: LiveDependencyKey {
+  extension Witness: AnyDependencyKey where T: DependencyKey {
     static var liveValue: Any { T.liveValue }
   }
 #endif

--- a/Sources/Dependencies/Internal/TypeName.swift
+++ b/Sources/Dependencies/Internal/TypeName.swift
@@ -4,11 +4,12 @@ func typeName(_ type: Any.Type) -> String {
   if let index = name.firstIndex(of: ".") {
     name.removeSubrange(...index)
   }
-  return
-  name
+  let sanitizedName =
+    name
     .replacingOccurrences(
       of: #"<.+>|\(unknown context at \$[[:xdigit:]]+\)\."#,
       with: "",
       options: .regularExpression
     )
+  return sanitizedName
 }

--- a/Tests/ComposableArchitectureTests/DependencyKeyTests.swift
+++ b/Tests/ComposableArchitectureTests/DependencyKeyTests.swift
@@ -1,0 +1,33 @@
+import ComposableArchitecture
+import XCTest
+
+final class DependencyKeyTests: XCTestCase {
+  func testTestDependencyKeyDefaultPreviewValue() {
+    enum Key: TestDependencyKey {
+      typealias Value = Int
+      static let testValue = 42
+    }
+
+    XCTAssertEqual(42, Key.previewValue)
+  }
+
+  func testDependencyKeyDefaultValues() {
+    enum Key: DependencyKey {
+      typealias Value = Int
+      static let liveValue = 42
+    }
+
+    XCTAssertEqual(42, Key.previewValue)
+    XCTAssertEqual(42, Key.testValue)
+  }
+
+  func testDependencyKeyDefaultPreviewValue() {
+    enum Key: DependencyKey {
+      typealias Value = Int
+      static let liveValue = 42
+      static let testValue = 1729
+    }
+
+    XCTAssertEqual(42, Key.previewValue)
+  }
+}

--- a/Tests/ComposableArchitectureTests/DependencyKeyWritingReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/DependencyKeyWritingReducerTests.swift
@@ -94,7 +94,7 @@ private struct Feature: ReducerProtocol {
   }
 }
 
-private enum MyValue: LiveDependencyKey {
+private enum MyValue: DependencyKey {
   static let liveValue = 0
   static let testValue = 0
 }


### PR DESCRIPTION
This PR does a few breaking changes to the naming of the `DependencyKey` protocols:

- `DependencyKey` is now `TestDependencyKey` to emphasize that conforming to it directly is for the purpose of testing and separating interface from implementation. 
- `LiveDependencyKey` is now simply `DependencyKey`, which the Store expects a conformance to in production (and will issue runtime warnings if a dependency is accessed that only conforms to `TestDependencyKey`).