### PR TITLE
Use publishers in `Effect.debounce` and `Effect.deferred`

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -154,8 +154,35 @@ extension Effect {
 
 /// Execute an operation with a cancellation identifier.
 ///
-/// If the operation is in-flight when `Task.cancel(id:)` is called with the same identifier, the
+/// If the operation is in-flight when `Task.cancel(id:)` is called with the same identifier, or
 /// operation will be cancelled.
+///
+/// ```
+/// enum CancelID.self {}
+///
+/// await withTaskCancellation(id: CancelID.self) {
+///   // ...
+/// }
+/// ```
+///
+/// ### Debouncing tasks
+///
+/// When paired with a scheduler, this function can be used to debounce a unit of async work by
+/// specifying the `cancelInFlight`, which will automatically cancel any in-flight work with the
+/// same identifier:
+///
+/// ```swift
+/// enum CancelID {}
+///
+/// return .task {
+///   await withTaskCancellation(id: CancelID.self, cancelInFlight: true) {
+///     try await environment.scheduler.sleep(for: .seconds(0.3))
+///     return await .debouncedResponse(
+///       TaskResult { try await environment.request() }
+///     )
+///   }
+/// }
+/// ```
 ///
 /// - Parameters:
 ///   - id: A unique identifier for the operation.

--- a/Sources/ComposableArchitecture/Effects/Debouncing.swift
+++ b/Sources/ComposableArchitecture/Effects/Debouncing.swift
@@ -24,6 +24,26 @@ extension Effect {
   ///   - scheduler: The scheduler you want to deliver the debounced output to.
   ///   - options: Scheduler options that customize the effect's delivery of elements.
   /// - Returns: An effect that publishes events only after a specified time elapses.
+  @available(
+    iOS,
+    deprecated: 9999.0,
+    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'Effect.run', instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999.0,
+    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'Effect.run', instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999.0,
+    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'Effect.run', instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999.0,
+    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'Effect.run', instead."
+  )
   public func debounce<S: Scheduler>(
     id: AnyHashable,
     for dueTime: S.SchedulerTimeType.Stride,
@@ -33,7 +53,7 @@ extension Effect {
     switch self.operation {
     case .none:
       return .none
-    case .publisher:
+    case .publisher, .run:
       return Self(
         operation: .publisher(
           Just(())
@@ -44,23 +64,6 @@ extension Effect {
         )
       )
       .cancellable(id: id, cancelInFlight: true)
-    case let .run(priority, operation):
-      return Self(
-        operation: .run(priority) { send in
-          await withTaskCancellation(id: id, cancelInFlight: true) {
-            do {
-              try await scheduler.sleep(for: dueTime, options: options)
-              await operation(
-                Send { output in
-                  scheduler.schedule {
-                    send(output)
-                  }
-                }
-              )
-            } catch {}
-          }
-        }
-      )
     }
   }
 

--- a/Sources/ComposableArchitecture/Effects/Deferring.swift
+++ b/Sources/ComposableArchitecture/Effects/Deferring.swift
@@ -29,7 +29,7 @@ extension Effect {
     switch self.operation {
     case .none:
       return .none
-    case .publisher:
+    case .publisher, .run:
       return Self(
         operation: .publisher(
           Just(())
@@ -38,21 +38,6 @@ extension Effect {
             .flatMap { self.publisher.receive(on: scheduler) }
             .eraseToAnyPublisher()
         )
-      )
-    case let .run(priority, operation):
-      return Self(
-        operation: .run(priority) { send in
-          do {
-            try await scheduler.sleep(for: dueTime)
-            await operation(
-              Send { output in
-                scheduler.schedule {
-                  send(output)
-                }
-              }
-            )
-          } catch {}
-        }
       )
     }
   }


### PR DESCRIPTION
These implementations are problematic for test schedulers because they schedule two discrete units of work. While we can probably work around it, let's avoid the bug for now.