### PR TITLE
Update Effect internals to be more efficient.

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
@@ -276,8 +276,6 @@ let rootReducer = Reducer<RootState, RootAction, RootEnvironment>.combine(
       environment: { .init(mainQueue: $0.mainQueue, webSocket: $0.webSocket) }
     )
 )
-.debug()
-.signpost()
 
 @Sendable private func liveFetchNumber() async throws -> Int {
   try await Task.sleep(nanoseconds: NSEC_PER_SEC)

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadClient.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadClient.swift
@@ -1,6 +1,7 @@
 import Combine
 import ComposableArchitecture
 import Foundation
+import XCTestDynamicOverlay
 
 struct DownloadClient {
   var download: @Sendable (URL) -> AsyncThrowingStream<Event, Error>
@@ -37,5 +38,9 @@ extension DownloadClient {
         }
       }
     }
+  )
+
+  static let unimplemented = Self(
+    download: XCTUnimplemented("\(Self.self).asyncDownload")
   )
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/CaseStudiesApp.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/CaseStudiesApp.swift
@@ -8,7 +8,9 @@ struct CaseStudiesApp: App {
       RootView(
         store: Store(
           initialState: RootState(),
-          reducer: rootReducer,
+          reducer: rootReducer
+            .debug()
+            .signpost(),
           environment: .live
         )
       )

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
@@ -1,7 +1,6 @@
 import Combine
 import ComposableArchitecture
 import XCTest
-import XCTestDynamicOverlay
 
 @testable import SwiftUICaseStudies
 
@@ -160,10 +159,4 @@ final class ReusableComponentsDownloadComponentTests: XCTestCase {
       $0.mode = .notDownloaded
     }
   }
-}
-
-extension DownloadClient {
-  static let unimplemented = Self(
-    download: XCTUnimplemented("\(Self.self).asyncDownload")
-  )
 }

