### PR TITLE
Rename some generics in the store rescoping.

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -54,6 +54,7 @@ public struct Effect<Output, Failure: Error> {
 extension Effect {
   /// An effect that does nothing and completes immediately. Useful for situations where you must
   /// return an effect, but you don't need to do anything.
+  @inlinable
   public static var none: Self {
     Self(operation: .none)
   }


### PR DESCRIPTION
In the last PR #1316 we left the naming of certain things in a weird spot, so we are correcting that now.