### PR TITLE
Force `Effect.{debounce,deferred}` through publisher

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Debouncing.swift
+++ b/Sources/ComposableArchitecture/Effects/Debouncing.swift
@@ -33,28 +33,17 @@ extension Effect {
     switch self.operation {
     case .none:
       return .none
-    case let .publisher(publisher):
+    case .publisher, .run:
       return Self(
         operation: .publisher(
           Just(())
             .setFailureType(to: Failure.self)
             .delay(for: dueTime, scheduler: scheduler, options: options)
-            .flatMap { publisher.receive(on: scheduler) }
+            .flatMap { self.publisher.receive(on: scheduler) }
             .eraseToAnyPublisher()
         )
       )
       .cancellable(id: id, cancelInFlight: true)
-    case let .run(priority, operation):
-      return Self(
-        operation: .run(priority) { send in
-          await withTaskCancellation(id: id, cancelInFlight: true) {
-            do {
-              try await scheduler.sleep(for: dueTime, options: options)
-              await operation(send)
-            } catch {}
-          }
-        }
-      )
     }
   }
 

--- a/Sources/ComposableArchitecture/Effects/Deferring.swift
+++ b/Sources/ComposableArchitecture/Effects/Deferring.swift
@@ -15,6 +15,12 @@ extension Effect {
   ///   - scheduler: The scheduler you want to deliver the defer output to.
   ///   - options: Scheduler options that customize the effect's delivery of elements.
   /// - Returns: An effect that will be executed after `dueTime`
+  @available(iOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'Effect.run', instead.")
+  @available(macOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'Effect.run', instead.")
+  @available(tvOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'Effect.run', instead.")
+  @available(
+    watchOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'Effect.run', instead."
+  )
   public func deferred<S: Scheduler>(
     for dueTime: S.SchedulerTimeType.Stride,
     scheduler: S,
@@ -23,7 +29,7 @@ extension Effect {
     switch self.operation {
     case .none:
       return .none
-    case .publisher, .run:
+    case .publisher:
       return Self(
         operation: .publisher(
           Just(())
@@ -32,6 +38,21 @@ extension Effect {
             .flatMap { self.publisher.receive(on: scheduler) }
             .eraseToAnyPublisher()
         )
+      )
+    case let .run(priority, operation):
+      return Self(
+        operation: .run(priority) { send in
+          do {
+            try await scheduler.sleep(for: dueTime)
+            await operation(
+              Send { output in
+                scheduler.schedule {
+                  send(output)
+                }
+              }
+            )
+          } catch {}
+        }
       )
     }
   }

--- a/Sources/ComposableArchitecture/Effects/Deferring.swift
+++ b/Sources/ComposableArchitecture/Effects/Deferring.swift
@@ -23,24 +23,15 @@ extension Effect {
     switch self.operation {
     case .none:
       return .none
-    case let .publisher(publisher):
+    case .publisher, .run:
       return Self(
         operation: .publisher(
           Just(())
             .setFailureType(to: Failure.self)
             .delay(for: dueTime, scheduler: scheduler, options: options)
-            .flatMap { publisher.receive(on: scheduler) }
+            .flatMap { self.publisher.receive(on: scheduler) }
             .eraseToAnyPublisher()
         )
-      )
-    case let .run(priority, operation):
-      return Self(
-        operation: .run(priority) { send in
-          do {
-            try await scheduler.sleep(for: dueTime)
-            await operation(send)
-          } catch {}
-        }
       )
     }
   }

--- a/Sources/ComposableArchitecture/Effects/Timer.swift
+++ b/Sources/ComposableArchitecture/Effects/Timer.swift
@@ -125,6 +125,12 @@ extension Effect where Failure == Never {
   ///   - tolerance: The allowed timing variance when emitting events. Defaults to `nil`, which
   ///     allows any variance.
   ///   - options: Scheduler options passed to the timer. Defaults to `nil`.
+  @available(iOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead.")
+  @available(macOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead.")
+  @available(tvOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead.")
+  @available(
+    watchOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead."
+  )
   public static func timer<S: Scheduler>(
     id: Any.Type,
     every interval: S.SchedulerTimeType.Stride,


### PR DESCRIPTION
Because publishers can be animated (and in general are responsible for scheduling work within a specific context), we should continue to force these helpers through our publisher endpoints, otherwise our next release could break animated schedulers.

We can consider soft-deprecating these endpoints, but we need to figure out the upgrade paths.