### PR TITLE
Update combine-schedulers and fix implicit Foundation imports.

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
@@ -1,5 +1,6 @@
 import Combine
 import ComposableArchitecture
+import Foundation
 import XCTestDynamicOverlay
 
 struct FactClient {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
   ],
   dependencies: [
     .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
-    .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "0.7.0"),
+    .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "0.7.3"),
     .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.8.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.3.0"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "0.3.2"),

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 
 extension Effect {
   /// Turns an effect into one that is capable of being canceled.

--- a/Sources/ComposableArchitecture/Effects/Throttling.swift
+++ b/Sources/ComposableArchitecture/Effects/Throttling.swift
@@ -1,5 +1,6 @@
 import Combine
 import Dispatch
+import Foundation
 
 extension Effect {
   /// Throttles an effect so that it only publishes one output per given interval.


### PR DESCRIPTION
We just made a [fix](https://github.com/pointfreeco/combine-schedulers/commit/9e42b4b0453da417a44daa17174103e7d1c5be07) to combine-schedulers that was breaking DocC builds from Xcode since beta 4. But, that exposed a few spots we were implicitly using that Foundation import, so let's make things more explicit.