### PR TITLE
Add deprecations to non-view `WithViewStore` initializers

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -101,7 +101,7 @@ struct AppView: View {
         )
         .badge("\(viewStore.unreadActivityCount)")
 
-        …
+        // ...
       }
     }
   }
@@ -131,7 +131,7 @@ So, instead of performing intense work like this in your reducer:
 
 ```swift
 case .buttonTapped:
-  var result = …
+  var result = // ...
   for value in someLargeCollection {
     // Some intense computation with value
   }
@@ -144,7 +144,7 @@ and then delivering the result in an action:
 ```swift
 case .buttonTapped:
   return .task {
-    var result = …
+    var result = // ...
     for (index, value) in someLargeCollection.enumerated() {
       // Some intense computation with value
 
@@ -226,11 +226,11 @@ incurring unnecessary costs for sending actions.
 
 ### Compiler performance
 
-In very large applications you may experience degraded compiler performance causing long compile
-times, and possibly even compiler failures due to "complex expressions." The ``WithViewStore`` 
-helpers that comes with the library can exacerbate that problem for very complex views. If
-you are running into issues using ``WithViewStore`` you can make a small change to your view
-to use an `@ObservedObject` directly.
+In very large SwiftUI applications you may experience degraded compiler performance causing long
+compile times, and possibly even compiler failures due to "complex expressions." The
+``WithViewStore``  helpers that comes with the library can exacerbate that problem for very complex
+views. If you are running into issues using ``WithViewStore`` you can make a small change to your
+view to use an `@ObservedObject` directly.
 
 For example, if your view looks like this:
 
@@ -246,7 +246,7 @@ struct FeatureView: View {
 }
 ```
 
-…and you start running into compiler troubles, then you an refactor to the following:
+...and you start running into compiler troubles, then you can refactor to the following:
 
 ```swift
 struct FeatureView: View {
@@ -264,4 +264,4 @@ struct FeatureView: View {
 }
 ```
 
-That should greatly improve the compiler's ability to typecheck your view.
+That should greatly improve the compiler's ability to type-check your view.

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -223,3 +223,45 @@ This greatly reduces the bandwidth of actions being sent into the system so that
 incurring unnecessary costs for sending actions.
 
 <!--### Memory usage-->
+
+### Compiler performance
+
+In very large applications you may experience degraded compiler performance causing long compile
+times, and possibly even compiler failures due to "complex expressions." The ``WithViewStore`` 
+helpers that comes with the library can exacerbate that problem for very complex views. If
+you are running into issues using ``WithViewStore`` you can make a small change to your view
+to use an `@ObservedObject` directly.
+
+For example, if your view looks like this:
+
+```swift
+struct FeatureView: View {
+  let store: Store<FeatureState, FeatureAction>
+
+  var body: some View {
+    WithViewStore(self.store) { viewStore in
+      // A large, complex view inside here...
+    }
+  }
+}
+```
+
+…and you start running into compiler troubles, then you an refactor to the following:
+
+```swift
+struct FeatureView: View {
+  let store: Store<FeatureState, FeatureAction>
+  @ObservedObject var viewStore: ViewStore<FeatureState, FeatureAction>
+
+  init(store: Store<FeatureState, FeatureAction>) {
+    self.store = store
+    self.viewStore = ViewStore(self.store))
+  }
+
+  var body: some View {
+    // A large, complex view inside here...
+  }
+}
+```
+
+That should greatly improve the compiler's ability to typecheck your view.

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -162,6 +162,14 @@ extension WithViewStore: AccessibilityRotorContent where Content: AccessibilityR
   ///   - isDuplicate: A function to determine when two `State` values are equal. When values are
   ///     equal, repeat view computations are removed,
   ///   - content: A function that can generate content from a view store.
+  @available(
+    *,
+     deprecated,
+     message:
+      """
+      WithViewStore for accessibility rotor content is deprecated. To fix, wrap the parent view in 
+      """
+  )
   public init(
     _ store: Store<State, Action>,
     removeDuplicates isDuplicate: @escaping (State, State) -> Bool,

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -2,8 +2,50 @@ import Combine
 import CustomDump
 import SwiftUI
 
-/// A structure that transforms a store into an observable view store in order to compute views from
-/// store state.
+/// A view helper that transforms a ``Store`` into a ``ViewStore`` so that its state can be observed
+/// by a view builder.
+///
+/// This helper is an alternative to observing the view store manually on your view, which requires
+/// the boilerplate of a custom initializer.
+///
+/// For example, the following view, which manually observes the store it is handed by constructing
+/// a view store in its initializer:
+///
+/// ```swift
+/// struct ProfileView: View {
+///   let store: Store<ProfileState, ProfileAction>
+///   @ObservedObject var viewStore: ViewStore<ProfileState, ProfileAction>
+///
+///   init(store: Store<ProfileState, ProfileAction>) {
+///     self.store = store
+///     self.viewStore = ViewStore(store)
+///   }
+///
+///   var body: some View {
+///     Text("\(self.viewStore.username)")
+///     // ...
+///   }
+/// }
+/// ```
+///
+/// Can be written more simply using `WithViewStore`:
+///
+/// ```swift
+/// struct ProfileView: View {
+///   let store: Store<ProfileState, ProfileAction>
+///
+///   var body: some View {
+///     WithViewStore(self.store) { viewStore in
+///       Text("\(viewStore.username)")
+///       // ...
+///     }
+///   }
+/// }
+/// ```
+///
+/// > **Note:** `WithViewStore` expressions are more complex than views that observe view stores
+/// > using `@ObservedObject`, and can lead to a degraded build experience. For large, complex
+/// > views, consider manually observing the store, instead.
 public struct WithViewStore<State, Action, Content> {
   private let content: (ViewStore<State, Action>) -> Content
   #if DEBUG

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -190,7 +190,7 @@ extension WithViewStore: DynamicViewContent where State: Collection, Content: Dy
 }
 
 // MARK: - AccessibilityRotorContent
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
 extension WithViewStore: AccessibilityRotorContent where Content: AccessibilityRotorContent {
   /// Initializes a structure that transforms a store into an observable view store in order to
   /// compute accessibility rotor content from store state.
@@ -225,7 +225,7 @@ extension WithViewStore: AccessibilityRotorContent where Content: AccessibilityR
   }
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
 extension WithViewStore where State: Equatable, Content: AccessibilityRotorContent {
   /// Initializes a structure that transforms a store into an observable view store in order to
   /// compute accessibility rotor content from equatable store state.
@@ -251,7 +251,7 @@ extension WithViewStore where State: Equatable, Content: AccessibilityRotorConte
   }
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
 extension WithViewStore where State == Void, Content: AccessibilityRotorContent {
   /// Initializes a structure that transforms a store into an observable view store in order to
   /// compute accessibility rotor content from void store state.
@@ -279,7 +279,7 @@ extension WithViewStore where State == Void, Content: AccessibilityRotorContent 
 
 // MARK: - Commands
 
-@available(iOS 14.0, macOS 11.0, *)
+@available(iOS 14, macOS 11, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 extension WithViewStore: Commands where Content: Commands {
@@ -316,7 +316,7 @@ extension WithViewStore: Commands where Content: Commands {
   }
 }
 
-@available(iOS 14.0, macOS 11.0, *)
+@available(iOS 14, macOS 11, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 extension WithViewStore where State: Equatable, Content: Commands {
@@ -344,7 +344,7 @@ extension WithViewStore where State: Equatable, Content: Commands {
   }
 }
 
-@available(iOS 14.0, macOS 11.0, *)
+@available(iOS 14, macOS 11, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 extension WithViewStore where State == Void, Content: Commands {
@@ -462,7 +462,7 @@ extension WithViewStore where State == Void, Content: Scene {
 
 // MARK: - ToolbarContent
 
-@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
 extension WithViewStore: ToolbarContent where Content: ToolbarContent {
   /// Initializes a structure that transforms a store into an observable view store in order to
   /// compute toolbar content from store state.
@@ -497,7 +497,7 @@ extension WithViewStore: ToolbarContent where Content: ToolbarContent {
   }
 }
 
-@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
 extension WithViewStore where State: Equatable, Content: ToolbarContent {
   /// Initializes a structure that transforms a store into an observable view store in order to
   /// compute toolbar content from equatable store state.
@@ -523,7 +523,7 @@ extension WithViewStore where State: Equatable, Content: ToolbarContent {
   }
 }
 
-@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
 extension WithViewStore where State == Void, Content: ToolbarContent {
   /// Initializes a structure that transforms a store into an observable view store in order to
   /// compute toolbar content from void store state.

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -46,7 +46,7 @@ public struct WithViewStore<State, Action, Content> {
     return view
   }
 
-  fileprivate var _body: Content {
+  public var body: Content {
     #if DEBUG
       if let prefix = self.prefix {
         var stateDump = ""
@@ -102,10 +102,6 @@ extension WithViewStore: View where Content: View {
       line: line,
       content: content
     )
-  }
-
-  public var body: Content {
-    self._body
   }
 }
 
@@ -164,10 +160,10 @@ extension WithViewStore: AccessibilityRotorContent where Content: AccessibilityR
   ///   - content: A function that can generate content from a view store.
   @available(
     *,
-     deprecated,
-     message:
+    deprecated,
+    message:
       """
-      WithViewStore for accessibility rotor content is deprecated. To fix, wrap the parent view in 
+      For compiler performance, using "WithViewStore" from an accessibility rotor content builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
       """
   )
   public init(
@@ -185,9 +181,6 @@ extension WithViewStore: AccessibilityRotorContent where Content: AccessibilityR
       content: content
     )
   }
-  public var body: some AccessibilityRotorContent {
-    self._body
-  }
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -198,6 +191,14 @@ extension WithViewStore where State: Equatable, Content: AccessibilityRotorConte
   /// - Parameters:
   ///   - store: A store of equatable state.
   ///   - content: A function that can generate content from a view store.
+  @available(
+    *,
+    deprecated,
+    message:
+      """
+      For compiler performance, using "WithViewStore" from an accessibility rotor content builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+      """
+  )
   public init(
     _ store: Store<State, Action>,
     file: StaticString = #fileID,
@@ -216,6 +217,14 @@ extension WithViewStore where State == Void, Content: AccessibilityRotorContent 
   /// - Parameters:
   ///   - store: A store of equatable state.
   ///   - content: A function that can generate content from a view store.
+  @available(
+    *,
+    deprecated,
+    message:
+      """
+      For compiler performance, using "WithViewStore" from an accessibility rotor content builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+      """
+  )
   public init(
     _ store: Store<State, Action>,
     file: StaticString = #fileID,
@@ -227,6 +236,7 @@ extension WithViewStore where State == Void, Content: AccessibilityRotorContent 
 }
 
 // MARK: - Commands
+
 @available(iOS 14.0, macOS 11.0, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
@@ -239,6 +249,14 @@ extension WithViewStore: Commands where Content: Commands {
   ///   - isDuplicate: A function to determine when two `State` values are equal. When values are
   ///     equal, repeat view computations are removed,
   ///   - content: A function that can generate content from a view store.
+  @available(
+    *,
+    deprecated,
+    message:
+      """
+      For compiler performance, using "WithViewStore" from a command builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+      """
+  )
   public init(
     _ store: Store<State, Action>,
     removeDuplicates isDuplicate: @escaping (State, State) -> Bool,
@@ -254,9 +272,6 @@ extension WithViewStore: Commands where Content: Commands {
       content: content
     )
   }
-  public var body: some Commands {
-    self._body
-  }
 }
 
 @available(iOS 14.0, macOS 11.0, *)
@@ -269,6 +284,14 @@ extension WithViewStore where State: Equatable, Content: Commands {
   /// - Parameters:
   ///   - store: A store of equatable state.
   ///   - content: A function that can generate content from a view store.
+  @available(
+    *,
+    deprecated,
+    message:
+      """
+      For compiler performance, using "WithViewStore" from a command builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+      """
+  )
   public init(
     _ store: Store<State, Action>,
     file: StaticString = #fileID,
@@ -289,6 +312,14 @@ extension WithViewStore where State == Void, Content: Commands {
   /// - Parameters:
   ///   - store: A store of equatable state.
   ///   - content: A function that can generate content from a view store.
+  @available(
+    *,
+    deprecated,
+    message:
+      """
+      For compiler performance, using "WithViewStore" from a command builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+      """
+  )
   public init(
     _ store: Store<State, Action>,
     file: StaticString = #fileID,
@@ -324,10 +355,6 @@ extension WithViewStore: Scene where Content: Scene {
       line: line,
       content: content
     )
-  }
-
-  public var body: Content {
-    self._body
   }
 }
 
@@ -368,6 +395,7 @@ extension WithViewStore where State == Void, Content: Scene {
 }
 
 // MARK: - ToolbarContent
+
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension WithViewStore: ToolbarContent where Content: ToolbarContent {
   /// Initializes a structure that transforms a store into an observable view store in order to
@@ -378,6 +406,14 @@ extension WithViewStore: ToolbarContent where Content: ToolbarContent {
   ///   - isDuplicate: A function to determine when two `State` values are equal. When values are
   ///     equal, repeat view computations are removed,
   ///   - content: A function that can generate content from a view store.
+  @available(
+    *,
+    deprecated,
+    message:
+      """
+      For compiler performance, using "WithViewStore" from a toolbar content builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+      """
+  )
   public init(
     _ store: Store<State, Action>,
     removeDuplicates isDuplicate: @escaping (State, State) -> Bool,
@@ -393,9 +429,6 @@ extension WithViewStore: ToolbarContent where Content: ToolbarContent {
       content: content
     )
   }
-  public var body: some ToolbarContent {
-    self._body
-  }
 }
 
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
@@ -406,6 +439,14 @@ extension WithViewStore where State: Equatable, Content: ToolbarContent {
   /// - Parameters:
   ///   - store: A store of equatable state.
   ///   - content: A function that can generate content from a view store.
+  @available(
+    *,
+    deprecated,
+    message:
+      """
+      For compiler performance, using "WithViewStore" from a toolbar content builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+      """
+  )
   public init(
     _ store: Store<State, Action>,
     file: StaticString = #fileID,
@@ -424,6 +465,14 @@ extension WithViewStore where State == Void, Content: ToolbarContent {
   /// - Parameters:
   ///   - store: A store of equatable state.
   ///   - content: A function that can generate content from a view store.
+  @available(
+    *,
+    deprecated,
+    message:
+      """
+      For compiler performance, using "WithViewStore" from a toolbar content builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+      """
+  )
   public init(
     _ store: Store<State, Action>,
     file: StaticString = #fileID,

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -185,6 +185,7 @@ public struct WithViewStore<State, Action, Content> {
 }
 
 // MARK: - View
+
 extension WithViewStore: View where Content: View {
   /// Initializes a structure that transforms a store into an observable view store in order to
   /// compute views from store state.
@@ -254,6 +255,7 @@ extension WithViewStore: DynamicViewContent where State: Collection, Content: Dy
 }
 
 // MARK: - AccessibilityRotorContent
+
 @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
 extension WithViewStore: AccessibilityRotorContent where Content: AccessibilityRotorContent {
   /// Initializes a structure that transforms a store into an observable view store in order to
@@ -270,6 +272,8 @@ extension WithViewStore: AccessibilityRotorContent where Content: AccessibilityR
     message:
       """
       For compiler performance, using "WithViewStore" from an accessibility rotor content builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+
+      See the documentation for "WithViewStore" (https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/viewstore#overview) for more information.
       """
   )
   public init(
@@ -303,6 +307,8 @@ extension WithViewStore where State: Equatable, Content: AccessibilityRotorConte
     message:
       """
       For compiler performance, using "WithViewStore" from an accessibility rotor content builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+
+      See the documentation for "WithViewStore" (https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/viewstore#overview) for more information.
       """
   )
   public init(
@@ -329,6 +335,8 @@ extension WithViewStore where State == Void, Content: AccessibilityRotorContent 
     message:
       """
       For compiler performance, using "WithViewStore" from an accessibility rotor content builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+
+      See the documentation for "WithViewStore" (https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/viewstore#overview) for more information.
       """
   )
   public init(
@@ -361,6 +369,8 @@ extension WithViewStore: Commands where Content: Commands {
     message:
       """
       For compiler performance, using "WithViewStore" from a command builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+
+      See the documentation for "WithViewStore" (https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/viewstore#overview) for more information.
       """
   )
   public init(
@@ -396,6 +406,8 @@ extension WithViewStore where State: Equatable, Content: Commands {
     message:
       """
       For compiler performance, using "WithViewStore" from a command builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+
+      See the documentation for "WithViewStore" (https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/viewstore#overview) for more information.
       """
   )
   public init(
@@ -424,6 +436,8 @@ extension WithViewStore where State == Void, Content: Commands {
     message:
       """
       For compiler performance, using "WithViewStore" from a command builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+
+      See the documentation for "WithViewStore" (https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/viewstore#overview) for more information.
       """
   )
   public init(
@@ -437,6 +451,7 @@ extension WithViewStore where State == Void, Content: Commands {
 }
 
 // MARK: - Scene
+
 @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
 extension WithViewStore: Scene where Content: Scene {
   /// Initializes a structure that transforms a store into an observable view store in order to
@@ -453,6 +468,8 @@ extension WithViewStore: Scene where Content: Scene {
     message:
       """
       For compiler performance, using "WithViewStore" from a scene builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+
+      See the documentation for "WithViewStore" (https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/viewstore#overview) for more information.
       """
   )
   public init(
@@ -486,6 +503,8 @@ extension WithViewStore where State: Equatable, Content: Scene {
     message:
       """
       For compiler performance, using "WithViewStore" from a scene builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+
+      See the documentation for "WithViewStore" (https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/viewstore#overview) for more information.
       """
   )
   public init(
@@ -512,6 +531,8 @@ extension WithViewStore where State == Void, Content: Scene {
     message:
       """
       For compiler performance, using "WithViewStore" from a scene builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+
+      See the documentation for "WithViewStore" (https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/viewstore#overview) for more information.
       """
   )
   public init(
@@ -542,6 +563,8 @@ extension WithViewStore: ToolbarContent where Content: ToolbarContent {
     message:
       """
       For compiler performance, using "WithViewStore" from a toolbar content builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+
+      See the documentation for "WithViewStore" (https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/viewstore#overview) for more information.
       """
   )
   public init(
@@ -575,6 +598,8 @@ extension WithViewStore where State: Equatable, Content: ToolbarContent {
     message:
       """
       For compiler performance, using "WithViewStore" from a toolbar content builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+
+      See the documentation for "WithViewStore" (https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/viewstore#overview) for more information.
       """
   )
   public init(
@@ -601,6 +626,8 @@ extension WithViewStore where State == Void, Content: ToolbarContent {
     message:
       """
       For compiler performance, using "WithViewStore" from a toolbar content builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+
+      See the documentation for "WithViewStore" (https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/viewstore#overview) for more information.
       """
   )
   public init(

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -61,8 +61,8 @@ import SwiftUI
 ///    ```swift
 ///    @main
 ///    struct MyApp: App {
-///      let store = Store<AppState, AppAction>(...)
-///      @ObservedObject var viewStore: ViewStore<SceneState, AppAction>
+///      let store = Store<AppState, AppAction>(/* ... */)
+///      @ObservedObject var viewStore: ViewStore<SceneState, CommandAction>
 ///
 ///      struct SceneState: Equatable {
 ///        // ...
@@ -72,12 +72,24 @@ import SwiftUI
 ///      }
 ///
 ///      init() {
-///        self.viewStore = ViewStore(self.store.scope(state: SceneState.init)
+///        self.viewStore = ViewStore(
+///          self.store.scope(
+///            state: SceneState.init(state:)
+///            action: AppAction.scene
+///          )
+///        )
 ///      }
 ///
 ///      var body: some Scene {
 ///        WindowGroup {
 ///          MyRootView()
+///        }
+///        .commands {
+///          CommandMenu("Help") {
+///            Button("About \(self.viewStore.appName)") {
+///              self.viewStore.send(.aboutButtonTapped)
+///            }
+///          }
 ///        }
 ///      }
 ///    }

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -43,9 +43,9 @@ import SwiftUI
 /// }
 /// ```
 ///
-/// > **Note:** `WithViewStore` expressions are more complex than views that observe view stores
-/// > using `@ObservedObject`, and can lead to a degraded build experience. For large, complex
-/// > views, consider manually observing the store, instead.
+/// > Note: `WithViewStore` expressions are more complex than views that observe view stores using
+/// > `@ObservedObject`, and can lead to a degraded compiler performance. For large, complex view,
+/// > consider manually observing the store using `@ObservedObject`, instead.
 public struct WithViewStore<State, Action, Content> {
   private let content: (ViewStore<State, Action>) -> Content
   #if DEBUG
@@ -383,6 +383,14 @@ extension WithViewStore: Scene where Content: Scene {
   ///   - isDuplicate: A function to determine when two `State` values are equal. When values are
   ///     equal, repeat view computations are removed,
   ///   - content: A function that can generate content from a view store.
+  @available(
+    *,
+    deprecated,
+    message:
+      """
+      For compiler performance, using "WithViewStore" from a scene builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+      """
+  )
   public init(
     _ store: Store<State, Action>,
     removeDuplicates isDuplicate: @escaping (State, State) -> Bool,
@@ -408,6 +416,14 @@ extension WithViewStore where State: Equatable, Content: Scene {
   /// - Parameters:
   ///   - store: A store of equatable state.
   ///   - content: A function that can generate content from a view store.
+  @available(
+    *,
+    deprecated,
+    message:
+      """
+      For compiler performance, using "WithViewStore" from a scene builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+      """
+  )
   public init(
     _ store: Store<State, Action>,
     file: StaticString = #fileID,
@@ -426,6 +442,14 @@ extension WithViewStore where State == Void, Content: Scene {
   /// - Parameters:
   ///   - store: A store of equatable state.
   ///   - content: A function that can generate content from a view store.
+  @available(
+    *,
+    deprecated,
+    message:
+      """
+      For compiler performance, using "WithViewStore" from a scene builder is no longer supported. Extract this "WithViewStore" to the parent view, instead, or observe your view store from an "@ObservedObject" property.
+      """
+  )
   public init(
     _ store: Store<State, Action>,
     file: StaticString = #fileID,

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -20,7 +20,18 @@ import SwiftUI
 /// }
 /// ```
 ///
-/// In UIKit applications a ``ViewStore`` can be created from a ``Store`` and then subscribed to for
+/// It can also be observed directly by views, scenes, commands, and other contexts that support the
+/// `@ObservedObject` property wrapper:
+///
+/// ```swift
+/// @ObservedObject var viewStore: ViewStore<State, Action>
+/// ```
+///
+/// > Tip: If you experience compile-time issues with views that use ``WithViewStore``, try
+/// > observing the view store directly using an `@ObservedObject`, instead, which is easier on the
+/// > compiler.
+///
+/// In UIKit applications a `ViewStore` can be created from a ``Store`` and then subscribed to for
 /// state updates:
 ///
 /// ```swift
@@ -45,7 +56,7 @@ import SwiftUI
 /// }
 /// ```
 ///
-/// > Important: The ``ViewStore`` class is not thread-safe, and all interactions with it (and the
+/// > Important: The `ViewStore` class is not thread-safe, and all interactions with it (and the
 /// > store it was derived from) must happen on the same thread. Further, for SwiftUI applications,
 /// > all interactions must happen on the _main_ thread. See the documentation of the ``Store``
 /// > class for more information as to why this decision was made.

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -1,13 +1,13 @@
 import Combine
 import SwiftUI
 
-/// A ``ViewStore`` is an object that can observe state changes and send actions. They are most
-/// commonly used in views, such as SwiftUI views, UIView or UIViewController, but they can be
-/// used anywhere it makes sense to observe state and send actions.
+/// A `ViewStore` is an object that can observe state changes and send actions. They are most
+/// commonly used in views, such as SwiftUI views, UIView or UIViewController, but they can be used
+/// anywhere it makes sense to observe state or send actions.
 ///
-/// In SwiftUI applications, a ``ViewStore`` is accessed most commonly using the ``WithViewStore``
-/// view. It can be initialized with a store and a closure that is handed a view store and must
-/// return a view to be rendered:
+/// In SwiftUI applications, a `ViewStore` is accessed most commonly using the ``WithViewStore``
+/// view. It can be initialized with a store and a closure that is handed a view store and returns a
+/// view:
 ///
 /// ```swift
 /// var body: some View {
@@ -20,16 +20,16 @@ import SwiftUI
 /// }
 /// ```
 ///
-/// It can also be observed directly by views, scenes, commands, and other contexts that support the
-/// `@ObservedObject` property wrapper:
+/// View stores can also be observed directly by views, scenes, commands, and other contexts that
+/// support the `@ObservedObject` property wrapper:
 ///
 /// ```swift
 /// @ObservedObject var viewStore: ViewStore<State, Action>
 /// ```
 ///
 /// > Tip: If you experience compile-time issues with views that use ``WithViewStore``, try
-/// > observing the view store directly using an `@ObservedObject`, instead, which is easier on the
-/// > compiler.
+/// > observing the view store directly using the `@ObservedObject` property wrapper, instead, which
+/// > is easier on the compiler.
 ///
 /// In UIKit applications a `ViewStore` can be created from a ``Store`` and then subscribed to for
 /// state updates:

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -37,6 +37,7 @@ import SwiftUI
 /// ```swift
 /// let store: Store<State, Action>
 /// let viewStore: ViewStore<State, Action>
+/// private var cancellables: Set<AnyCancellable> = []
 ///
 /// init(store: Store<State, Action>) {
 ///   self.store = store

--- a/Tests/ComposableArchitectureTests/WithViewStoreAppTest.swift
+++ b/Tests/ComposableArchitectureTests/WithViewStoreAppTest.swift
@@ -16,6 +16,7 @@ struct TestApp: App {
     environment: ()
   )
 
+  @available(*, deprecated)
   var body: some Scene {
     WithViewStore(self.store) { viewStore in
       WindowGroup {
@@ -26,6 +27,7 @@ struct TestApp: App {
   }
 
   #if os(iOS) || os(macOS)
+    @available(*, deprecated)
     var commands: some Scene {
       self.body.commands {
         WithViewStore(self.store) { viewStore in
@@ -39,6 +41,7 @@ struct TestApp: App {
     }
   #endif
 
+  @available(*, deprecated)
   @ViewBuilder
   func checkToolbar() -> some View {
     Color.clear
@@ -51,6 +54,7 @@ struct TestApp: App {
       }
   }
 
+  @available(*, deprecated)
   @ViewBuilder
   func checkAccessibilityRotor() -> some View {
     if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {


### PR DESCRIPTION
We've found that `WithViewStore`s overloads can really tax the compiler, so it's time to get prepare to remove them. The vast majority of uses are in SwiftUI views, so we can privilege the helper for that use case, and require a bit of extra work of manually observing a view store via `@ObservedObject` in the other cases.

In the future it would be nice to deprecate `WithViewStore` entirely, but we would want to offer a simpler tool, _e.g._ a property wrapper called `@ObservedStore` that smashes the concepts of `Store` and `ViewStore` together without a lot of boilerplate. This would lessen compiler strain by avoiding escaping closures and generic transforms in the view builder layer. Unfortunately, we still haven't figured out how to get property wrappers to work in a way that we find simple and intuitive.

In the meantime we can hopefully improve performance of the tool we provide by narrowing its focus to the most common builder.