### PR TITLE
Add `_StateObject`, an iOS 13 compatible substitute of `StateObject`

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -698,10 +698,7 @@ extension ForEachStore {
   where
     Data == [EachState],
     Content == WithViewStore<
-      [ID], (Data.Index, EachAction),
-      _StateObjectViewStore<
-        [ID], (Int, EachAction), ForEach<[(offset: Int, element: ID)], ID, EachContent>
-      >
+      [ID], (Data.Index, EachAction), ForEach<[(offset: Int, element: ID)], ID, EachContent>
     >
   {
     let data = store.state.value
@@ -728,10 +725,7 @@ extension ForEachStore {
   where
     Data == [EachState],
     Content == WithViewStore<
-      [ID], (Data.Index, EachAction),
-      _StateObjectViewStore<
-        [ID], (Int, EachAction), ForEach<[(offset: Int, element: ID)], ID, EachContent>
-      >
+      [ID], (Data.Index, EachAction), ForEach<[(offset: Int, element: ID)], ID, EachContent>
     >,
     EachState: Identifiable,
     EachState.ID == ID

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -699,11 +699,8 @@ extension ForEachStore {
     Data == [EachState],
     Content == WithViewStore<
       [ID], (Data.Index, EachAction),
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          [ID], (Int, EachAction), ForEach<[(offset: Int, element: ID)], ID, EachContent>
-        >
+      _StateObjectViewStore<
+        [ID], (Int, EachAction), ForEach<[(offset: Int, element: ID)], ID, EachContent>
       >
     >
   {
@@ -732,11 +729,8 @@ extension ForEachStore {
     Data == [EachState],
     Content == WithViewStore<
       [ID], (Data.Index, EachAction),
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          [ID], (Int, EachAction), ForEach<[(offset: Int, element: ID)], ID, EachContent>
-        >
+      _StateObjectViewStore<
+        [ID], (Int, EachAction), ForEach<[(offset: Int, element: ID)], ID, EachContent>
       >
     >,
     EachState: Identifiable,

--- a/Sources/ComposableArchitecture/Internal/_StateObject.swift
+++ b/Sources/ComposableArchitecture/Internal/_StateObject.swift
@@ -37,7 +37,7 @@ struct _StateObject<Object: ObservableObject>: DynamicProperty {
 
   func update() {
     if !storage.objectWillSendIsRelayed {
-      // We're capturing an `ObjectWillSend` instance through its
+      // We're capturing an `ObjectWillChange` instance through its
       // `objectWillChange` publisher here. `View` invalidation still
       // seems to be effective even if the `objectWillChange` publisher
       // is issued from another `@ObservedObject` instance than the current

--- a/Sources/ComposableArchitecture/Internal/_StateObject.swift
+++ b/Sources/ComposableArchitecture/Internal/_StateObject.swift
@@ -37,12 +37,9 @@ struct _StateObject<Object: ObservableObject>: DynamicProperty {
 
   func update() {
     if !storage.objectWillSendIsRelayed {
-      // We're capturing an `ObjectWillChange` instance through its
-      // `objectWillChange` publisher here. `View` invalidation still
-      // seems to be effective even if the `objectWillChange` publisher
-      // is issued from another `@ObservedObject` instance than the current
-      // one. It is likely that these publishers are bound to the `View`'s
-      // identity.
+      // `View` invalidation still seems to be effective even if the `objectWillChange`
+      // publisher is issued from another `@ObservedObject` instance than the current
+      // one. It is likely that these publishers are bound to the `View`'s identity.
       objectWillChange.relay(from: storage)
     }
   }

--- a/Sources/ComposableArchitecture/Internal/_StateObject.swift
+++ b/Sources/ComposableArchitecture/Internal/_StateObject.swift
@@ -22,9 +22,9 @@ struct _StateObject<Object: ObservableObject>: DynamicProperty {
   }
 
   private final class Storage {
-    lazy var object: Object = thunk()
+    lazy var object: Object = initially()
     var objectWillSendIsRelayed: Bool = false
-    var thunk: (() -> Object)!
+    var initially: (() -> Object)!
     init() {}
   }
 
@@ -32,7 +32,7 @@ struct _StateObject<Object: ObservableObject>: DynamicProperty {
   @State private var storage = Storage()
 
   init(wrappedValue: @autoclosure @escaping () -> Object) {
-    storage.thunk = wrappedValue
+    storage.initially = wrappedValue
   }
 
   func update() {

--- a/Sources/ComposableArchitecture/Internal/_StateObject.swift
+++ b/Sources/ComposableArchitecture/Internal/_StateObject.swift
@@ -1,0 +1,53 @@
+import Combine
+import SwiftUI
+
+@propertyWrapper
+struct _StateObject<Object: ObservableObject>: DynamicProperty {
+  private final class ObjectWillChange: ObservableObject {
+    private var subscription: AnyCancellable?
+    // Manually defining this property allows to keep it `lazy` and improves
+    // performance, as we ultimately only need this publisher once in the
+    // lifetime of the view.
+    lazy var objectWillChange = ObservableObjectPublisher()
+
+    init() {}
+    func relay(from storage: Storage) {
+      defer { storage.objectWillSendIsRelayed = true }
+      subscription = storage.object.objectWillChange.sink {
+        [weak objectWillChange = self.objectWillChange] _ in
+          guard let objectWillChange = objectWillChange else { return }
+          objectWillChange.send()
+      }
+    }
+  }
+
+  private final class Storage {
+    lazy var object: Object = thunk()
+    var objectWillSendIsRelayed: Bool = false
+    var thunk: (() -> Object)!
+    init() {}
+  }
+
+  @ObservedObject private var objectWillChange = ObjectWillChange()
+  @State private var storage = Storage()
+
+  init(wrappedValue: @autoclosure @escaping () -> Object) {
+    storage.thunk = wrappedValue
+  }
+
+  func update() {
+    if !storage.objectWillSendIsRelayed {
+      // We're capturing an `ObjectWillSend` instance through its
+      // `objectWillChange` publisher here. `View` invalidation still
+      // seems to be effective even if the `objectWillChange` publisher
+      // is issued from another `@ObservedObject` instance than the current
+      // one. It is likely that these publishers are bound to the `View`'s
+      // identity.
+      objectWillChange.relay(from: storage)
+    }
+  }
+
+  var wrappedValue: Object {
+    storage.object
+  }
+}

--- a/Sources/ComposableArchitecture/Internal/_StateObject.swift
+++ b/Sources/ComposableArchitecture/Internal/_StateObject.swift
@@ -4,11 +4,11 @@ import SwiftUI
 @propertyWrapper
 struct _StateObject<Object: ObservableObject>: DynamicProperty {
   private final class ObjectWillChange: ObservableObject {
-    private var subscription: AnyCancellable?
     // Manually defining this property allows to keep it `lazy` and improves
     // performance, as we ultimately only need this publisher once in the
     // lifetime of the view.
     lazy var objectWillChange = ObservableObjectPublisher()
+    private var subscription: AnyCancellable?
 
     init() {}
     func relay(from storage: Storage) {

--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -90,11 +90,8 @@ public struct ForEachStore<
     Data == IdentifiedArray<ID, EachState>,
     Content == WithViewStore<
       OrderedSet<ID>, (ID, EachAction),
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          OrderedSet<ID>, (ID, EachAction), ForEach<OrderedSet<ID>, ID, EachContent>
-        >
+      _StateObjectViewStore<
+        OrderedSet<ID>, (ID, EachAction), ForEach<OrderedSet<ID>, ID, EachContent>
       >
     >
   {

--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -89,10 +89,7 @@ public struct ForEachStore<
   where
     Data == IdentifiedArray<ID, EachState>,
     Content == WithViewStore<
-      OrderedSet<ID>, (ID, EachAction),
-      _StateObjectViewStore<
-        OrderedSet<ID>, (ID, EachAction), ForEach<OrderedSet<ID>, ID, EachContent>
-      >
+      OrderedSet<ID>, (ID, EachAction), ForEach<OrderedSet<ID>, ID, EachContent>
     >
   {
     self.data = store.state.value

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -164,13 +164,10 @@ extension SwitchStore {
   where
     Content == WithViewStore<
       State, Action,
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          State, Action,
-          _ConditionalContent<
-            CaseLet<State, Action, State1, Action1, Content1>, Default<DefaultContent>
-          >
+      _StateObjectViewStore<
+        State, Action,
+        _ConditionalContent<
+          CaseLet<State, Action, State1, Action1, Content1>, Default<DefaultContent>
         >
       >
     >
@@ -198,14 +195,11 @@ extension SwitchStore {
     Content == WithViewStore<
       State,
       Action,
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          State, Action,
-          _ConditionalContent<
-            CaseLet<State, Action, State1, Action1, Content1>,
-            Default<_ExhaustivityCheckView<State, Action>>
-          >
+      _StateObjectViewStore<
+        State, Action,
+        _ConditionalContent<
+          CaseLet<State, Action, State1, Action1, Content1>,
+          Default<_ExhaustivityCheckView<State, Action>>
         >
       >
     >
@@ -229,17 +223,14 @@ extension SwitchStore {
   where
     Content == WithViewStore<
       State, Action,
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          State, Action,
+      _StateObjectViewStore<
+        State, Action,
+        _ConditionalContent<
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State1, Action1, Content1>,
-              CaseLet<State, Action, State2, Action2, Content2>
-            >,
-            Default<DefaultContent>
-          >
+            CaseLet<State, Action, State1, Action1, Content1>,
+            CaseLet<State, Action, State2, Action2, Content2>
+          >,
+          Default<DefaultContent>
         >
       >
     >
@@ -274,17 +265,14 @@ extension SwitchStore {
     Content == WithViewStore<
       State,
       Action,
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          State, Action,
+      _StateObjectViewStore<
+        State, Action,
+        _ConditionalContent<
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State1, Action1, Content1>,
-              CaseLet<State, Action, State2, Action2, Content2>
-            >,
-            Default<_ExhaustivityCheckView<State, Action>>
-          >
+            CaseLet<State, Action, State1, Action1, Content1>,
+            CaseLet<State, Action, State2, Action2, Content2>
+          >,
+          Default<_ExhaustivityCheckView<State, Action>>
         >
       >
     >
@@ -316,18 +304,15 @@ extension SwitchStore {
   where
     Content == WithViewStore<
       State, Action,
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          State, Action,
+      _StateObjectViewStore<
+        State, Action,
+        _ConditionalContent<
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State1, Action1, Content1>,
-              CaseLet<State, Action, State2, Action2, Content2>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State3, Action3, Content3>, Default<DefaultContent>
-            >
+            CaseLet<State, Action, State1, Action1, Content1>,
+            CaseLet<State, Action, State2, Action2, Content2>
+          >,
+          _ConditionalContent<
+            CaseLet<State, Action, State3, Action3, Content3>, Default<DefaultContent>
           >
         >
       >
@@ -366,19 +351,16 @@ extension SwitchStore {
     Content == WithViewStore<
       State,
       Action,
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          State, Action,
+      _StateObjectViewStore<
+        State, Action,
+        _ConditionalContent<
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State1, Action1, Content1>,
-              CaseLet<State, Action, State2, Action2, Content2>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State3, Action3, Content3>,
-              Default<_ExhaustivityCheckView<State, Action>>
-            >
+            CaseLet<State, Action, State1, Action1, Content1>,
+            CaseLet<State, Action, State2, Action2, Content2>
+          >,
+          _ConditionalContent<
+            CaseLet<State, Action, State3, Action3, Content3>,
+            Default<_ExhaustivityCheckView<State, Action>>
           >
         >
       >
@@ -414,22 +396,19 @@ extension SwitchStore {
   where
     Content == WithViewStore<
       State, Action,
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          State, Action,
+      _StateObjectViewStore<
+        State, Action,
+        _ConditionalContent<
           _ConditionalContent<
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State1, Action1, Content1>,
-                CaseLet<State, Action, State2, Action2, Content2>
-              >,
-              _ConditionalContent<
-                CaseLet<State, Action, State3, Action3, Content3>,
-                CaseLet<State, Action, State4, Action4, Content4>
-              >
-            >, Default<DefaultContent>
-          >
+              CaseLet<State, Action, State1, Action1, Content1>,
+              CaseLet<State, Action, State2, Action2, Content2>
+            >,
+            _ConditionalContent<
+              CaseLet<State, Action, State3, Action3, Content3>,
+              CaseLet<State, Action, State4, Action4, Content4>
+            >
+          >, Default<DefaultContent>
         >
       >
     >
@@ -475,23 +454,20 @@ extension SwitchStore {
     Content == WithViewStore<
       State,
       Action,
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          State, Action,
+      _StateObjectViewStore<
+        State, Action,
+        _ConditionalContent<
           _ConditionalContent<
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State1, Action1, Content1>,
-                CaseLet<State, Action, State2, Action2, Content2>
-              >,
-              _ConditionalContent<
-                CaseLet<State, Action, State3, Action3, Content3>,
-                CaseLet<State, Action, State4, Action4, Content4>
-              >
+              CaseLet<State, Action, State1, Action1, Content1>,
+              CaseLet<State, Action, State2, Action2, Content2>
             >,
-            Default<_ExhaustivityCheckView<State, Action>>
-          >
+            _ConditionalContent<
+              CaseLet<State, Action, State3, Action3, Content3>,
+              CaseLet<State, Action, State4, Action4, Content4>
+            >
+          >,
+          Default<_ExhaustivityCheckView<State, Action>>
         >
       >
     >
@@ -529,24 +505,21 @@ extension SwitchStore {
   where
     Content == WithViewStore<
       State, Action,
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          State, Action,
+      _StateObjectViewStore<
+        State, Action,
+        _ConditionalContent<
           _ConditionalContent<
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State1, Action1, Content1>,
-                CaseLet<State, Action, State2, Action2, Content2>
-              >,
-              _ConditionalContent<
-                CaseLet<State, Action, State3, Action3, Content3>,
-                CaseLet<State, Action, State4, Action4, Content4>
-              >
+              CaseLet<State, Action, State1, Action1, Content1>,
+              CaseLet<State, Action, State2, Action2, Content2>
             >,
             _ConditionalContent<
-              CaseLet<State, Action, State5, Action5, Content5>, Default<DefaultContent>
+              CaseLet<State, Action, State3, Action3, Content3>,
+              CaseLet<State, Action, State4, Action4, Content4>
             >
+          >,
+          _ConditionalContent<
+            CaseLet<State, Action, State5, Action5, Content5>, Default<DefaultContent>
           >
         >
       >
@@ -597,25 +570,22 @@ extension SwitchStore {
     Content == WithViewStore<
       State,
       Action,
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          State, Action,
+      _StateObjectViewStore<
+        State, Action,
+        _ConditionalContent<
           _ConditionalContent<
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State1, Action1, Content1>,
-                CaseLet<State, Action, State2, Action2, Content2>
-              >,
-              _ConditionalContent<
-                CaseLet<State, Action, State3, Action3, Content3>,
-                CaseLet<State, Action, State4, Action4, Content4>
-              >
+              CaseLet<State, Action, State1, Action1, Content1>,
+              CaseLet<State, Action, State2, Action2, Content2>
             >,
             _ConditionalContent<
-              CaseLet<State, Action, State5, Action5, Content5>,
-              Default<_ExhaustivityCheckView<State, Action>>
+              CaseLet<State, Action, State3, Action3, Content3>,
+              CaseLet<State, Action, State4, Action4, Content4>
             >
+          >,
+          _ConditionalContent<
+            CaseLet<State, Action, State5, Action5, Content5>,
+            Default<_ExhaustivityCheckView<State, Action>>
           >
         >
       >
@@ -657,27 +627,24 @@ extension SwitchStore {
   where
     Content == WithViewStore<
       State, Action,
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          State, Action,
+      _StateObjectViewStore<
+        State, Action,
+        _ConditionalContent<
           _ConditionalContent<
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State1, Action1, Content1>,
-                CaseLet<State, Action, State2, Action2, Content2>
-              >,
-              _ConditionalContent<
-                CaseLet<State, Action, State3, Action3, Content3>,
-                CaseLet<State, Action, State4, Action4, Content4>
-              >
+              CaseLet<State, Action, State1, Action1, Content1>,
+              CaseLet<State, Action, State2, Action2, Content2>
             >,
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State5, Action5, Content5>,
-                CaseLet<State, Action, State6, Action6, Content6>
-              >, Default<DefaultContent>
+              CaseLet<State, Action, State3, Action3, Content3>,
+              CaseLet<State, Action, State4, Action4, Content4>
             >
+          >,
+          _ConditionalContent<
+            _ConditionalContent<
+              CaseLet<State, Action, State5, Action5, Content5>,
+              CaseLet<State, Action, State6, Action6, Content6>
+            >, Default<DefaultContent>
           >
         >
       >
@@ -732,28 +699,25 @@ extension SwitchStore {
     Content == WithViewStore<
       State,
       Action,
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          State, Action,
+      _StateObjectViewStore<
+        State, Action,
+        _ConditionalContent<
           _ConditionalContent<
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State1, Action1, Content1>,
-                CaseLet<State, Action, State2, Action2, Content2>
-              >,
-              _ConditionalContent<
-                CaseLet<State, Action, State3, Action3, Content3>,
-                CaseLet<State, Action, State4, Action4, Content4>
-              >
+              CaseLet<State, Action, State1, Action1, Content1>,
+              CaseLet<State, Action, State2, Action2, Content2>
             >,
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State5, Action5, Content5>,
-                CaseLet<State, Action, State6, Action6, Content6>
-              >,
-              Default<_ExhaustivityCheckView<State, Action>>
+              CaseLet<State, Action, State3, Action3, Content3>,
+              CaseLet<State, Action, State4, Action4, Content4>
             >
+          >,
+          _ConditionalContent<
+            _ConditionalContent<
+              CaseLet<State, Action, State5, Action5, Content5>,
+              CaseLet<State, Action, State6, Action6, Content6>
+            >,
+            Default<_ExhaustivityCheckView<State, Action>>
           >
         >
       >
@@ -798,29 +762,26 @@ extension SwitchStore {
   where
     Content == WithViewStore<
       State, Action,
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          State, Action,
+      _StateObjectViewStore<
+        State, Action,
+        _ConditionalContent<
           _ConditionalContent<
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State1, Action1, Content1>,
-                CaseLet<State, Action, State2, Action2, Content2>
-              >,
-              _ConditionalContent<
-                CaseLet<State, Action, State3, Action3, Content3>,
-                CaseLet<State, Action, State4, Action4, Content4>
-              >
+              CaseLet<State, Action, State1, Action1, Content1>,
+              CaseLet<State, Action, State2, Action2, Content2>
             >,
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State5, Action5, Content5>,
-                CaseLet<State, Action, State6, Action6, Content6>
-              >,
-              _ConditionalContent<
-                CaseLet<State, Action, State7, Action7, Content7>, Default<DefaultContent>
-              >
+              CaseLet<State, Action, State3, Action3, Content3>,
+              CaseLet<State, Action, State4, Action4, Content4>
+            >
+          >,
+          _ConditionalContent<
+            _ConditionalContent<
+              CaseLet<State, Action, State5, Action5, Content5>,
+              CaseLet<State, Action, State6, Action6, Content6>
+            >,
+            _ConditionalContent<
+              CaseLet<State, Action, State7, Action7, Content7>, Default<DefaultContent>
             >
           >
         >
@@ -880,30 +841,27 @@ extension SwitchStore {
     Content == WithViewStore<
       State,
       Action,
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          State, Action,
+      _StateObjectViewStore<
+        State, Action,
+        _ConditionalContent<
           _ConditionalContent<
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State1, Action1, Content1>,
-                CaseLet<State, Action, State2, Action2, Content2>
-              >,
-              _ConditionalContent<
-                CaseLet<State, Action, State3, Action3, Content3>,
-                CaseLet<State, Action, State4, Action4, Content4>
-              >
+              CaseLet<State, Action, State1, Action1, Content1>,
+              CaseLet<State, Action, State2, Action2, Content2>
             >,
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State5, Action5, Content5>,
-                CaseLet<State, Action, State6, Action6, Content6>
-              >,
-              _ConditionalContent<
-                CaseLet<State, Action, State7, Action7, Content7>,
-                Default<_ExhaustivityCheckView<State, Action>>
-              >
+              CaseLet<State, Action, State3, Action3, Content3>,
+              CaseLet<State, Action, State4, Action4, Content4>
+            >
+          >,
+          _ConditionalContent<
+            _ConditionalContent<
+              CaseLet<State, Action, State5, Action5, Content5>,
+              CaseLet<State, Action, State6, Action6, Content6>
+            >,
+            _ConditionalContent<
+              CaseLet<State, Action, State7, Action7, Content7>,
+              Default<_ExhaustivityCheckView<State, Action>>
             >
           >
         >
@@ -952,34 +910,31 @@ extension SwitchStore {
   where
     Content == WithViewStore<
       State, Action,
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          State, Action,
+      _StateObjectViewStore<
+        State, Action,
+        _ConditionalContent<
           _ConditionalContent<
             _ConditionalContent<
               _ConditionalContent<
-                _ConditionalContent<
-                  CaseLet<State, Action, State1, Action1, Content1>,
-                  CaseLet<State, Action, State2, Action2, Content2>
-                >,
-                _ConditionalContent<
-                  CaseLet<State, Action, State3, Action3, Content3>,
-                  CaseLet<State, Action, State4, Action4, Content4>
-                >
+                CaseLet<State, Action, State1, Action1, Content1>,
+                CaseLet<State, Action, State2, Action2, Content2>
               >,
               _ConditionalContent<
-                _ConditionalContent<
-                  CaseLet<State, Action, State5, Action5, Content5>,
-                  CaseLet<State, Action, State6, Action6, Content6>
-                >,
-                _ConditionalContent<
-                  CaseLet<State, Action, State7, Action7, Content7>,
-                  CaseLet<State, Action, State8, Action8, Content8>
-                >
+                CaseLet<State, Action, State3, Action3, Content3>,
+                CaseLet<State, Action, State4, Action4, Content4>
               >
-            >, Default<DefaultContent>
-          >
+            >,
+            _ConditionalContent<
+              _ConditionalContent<
+                CaseLet<State, Action, State5, Action5, Content5>,
+                CaseLet<State, Action, State6, Action6, Content6>
+              >,
+              _ConditionalContent<
+                CaseLet<State, Action, State7, Action7, Content7>,
+                CaseLet<State, Action, State8, Action8, Content8>
+              >
+            >
+          >, Default<DefaultContent>
         >
       >
     >
@@ -1041,35 +996,32 @@ extension SwitchStore {
     Content == WithViewStore<
       State,
       Action,
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          State, Action,
+      _StateObjectViewStore<
+        State, Action,
+        _ConditionalContent<
           _ConditionalContent<
             _ConditionalContent<
               _ConditionalContent<
-                _ConditionalContent<
-                  CaseLet<State, Action, State1, Action1, Content1>,
-                  CaseLet<State, Action, State2, Action2, Content2>
-                >,
-                _ConditionalContent<
-                  CaseLet<State, Action, State3, Action3, Content3>,
-                  CaseLet<State, Action, State4, Action4, Content4>
-                >
+                CaseLet<State, Action, State1, Action1, Content1>,
+                CaseLet<State, Action, State2, Action2, Content2>
               >,
               _ConditionalContent<
-                _ConditionalContent<
-                  CaseLet<State, Action, State5, Action5, Content5>,
-                  CaseLet<State, Action, State6, Action6, Content6>
-                >,
-                _ConditionalContent<
-                  CaseLet<State, Action, State7, Action7, Content7>,
-                  CaseLet<State, Action, State8, Action8, Content8>
-                >
+                CaseLet<State, Action, State3, Action3, Content3>,
+                CaseLet<State, Action, State4, Action4, Content4>
               >
             >,
-            Default<_ExhaustivityCheckView<State, Action>>
-          >
+            _ConditionalContent<
+              _ConditionalContent<
+                CaseLet<State, Action, State5, Action5, Content5>,
+                CaseLet<State, Action, State6, Action6, Content6>
+              >,
+              _ConditionalContent<
+                CaseLet<State, Action, State7, Action7, Content7>,
+                CaseLet<State, Action, State8, Action8, Content8>
+              >
+            >
+          >,
+          Default<_ExhaustivityCheckView<State, Action>>
         >
       >
     >
@@ -1119,36 +1071,33 @@ extension SwitchStore {
   where
     Content == WithViewStore<
       State, Action,
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          State, Action,
+      _StateObjectViewStore<
+        State, Action,
+        _ConditionalContent<
           _ConditionalContent<
             _ConditionalContent<
               _ConditionalContent<
-                _ConditionalContent<
-                  CaseLet<State, Action, State1, Action1, Content1>,
-                  CaseLet<State, Action, State2, Action2, Content2>
-                >,
-                _ConditionalContent<
-                  CaseLet<State, Action, State3, Action3, Content3>,
-                  CaseLet<State, Action, State4, Action4, Content4>
-                >
+                CaseLet<State, Action, State1, Action1, Content1>,
+                CaseLet<State, Action, State2, Action2, Content2>
               >,
               _ConditionalContent<
-                _ConditionalContent<
-                  CaseLet<State, Action, State5, Action5, Content5>,
-                  CaseLet<State, Action, State6, Action6, Content6>
-                >,
-                _ConditionalContent<
-                  CaseLet<State, Action, State7, Action7, Content7>,
-                  CaseLet<State, Action, State8, Action8, Content8>
-                >
+                CaseLet<State, Action, State3, Action3, Content3>,
+                CaseLet<State, Action, State4, Action4, Content4>
               >
             >,
             _ConditionalContent<
-              CaseLet<State, Action, State9, Action9, Content9>, Default<DefaultContent>
+              _ConditionalContent<
+                CaseLet<State, Action, State5, Action5, Content5>,
+                CaseLet<State, Action, State6, Action6, Content6>
+              >,
+              _ConditionalContent<
+                CaseLet<State, Action, State7, Action7, Content7>,
+                CaseLet<State, Action, State8, Action8, Content8>
+              >
             >
+          >,
+          _ConditionalContent<
+            CaseLet<State, Action, State9, Action9, Content9>, Default<DefaultContent>
           >
         >
       >
@@ -1215,37 +1164,34 @@ extension SwitchStore {
     Content == WithViewStore<
       State,
       Action,
-      _ConditionalContent<
-        AnyView,
-        _ObservedObjectViewStore<
-          State, Action,
+      _StateObjectViewStore<
+        State, Action,
+        _ConditionalContent<
           _ConditionalContent<
             _ConditionalContent<
               _ConditionalContent<
-                _ConditionalContent<
-                  CaseLet<State, Action, State1, Action1, Content1>,
-                  CaseLet<State, Action, State2, Action2, Content2>
-                >,
-                _ConditionalContent<
-                  CaseLet<State, Action, State3, Action3, Content3>,
-                  CaseLet<State, Action, State4, Action4, Content4>
-                >
+                CaseLet<State, Action, State1, Action1, Content1>,
+                CaseLet<State, Action, State2, Action2, Content2>
               >,
               _ConditionalContent<
-                _ConditionalContent<
-                  CaseLet<State, Action, State5, Action5, Content5>,
-                  CaseLet<State, Action, State6, Action6, Content6>
-                >,
-                _ConditionalContent<
-                  CaseLet<State, Action, State7, Action7, Content7>,
-                  CaseLet<State, Action, State8, Action8, Content8>
-                >
+                CaseLet<State, Action, State3, Action3, Content3>,
+                CaseLet<State, Action, State4, Action4, Content4>
               >
             >,
             _ConditionalContent<
-              CaseLet<State, Action, State9, Action9, Content9>,
-              Default<_ExhaustivityCheckView<State, Action>>
+              _ConditionalContent<
+                CaseLet<State, Action, State5, Action5, Content5>,
+                CaseLet<State, Action, State6, Action6, Content6>
+              >,
+              _ConditionalContent<
+                CaseLet<State, Action, State7, Action7, Content7>,
+                CaseLet<State, Action, State8, Action8, Content8>
+              >
             >
+          >,
+          _ConditionalContent<
+            CaseLet<State, Action, State9, Action9, Content9>,
+            Default<_ExhaustivityCheckView<State, Action>>
           >
         >
       >

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -163,18 +163,17 @@ extension SwitchStore {
   )
   where
     Content == WithViewStore<
-      State, Action,
-      _StateObjectViewStore<
-        State, Action,
-        _ConditionalContent<
-          CaseLet<State, Action, State1, Action1, Content1>, Default<DefaultContent>
-        >
+      State,
+      Action,
+      _ConditionalContent<
+        CaseLet<State, Action, State1, Action1, Content1>,
+        Default<DefaultContent>
       >
     >
   {
     self.init(store: store) {
       let content = content().value
-      WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
+      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
         } else {
@@ -195,12 +194,9 @@ extension SwitchStore {
     Content == WithViewStore<
       State,
       Action,
-      _StateObjectViewStore<
-        State, Action,
-        _ConditionalContent<
-          CaseLet<State, Action, State1, Action1, Content1>,
-          Default<_ExhaustivityCheckView<State, Action>>
-        >
+      _ConditionalContent<
+        CaseLet<State, Action, State1, Action1, Content1>,
+        Default<_ExhaustivityCheckView<State, Action>>
       >
     >
   {
@@ -222,22 +218,20 @@ extension SwitchStore {
   )
   where
     Content == WithViewStore<
-      State, Action,
-      _StateObjectViewStore<
-        State, Action,
+      State,
+      Action,
+      _ConditionalContent<
         _ConditionalContent<
-          _ConditionalContent<
-            CaseLet<State, Action, State1, Action1, Content1>,
-            CaseLet<State, Action, State2, Action2, Content2>
-          >,
-          Default<DefaultContent>
-        >
+          CaseLet<State, Action, State1, Action1, Content1>,
+          CaseLet<State, Action, State2, Action2, Content2>
+        >,
+        Default<DefaultContent>
       >
     >
   {
     self.init(store: store) {
       let content = content().value
-      WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
+      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
         } else if content.1.toCaseState(viewStore.state) != nil {
@@ -265,15 +259,12 @@ extension SwitchStore {
     Content == WithViewStore<
       State,
       Action,
-      _StateObjectViewStore<
-        State, Action,
+      _ConditionalContent<
         _ConditionalContent<
-          _ConditionalContent<
-            CaseLet<State, Action, State1, Action1, Content1>,
-            CaseLet<State, Action, State2, Action2, Content2>
-          >,
-          Default<_ExhaustivityCheckView<State, Action>>
-        >
+          CaseLet<State, Action, State1, Action1, Content1>,
+          CaseLet<State, Action, State2, Action2, Content2>
+        >,
+        Default<_ExhaustivityCheckView<State, Action>>
       >
     >
   {
@@ -303,24 +294,23 @@ extension SwitchStore {
   )
   where
     Content == WithViewStore<
-      State, Action,
-      _StateObjectViewStore<
-        State, Action,
+      State,
+      Action,
+      _ConditionalContent<
         _ConditionalContent<
-          _ConditionalContent<
-            CaseLet<State, Action, State1, Action1, Content1>,
-            CaseLet<State, Action, State2, Action2, Content2>
-          >,
-          _ConditionalContent<
-            CaseLet<State, Action, State3, Action3, Content3>, Default<DefaultContent>
-          >
+          CaseLet<State, Action, State1, Action1, Content1>,
+          CaseLet<State, Action, State2, Action2, Content2>
+        >,
+        _ConditionalContent<
+          CaseLet<State, Action, State3, Action3, Content3>,
+          Default<DefaultContent>
         >
       >
     >
   {
     self.init(store: store) {
       let content = content().value
-      WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
+      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
         } else if content.1.toCaseState(viewStore.state) != nil {
@@ -351,17 +341,14 @@ extension SwitchStore {
     Content == WithViewStore<
       State,
       Action,
-      _StateObjectViewStore<
-        State, Action,
+      _ConditionalContent<
         _ConditionalContent<
-          _ConditionalContent<
-            CaseLet<State, Action, State1, Action1, Content1>,
-            CaseLet<State, Action, State2, Action2, Content2>
-          >,
-          _ConditionalContent<
-            CaseLet<State, Action, State3, Action3, Content3>,
-            Default<_ExhaustivityCheckView<State, Action>>
-          >
+          CaseLet<State, Action, State1, Action1, Content1>,
+          CaseLet<State, Action, State2, Action2, Content2>
+        >,
+        _ConditionalContent<
+          CaseLet<State, Action, State3, Action3, Content3>,
+          Default<_ExhaustivityCheckView<State, Action>>
         >
       >
     >
@@ -395,27 +382,26 @@ extension SwitchStore {
   )
   where
     Content == WithViewStore<
-      State, Action,
-      _StateObjectViewStore<
-        State, Action,
+      State,
+      Action,
+      _ConditionalContent<
         _ConditionalContent<
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State1, Action1, Content1>,
-              CaseLet<State, Action, State2, Action2, Content2>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State3, Action3, Content3>,
-              CaseLet<State, Action, State4, Action4, Content4>
-            >
-          >, Default<DefaultContent>
-        >
+            CaseLet<State, Action, State1, Action1, Content1>,
+            CaseLet<State, Action, State2, Action2, Content2>
+          >,
+          _ConditionalContent<
+            CaseLet<State, Action, State3, Action3, Content3>,
+            CaseLet<State, Action, State4, Action4, Content4>
+          >
+        >,
+        Default<DefaultContent>
       >
     >
   {
     self.init(store: store) {
       let content = content().value
-      WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
+      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
         } else if content.1.toCaseState(viewStore.state) != nil {
@@ -454,21 +440,18 @@ extension SwitchStore {
     Content == WithViewStore<
       State,
       Action,
-      _StateObjectViewStore<
-        State, Action,
+      _ConditionalContent<
         _ConditionalContent<
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State1, Action1, Content1>,
-              CaseLet<State, Action, State2, Action2, Content2>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State3, Action3, Content3>,
-              CaseLet<State, Action, State4, Action4, Content4>
-            >
+            CaseLet<State, Action, State1, Action1, Content1>,
+            CaseLet<State, Action, State2, Action2, Content2>
           >,
-          Default<_ExhaustivityCheckView<State, Action>>
-        >
+          _ConditionalContent<
+            CaseLet<State, Action, State3, Action3, Content3>,
+            CaseLet<State, Action, State4, Action4, Content4>
+          >
+        >,
+        Default<_ExhaustivityCheckView<State, Action>>
       >
     >
   {
@@ -504,30 +487,29 @@ extension SwitchStore {
   )
   where
     Content == WithViewStore<
-      State, Action,
-      _StateObjectViewStore<
-        State, Action,
+      State,
+      Action,
+      _ConditionalContent<
         _ConditionalContent<
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State1, Action1, Content1>,
-              CaseLet<State, Action, State2, Action2, Content2>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State3, Action3, Content3>,
-              CaseLet<State, Action, State4, Action4, Content4>
-            >
+            CaseLet<State, Action, State1, Action1, Content1>,
+            CaseLet<State, Action, State2, Action2, Content2>
           >,
           _ConditionalContent<
-            CaseLet<State, Action, State5, Action5, Content5>, Default<DefaultContent>
+            CaseLet<State, Action, State3, Action3, Content3>,
+            CaseLet<State, Action, State4, Action4, Content4>
           >
+        >,
+        _ConditionalContent<
+          CaseLet<State, Action, State5, Action5, Content5>,
+          Default<DefaultContent>
         >
       >
     >
   {
     self.init(store: store) {
       let content = content().value
-      WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
+      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
         } else if content.1.toCaseState(viewStore.state) != nil {
@@ -570,23 +552,20 @@ extension SwitchStore {
     Content == WithViewStore<
       State,
       Action,
-      _StateObjectViewStore<
-        State, Action,
+      _ConditionalContent<
         _ConditionalContent<
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State1, Action1, Content1>,
-              CaseLet<State, Action, State2, Action2, Content2>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State3, Action3, Content3>,
-              CaseLet<State, Action, State4, Action4, Content4>
-            >
+            CaseLet<State, Action, State1, Action1, Content1>,
+            CaseLet<State, Action, State2, Action2, Content2>
           >,
           _ConditionalContent<
-            CaseLet<State, Action, State5, Action5, Content5>,
-            Default<_ExhaustivityCheckView<State, Action>>
+            CaseLet<State, Action, State3, Action3, Content3>,
+            CaseLet<State, Action, State4, Action4, Content4>
           >
+        >,
+        _ConditionalContent<
+          CaseLet<State, Action, State5, Action5, Content5>,
+          Default<_ExhaustivityCheckView<State, Action>>
         >
       >
     >
@@ -626,33 +605,32 @@ extension SwitchStore {
   )
   where
     Content == WithViewStore<
-      State, Action,
-      _StateObjectViewStore<
-        State, Action,
+      State,
+      Action,
+      _ConditionalContent<
         _ConditionalContent<
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State1, Action1, Content1>,
-              CaseLet<State, Action, State2, Action2, Content2>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State3, Action3, Content3>,
-              CaseLet<State, Action, State4, Action4, Content4>
-            >
+            CaseLet<State, Action, State1, Action1, Content1>,
+            CaseLet<State, Action, State2, Action2, Content2>
           >,
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State5, Action5, Content5>,
-              CaseLet<State, Action, State6, Action6, Content6>
-            >, Default<DefaultContent>
+            CaseLet<State, Action, State3, Action3, Content3>,
+            CaseLet<State, Action, State4, Action4, Content4>
           >
+        >,
+        _ConditionalContent<
+          _ConditionalContent<
+            CaseLet<State, Action, State5, Action5, Content5>,
+            CaseLet<State, Action, State6, Action6, Content6>
+          >,
+          Default<DefaultContent>
         >
       >
     >
   {
     self.init(store: store) {
       let content = content().value
-      WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
+      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
         } else if content.1.toCaseState(viewStore.state) != nil {
@@ -699,26 +677,23 @@ extension SwitchStore {
     Content == WithViewStore<
       State,
       Action,
-      _StateObjectViewStore<
-        State, Action,
+      _ConditionalContent<
         _ConditionalContent<
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State1, Action1, Content1>,
-              CaseLet<State, Action, State2, Action2, Content2>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State3, Action3, Content3>,
-              CaseLet<State, Action, State4, Action4, Content4>
-            >
+            CaseLet<State, Action, State1, Action1, Content1>,
+            CaseLet<State, Action, State2, Action2, Content2>
           >,
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State5, Action5, Content5>,
-              CaseLet<State, Action, State6, Action6, Content6>
-            >,
-            Default<_ExhaustivityCheckView<State, Action>>
+            CaseLet<State, Action, State3, Action3, Content3>,
+            CaseLet<State, Action, State4, Action4, Content4>
           >
+        >,
+        _ConditionalContent<
+          _ConditionalContent<
+            CaseLet<State, Action, State5, Action5, Content5>,
+            CaseLet<State, Action, State6, Action6, Content6>
+          >,
+          Default<_ExhaustivityCheckView<State, Action>>
         >
       >
     >
@@ -761,28 +736,27 @@ extension SwitchStore {
   )
   where
     Content == WithViewStore<
-      State, Action,
-      _StateObjectViewStore<
-        State, Action,
+      State,
+      Action,
+      _ConditionalContent<
         _ConditionalContent<
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State1, Action1, Content1>,
-              CaseLet<State, Action, State2, Action2, Content2>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State3, Action3, Content3>,
-              CaseLet<State, Action, State4, Action4, Content4>
-            >
+            CaseLet<State, Action, State1, Action1, Content1>,
+            CaseLet<State, Action, State2, Action2, Content2>
           >,
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State5, Action5, Content5>,
-              CaseLet<State, Action, State6, Action6, Content6>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State7, Action7, Content7>, Default<DefaultContent>
-            >
+            CaseLet<State, Action, State3, Action3, Content3>,
+            CaseLet<State, Action, State4, Action4, Content4>
+          >
+        >,
+        _ConditionalContent<
+          _ConditionalContent<
+            CaseLet<State, Action, State5, Action5, Content5>,
+            CaseLet<State, Action, State6, Action6, Content6>
+          >,
+          _ConditionalContent<
+            CaseLet<State, Action, State7, Action7, Content7>,
+            Default<DefaultContent>
           >
         >
       >
@@ -790,7 +764,7 @@ extension SwitchStore {
   {
     self.init(store: store) {
       let content = content().value
-      WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
+      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
         } else if content.1.toCaseState(viewStore.state) != nil {
@@ -841,28 +815,25 @@ extension SwitchStore {
     Content == WithViewStore<
       State,
       Action,
-      _StateObjectViewStore<
-        State, Action,
+      _ConditionalContent<
         _ConditionalContent<
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State1, Action1, Content1>,
-              CaseLet<State, Action, State2, Action2, Content2>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State3, Action3, Content3>,
-              CaseLet<State, Action, State4, Action4, Content4>
-            >
+            CaseLet<State, Action, State1, Action1, Content1>,
+            CaseLet<State, Action, State2, Action2, Content2>
           >,
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State5, Action5, Content5>,
-              CaseLet<State, Action, State6, Action6, Content6>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State7, Action7, Content7>,
-              Default<_ExhaustivityCheckView<State, Action>>
-            >
+            CaseLet<State, Action, State3, Action3, Content3>,
+            CaseLet<State, Action, State4, Action4, Content4>
+          >
+        >,
+        _ConditionalContent<
+          _ConditionalContent<
+            CaseLet<State, Action, State5, Action5, Content5>,
+            CaseLet<State, Action, State6, Action6, Content6>
+          >,
+          _ConditionalContent<
+            CaseLet<State, Action, State7, Action7, Content7>,
+            Default<_ExhaustivityCheckView<State, Action>>
           >
         >
       >
@@ -909,39 +880,38 @@ extension SwitchStore {
   )
   where
     Content == WithViewStore<
-      State, Action,
-      _StateObjectViewStore<
-        State, Action,
+      State,
+      Action,
+      _ConditionalContent<
         _ConditionalContent<
           _ConditionalContent<
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State1, Action1, Content1>,
-                CaseLet<State, Action, State2, Action2, Content2>
-              >,
-              _ConditionalContent<
-                CaseLet<State, Action, State3, Action3, Content3>,
-                CaseLet<State, Action, State4, Action4, Content4>
-              >
+              CaseLet<State, Action, State1, Action1, Content1>,
+              CaseLet<State, Action, State2, Action2, Content2>
             >,
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State5, Action5, Content5>,
-                CaseLet<State, Action, State6, Action6, Content6>
-              >,
-              _ConditionalContent<
-                CaseLet<State, Action, State7, Action7, Content7>,
-                CaseLet<State, Action, State8, Action8, Content8>
-              >
+              CaseLet<State, Action, State3, Action3, Content3>,
+              CaseLet<State, Action, State4, Action4, Content4>
             >
-          >, Default<DefaultContent>
-        >
+          >,
+          _ConditionalContent<
+            _ConditionalContent<
+              CaseLet<State, Action, State5, Action5, Content5>,
+              CaseLet<State, Action, State6, Action6, Content6>
+            >,
+            _ConditionalContent<
+              CaseLet<State, Action, State7, Action7, Content7>,
+              CaseLet<State, Action, State8, Action8, Content8>
+            >
+          >
+        >,
+        Default<DefaultContent>
       >
     >
   {
     self.init(store: store) {
       let content = content().value
-      WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
+      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
         } else if content.1.toCaseState(viewStore.state) != nil {
@@ -996,33 +966,30 @@ extension SwitchStore {
     Content == WithViewStore<
       State,
       Action,
-      _StateObjectViewStore<
-        State, Action,
+      _ConditionalContent<
         _ConditionalContent<
           _ConditionalContent<
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State1, Action1, Content1>,
-                CaseLet<State, Action, State2, Action2, Content2>
-              >,
-              _ConditionalContent<
-                CaseLet<State, Action, State3, Action3, Content3>,
-                CaseLet<State, Action, State4, Action4, Content4>
-              >
+              CaseLet<State, Action, State1, Action1, Content1>,
+              CaseLet<State, Action, State2, Action2, Content2>
             >,
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State5, Action5, Content5>,
-                CaseLet<State, Action, State6, Action6, Content6>
-              >,
-              _ConditionalContent<
-                CaseLet<State, Action, State7, Action7, Content7>,
-                CaseLet<State, Action, State8, Action8, Content8>
-              >
+              CaseLet<State, Action, State3, Action3, Content3>,
+              CaseLet<State, Action, State4, Action4, Content4>
             >
           >,
-          Default<_ExhaustivityCheckView<State, Action>>
-        >
+          _ConditionalContent<
+            _ConditionalContent<
+              CaseLet<State, Action, State5, Action5, Content5>,
+              CaseLet<State, Action, State6, Action6, Content6>
+            >,
+            _ConditionalContent<
+              CaseLet<State, Action, State7, Action7, Content7>,
+              CaseLet<State, Action, State8, Action8, Content8>
+            >
+          >
+        >,
+        Default<_ExhaustivityCheckView<State, Action>>
       >
     >
   {
@@ -1070,42 +1037,41 @@ extension SwitchStore {
   )
   where
     Content == WithViewStore<
-      State, Action,
-      _StateObjectViewStore<
-        State, Action,
+      State,
+      Action,
+      _ConditionalContent<
         _ConditionalContent<
           _ConditionalContent<
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State1, Action1, Content1>,
-                CaseLet<State, Action, State2, Action2, Content2>
-              >,
-              _ConditionalContent<
-                CaseLet<State, Action, State3, Action3, Content3>,
-                CaseLet<State, Action, State4, Action4, Content4>
-              >
+              CaseLet<State, Action, State1, Action1, Content1>,
+              CaseLet<State, Action, State2, Action2, Content2>
             >,
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State5, Action5, Content5>,
-                CaseLet<State, Action, State6, Action6, Content6>
-              >,
-              _ConditionalContent<
-                CaseLet<State, Action, State7, Action7, Content7>,
-                CaseLet<State, Action, State8, Action8, Content8>
-              >
+              CaseLet<State, Action, State3, Action3, Content3>,
+              CaseLet<State, Action, State4, Action4, Content4>
             >
           >,
           _ConditionalContent<
-            CaseLet<State, Action, State9, Action9, Content9>, Default<DefaultContent>
+            _ConditionalContent<
+              CaseLet<State, Action, State5, Action5, Content5>,
+              CaseLet<State, Action, State6, Action6, Content6>
+            >,
+            _ConditionalContent<
+              CaseLet<State, Action, State7, Action7, Content7>,
+              CaseLet<State, Action, State8, Action8, Content8>
+            >
           >
+        >,
+        _ConditionalContent<
+          CaseLet<State, Action, State9, Action9, Content9>,
+          Default<DefaultContent>
         >
       >
     >
   {
     self.init(store: store) {
       let content = content().value
-      WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
+      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
         } else if content.1.toCaseState(viewStore.state) != nil {
@@ -1164,35 +1130,32 @@ extension SwitchStore {
     Content == WithViewStore<
       State,
       Action,
-      _StateObjectViewStore<
-        State, Action,
+      _ConditionalContent<
         _ConditionalContent<
           _ConditionalContent<
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State1, Action1, Content1>,
-                CaseLet<State, Action, State2, Action2, Content2>
-              >,
-              _ConditionalContent<
-                CaseLet<State, Action, State3, Action3, Content3>,
-                CaseLet<State, Action, State4, Action4, Content4>
-              >
+              CaseLet<State, Action, State1, Action1, Content1>,
+              CaseLet<State, Action, State2, Action2, Content2>
             >,
             _ConditionalContent<
-              _ConditionalContent<
-                CaseLet<State, Action, State5, Action5, Content5>,
-                CaseLet<State, Action, State6, Action6, Content6>
-              >,
-              _ConditionalContent<
-                CaseLet<State, Action, State7, Action7, Content7>,
-                CaseLet<State, Action, State8, Action8, Content8>
-              >
+              CaseLet<State, Action, State3, Action3, Content3>,
+              CaseLet<State, Action, State4, Action4, Content4>
             >
           >,
           _ConditionalContent<
-            CaseLet<State, Action, State9, Action9, Content9>,
-            Default<_ExhaustivityCheckView<State, Action>>
+            _ConditionalContent<
+              CaseLet<State, Action, State5, Action5, Content5>,
+              CaseLet<State, Action, State6, Action6, Content6>
+            >,
+            _ConditionalContent<
+              CaseLet<State, Action, State7, Action7, Content7>,
+              CaseLet<State, Action, State8, Action8, Content8>
+            >
           >
+        >,
+        _ConditionalContent<
+          CaseLet<State, Action, State9, Action9, Content9>,
+          Default<_ExhaustivityCheckView<State, Action>>
         >
       >
     >

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -176,12 +176,15 @@ struct _StateObject<Object: ObservableObject>: DynamicProperty {
   init(wrappedValue: @autoclosure @escaping () -> Object) {
     self.storage.thunk = wrappedValue
   }
-
-  var wrappedValue: Object {
+  
+  func update() {
     if observedObject.subscription == nil {
       observedObject.subscribeTo(storage.object)
     }
-    return observedObject.object
+  }
+
+  var wrappedValue: Object {
+    observedObject.object
   }
   // This is probably not a good idea, as we don't know what it does.
 //  var _propertyBehaviors: UInt32 {

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -1,4 +1,3 @@
-import Combine
 import CustomDump
 import SwiftUI
 
@@ -144,57 +143,6 @@ public struct WithViewStore<State, Action, Content> {
     #else
       return self.content(self.store, nil)
     #endif
-  }
-}
-
-@propertyWrapper
-struct _StateObject<Object: ObservableObject>: DynamicProperty {
-  private final class ObjectWillChange: ObservableObject {
-    private var subscription: AnyCancellable?
-    // Manually defining this property allows to keep it `lazy` and improves
-    // performance, as we ultimately only need this publisher once in the
-    // lifetime of the view.
-    lazy var objectWillChange = ObservableObjectPublisher()
-
-    init() {}
-    func relay(from storage: Storage) {
-      defer { storage.objectWillSendIsRelayed = true }
-      self.subscription = storage.object.objectWillChange.sink {
-        [weak objectWillChange = self.objectWillChange] _ in
-        guard let objectWillChange = objectWillChange else { return }
-        objectWillChange.send()
-      }
-    }
-  }
-
-  private final class Storage {
-    lazy var object: Object = thunk()
-    var objectWillSendIsRelayed: Bool = false
-    var thunk: (() -> Object)!
-    init() {}
-  }
-
-  @ObservedObject private var objectWillChange = ObjectWillChange()
-  @State private var storage = Storage()
-
-  init(wrappedValue: @autoclosure @escaping () -> Object) {
-    self.storage.thunk = wrappedValue
-  }
-
-  func update() {
-    if !storage.objectWillSendIsRelayed {
-      // We're capturing an `ObjectWillSend` instance through its
-      // `objectWillChange` publisher here. `View` invalidation still
-      // seems to be effective even if the `objectWillChange` publisher
-      // is issued from another `@ObservedObject` instance than the current
-      // one. It is likely that these publishers are bound to the `View`'s
-      // identity.
-      objectWillChange.relay(from: storage)
-    }
-  }
-
-  var wrappedValue: Object {
-    storage.object
   }
 }
 

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -148,8 +148,7 @@ public struct WithViewStore<State, Action, Content> {
 }
 
 @propertyWrapper
-struct _StateObject<Object: ObservableObject>: DynamicProperty
-where Object.ObjectWillChangePublisher.Output == Void {
+struct _StateObject<Object: ObservableObject>: DynamicProperty {
   private final class ObjectWillChange: ObservableObject {
     private var subscription: AnyCancellable?
     // Manually defining this property allows to keep it `lazy` and improves

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -147,7 +147,6 @@ public struct WithViewStore<State, Action, Content> {
   }
 }
 
-
 @propertyWrapper
 struct _StateObject<Object: ObservableObject>: DynamicProperty {
   private final class Observed: ObservableObject {
@@ -160,27 +159,25 @@ struct _StateObject<Object: ObservableObject>: DynamicProperty {
     }
     init() {}
   }
-  
+
   private final class Storage: ObservableObject {
     lazy var object: Object = makeObject()
     var makeObject: (() -> Object)!
     init() {}
   }
-  
+
   @ObservedObject private var observed = Observed()
   @State private var storage = Storage()
-  
+
   init(wrappedValue: @autoclosure @escaping () -> Object) {
     self.storage.makeObject = wrappedValue
   }
   
   var wrappedValue: Object {
-    get {
-      if observed.object == nil {
-        observed.install(storage.object)
-      }
-      return observed.object!
+    if observed.object == nil {
+      observed.install(storage.object)
     }
+    return observed.object!
   }
 }
 

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -160,7 +160,7 @@ struct _StateObject<Object: ObservableObject>: DynamicProperty {
     init() {}
   }
 
-  private final class Storage: ObservableObject {
+  private final class Storage {
     lazy var object: Object = makeObject()
     var makeObject: (() -> Object)!
     init() {}

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -61,9 +61,6 @@ import SwiftUI
 /// > store it was derived from) must happen on the same thread. Further, for SwiftUI applications,
 /// > all interactions must happen on the _main_ thread. See the documentation of the ``Store``
 /// > class for more information as to why this decision was made.
-///
-var initializationsCount = 0
-var objectWillChangesCount = 0
 @dynamicMemberLookup
 public final class ViewStore<State, Action>: ObservableObject {
   // N.B. `ViewStore` does not use a `@Published` property, so `objectWillChange`
@@ -86,14 +83,10 @@ public final class ViewStore<State, Action>: ObservableObject {
   ) {
     self._send = { store.send($0) }
     self._state = CurrentValueRelay(store.state.value)
-    initializationsCount += 1
-    print("initializations", initializationsCount)
     self.viewCancellable = store.state
       .removeDuplicates(by: isDuplicate)
       .sink { [weak objectWillChange = self.objectWillChange, weak _state = self._state] in
         guard let objectWillChange = objectWillChange, let _state = _state else { return }
-        objectWillChangesCount += 1
-        print("objectWillChanges", objectWillChangesCount)
         objectWillChange.send()
         _state.value = $0
       }

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -61,6 +61,9 @@ import SwiftUI
 /// > store it was derived from) must happen on the same thread. Further, for SwiftUI applications,
 /// > all interactions must happen on the _main_ thread. See the documentation of the ``Store``
 /// > class for more information as to why this decision was made.
+///
+var initializationsCount = 0
+var objectWillChangesCount = 0
 @dynamicMemberLookup
 public final class ViewStore<State, Action>: ObservableObject {
   // N.B. `ViewStore` does not use a `@Published` property, so `objectWillChange`
@@ -83,11 +86,14 @@ public final class ViewStore<State, Action>: ObservableObject {
   ) {
     self._send = { store.send($0) }
     self._state = CurrentValueRelay(store.state.value)
-
+    initializationsCount += 1
+    print("initializations", initializationsCount)
     self.viewCancellable = store.state
       .removeDuplicates(by: isDuplicate)
       .sink { [weak objectWillChange = self.objectWillChange, weak _state = self._state] in
         guard let objectWillChange = objectWillChange, let _state = _state else { return }
+        objectWillChangesCount += 1
+        print("objectWillChanges", objectWillChangesCount)
         objectWillChange.send()
         _state.value = $0
       }


### PR DESCRIPTION
The latest version of `WithViewStore` now uses a `@StateObject` that holds the `ViewStore` value it initially accessed (#1325). This allows to avoid many `ViewStore` instantiations and state comparisons in some cases.

However, the `@StateObject` property wrapper is only available for iOS 14+ (and other Apple OSes of this generation). Because TCA is currently supporting iOS 13, an availability check is performed to switch over the `StateObject` variant when possible, and fall back to `ObservedObject` like it was the case before. Because of the way result builders are working, this availability check wraps the whole `StateObject` branch in an `AnyView`.

`AnyView` have usually bad press. Their performance in extremal setups (root or leaf view) is usually [on par with fully typed views](https://nalexn.github.io/anyview-vs-group/). However, there are cases where it can seriously degrade performance.

Apparently, a `ScrollView` or a `List` having a nested `ForEach`[^1] can communicate its current visible bounds to it. This seemingly allows `ForEach` to only create and render a subset of its views. This communication seems direct, without involving the `Environment`. However, when this `ForEach` is wrapped in an `AnyView`, the `List/ScrollView` can't see it, and therefore can't communicate its visible bounds to it. As a result, the unconstrained `ForEach` will load all of its hierarchy, which can be consequent (sometimes more than a thousand views). As it does this at each rendered frame, this degrades the performance drastically.

[^1]: Or maybe any `DynamicViewContent`, as `ForEach` is the only built-in type conforming to this protocol.

Because the very generic `WithViewStore` view can be used in almost any position, there were cases where it could have unwillingly uncoupled `List/ScrollView` from their inner `ForEach` by wrapping its `Content` view in some `AnyView` on recent OS.

A `StateObject` is an `ObservedObject` that holds a reference to the `ObservableObject` you pass to it. It captures this object in the form of an escaping autoclosure and creates an instance only on the first effective access in a body.

This PR intends to reimplement `StateObject` using API's compatible with iOS 13. This should not only improve the situation on this OS, but most of all, will allow to avoid the availability check and thus, the `AnyView` wrapping.

This internal property wrapper called `_StateObject` is relatively lean and performs similarly to `StateObject` while exhibiting the same `ViewStore` initialization/deduplication behavior. Unfortunately, conditionally upgrading to `StateObject` on compatible OS is not possible with the way Swift works.

This PR rolls back `WithViewStore` to its recent implementation, and replaces the inner `@ObservedObject` with `@_StateObject`.