### PR TITLE
Don't warn for overridden test dependencies

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
@@ -46,9 +46,9 @@ public struct _DependencyKeyWritingReducer<Base: ReducerProtocol>: ReducerProtoc
   public func reduce(
     into state: inout Base.State, action: Base.Action
   ) -> Effect<Base.Action, Never> {
-    var values = DependencyValues.current
-    self.update(&values)
-    return DependencyValues.$current.withValue(values) {
+    return DependencyValues.withValue {
+      self.update(&$0)
+    } operation: {
       self.base.reduce(into: &state, action: action)
     }
   }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
@@ -46,7 +46,7 @@ public struct _DependencyKeyWritingReducer<Base: ReducerProtocol>: ReducerProtoc
   public func reduce(
     into state: inout Base.State, action: Base.Action
   ) -> Effect<Base.Action, Never> {
-    return DependencyValues.withValue {
+    return DependencyValues.withValues {
       self.update(&$0)
     } operation: {
       self.base.reduce(into: &state, action: action)


### PR DESCRIPTION
It is possible to define test dependencies via `TestDependencyKey` and never have a `DependencyKey` conformance. By default we want to warn about test dependencies used in production, but we should _not_ warn if the test dependency is overridden by a `dependency` reducer modifier.

Swift property semantics always does a `get` to the underlying property, so we need to set some temporary state when overriding dependencies to avoid emitting this warning. Not sure if other property trickery could simplify the implementation in this PR.

Thanks @andreyz for the report!