### PR TITLE
Fix long-living effect leak

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -395,6 +395,7 @@ public final class Store<State, Action> {
       }
     }
 
+    guard !tasks.wrappedValue.isEmpty else { return nil }
     return Task {
       await withTaskCancellationHandler {
         var index = tasks.wrappedValue.startIndex


### PR DESCRIPTION
`Store.send` is currently spinning up a task for every batch of actions sent through it, even if no effects are in-flight. This issue compounds itself recursively when long-living effects feed actions back into the store.

Instead, let's only spin up tasks when we need to.

Fixes #1337
