### PR TITLE
Use `memcmp` to improve `ForEachStore`'s performance

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -94,7 +94,10 @@ public struct ForEachStore<
   {
     self.data = store.state.value
     self.content = {
-      WithViewStore(store.scope(state: { $0.ids })) { viewStore in
+      WithViewStore(
+        store.scope(state: { $0.ids }),
+        removeDuplicates: areOrderedSetsDuplicates
+      ) { viewStore in
         ForEach(viewStore.state, id: \.self) { id -> EachContent in
           // NB: We cache elements here to avoid a potential crash where SwiftUI may re-evaluate
           //     views for elements no longer in the collection.
@@ -118,4 +121,13 @@ public struct ForEachStore<
   public var body: some View {
     self.content()
   }
+}
+
+func areOrderedSetsDuplicates<ID: Hashable>(lhs: OrderedSet<ID>, rhs: OrderedSet<ID>) -> Bool {
+  var lhs = lhs
+  var rhs = rhs
+  if memcmp(&lhs, &rhs, MemoryLayout<OrderedSet<ID>>.size) == 0 {
+    return true
+  }
+  return lhs == rhs
 }


### PR DESCRIPTION
This PR's proposes to use `memcmp` to return early if the identifiers of a `ForEachStore` can't be different. This should improve the rendering performance when the `IdentifiedArray`'s identifiers are unchanged.

With the current approach, `ForEachStore`'s internal `ViewStore` compares `OrderedSet<ID>`'s using the canonical `==` to decide if successive values it receives are duplicate or not. `OrderedSet` stack memory consists of two pointers to some internal reference type storage. Because `OrderedSet` is Copy-on-Write, a copy of this private storage is performed when an `OrderedSet` is mutated, and this mutated `OrderedSet` gets new pointers to its own storage. For this reason, **if two `OrderedSet`s are sharing the same pointers, their content can't be different**. Comparing these references is fast and allows us to respond very quickly by the affirmative in this occurrence.
In any case pointers differ, the comparison falls back to `==` where elements are checked one by one, as it is currently performed.

As an example, here are the results when comparing:
- Two different `OrderedSet` values of 10000 `Int`s with the same elements.
- A given `OrderedSet` of 10000 `Int`'s with itself (or a non-mutated "copy").
```
name                         time          std        iterations
----------------------------------------------------------------
Current, same elements       149583.000 ns ±   4.16 %       9211
PR, same elements            149583.000 ns ±   4.31 %       9227

Current, same OrderedSet     149542.000 ns ±   4.63 %       9220
PR, same OrderedSet              42.000 ns ± 247.31 %    1000000
```
This shouldn't affect noticeably the comparison performance of `OrderedSet` with different elements.