### PR TITLE
Replace UUID.incrementing to newUUIDForTest and remove captured value  from concurrent context in Todos Demo

### DIFF
--- a/Examples/Todos/TodosTests/TodosTests.swift
+++ b/Examples/Todos/TodosTests/TodosTests.swift
@@ -6,6 +6,10 @@ import XCTest
 @MainActor
 final class TodosTests: XCTestCase {
   let mainQueue = DispatchQueue.test
+    
+  override class func setUp() {
+    UUID.uuIdTestCounter = 0
+  }
 
   func testAddTodo() async {
     let store = TestStore(
@@ -13,7 +17,7 @@ final class TodosTests: XCTestCase {
       reducer: appReducer,
       environment: AppEnvironment(
         mainQueue: self.mainQueue.eraseToAnyScheduler(),
-        uuid: { UUID.incrementing() }
+        uuid: { UUID.newUUIDForTest }
       )
     )
 
@@ -26,6 +30,21 @@ final class TodosTests: XCTestCase {
         ),
         at: 0
       )
+    }
+      
+    await store.send(.addTodoButtonTapped) {
+      $0.todos = [
+        TodoState(
+          description: "",
+          id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+          isComplete: false
+        ),
+        TodoState(
+          description: "",
+          id: UUID(uuidString: "00000000-0000-0000-0000-000000000000")!,
+          isComplete: false
+        )
+      ]
     }
   }
 
@@ -44,7 +63,7 @@ final class TodosTests: XCTestCase {
       reducer: appReducer,
       environment: AppEnvironment(
         mainQueue: self.mainQueue.eraseToAnyScheduler(),
-        uuid: { UUID.incrementing() }
+        uuid: { UUID.newUUIDForTest }
       )
     )
 
@@ -75,7 +94,7 @@ final class TodosTests: XCTestCase {
       reducer: appReducer,
       environment: AppEnvironment(
         mainQueue: self.mainQueue.eraseToAnyScheduler(),
-        uuid: { UUID.incrementing() }
+        uuid: { UUID.newUUIDForTest }
       )
     )
 
@@ -111,7 +130,7 @@ final class TodosTests: XCTestCase {
       reducer: appReducer,
       environment: AppEnvironment(
         mainQueue: self.mainQueue.eraseToAnyScheduler(),
-        uuid: { UUID.incrementing() }
+        uuid: { UUID.newUUIDForTest }
       )
     )
 
@@ -146,7 +165,7 @@ final class TodosTests: XCTestCase {
       reducer: appReducer,
       environment: AppEnvironment(
         mainQueue: self.mainQueue.eraseToAnyScheduler(),
-        uuid: { UUID.incrementing() }
+        uuid: { UUID.newUUIDForTest }
       )
     )
 
@@ -182,7 +201,7 @@ final class TodosTests: XCTestCase {
       reducer: appReducer,
       environment: AppEnvironment(
         mainQueue: self.mainQueue.eraseToAnyScheduler(),
-        uuid: { UUID.incrementing() }
+        uuid: { UUID.newUUIDForTest }
       )
     )
 
@@ -219,7 +238,7 @@ final class TodosTests: XCTestCase {
       reducer: appReducer,
       environment: AppEnvironment(
         mainQueue: self.mainQueue.eraseToAnyScheduler(),
-        uuid: { UUID.incrementing() }
+        uuid: { UUID.newUUIDForTest }
       )
     )
 
@@ -267,7 +286,7 @@ final class TodosTests: XCTestCase {
       reducer: appReducer,
       environment: AppEnvironment(
         mainQueue: self.mainQueue.eraseToAnyScheduler(),
-        uuid: { UUID.incrementing() }
+        uuid: { UUID.newUUIDForTest }
       )
     )
 
@@ -309,7 +328,7 @@ final class TodosTests: XCTestCase {
       reducer: appReducer,
       environment: AppEnvironment(
         mainQueue: self.mainQueue.eraseToAnyScheduler(),
-        uuid: { UUID.incrementing() }
+        uuid: { UUID.newUUIDForTest }
       )
     )
 
@@ -323,12 +342,13 @@ final class TodosTests: XCTestCase {
 }
 
 extension UUID {
-  // A deterministic, auto-incrementing "UUID" generator for testing.
-  static var incrementing: () -> UUID {
-    var uuid = 0
-    return {
-      defer { uuid += 1 }
-      return UUID(uuidString: "00000000-0000-0000-0000-\(String(format: "%012x", uuid))")!
+    // uuIdTestCounter needs to be set to 0 on setUp() method
+    static var uuIdTestCounter: UInt = 0
+    
+    static var newUUIDForTest: UUID {
+        defer {
+            uuIdTestCounter += 1
+        }
+        return UUID(uuidString: "00000000-0000-0000-0000-\(String(format: "%012x", uuIdTestCounter))")!
     }
-  }
 }


### PR DESCRIPTION
Hi there, 

Reviewing Todos demo,  I found out that `UUID.incrementing()` is always returning `"00000000-0000-0000-0000-000000000000"`, in other words, the captured value `uuid` is not working correctly. 

This is because we added Sendable to the `uuid` parameter in `AppEnvironment`.

To fix this, I added a few things:
- Added a new action to test two Todos instead of just one. This ensures that we are generating at least two different UUIDs in testAddTodo.
- Added static `newUUIDForTest` method that uses static `uuIdTestCounter` to generate the `UUID` values. uuIdTestCounter starts at 0.
- Added a `setUp` method to initialize `uuIdTestCounter` to zero every time we run a new test.

Take a look and see if it is worth adding it.

Regards,
Pitt