### PR TITLE
Add benchmark for effect merging

### DIFF
--- a/Sources/swift-composable-architecture-benchmark/Common.swift
+++ b/Sources/swift-composable-architecture-benchmark/Common.swift
@@ -1,0 +1,46 @@
+import Benchmark
+
+extension BenchmarkSuite {
+  func benchmark(
+    _ name: String,
+    run: @escaping () throws -> Void,
+    setUp: @escaping () -> Void = {},
+    tearDown: @escaping () -> Void
+  ) {
+    self.register(
+      benchmark: Benchmarking(name: name, run: run, setUp: setUp, tearDown: tearDown)
+    )
+  }
+}
+
+struct Benchmarking: AnyBenchmark {
+  let name: String
+  let settings: [BenchmarkSetting] = []
+  private let _run: () throws -> Void
+  private let _setUp: () -> Void
+  private let _tearDown: () -> Void
+
+  init(
+    name: String,
+    run: @escaping () throws -> Void,
+    setUp: @escaping () -> Void = {},
+    tearDown: @escaping () -> Void = {}
+  ) {
+    self.name = name
+    self._run = run
+    self._setUp = setUp
+    self._tearDown = tearDown
+  }
+
+  func setUp() {
+    self._setUp()
+  }
+
+  func run(_ state: inout BenchmarkState) throws {
+    try self._run()
+  }
+
+  func tearDown() {
+    self._tearDown()
+  }
+}

--- a/Sources/swift-composable-architecture-benchmark/Common.swift
+++ b/Sources/swift-composable-architecture-benchmark/Common.swift
@@ -44,3 +44,11 @@ struct Benchmarking: AnyBenchmark {
     self._tearDown()
   }
 }
+
+@inline(__always)
+func doNotOptimizeAway<T>(_ x: T) {
+  @_optimize(none)
+  func assumePointeeIsRead(_ x: UnsafeRawPointer) {}
+
+  withUnsafePointer(to: x) { assumePointeeIsRead($0) }
+}

--- a/Sources/swift-composable-architecture-benchmark/Effects.swift
+++ b/Sources/swift-composable-architecture-benchmark/Effects.swift
@@ -15,11 +15,11 @@ let effectSuite = BenchmarkSuite(name: "Effects") {
     }
   }
 
-  var effect = Effect<Int, Never>.none
-  for _ in 1...100 {
-    effect = .merge(effect, .none)
-  }
+  let effect = Effect<Int, Never>.merge((1...100).map { _ in .none })
+  var didComplete = false
   $0.benchmark("Merged Effect.none (sink)") {
-    _ = effect.sink(receiveCompletion: { _ in }, receiveValue: { _ in })
+    _ = effect.sink(receiveCompletion: { _ in didComplete = true }, receiveValue: { _ in })
+  } tearDown: {
+    precondition(didComplete)
   }
 }

--- a/Sources/swift-composable-architecture-benchmark/Effects.swift
+++ b/Sources/swift-composable-architecture-benchmark/Effects.swift
@@ -5,7 +5,7 @@ import Foundation
 
 let effectSuite = BenchmarkSuite(name: "Effects") {
   $0.benchmark("Merged Effect.none (create, flat)") {
-    let effect = Effect<Int, Never>.merge((1...100).map { _ in .none })
+    doNotOptimizeAway(Effect<Int, Never>.merge((1...100).map { _ in .none }))
   }
 
   $0.benchmark("Merged Effect.none (create, nested)") {
@@ -13,12 +13,15 @@ let effectSuite = BenchmarkSuite(name: "Effects") {
     for _ in 1...100 {
       effect = .merge(effect, .none)
     }
+    doNotOptimizeAway(effect)
   }
 
   let effect = Effect<Int, Never>.merge((1...100).map { _ in .none })
   var didComplete = false
   $0.benchmark("Merged Effect.none (sink)") {
-    _ = effect.sink(receiveCompletion: { _ in didComplete = true }, receiveValue: { _ in })
+    doNotOptimizeAway(
+      effect.sink(receiveCompletion: { _ in didComplete = true }, receiveValue: { _ in })
+    )
   } tearDown: {
     precondition(didComplete)
   }

--- a/Sources/swift-composable-architecture-benchmark/Effects.swift
+++ b/Sources/swift-composable-architecture-benchmark/Effects.swift
@@ -1,0 +1,14 @@
+import Benchmark
+import Combine
+import ComposableArchitecture
+import Foundation
+
+let effectSuite = BenchmarkSuite(name: "Effects") {
+  $0.benchmark("Merging Effect.none") {
+    var effect = Effect<Int, Never>.none
+    for _ in 1...1_000 {
+      effect = .merge(effect, .none)
+    }
+    _ = effect.sink(receiveCompletion: { _ in }, receiveValue: { _ in })
+  }
+}

--- a/Sources/swift-composable-architecture-benchmark/Effects.swift
+++ b/Sources/swift-composable-architecture-benchmark/Effects.swift
@@ -4,11 +4,22 @@ import ComposableArchitecture
 import Foundation
 
 let effectSuite = BenchmarkSuite(name: "Effects") {
-  $0.benchmark("Merging Effect.none") {
+  $0.benchmark("Merged Effect.none (create, flat)") {
+    let effect = Effect<Int, Never>.merge((1...100).map { _ in .none })
+  }
+
+  $0.benchmark("Merged Effect.none (create, nested)") {
     var effect = Effect<Int, Never>.none
-    for _ in 1...1_000 {
+    for _ in 1...100 {
       effect = .merge(effect, .none)
     }
+  }
+
+  var effect = Effect<Int, Never>.none
+  for _ in 1...100 {
+    effect = .merge(effect, .none)
+  }
+  $0.benchmark("Merged Effect.none (sink)") {
     _ = effect.sink(receiveCompletion: { _ in }, receiveValue: { _ in })
   }
 }

--- a/Sources/swift-composable-architecture-benchmark/main.swift
+++ b/Sources/swift-composable-architecture-benchmark/main.swift
@@ -39,4 +39,7 @@ benchmark("Scoping (4)") {
   viewStore4.send(true)
 }
 
-Benchmark.main()
+Benchmark.main([
+  defaultBenchmarkSuite,
+  effectSuite,
+])


### PR DESCRIPTION
Let's get a simple baseline benchmark in place for merging effects, which is a common operation baked into composing reducers.