### PR TITLE
`Send` should explicitly wrap `@MainActor` closure

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -301,9 +301,9 @@ extension Effect where Failure == Never {
 /// [callAsFunction]: https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#ID622
 @MainActor
 public struct Send<Action> {
-  public let send: (Action) -> Void
+  public let send: @MainActor (Action) -> Void
 
-  public init(send: @escaping (Action) -> Void) {
+  public init(send: @escaping @MainActor (Action) -> Void) {
     self.send = send
   }
 


### PR DESCRIPTION
It can be useful to explicitly create `Send` types when building helpers that call `Effect.run` under the hood, but the lack of `@MainActor` on the closure prevents it from being invoked without a Swift 6 warning. This fixes the warning.