### PR TITLE
Defer action removal until performing last action

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -334,8 +334,11 @@ public final class Store<State, Action> {
 
     let tasks = Box<[Task<Void, Never>]>(wrappedValue: [])
 
-    while !self.bufferedActions.isEmpty {
-      let action = self.bufferedActions.removeFirst()
+    var index = self.bufferedActions.startIndex
+    defer { self.bufferedActions = [] }
+    while index < self.bufferedActions.endIndex {
+      defer { index += 1 }
+      let action = self.bufferedActions[index]
       let effect = self.reducer(&currentState, action)
 
       switch effect.operation {


### PR DESCRIPTION
This PR suggests another possible performance improvement.

Right now we use `.removeFirst()` to access the next action. We could instead use an incrementing index and clear `bufferedActions` at the end of the `send` block. 

There have been [discussions](https://github.com/pointfreeco/swift-composable-architecture/discussions/618#discussioncomment-935699) about using `Deque` instead of `Array`, I think this could be a possible alternative. 

I've held off on this one in the past because I was unclear on the memory implications. With all the performance improvements lately, I thought it would be a good time to revisit it and see what people thought. 

Here's the `Store scoping` benchmarks for `main` vs this pr:

```
name                                   time        std        iterations
------------------------------------------------------------------------
Store scoping.Nested store (main)      5000.000 ns ±  27.54 %     262884
Store scoping.Nested store (this pr)   4167.000 ns ±  38.67 %     300487
```