--- a/Examples/Search/Search/SearchApp.swift
+++ b/Examples/Search/Search/SearchApp.swift
@@ -8,7 +8,8 @@ struct SearchApp: App {
       SearchView(
         store: Store(
           initialState: SearchState(),
-          reducer: searchReducer.debug(),
+          reducer: searchReducer
+            .debug(),
           environment: SearchEnvironment(
             weatherClient: WeatherClient.live
           )

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
@@ -103,7 +103,6 @@ let appReducer = Reducer<AppState, AppAction, AppEnvironment> { state, action, e
     }
   }
 }
-.debug()
 
 struct SpeechRecognitionView: View {
   let store: Store<AppState, AppAction>

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognitionApp.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognitionApp.swift
@@ -8,7 +8,8 @@ struct SpeechRecognitionApp: App {
       SpeechRecognitionView(
         store: Store(
           initialState: AppState(),
-          reducer: appReducer,
+          reducer: appReducer
+            .debug(),
           environment: AppEnvironment(
             speechClient: .live
           )

--- a/Examples/TicTacToe/App/RootView.swift
+++ b/Examples/TicTacToe/App/RootView.swift
@@ -30,7 +30,8 @@ enum GameType: Identifiable {
 struct RootView: View {
   let store = Store(
     initialState: AppState(),
-    reducer: appReducer,
+    reducer: appReducer
+      .debug(),
     environment: AppEnvironment(
       authenticationClient: .live
     )

--- a/Examples/TicTacToe/tic-tac-toe/Sources/AppCore/AppCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/AppCore/AppCore.swift
@@ -60,4 +60,3 @@ public let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
     }
   }
 )
-.debug()

--- a/Examples/Todos/Todos/TodosApp.swift
+++ b/Examples/Todos/Todos/TodosApp.swift
@@ -8,7 +8,8 @@ struct TodosApp: App {
       AppView(
         store: Store(
           initialState: AppState(),
-          reducer: appReducer.debug(),
+          reducer: appReducer
+            .debug(),
           environment: AppEnvironment(
             mainQueue: .main,
             uuid: { UUID() }

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemosApp.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemosApp.swift
@@ -9,7 +9,8 @@ struct VoiceMemosApp: App {
       VoiceMemosView(
         store: Store(
           initialState: VoiceMemosState(),
-          reducer: voiceMemosReducer.debug(),
+          reducer: voiceMemosReducer
+            .debug(),
           environment: VoiceMemosEnvironment(
             audioPlayer: .live,
             audioRecorder: .live,

--- a/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
@@ -47,43 +47,71 @@ extension Reducer {
         return
           effects
           .effectSignpost(prefix, log: log, actionOutput: actionOutput)
-          .eraseToEffect()
       }
       return effects
     }
   }
 }
 
-extension Publisher where Failure == Never {
+extension Effect where Failure == Never {
   func effectSignpost(
     _ prefix: String,
     log: OSLog,
     actionOutput: String
-  ) -> Publishers.HandleEvents<Self> {
+  ) -> Self {
     let sid = OSSignpostID(log: log)
 
-    return
-      self
-      .handleEvents(
-        receiveSubscription: { _ in
+    switch self.operation {
+    case .none:
+      return self
+    case let .publisher(publisher):
+      return .init(
+        operation: .publisher(
+          publisher.handleEvents(
+            receiveSubscription: { _ in
+              os_signpost(
+                .begin, log: log, name: "Effect", signpostID: sid, "%sStarted from %s", prefix,
+                actionOutput)
+            },
+            receiveOutput: { value in
+              os_signpost(
+                .event, log: log, name: "Effect Output", "%sOutput from %s", prefix, actionOutput)
+            },
+            receiveCompletion: { completion in
+              switch completion {
+              case .finished:
+                os_signpost(.end, log: log, name: "Effect", signpostID: sid, "%sFinished", prefix)
+              }
+            },
+            receiveCancel: {
+              os_signpost(.end, log: log, name: "Effect", signpostID: sid, "%sCancelled", prefix)
+            }
+          )
+          .eraseToAnyPublisher()
+        )
+      )
+    case let .run(priority, operation):
+      return .init(
+        operation: .run(priority) { send in
           os_signpost(
             .begin, log: log, name: "Effect", signpostID: sid, "%sStarted from %s", prefix,
-            actionOutput)
-        },
-        receiveOutput: { value in
-          os_signpost(
-            .event, log: log, name: "Effect Output", "%sOutput from %s", prefix, actionOutput)
-        },
-        receiveCompletion: { completion in
-          switch completion {
-          case .finished:
-            os_signpost(.end, log: log, name: "Effect", signpostID: sid, "%sFinished", prefix)
+            actionOutput
+          )
+          await operation(
+            Send { output in
+              os_signpost(
+                .event, log: log, name: "Effect Output", "%sOutput from %s", prefix, actionOutput
+              )
+              send(output)
+            }
+          )
+          if Task.isCancelled {
+            os_signpost(.end, log: log, name: "Effect", signpostID: sid, "%sCancelled", prefix)
           }
-        },
-        receiveCancel: {
-          os_signpost(.end, log: log, name: "Effect", signpostID: sid, "%sCancelled", prefix)
+          os_signpost(.end, log: log, name: "Effect", signpostID: sid, "%sFinished", prefix)
         }
       )
+    }
   }
 }
 

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -383,12 +383,6 @@ extension Effect {
   /// Concatenates a variadic list of effects together into a single effect, which runs the effects
   /// one after the other.
   ///
-  /// - Warning: Combine's `Publishers.Concatenate` operator, which this function uses, can leak
-  ///   when its suffix is a `Publishers.MergeMany` operator, which is used throughout the
-  ///   Composable Architecture in functions like ``Reducer/combine(_:)-1ern2``.
-  ///
-  ///   Feedback filed: <https://gist.github.com/mbrandonw/611c8352e1bd1c22461bd505e320ab58>
-  ///
   /// - Parameter effects: A variadic list of effects.
   /// - Returns: A new effect
   @inlinable
@@ -398,12 +392,6 @@ extension Effect {
 
   /// Concatenates a collection of effects together into a single effect, which runs the effects one
   /// after the other.
-  ///
-  /// - Warning: Combine's `Publishers.Concatenate` operator, which this function uses, can leak
-  ///   when its suffix is a `Publishers.MergeMany` operator, which is used throughout the
-  ///   Composable Architecture in functions like ``Reducer/combine(_:)-1ern2``.
-  ///
-  ///   Feedback filed: <https://gist.github.com/mbrandonw/611c8352e1bd1c22461bd505e320ab58>
   ///
   /// - Parameter effects: A collection of effects.
   /// - Returns: A new effect

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -33,7 +33,20 @@ import XCTestDynamicOverlay
 /// you are using Swift's concurrency tools and the `.task`, `.run` and `.fireAndForget`
 /// functions on ``Effect``, then threading is automatically handled for you.
 public struct Effect<Output, Failure: Error> {
-  let publisher: AnyPublisher<Output, Failure>
+  @usableFromInline
+  enum Operation {
+    case none
+    case publisher(AnyPublisher<Output, Failure>)
+    case run(TaskPriority? = nil, @Sendable (Send<Output>) async -> Void)
+  }
+
+  @usableFromInline
+  let operation: Operation
+
+  @usableFromInline
+  init(operation: Operation) {
+    self.operation = operation
+  }
 }
 
 // MARK: - Creating Effects
@@ -42,7 +55,7 @@ extension Effect {
   /// An effect that does nothing and completes immediately. Useful for situations where you must
   /// return an effect, but you don't need to do anything.
   public static var none: Self {
-    Empty(completeImmediately: true).eraseToEffect()
+    Self(operation: .none)
   }
 }
 
@@ -107,15 +120,10 @@ extension Effect where Failure == Never {
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) -> Self {
-    Deferred<Publishers.HandleEvents<PassthroughSubject<Output, Failure>>> {
-      let subject = PassthroughSubject<Output, Failure>()
-      let task = Task(priority: priority) { @MainActor in
-        defer { subject.send(completion: .finished) }
+    Self(
+      operation: .run(priority) { send in
         do {
-          try Task.checkCancellation()
-          let output = try await operation()
-          try Task.checkCancellation()
-          subject.send(output)
+          try await send(operation())
         } catch is CancellationError {
           return
         } catch {
@@ -143,12 +151,10 @@ extension Effect where Failure == Never {
             #endif
             return
           }
-          await subject.send(handler(error))
+          await send(handler(error))
         }
       }
-      return subject.handleEvents(receiveCancel: task.cancel)
-    }
-    .eraseToEffect()
+    )
   }
 
   /// Wraps an asynchronous unit of work that can emit any number of times in an effect.
@@ -198,10 +204,8 @@ extension Effect where Failure == Never {
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) -> Self {
-    .run { subscriber in
-      let task = Task(priority: priority) { @MainActor in
-        defer { subscriber.send(completion: .finished) }
-        let send = Send(send: { subscriber.send($0) })
+    Self(
+      operation: .run(priority) { send in
         do {
           try await operation(send)
         } catch is CancellationError {
@@ -234,10 +238,7 @@ extension Effect where Failure == Never {
           await handler(error, send)
         }
       }
-      return AnyCancellable {
-        task.cancel()
-      }
-    }
+    )
   }
 
   /// Creates an effect that executes some work in the real world that doesn't need to feed data
@@ -266,8 +267,7 @@ extension Effect where Failure == Never {
     priority: TaskPriority? = nil,
     _ work: @escaping @Sendable () async throws -> Void
   ) -> Self {
-    Effect<Void, Never>.task(priority: priority) { try? await work() }
-      .fireAndForget()
+    Self.run(priority: priority) { _ in try? await work() }
   }
 }
 
@@ -301,9 +301,9 @@ extension Effect where Failure == Never {
 /// [callAsFunction]: https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#ID622
 @MainActor
 public struct Send<Action> {
-  public let send: (Action) -> Void
+  public let send: @MainActor (Action) -> Void
 
-  public init(send: @escaping (Action) -> Void) {
+  public init(send: @MainActor @escaping (Action) -> Void) {
     self.send = send
   }
 
@@ -336,8 +336,9 @@ extension Effect {
   ///
   /// - Parameter effects: A list of effects.
   /// - Returns: A new effect
+  @inlinable
   public static func merge(_ effects: Self...) -> Self {
-    .merge(effects)
+    Self.merge(effects)
   }
 
   /// Merges a sequence of effects together into a single effect, which runs the effects at the same
@@ -345,8 +346,38 @@ extension Effect {
   ///
   /// - Parameter effects: A sequence of effects.
   /// - Returns: A new effect
-  public static func merge<S: Sequence>(_ effects: S) -> Self where S.Element == Effect {
-    Publishers.MergeMany(effects).eraseToEffect()
+  @inlinable
+  public static func merge<S: Sequence>(_ effects: S) -> Self where S.Element == Self {
+    effects.reduce(.none) { $0.merge(with: $1) }
+  }
+
+  /// Merges this effect and another into a single effect that runs both at the same time.
+  ///
+  /// - Parameter other: Another effect.
+  /// - Returns: An effect that runs this effect and the other at the same time.
+  @inlinable
+  public func merge(with other: Self) -> Self {
+    switch (self.operation, other.operation) {
+    case (_, .none):
+      return self
+    case (.none, _):
+      return other
+    case (.publisher, .publisher), (.run, .publisher), (.publisher, .run):
+      return Self(operation: .publisher(Publishers.Merge(self, other).eraseToAnyPublisher()))
+    case let (.run(lhsPriority, lhsOperation), .run(rhsPriority, rhsOperation)):
+      return Self(
+        operation: .run { send in
+          await withTaskGroup(of: Void.self) { group in
+            group.addTask(priority: lhsPriority) {
+              await lhsOperation(send)
+            }
+            group.addTask(priority: rhsPriority) {
+              await rhsOperation(send)
+            }
+          }
+        }
+      )
+    }
   }
 
   /// Concatenates a variadic list of effects together into a single effect, which runs the effects
@@ -360,8 +391,9 @@ extension Effect {
   ///
   /// - Parameter effects: A variadic list of effects.
   /// - Returns: A new effect
+  @inlinable
   public static func concatenate(_ effects: Self...) -> Self {
-    .concatenate(effects)
+    Self.concatenate(effects)
   }
 
   /// Concatenates a collection of effects together into a single effect, which runs the effects one
@@ -375,14 +407,38 @@ extension Effect {
   ///
   /// - Parameter effects: A collection of effects.
   /// - Returns: A new effect
+  @inlinable
   public static func concatenate<C: Collection>(_ effects: C) -> Self where C.Element == Effect {
-    effects.isEmpty
-      ? .none
-      : effects
-        .dropFirst()
-        .reduce(into: effects[effects.startIndex]) { effects, effect in
-          effects = effects.append(effect).eraseToEffect()
+    effects.reduce(.none) { $0.concatenate(with: $1) }
+  }
+
+  /// Concatenates this effect and another into a single effect that first runs this effect, and
+  /// after it completes or is cancelled, runs the other.
+  ///
+  /// - Parameter other: Another effect.
+  /// - Returns: An effect that runs this effect, and after it completes or is cancelled, runs the
+  ///   other.
+  @inlinable
+  public func concatenate(with other: Self) -> Self {
+    switch (self.operation, other.operation) {
+    case (_, .none):
+      return self
+    case (.none, _):
+      return other
+    case (.publisher, .publisher), (.run, .publisher), (.publisher, .run):
+      return Self(
+        operation: .publisher(
+          Publishers.Concatenate(prefix: self, suffix: other).eraseToAnyPublisher()
+        )
+      )
+    case let (.run(lhsPriority, lhsOperation), .run(rhsPriority, rhsOperation)):
+      return Self(
+        operation: .run(Swift.max(lhsPriority ?? .medium, rhsPriority ?? .medium)) { send in
+          await lhsOperation(send)
+          await rhsOperation(send)
         }
+      )
+    }
   }
 
   /// Transforms all elements from the upstream effect with a provided closure.
@@ -390,8 +446,26 @@ extension Effect {
   /// - Parameter transform: A closure that transforms the upstream effect's output to a new output.
   /// - Returns: A publisher that uses the provided closure to map elements from the upstream effect
   ///   to new elements that it then publishes.
+  @inlinable
   public func map<T>(_ transform: @escaping (Output) -> T) -> Effect<T, Failure> {
-    .init(self.map(transform) as Publishers.Map<Self, T>)
+    switch self.operation {
+    case .none:
+      return .none
+    case let .publisher(publisher):
+      return .init(operation: .publisher(publisher.map(transform).eraseToAnyPublisher()))
+    case let .run(priority, operation):
+      return .init(
+        operation: .run(priority) { send in
+          await operation(
+            .init(
+              send: { output in
+                send(transform(output))
+              }
+            )
+          )
+        }
+      )
+    }
   }
 }
 

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -419,7 +419,7 @@ extension Effect {
   /// - Returns: An effect that runs this effect, and after it completes or is cancelled, runs the
   ///   other.
   @inlinable
-  @_disfavoredOverload  // TODO: Why is this needed?
+  @_disfavoredOverload
   public func concatenate(with other: Self) -> Self {
     switch (self.operation, other.operation) {
     case (_, .none):
@@ -434,9 +434,9 @@ extension Effect {
       )
     case let (.run(lhsPriority, lhsOperation), .run(rhsPriority, rhsOperation)):
       return Self(
-        operation: .run(Swift.max(lhsPriority ?? .medium, rhsPriority ?? .medium)) { send in
-          await lhsOperation(send)
-          await rhsOperation(send)
+        operation: .run { send in
+          await Task(priority: lhsPriority) { await lhsOperation(send) }.cancellableValue
+          await Task(priority: rhsPriority) { await rhsOperation(send) }.cancellableValue
         }
       )
     }

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -435,8 +435,16 @@ extension Effect {
     case let (.run(lhsPriority, lhsOperation), .run(rhsPriority, rhsOperation)):
       return Self(
         operation: .run { send in
-          await Task(priority: lhsPriority) { await lhsOperation(send) }.cancellableValue
-          await Task(priority: rhsPriority) { await rhsOperation(send) }.cancellableValue
+          if let lhsPriority = lhsPriority {
+            await Task(priority: lhsPriority) { await lhsOperation(send) }.cancellableValue
+          } else {
+            await lhsOperation(send)
+          }
+          if let rhsPriority = rhsPriority {
+            await Task(priority: rhsPriority) { await rhsOperation(send) }.cancellableValue
+          } else {
+            await rhsOperation(send)
+          }
         }
       )
     }

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -408,7 +408,7 @@ extension Effect {
   /// - Parameter effects: A collection of effects.
   /// - Returns: A new effect
   @inlinable
-  public static func concatenate<C: Collection>(_ effects: C) -> Self where C.Element == Effect {
+  public static func concatenate<C: Collection>(_ effects: C) -> Self where C.Element == Self {
     effects.reduce(.none) { $0.concatenate(with: $1) }
   }
 
@@ -419,6 +419,7 @@ extension Effect {
   /// - Returns: An effect that runs this effect, and after it completes or is cancelled, runs the
   ///   other.
   @inlinable
+  @_disfavoredOverload  // TODO: Why is this needed?
   public func concatenate(with other: Self) -> Self {
     switch (self.operation, other.operation) {
     case (_, .none):

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -29,47 +29,66 @@ extension Effect {
   ///     canceled before starting this new one.
   /// - Returns: A new effect that is capable of being canceled by an identifier.
   public func cancellable(id: AnyHashable, cancelInFlight: Bool = false) -> Self {
-    Deferred {
-      ()
-        -> Publishers.HandleEvents<
-          Publishers.PrefixUntilOutput<Self, PassthroughSubject<Void, Never>>
-        > in
-      cancellablesLock.lock()
-      defer { cancellablesLock.unlock() }
+    switch self.operation {
+    case .none:
+      return .none
+    case let .publisher(publisher):
+      return Self(
+        operation: .publisher(
+          Deferred {
+            ()
+              -> Publishers.HandleEvents<
+                Publishers.PrefixUntilOutput<
+                  AnyPublisher<Output, Failure>, PassthroughSubject<Void, Never>
+                >
+              > in
+            cancellablesLock.lock()
+            defer { cancellablesLock.unlock() }
 
-      let id = CancelToken(id: id)
-      if cancelInFlight {
-        cancellationCancellables[id]?.forEach { $0.cancel() }
-      }
+            let id = CancelToken(id: id)
+            if cancelInFlight {
+              cancellationCancellables[id]?.forEach { $0.cancel() }
+            }
 
-      let cancellationSubject = PassthroughSubject<Void, Never>()
+            let cancellationSubject = PassthroughSubject<Void, Never>()
 
-      var cancellationCancellable: AnyCancellable!
-      cancellationCancellable = AnyCancellable {
-        cancellablesLock.sync {
-          cancellationSubject.send(())
-          cancellationSubject.send(completion: .finished)
-          cancellationCancellables[id]?.remove(cancellationCancellable)
-          if cancellationCancellables[id]?.isEmpty == .some(true) {
-            cancellationCancellables[id] = nil
+            var cancellationCancellable: AnyCancellable!
+            cancellationCancellable = AnyCancellable {
+              cancellablesLock.sync {
+                cancellationSubject.send(())
+                cancellationSubject.send(completion: .finished)
+                cancellationCancellables[id]?.remove(cancellationCancellable)
+                if cancellationCancellables[id]?.isEmpty == .some(true) {
+                  cancellationCancellables[id] = nil
+                }
+              }
+            }
+
+            return publisher.prefix(untilOutputFrom: cancellationSubject)
+              .handleEvents(
+                receiveSubscription: { _ in
+                  _ = cancellablesLock.sync {
+                    cancellationCancellables[id, default: []].insert(
+                      cancellationCancellable
+                    )
+                  }
+                },
+                receiveCompletion: { _ in cancellationCancellable.cancel() },
+                receiveCancel: cancellationCancellable.cancel
+              )
+          }
+          .eraseToAnyPublisher()
+        )
+      )
+    case let .run(priority, operation):
+      return Self(
+        operation: .run(priority) { send in
+          await withTaskCancellation(id: id, cancelInFlight: cancelInFlight) {
+            await operation(send)
           }
         }
-      }
-
-      return self.prefix(untilOutputFrom: cancellationSubject)
-        .handleEvents(
-          receiveSubscription: { _ in
-            _ = cancellablesLock.sync {
-              cancellationCancellables[id, default: []].insert(
-                cancellationCancellable
-              )
-            }
-          },
-          receiveCompletion: { _ in cancellationCancellable.cancel() },
-          receiveCancel: cancellationCancellable.cancel
-        )
+      )
     }
-    .eraseToEffect()
   }
 
   /// Turns an effect into one that is capable of being canceled.

--- a/Sources/ComposableArchitecture/Effects/Debouncing.swift
+++ b/Sources/ComposableArchitecture/Effects/Debouncing.swift
@@ -47,8 +47,11 @@ extension Effect {
     case let .run(priority, operation):
       return Self(
         operation: .run(priority) { send in
-          await withTaskCancellation(id: id) {
-            await operation(send)
+          await withTaskCancellation(id: id, cancelInFlight: true) {
+            do {
+              try await scheduler.sleep(for: dueTime, options: options)
+              await operation(send)
+            } catch {}
           }
         }
       )

--- a/Sources/ComposableArchitecture/Effects/Deferring.swift
+++ b/Sources/ComposableArchitecture/Effects/Deferring.swift
@@ -20,10 +20,28 @@ extension Effect {
     scheduler: S,
     options: S.SchedulerOptions? = nil
   ) -> Self {
-    Just(())
-      .setFailureType(to: Failure.self)
-      .delay(for: dueTime, scheduler: scheduler, options: options)
-      .flatMap { self.receive(on: scheduler) }
-      .eraseToEffect()
+    switch self.operation {
+    case .none:
+      return .none
+    case let .publisher(publisher):
+      return Self(
+        operation: .publisher(
+          Just(())
+            .setFailureType(to: Failure.self)
+            .delay(for: dueTime, scheduler: scheduler, options: options)
+            .flatMap { publisher.receive(on: scheduler) }
+            .eraseToAnyPublisher()
+        )
+      )
+    case let .run(priority, operation):
+      return Self(
+        operation: .run(priority) { send in
+          do {
+            try await scheduler.sleep(for: dueTime)
+            await operation(send)
+          } catch {}
+        }
+      )
+    }
   }
 }

--- a/Sources/ComposableArchitecture/Effects/Throttling.swift
+++ b/Sources/ComposableArchitecture/Effects/Throttling.swift
@@ -20,44 +20,49 @@ extension Effect {
     scheduler: S,
     latest: Bool
   ) -> Self {
-    self.receive(on: scheduler)
-      .flatMap { value -> AnyPublisher<Output, Failure> in
-        throttleLock.lock()
-        defer { throttleLock.unlock() }
+    switch self.operation {
+    case .none:
+      return .none
+    case .publisher, .run:
+      return self.receive(on: scheduler)
+        .flatMap { value -> AnyPublisher<Output, Failure> in
+          throttleLock.lock()
+          defer { throttleLock.unlock() }
 
-        guard let throttleTime = throttleTimes[id] as! S.SchedulerTimeType? else {
-          throttleTimes[id] = scheduler.now
-          throttleValues[id] = nil
-          return Just(value).setFailureType(to: Failure.self).eraseToAnyPublisher()
-        }
+          guard let throttleTime = throttleTimes[id] as! S.SchedulerTimeType? else {
+            throttleTimes[id] = scheduler.now
+            throttleValues[id] = nil
+            return Just(value).setFailureType(to: Failure.self).eraseToAnyPublisher()
+          }
 
-        let value = latest ? value : (throttleValues[id] as! Output? ?? value)
-        throttleValues[id] = value
+          let value = latest ? value : (throttleValues[id] as! Output? ?? value)
+          throttleValues[id] = value
 
-        guard throttleTime.distance(to: scheduler.now) < interval else {
-          throttleTimes[id] = scheduler.now
-          throttleValues[id] = nil
-          return Just(value).setFailureType(to: Failure.self).eraseToAnyPublisher()
-        }
+          guard throttleTime.distance(to: scheduler.now) < interval else {
+            throttleTimes[id] = scheduler.now
+            throttleValues[id] = nil
+            return Just(value).setFailureType(to: Failure.self).eraseToAnyPublisher()
+          }
 
-        return Just(value)
-          .delay(
-            for: scheduler.now.distance(to: throttleTime.advanced(by: interval)),
-            scheduler: scheduler
-          )
-          .handleEvents(
-            receiveOutput: { _ in
-              throttleLock.sync {
-                throttleTimes[id] = scheduler.now
-                throttleValues[id] = nil
+          return Just(value)
+            .delay(
+              for: scheduler.now.distance(to: throttleTime.advanced(by: interval)),
+              scheduler: scheduler
+            )
+            .handleEvents(
+              receiveOutput: { _ in
+                throttleLock.sync {
+                  throttleTimes[id] = scheduler.now
+                  throttleValues[id] = nil
+                }
               }
-            }
-          )
-          .setFailureType(to: Failure.self)
-          .eraseToAnyPublisher()
-      }
-      .eraseToEffect()
-      .cancellable(id: id, cancelInFlight: true)
+            )
+            .setFailureType(to: Failure.self)
+            .eraseToAnyPublisher()
+        }
+        .eraseToEffect()
+        .cancellable(id: id, cancelInFlight: true)
+    }
   }
 
   /// Throttles an effect so that it only publishes one output per given interval.

--- a/Sources/ComposableArchitecture/Internal/TaskCancellableValue.swift
+++ b/Sources/ComposableArchitecture/Internal/TaskCancellableValue.swift
@@ -11,6 +11,7 @@ extension Task where Failure == Error {
 }
 
 extension Task where Failure == Never {
+  @usableFromInline
   var cancellableValue: Success {
     get async {
       await withTaskCancellationHandler {

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -127,8 +127,8 @@ public struct Reducer<State, Action, Environment> {
   /// - Parameter reducers: An array of reducers.
   /// - Returns: A single reducer.
   public static func combine(_ reducers: [Self]) -> Self {
-    Self { value, action, environment in
-      .merge(reducers.map { $0.reducer(&value, action, environment) })
+    Self { state, action, environment in
+      reducers.reduce(.none) { $0.merge(with: $1(&state, action, environment)) }
     }
   }
 
@@ -143,7 +143,9 @@ public struct Reducer<State, Action, Environment> {
   /// - Parameter other: Another reducer.
   /// - Returns: A single reducer.
   public func combined(with other: Self) -> Self {
-    .combine(self, other)
+    Self { state, action, environment in
+      self(&state, action, environment).merge(with: other(&state, action, environment))
+    }
   }
 
   /// Transforms a reducer that works on child state, action, and environment into one that works on

--- a/Sources/swift-composable-architecture-benchmark/Effects.swift
+++ b/Sources/swift-composable-architecture-benchmark/Effects.swift
@@ -11,7 +11,7 @@ let effectSuite = BenchmarkSuite(name: "Effects") {
   $0.benchmark("Merged Effect.none (create, nested)") {
     var effect = Effect<Int, Never>.none
     for _ in 1...100 {
-      effect = .merge(effect, .none)
+      effect = effect.merge(with: .none)
     }
     doNotOptimizeAway(effect)
   }

--- a/Tests/ComposableArchitectureTests/EffectFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectFailureTests.swift
@@ -6,19 +6,12 @@ import XCTest
 final class EffectFailureTests: XCTestCase {
   var cancellables: Set<AnyCancellable> = []
 
-  func testTaskUnexpectedThrows() {
-    XCTExpectFailure {
-      Effect<Void, Never>.task {
-        struct Unexpected: Error {}
-        throw Unexpected()
-      }
-      .sink { _ in }
-      .store(in: &self.cancellables)
+  func testTaskUnexpectedThrows() async {
+    guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else { return }
 
-      _ = XCTWaiter.wait(for: [.init()], timeout: 0.1)
-    } issueMatcher: {
+    XCTExpectFailure {
       $0.compactDescription == """
-        An 'Effect.task' returned from "ComposableArchitectureTests/EffectFailureTests.swift:11" \
+        An 'Effect.task' returned from "ComposableArchitectureTests/EffectFailureTests.swift:24" \
         threw an unhandled error. …
 
             EffectFailureTests.Unexpected()
@@ -27,21 +20,21 @@ final class EffectFailureTests: XCTestCase {
         'Effect.task', or via a 'do' block.
         """
     }
+
+    let effect = Effect<Void, Never>.task {
+      struct Unexpected: Error {}
+      throw Unexpected()
+    }
+
+    for await _ in effect.values {}
   }
 
-  func testRunUnexpectedThrows() {
-    XCTExpectFailure {
-      Effect<Void, Never>.run { _ in
-        struct Unexpected: Error {}
-        throw Unexpected()
-      }
-      .sink { _ in }
-      .store(in: &self.cancellables)
+  func testRunUnexpectedThrows() async {
+    guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else { return }
 
-      _ = XCTWaiter.wait(for: [.init()], timeout: 0.1)
-    } issueMatcher: {
+    XCTExpectFailure {
       $0.compactDescription == """
-        An 'Effect.run' returned from "ComposableArchitectureTests/EffectFailureTests.swift:34" \
+        An 'Effect.run' returned from "ComposableArchitectureTests/EffectFailureTests.swift:47" \
         threw an unhandled error. …
 
             EffectFailureTests.Unexpected()
@@ -50,5 +43,12 @@ final class EffectFailureTests: XCTestCase {
         'Effect.run', or via a 'do' block.
         """
     }
+
+    let effect = Effect<Void, Never>.run { _ in
+      struct Unexpected: Error {}
+      throw Unexpected()
+    }
+
+    for await _ in effect.values {}
   }
 }

--- a/Tests/ComposableArchitectureTests/EffectOperationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectOperationTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+
+@testable import ComposableArchitecture
+
+@MainActor
+class EffectOperationTests: XCTestCase {
+  func testMergeDiscardsNones() async {
+    var effect = Effect<Int, Never>.none
+      .merge(with: .none)
+    switch effect.operation {
+    case .none:
+      XCTAssertTrue(true)
+    default:
+      XCTFail()
+    }
+
+    effect = Effect<Int, Never>.task { 42 }
+      .merge(with: .none)
+    switch effect.operation {
+    case let .run(_, send):
+      await send(.init(send: { XCTAssertEqual($0, 42) }))
+    default:
+      XCTFail()
+    }
+
+    effect = Effect<Int, Never>.none
+      .merge(with: .task { 42 })
+    switch effect.operation {
+    case let .run(_, send):
+      await send(.init(send: { XCTAssertEqual($0, 42) }))
+    default:
+      XCTFail()
+    }
+
+    effect = Effect<Int, Never>.run { await $0(42) }
+      .merge(with: .none)
+    switch effect.operation {
+    case let .run(_, send):
+      await send(.init(send: { XCTAssertEqual($0, 42) }))
+    default:
+      XCTFail()
+    }
+
+    effect = Effect<Int, Never>.none
+      .merge(with: .run { await $0(42) })
+    switch effect.operation {
+    case let .run(_, send):
+      await send(.init(send: { XCTAssertEqual($0, 42) }))
+    default:
+      XCTFail()
+    }
+  }
+
+  func testConcatenateDiscardsNones() async {
+    var effect = Effect<Int, Never>.none
+      .concatenate(with: .none)
+    switch effect.operation {
+    case .none:
+      XCTAssertTrue(true)
+    default:
+      XCTFail()
+    }
+
+    effect = Effect<Int, Never>.task { 42 }
+      .concatenate(with: .none)
+    switch effect.operation {
+    case let .run(_, send):
+      await send(.init(send: { XCTAssertEqual($0, 42) }))
+    default:
+      XCTFail()
+    }
+
+    effect = Effect<Int, Never>.none
+      .concatenate(with: .task { 42 })
+    switch effect.operation {
+    case let .run(_, send):
+      await send(.init(send: { XCTAssertEqual($0, 42) }))
+    default:
+      XCTFail()
+    }
+
+    effect = Effect<Int, Never>.run { await $0(42) }
+      .concatenate(with: .none)
+    switch effect.operation {
+    case let .run(_, send):
+      await send(.init(send: { XCTAssertEqual($0, 42) }))
+    default:
+      XCTFail()
+    }
+
+    effect = Effect<Int, Never>.none
+      .concatenate(with: .run { await $0(42) })
+    switch effect.operation {
+    case let .run(_, send):
+      await send(.init(send: { XCTAssertEqual($0, 42) }))
+    default:
+      XCTFail()
+    }
+  }
+
+  func testMergeFuses() async {
+    var values = [Int]()
+
+    let effect = Effect<Int, Never>.task { 42 }
+      .merge(with: .task { 1729 })
+    switch effect.operation {
+    case let .run(_, send):
+      await send(.init(send: { values.append($0) }))
+    default:
+      XCTFail()
+    }
+
+    XCTAssertEqual(values, [42, 1729])
+  }
+
+  func testConcatenateFuses() async {
+    var values = [Int]()
+
+    let effect = Effect<Int, Never>.task { 42 }
+      .concatenate(with: .task { 1729 })
+    switch effect.operation {
+    case let .run(_, send):
+      await send(.init(send: { values.append($0) }))
+    default:
+      XCTFail()
+    }
+
+    XCTAssertEqual(values, [42, 1729])
+  }
+
+  func testMap() async {
+    let effect = Effect<Int, Never>.task { 42 }
+      .map { "\($0)" }
+
+    switch effect.operation {
+    case let .run(_, send):
+      await send(.init(send: { XCTAssertEqual($0, "42") }))
+    default:
+      XCTFail()
+    }
+  }
+}

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -223,17 +223,12 @@ final class EffectTests: XCTestCase {
     }
   }
 
-  func testTask() {
-    let expectation = self.expectation(description: "Complete")
-    var result: Int?
-    Effect<Int, Never>.task { @MainActor in
-      expectation.fulfill()
-      return 42
+  func testTask() async {
+    guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else { return }
+    let effect = Effect<Int, Never>.task { 42 }
+    for await result in effect.values {
+      XCTAssertNoDifference(result, 42)
     }
-    .sink(receiveValue: { result = $0 })
-    .store(in: &self.cancellables)
-    self.wait(for: [expectation], timeout: 1)
-    XCTAssertNoDifference(result, 42)
   }
 
   func testCancellingTask_Infallible() {


### PR DESCRIPTION
Currently, highly composed applications built with the library suffer from producing massively merged effects where each layer is erased. The creation and running of such effects can be expensive, even if every layer of the effect was just a `Effect.none`.

If you wanna see something really wild, check out the [underlying type][effect-lol] for the effect that is run in the store when `.onAppear` is sent in our case studies app. That's nearly 4,000 lines of pretty formatted type info. To contrast, with the changes in this PR that monstrous effect is squashed down to a single `Effect.none`.

Here are some benchmarks to show how things have changed:

```
Effects.Merged Effect.none (create, flat)   13667.000 ns ±  11.25 %     100456
Effects.Merged Effect.none (create, nested) 14250.000 ns ±  12.10 %      94767
Effects.Merged Effect.none (sink)             625.000 ns ± 107.00 %    1000000
```

Here is what those same benchmarks look like on main right now (9a01fb412b4cd0bbc4d1032550b5621939430ddb):

```
name                                        time         std        iterations
------------------------------------------------------------------------------
Effects.Merged Effect.none (create, flat)   11416.000 ns ±  22.42 %     113114
Effects.Merged Effect.none (create, nested) 42166.000 ns ±  15.61 %      31531
Effects.Merged Effect.none (sink)           63333.000 ns ±  24.17 %      21636
```

You will notice that creating a large merged effect is _slightly_ slower in the new style, but the running of the effect is massively faster. Further, the new reducer protocol stuff (#1282) will be able to take advantage of this to eke out even more performance.

This should be a 100% backwards compatible change, and gets us one step closer to a Combine-less world for the library. 🤩

[effect-lol]: https://gist.github.com/mbrandonw/4c88b045cc1c161931e9be875957654a
