### PR TITLE
Introduce `WithViewStore.init(_:observe:send:...)`

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 import UIKit
 import XCTestDynamicOverlay
 
-struct RootState {
+struct RootState: Equatable {
   var alertAndConfirmationDialog = AlertAndConfirmationDialogState()
   var animation = AnimationsState()
   var bindingBasics = BindingBasicsState()

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -6,289 +6,287 @@ struct RootView: View {
   let store: Store<RootState, RootAction>
 
   var body: some View {
-    WithViewStore(self.store.stateless) { viewStore in
-      NavigationView {
-        Form {
-          Section(header: Text("Getting started")) {
-            NavigationLink(
-              "Basics",
-              destination: CounterDemoView(
-                store: self.store.scope(
-                  state: \.counter,
-                  action: RootAction.counter
-                )
+    NavigationView {
+      Form {
+        Section(header: Text("Getting started")) {
+          NavigationLink(
+            "Basics",
+            destination: CounterDemoView(
+              store: self.store.scope(
+                state: \.counter,
+                action: RootAction.counter
               )
             )
+          )
 
-            NavigationLink(
-              "Pullback and combine",
-              destination: TwoCountersView(
-                store: self.store.scope(
-                  state: \.twoCounters,
-                  action: RootAction.twoCounters
-                )
+          NavigationLink(
+            "Pullback and combine",
+            destination: TwoCountersView(
+              store: self.store.scope(
+                state: \.twoCounters,
+                action: RootAction.twoCounters
               )
             )
+          )
 
-            NavigationLink(
-              "Bindings",
-              destination: BindingBasicsView(
-                store: self.store.scope(
-                  state: \.bindingBasics,
-                  action: RootAction.bindingBasics
-                )
+          NavigationLink(
+            "Bindings",
+            destination: BindingBasicsView(
+              store: self.store.scope(
+                state: \.bindingBasics,
+                action: RootAction.bindingBasics
               )
             )
+          )
 
-            NavigationLink(
-              "Form bindings",
-              destination: BindingFormView(
-                store: self.store.scope(
-                  state: \.bindingForm,
-                  action: RootAction.bindingForm
-                )
+          NavigationLink(
+            "Form bindings",
+            destination: BindingFormView(
+              store: self.store.scope(
+                state: \.bindingForm,
+                action: RootAction.bindingForm
               )
             )
+          )
 
-            NavigationLink(
-              "Optional state",
-              destination: OptionalBasicsView(
-                store: self.store.scope(
-                  state: \.optionalBasics,
-                  action: RootAction.optionalBasics
-                )
+          NavigationLink(
+            "Optional state",
+            destination: OptionalBasicsView(
+              store: self.store.scope(
+                state: \.optionalBasics,
+                action: RootAction.optionalBasics
               )
             )
+          )
 
-            NavigationLink(
-              "Shared state",
-              destination: SharedStateView(
-                store: self.store.scope(
-                  state: \.shared,
-                  action: RootAction.shared
-                )
+          NavigationLink(
+            "Shared state",
+            destination: SharedStateView(
+              store: self.store.scope(
+                state: \.shared,
+                action: RootAction.shared
               )
             )
+          )
 
-            NavigationLink(
-              "Alerts and Confirmation Dialogs",
-              destination: AlertAndConfirmationDialogView(
-                store: self.store.scope(
-                  state: \.alertAndConfirmationDialog,
-                  action: RootAction.alertAndConfirmationDialog
-                )
+          NavigationLink(
+            "Alerts and Confirmation Dialogs",
+            destination: AlertAndConfirmationDialogView(
+              store: self.store.scope(
+                state: \.alertAndConfirmationDialog,
+                action: RootAction.alertAndConfirmationDialog
               )
             )
+          )
 
-            NavigationLink(
-              "Focus State",
-              destination: FocusDemoView(
-                store: self.store.scope(
-                  state: \.focusDemo,
-                  action: RootAction.focusDemo
-                )
+          NavigationLink(
+            "Focus State",
+            destination: FocusDemoView(
+              store: self.store.scope(
+                state: \.focusDemo,
+                action: RootAction.focusDemo
               )
             )
+          )
 
-            NavigationLink(
-              "Animations",
-              destination: AnimationsView(
-                store: self.store.scope(
-                  state: \.animation,
-                  action: RootAction.animation
-                )
+          NavigationLink(
+            "Animations",
+            destination: AnimationsView(
+              store: self.store.scope(
+                state: \.animation,
+                action: RootAction.animation
               )
             )
-          }
-
-          Section(header: Text("Effects")) {
-            NavigationLink(
-              "Basics",
-              destination: EffectsBasicsView(
-                store: self.store.scope(
-                  state: \.effectsBasics,
-                  action: RootAction.effectsBasics
-                )
-              )
-            )
-
-            NavigationLink(
-              "Cancellation",
-              destination: EffectsCancellationView(
-                store: self.store.scope(
-                  state: \.effectsCancellation,
-                  action: RootAction.effectsCancellation)
-              )
-            )
-
-            NavigationLink(
-              "Long-living effects",
-              destination: LongLivingEffectsView(
-                store: self.store.scope(
-                  state: \.longLivingEffects,
-                  action: RootAction.longLivingEffects
-                )
-              )
-            )
-
-            NavigationLink(
-              "Refreshable",
-              destination: RefreshableView(
-                store: self.store.scope(
-                  state: \.refreshable,
-                  action: RootAction.refreshable
-                )
-              )
-            )
-
-            NavigationLink(
-              "Timers",
-              destination: TimersView(
-                store: self.store.scope(
-                  state: \.timers,
-                  action: RootAction.timers
-                )
-              )
-            )
-
-            NavigationLink(
-              "System environment",
-              destination: MultipleDependenciesView(
-                store: self.store.scope(
-                  state: \.multipleDependencies,
-                  action: RootAction.multipleDependencies
-                )
-              )
-            )
-
-            NavigationLink(
-              "Web socket",
-              destination: WebSocketView(
-                store: self.store.scope(
-                  state: \.webSocket,
-                  action: RootAction.webSocket
-                )
-              )
-            )
-          }
-
-          Section(header: Text("Navigation")) {
-            NavigationLink(
-              "Navigate and load data",
-              destination: NavigateAndLoadView(
-                store: self.store.scope(
-                  state: \.navigateAndLoad,
-                  action: RootAction.navigateAndLoad
-                )
-              )
-            )
-
-            NavigationLink(
-              "Load data then navigate",
-              destination: LoadThenNavigateView(
-                store: self.store.scope(
-                  state: \.loadThenNavigate,
-                  action: RootAction.loadThenNavigate
-                )
-              )
-            )
-
-            NavigationLink(
-              "Lists: Navigate and load data",
-              destination: NavigateAndLoadListView(
-                store: self.store.scope(
-                  state: \.navigateAndLoadList,
-                  action: RootAction.navigateAndLoadList
-                )
-              )
-            )
-
-            NavigationLink(
-              "Lists: Load data then navigate",
-              destination: LoadThenNavigateListView(
-                store: self.store.scope(
-                  state: \.loadThenNavigateList,
-                  action: RootAction.loadThenNavigateList
-                )
-              )
-            )
-
-            NavigationLink(
-              "Sheets: Present and load data",
-              destination: PresentAndLoadView(
-                store: self.store.scope(
-                  state: \.presentAndLoad,
-                  action: RootAction.presentAndLoad
-                )
-              )
-            )
-
-            NavigationLink(
-              "Sheets: Load data then present",
-              destination: LoadThenPresentView(
-                store: self.store.scope(
-                  state: \.loadThenPresent,
-                  action: RootAction.loadThenPresent
-                )
-              )
-            )
-          }
-
-          Section(header: Text("Higher-order reducers")) {
-            NavigationLink(
-              "Reusable favoriting component",
-              destination: EpisodesView(
-                store: self.store.scope(
-                  state: \.episodes,
-                  action: RootAction.episodes
-                )
-              )
-            )
-
-            NavigationLink(
-              "Reusable offline download component",
-              destination: CitiesView(
-                store: self.store.scope(
-                  state: \.map,
-                  action: RootAction.map
-                )
-              )
-            )
-
-            NavigationLink(
-              "Lifecycle",
-              destination: LifecycleDemoView(
-                store: self.store.scope(
-                  state: \.lifecycle,
-                  action: RootAction.lifecycle
-                )
-              )
-            )
-
-            NavigationLink(
-              "Elm-like subscriptions",
-              destination: ClockView(
-                store: self.store.scope(
-                  state: \.clock,
-                  action: RootAction.clock
-                )
-              )
-            )
-
-            NavigationLink(
-              "Recursive state and actions",
-              destination: NestedView(
-                store: self.store.scope(
-                  state: \.nested,
-                  action: RootAction.nested
-                )
-              )
-            )
-          }
+          )
         }
-        .navigationTitle("Case Studies")
-        .onAppear { viewStore.send(.onAppear) }
+
+        Section(header: Text("Effects")) {
+          NavigationLink(
+            "Basics",
+            destination: EffectsBasicsView(
+              store: self.store.scope(
+                state: \.effectsBasics,
+                action: RootAction.effectsBasics
+              )
+            )
+          )
+
+          NavigationLink(
+            "Cancellation",
+            destination: EffectsCancellationView(
+              store: self.store.scope(
+                state: \.effectsCancellation,
+                action: RootAction.effectsCancellation)
+            )
+          )
+
+          NavigationLink(
+            "Long-living effects",
+            destination: LongLivingEffectsView(
+              store: self.store.scope(
+                state: \.longLivingEffects,
+                action: RootAction.longLivingEffects
+              )
+            )
+          )
+
+          NavigationLink(
+            "Refreshable",
+            destination: RefreshableView(
+              store: self.store.scope(
+                state: \.refreshable,
+                action: RootAction.refreshable
+              )
+            )
+          )
+
+          NavigationLink(
+            "Timers",
+            destination: TimersView(
+              store: self.store.scope(
+                state: \.timers,
+                action: RootAction.timers
+              )
+            )
+          )
+
+          NavigationLink(
+            "System environment",
+            destination: MultipleDependenciesView(
+              store: self.store.scope(
+                state: \.multipleDependencies,
+                action: RootAction.multipleDependencies
+              )
+            )
+          )
+
+          NavigationLink(
+            "Web socket",
+            destination: WebSocketView(
+              store: self.store.scope(
+                state: \.webSocket,
+                action: RootAction.webSocket
+              )
+            )
+          )
+        }
+
+        Section(header: Text("Navigation")) {
+          NavigationLink(
+            "Navigate and load data",
+            destination: NavigateAndLoadView(
+              store: self.store.scope(
+                state: \.navigateAndLoad,
+                action: RootAction.navigateAndLoad
+              )
+            )
+          )
+
+          NavigationLink(
+            "Load data then navigate",
+            destination: LoadThenNavigateView(
+              store: self.store.scope(
+                state: \.loadThenNavigate,
+                action: RootAction.loadThenNavigate
+              )
+            )
+          )
+
+          NavigationLink(
+            "Lists: Navigate and load data",
+            destination: NavigateAndLoadListView(
+              store: self.store.scope(
+                state: \.navigateAndLoadList,
+                action: RootAction.navigateAndLoadList
+              )
+            )
+          )
+
+          NavigationLink(
+            "Lists: Load data then navigate",
+            destination: LoadThenNavigateListView(
+              store: self.store.scope(
+                state: \.loadThenNavigateList,
+                action: RootAction.loadThenNavigateList
+              )
+            )
+          )
+
+          NavigationLink(
+            "Sheets: Present and load data",
+            destination: PresentAndLoadView(
+              store: self.store.scope(
+                state: \.presentAndLoad,
+                action: RootAction.presentAndLoad
+              )
+            )
+          )
+
+          NavigationLink(
+            "Sheets: Load data then present",
+            destination: LoadThenPresentView(
+              store: self.store.scope(
+                state: \.loadThenPresent,
+                action: RootAction.loadThenPresent
+              )
+            )
+          )
+        }
+
+        Section(header: Text("Higher-order reducers")) {
+          NavigationLink(
+            "Reusable favoriting component",
+            destination: EpisodesView(
+              store: self.store.scope(
+                state: \.episodes,
+                action: RootAction.episodes
+              )
+            )
+          )
+
+          NavigationLink(
+            "Reusable offline download component",
+            destination: CitiesView(
+              store: self.store.scope(
+                state: \.map,
+                action: RootAction.map
+              )
+            )
+          )
+
+          NavigationLink(
+            "Lifecycle",
+            destination: LifecycleDemoView(
+              store: self.store.scope(
+                state: \.lifecycle,
+                action: RootAction.lifecycle
+              )
+            )
+          )
+
+          NavigationLink(
+            "Elm-like subscriptions",
+            destination: ClockView(
+              store: self.store.scope(
+                state: \.clock,
+                action: RootAction.clock
+              )
+            )
+          )
+
+          NavigationLink(
+            "Recursive state and actions",
+            destination: NestedView(
+              store: self.store.scope(
+                state: \.nested,
+                action: RootAction.nested
+              )
+            )
+          )
+        }
       }
+      .navigationTitle("Case Studies")
+      .onAppear { ViewStore(self.store).send(.onAppear) }
     }
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -87,7 +87,7 @@ struct AlertAndConfirmationDialogView: View {
   let store: Store<AlertAndConfirmationDialogState, AlertAndConfirmationDialogAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       Form {
         Section {
           AboutView(readMe: readMe)

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -91,7 +91,7 @@ struct AnimationsView: View {
   let store: Store<AnimationsState, AnimationsAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       VStack(alignment: .leading) {
         Text(template: readMe, .body)
           .padding()

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -63,7 +63,7 @@ struct BindingBasicsView: View {
   let store: Store<BindingBasicsState, BindingBasicsAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       Form {
         Section {
           AboutView(readMe: readMe)

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -51,7 +51,7 @@ struct BindingFormView: View {
   let store: Store<BindingFormState, BindingFormAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       Form {
         Section {
           AboutView(readMe: readMe)

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -35,7 +35,7 @@ struct CounterView: View {
   let store: Store<CounterState, CounterAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       HStack {
         Button {
           viewStore.send(.decrementButtonTapped)

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -48,7 +48,7 @@ struct FocusDemoView: View {
   @FocusState var focusedField: FocusDemoState.Field?
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       Form {
         AboutView(readMe: readMe)
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -52,7 +52,7 @@ struct OptionalBasicsView: View {
   let store: Store<OptionalBasicsState, OptionalBasicsAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       Form {
         Section {
           AboutView(readMe: readMe)

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
@@ -152,7 +152,7 @@ struct SharedStateView: View {
   let store: Store<SharedState, SharedStateAction>
 
   var body: some View {
-    WithViewStore(self.store.scope(state: \.currentTab)) { viewStore in
+    WithViewStore(self.store, observe: \.currentTab) { viewStore in
       VStack {
         Picker(
           "Tab",
@@ -187,7 +187,7 @@ struct SharedStateCounterView: View {
   let store: Store<SharedState.CounterState, SharedStateAction.CounterAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       VStack(spacing: 64) {
         Text(template: readMe, .caption)
 
@@ -223,7 +223,7 @@ struct SharedStateProfileView: View {
   let store: Store<SharedState.ProfileState, SharedStateAction.ProfileAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       VStack(spacing: 64) {
         Text(
           template: """

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -102,7 +102,7 @@ struct EffectsBasicsView: View {
   let store: Store<EffectsBasicsState, EffectsBasicsAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       Form {
         Section {
           AboutView(readMe: readMe)

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -77,7 +77,7 @@ struct EffectsCancellationView: View {
   let store: Store<EffectsCancellationState, EffectsCancellationAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       Form {
         Section {
           AboutView(readMe: readMe)

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -56,7 +56,7 @@ struct LongLivingEffectsView: View {
   let store: Store<LongLivingEffectsState, LongLivingEffectsAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       Form {
         Section {
           AboutView(readMe: readMe)

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -72,7 +72,7 @@ struct RefreshableView: View {
   let store: Store<RefreshableState, RefreshableAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       List {
         Section {
           AboutView(readMe: readMe)

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
@@ -81,7 +81,7 @@ struct MultipleDependenciesView: View {
   let store: Store<MultipleDependenciesState, MultipleDependenciesAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       Form {
         AboutView(readMe: readMe)
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -131,7 +131,7 @@ struct WebSocketView: View {
   let store: Store<WebSocketState, WebSocketAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       VStack(alignment: .leading) {
         AboutView(readMe: readMe)
           .padding(.bottom)

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -95,7 +95,7 @@ struct LoadThenNavigateListView: View {
   let store: Store<LoadThenNavigateListState, LoadThenNavigateListAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       Form {
         Section {
           AboutView(readMe: readMe)

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -80,7 +80,7 @@ struct NavigateAndLoadListView: View {
   let store: Store<NavigateAndLoadListState, NavigateAndLoadListAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       Form {
         Section {
           AboutView(readMe: readMe)

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -73,7 +73,7 @@ struct LoadThenNavigateView: View {
   let store: Store<LoadThenNavigateState, LoadThenNavigateAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       Form {
         Section {
           AboutView(readMe: readMe)

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -68,7 +68,7 @@ struct NavigateAndLoadView: View {
   let store: Store<NavigateAndLoadState, NavigateAndLoadAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       Form {
         Section {
           AboutView(readMe: readMe)

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -73,7 +73,7 @@ struct LoadThenPresentView: View {
   let store: Store<LoadThenPresentState, LoadThenPresentAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       Form {
         Section {
           AboutView(readMe: readMe)

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -66,7 +66,7 @@ struct PresentAndLoadView: View {
   let store: Store<PresentAndLoadState, PresentAndLoadAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       Form {
         Section {
           AboutView(readMe: readMe)

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -78,7 +78,7 @@ struct LifecycleDemoView: View {
   let store: Store<LifecycleDemoState, LifecycleDemoAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       Form {
         Section {
           AboutView(readMe: readMe)
@@ -141,7 +141,7 @@ private struct TimerView: View {
   let store: Store<Int, LifecycleAction<TimerAction>>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       Section {
         Text("Count: \(viewStore.state)")
           .onAppear { viewStore.send(.onAppear) }

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -73,7 +73,7 @@ struct NestedView: View {
   let store: Store<NestedState, NestedAction>
 
   var body: some View {
-    WithViewStore(self.store.scope(state: \.description)) { viewStore in
+    WithViewStore(self.store, observe: \.description) { viewStore in
       Form {
         Section {
           AboutView(readMe: readMe)
@@ -82,14 +82,14 @@ struct NestedView: View {
         ForEachStore(
           self.store.scope(state: \.children, action: NestedAction.node(id:action:))
         ) { childStore in
-          WithViewStore(childStore) { childViewStore in
+          WithViewStore(childStore, observe: \.description) { childViewStore in
             NavigationLink(
               destination: NestedView(store: childStore)
             ) {
               HStack {
                 TextField(
                   "Untitled",
-                  text: childViewStore.binding(get: \.description, send: NestedAction.rename)
+                  text: childViewStore.binding(send: NestedAction.rename)
                 )
                 Text("Next")
                   .font(.callout)

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
@@ -144,7 +144,7 @@ struct DownloadComponent<ID: Equatable>: View {
   let store: Store<DownloadComponentState<ID>, DownloadComponentAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       Button {
         viewStore.send(.buttonTapped)
       } label: {

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -79,7 +79,7 @@ struct CityMapRowView: View {
   let store: Store<CityMapState, CityMapAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       HStack {
         NavigationLink(
           destination: CityMapDetailView(store: self.store)
@@ -109,7 +109,7 @@ struct CityMapDetailView: View {
   let store: Store<CityMapState, CityMapAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       VStack(spacing: 32) {
         Text(viewStore.cityMap.blurb)
 
@@ -140,7 +140,7 @@ struct CityMapDetailView: View {
   }
 }
 
-struct MapAppState {
+struct MapAppState: Equatable {
   var cityMaps: IdentifiedArrayOf<CityMapState>
 }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -85,7 +85,7 @@ struct FavoriteButton<ID: Hashable>: View {
   let store: Store<FavoriteState<ID>, FavoriteAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       Button {
         viewStore.send(.buttonTapped)
       } label: {
@@ -123,7 +123,7 @@ struct EpisodeView: View {
   let store: Store<EpisodeState, EpisodeAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       HStack(alignment: .firstTextBaseline) {
         Text(viewStore.title)
 

--- a/Examples/CaseStudies/tvOSCaseStudies/FocusView.swift
+++ b/Examples/CaseStudies/tvOSCaseStudies/FocusView.swift
@@ -40,7 +40,7 @@ let focusReducer = Reducer<FocusState, FocusAction, FocusEnvironment> {
     @Namespace private var namespace
 
     var body: some View {
-      WithViewStore(self.store) { viewStore in
+      WithViewStore(self.store, observe: { $0 }) { viewStore in
         VStack(spacing: 100) {
           Text(readMe)
             .font(.headline)

--- a/Examples/Search/Search/SearchView.swift
+++ b/Examples/Search/Search/SearchView.swift
@@ -119,7 +119,7 @@ struct SearchView: View {
   let store: Store<SearchState, SearchAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       NavigationView {
         VStack(alignment: .leading) {
           Text(readMe)

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
@@ -108,7 +108,7 @@ struct SpeechRecognitionView: View {
   let store: Store<AppState, AppAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       VStack {
         VStack(alignment: .leading) {
           Text(readMe)

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
@@ -29,7 +29,7 @@ public struct GameView: View {
   }
 
   public var body: some View {
-    WithViewStore(self.store.scope(state: ViewState.init)) { viewStore in
+    WithViewStore(self.store, observe: ViewState.init) { viewStore in
       GeometryReader { proxy in
         VStack(spacing: 0.0) {
           VStack {

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -41,7 +41,7 @@ public struct LoginView: View {
   }
 
   public var body: some View {
-    WithViewStore(self.store.scope(state: ViewState.init, action: LoginAction.init)) { viewStore in
+    WithViewStore(self.store, observe: ViewState.init, send: LoginAction.init) { viewStore in
       Form {
         Text(
           """
@@ -79,7 +79,7 @@ public struct LoginView: View {
               //     if you disable a text field while it is focused. This hack will force all
               //     fields to unfocus before we send the action to the view store.
               // CF: https://stackoverflow.com/a/69653555
-              UIApplication.shared.sendAction(
+              _ = UIApplication.shared.sendAction(
                 #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
               )
               return $0 ? .loginButtonTapped : .twoFactorDismissed

--- a/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
@@ -34,7 +34,7 @@ public struct NewGameView: View {
   }
 
   public var body: some View {
-    WithViewStore(self.store.scope(state: ViewState.init, action: NewGameAction.init)) {
+    WithViewStore(self.store, observe: ViewState.init, send: NewGameAction.init) {
       viewStore in
       Form {
         Section {

--- a/Examples/Todos/Todos/Todo.swift
+++ b/Examples/Todos/Todos/Todo.swift
@@ -31,7 +31,7 @@ struct TodoView: View {
   let store: Store<TodoState, TodoAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       HStack {
         Button(action: { viewStore.send(.checkBoxToggled) }) {
           Image(systemName: viewStore.isComplete ? "checkmark.square" : "square")

--- a/Examples/VoiceMemos/VoiceMemos/RecordingMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/RecordingMemo.swift
@@ -87,7 +87,7 @@ struct RecordingMemoView: View {
   let store: Store<RecordingMemoState, RecordingMemoAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       VStack(spacing: 12) {
         Text("Recording")
           .font(.title)

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -143,7 +143,7 @@ struct VoiceMemosView: View {
   let store: Store<VoiceMemosState, VoiceMemosAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       NavigationView {
         VStack {
           List {

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ struct AppView: View {
   let store: Store<AppState, AppAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       VStack {
         HStack {
           Button("−") { viewStore.send(.decrementButtonTapped) }

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
@@ -143,7 +143,7 @@ struct AppView: View {
   let store: Store<AppState, AppAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       VStack {
         HStack {
           Button("−") { viewStore.send(.decrementButtonTapped) }

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -18,7 +18,7 @@ constructed naively, using either view store's initializer ``ViewStore/init(_:)-
 SwiftUI helper ``WithViewStore``, it will observe every change to state in the store:
 
 ```swift
-WithViewStore(self.store) { viewStore in 
+WithViewStore(self.store, observe: { $0 }) { viewStore in 
   // This is executed for every action sent into the system 
   // that causes self.store.state to change. 
 }
@@ -91,9 +91,7 @@ struct AppView: View {
   }
 
   var body: some View {
-    WithViewStore(
-      self.store.scope(state: ViewState.init)
-    ) { viewStore in 
+    WithViewStore(self.store, observe: ViewState.init) { viewStore in 
       TabView {
         ActivityView(
           store: self.store
@@ -239,7 +237,7 @@ struct FeatureView: View {
   let store: Store<FeatureState, FeatureAction>
 
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       // A large, complex view inside here...
     }
   }

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -3,6 +3,16 @@ import Combine
 import SwiftUI
 import XCTestDynamicOverlay
 
+// NB: Deprecated after 0.39.1:
+
+extension WithViewStore {
+  @available(*, deprecated, renamed: "ViewState")
+  public typealias State = ViewState
+
+  @available(*, deprecated, renamed: "ViewAction")
+  public typealias Action = ViewAction
+}
+
 // NB: Deprecated after 0.39.0:
 
 extension CaseLet {

--- a/Sources/ComposableArchitecture/SwiftUI/TextState.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/TextState.swift
@@ -31,7 +31,7 @@ import SwiftUI
 ///
 /// ```swift
 /// var body: some View {
-///   WithViewStore(self.store) { viewStore in
+///   WithViewStore(self.store, observe: { $0 }) { viewStore in
 ///     viewStore.label
 ///   }
 /// }

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -34,7 +34,7 @@ import SwiftUI
 ///   let store: Store<ProfileState, ProfileAction>
 ///
 ///   var body: some View {
-///     WithViewStore(self.store) { viewStore in
+///     WithViewStore(self.store, observe: { $0 }) { viewStore in
 ///       Text("\(viewStore.username)")
 ///       // ...
 ///     }

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -411,7 +411,11 @@ extension WithViewStore where ViewState == Void, Content: View {
   }
 }
 
-extension WithViewStore: DynamicViewContent where ViewState: Collection, Content: DynamicViewContent {
+extension WithViewStore: DynamicViewContent
+where
+  ViewState: Collection,
+  Content: DynamicViewContent
+{
   public typealias Data = ViewState
 
   public var data: ViewState {
@@ -444,7 +448,8 @@ extension WithViewStore: AccessibilityRotorContent where Content: AccessibilityR
   public init(
     _ store: Store<ViewState, ViewAction>,
     removeDuplicates isDuplicate: @escaping (ViewState, ViewState) -> Bool,
-    @AccessibilityRotorContentBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
+    @AccessibilityRotorContentBuilder content: @escaping (ViewStore<ViewState, ViewAction>) ->
+      Content,
     file: StaticString = #fileID,
     line: UInt = #line
   ) {
@@ -478,7 +483,8 @@ extension WithViewStore where ViewState: Equatable, Content: AccessibilityRotorC
   )
   public init(
     _ store: Store<ViewState, ViewAction>,
-    @AccessibilityRotorContentBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
+    @AccessibilityRotorContentBuilder content: @escaping (ViewStore<ViewState, ViewAction>) ->
+      Content,
     file: StaticString = #fileID,
     line: UInt = #line
   ) {
@@ -508,7 +514,8 @@ extension WithViewStore where ViewState == Void, Content: AccessibilityRotorCont
     _ store: Store<ViewState, ViewAction>,
     file: StaticString = #fileID,
     line: UInt = #line,
-    @AccessibilityRotorContentBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content
+    @AccessibilityRotorContentBuilder content: @escaping (ViewStore<ViewState, ViewAction>) ->
+      Content
   ) {
     self.init(store, removeDuplicates: ==, content: content, file: file, line: line)
   }

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -109,28 +109,28 @@ import SwiftUI
 ///   ViewStore(self.store).send(.buttonTapped)
 /// }
 /// ```
-public struct WithViewStore<State, Action, Content> {
-  private let content: (ViewStore<State, Action>) -> Content
+public struct WithViewStore<ViewState, ViewAction, Content> {
+  private let content: (ViewStore<ViewState, ViewAction>) -> Content
   #if DEBUG
     private let file: StaticString
     private let line: UInt
     private var prefix: String?
-    private var previousState: (State) -> State?
+    private var previousState: (ViewState) -> ViewState?
   #endif
-  @_StateObject private var viewStore: ViewStore<State, Action>
+  @_StateObject private var viewStore: ViewStore<ViewState, ViewAction>
 
   fileprivate init(
-    store: Store<State, Action>,
-    removeDuplicates isDuplicate: @escaping (State, State) -> Bool,
+    store: Store<ViewState, ViewAction>,
+    removeDuplicates isDuplicate: @escaping (ViewState, ViewState) -> Bool,
+    content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
     file: StaticString = #fileID,
-    line: UInt = #line,
-    content: @escaping (ViewStore<State, Action>) -> Content
+    line: UInt = #line
   ) {
     self.content = content
     #if DEBUG
       self.file = file
       self.line = line
-      var previousState: State? = nil
+      var previousState: ViewState? = nil
       self.previousState = { currentState in
         defer { previousState = currentState }
         return previousState
@@ -173,7 +173,7 @@ public struct WithViewStore<State, Action, Content> {
         print(
           """
           \(prefix.isEmpty ? "" : "\(prefix): ")\
-          WithViewStore<\(typeName(State.self)), \(typeName(Action.self)), _>\
+          WithViewStore<\(typeName(ViewState.self)), \(typeName(ViewAction.self)), _>\
           @\(self.file):\(self.line) \(difference)
           """
         )
@@ -187,68 +187,234 @@ public struct WithViewStore<State, Action, Content> {
 
 extension WithViewStore: View where Content: View {
   /// Initializes a structure that transforms a store into an observable view store in order to
+  /// compute views from state.
+  ///
+  /// - Parameters:
+  ///   - store: A store.
+  ///   - toViewState: A function that transforms store state into observable view state.
+  ///   - fromViewAction: A function that transforms view actions into store action.
+  ///   - isDuplicate: A function to determine when two `ViewState` values are equal. When values
+  ///     are equal, repeat view computations are removed,
+  ///   - content: A function that can generate content from a view store.
+  public init<State, Action>(
+    _ store: Store<State, Action>,
+    observe toViewState: @escaping (State) -> ViewState,
+    send fromViewAction: @escaping (ViewAction) -> Action,
+    removeDuplicates isDuplicate: @escaping (ViewState, ViewState) -> Bool,
+    @ViewBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
+    file: StaticString = #fileID,
+    line: UInt = #line
+  ) {
+    self.init(
+      store: store.scope(state: toViewState, action: fromViewAction),
+      removeDuplicates: isDuplicate,
+      content: content,
+      file: file,
+      line: line
+    )
+  }
+
+  /// Initializes a structure that transforms a store into an observable view store in order to
+  /// compute views from state.
+  ///
+  /// - Parameters:
+  ///   - store: A store.
+  ///   - toViewState: A function that transforms store state into observable view state.
+  ///   - isDuplicate: A function to determine when two `ViewState` values are equal. When values
+  ///     are equal, repeat view computations are removed,
+  ///   - content: A function that can generate content from a view store.
+  public init<State>(
+    _ store: Store<State, ViewAction>,
+    observe toViewState: @escaping (State) -> ViewState,
+    removeDuplicates isDuplicate: @escaping (ViewState, ViewState) -> Bool,
+    @ViewBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
+    file: StaticString = #fileID,
+    line: UInt = #line
+  ) {
+    self.init(
+      store: store.scope(state: toViewState),
+      removeDuplicates: isDuplicate,
+      content: content,
+      file: file,
+      line: line
+    )
+  }
+
+  /// Initializes a structure that transforms a store into an observable view store in order to
   /// compute views from store state.
   ///
   /// - Parameters:
   ///   - store: A store.
-  ///   - isDuplicate: A function to determine when two `State` values are equal. When values are
-  ///     equal, repeat view computations are removed,
+  ///   - isDuplicate: A function to determine when two `ViewState` values are equal. When values
+  ///     are equal, repeat view computations are removed,
   ///   - content: A function that can generate content from a view store.
+  @available(
+    iOS,
+    deprecated: 9999.0,
+    message: "Use 'init(_:observe:removeDuplicates:content:)' to make state observation explicit."
+  )
+  @available(
+    macOS,
+    deprecated: 9999.0,
+    message: "Use 'init(_:observe:removeDuplicates:content:)' to make state observation explicit."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999.0,
+    message: "Use 'init(_:observe:removeDuplicates:content:)' to make state observation explicit."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999.0,
+    message: "Use 'init(_:observe:removeDuplicates:content:)' to make state observation explicit."
+  )
   public init(
-    _ store: Store<State, Action>,
-    removeDuplicates isDuplicate: @escaping (State, State) -> Bool,
+    _ store: Store<ViewState, ViewAction>,
+    removeDuplicates isDuplicate: @escaping (ViewState, ViewState) -> Bool,
+    @ViewBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
     file: StaticString = #fileID,
-    line: UInt = #line,
-    @ViewBuilder content: @escaping (ViewStore<State, Action>) -> Content
+    line: UInt = #line
   ) {
     self.init(
       store: store,
       removeDuplicates: isDuplicate,
+      content: content,
       file: file,
-      line: line,
-      content: content
+      line: line
     )
   }
 }
 
-extension WithViewStore where State: Equatable, Content: View {
+extension WithViewStore where ViewState: Equatable, Content: View {
+  /// Initializes a structure that transforms a store into an observable view store in order to
+  /// compute views from equatable state.
+  ///
+  /// - Parameters:
+  ///   - store: A store.
+  ///   - toViewState: A function that transforms store state into observable view state.
+  ///   - fromViewAction: A function that transforms view actions into store action.
+  ///   - isDuplicate: A function to determine when two `ViewState` values are equal. When values
+  ///     are equal, repeat view computations are removed,
+  ///   - content: A function that can generate content from a view store.
+  public init<State, Action>(
+    _ store: Store<State, Action>,
+    observe toViewState: @escaping (State) -> ViewState,
+    send fromViewAction: @escaping (ViewAction) -> Action,
+    @ViewBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
+    file: StaticString = #fileID,
+    line: UInt = #line
+  ) {
+    self.init(
+      store: store.scope(state: toViewState, action: fromViewAction),
+      removeDuplicates: ==,
+      content: content,
+      file: file,
+      line: line
+    )
+  }
+
+  /// Initializes a structure that transforms a store into an observable view store in order to
+  /// compute views from equatable state.
+  ///
+  /// - Parameters:
+  ///   - store: A store.
+  ///   - toViewState: A function that transforms store state into observable view state.
+  ///   - isDuplicate: A function to determine when two `ViewState` values are equal. When values
+  ///     are equal, repeat view computations are removed,
+  ///   - content: A function that can generate content from a view store.
+  public init<State>(
+    _ store: Store<State, ViewAction>,
+    observe toViewState: @escaping (State) -> ViewState,
+    @ViewBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
+    file: StaticString = #fileID,
+    line: UInt = #line
+  ) {
+    self.init(
+      store: store.scope(state: toViewState),
+      removeDuplicates: ==,
+      content: content,
+      file: file,
+      line: line
+    )
+  }
+
   /// Initializes a structure that transforms a store into an observable view store in order to
   /// compute views from equatable store state.
   ///
   /// - Parameters:
   ///   - store: A store of equatable state.
   ///   - content: A function that can generate content from a view store.
+  @available(
+    iOS,
+    deprecated: 9999.0,
+    message: "Use 'init(_:observe:content:)' to make state observation explicit."
+  )
+  @available(
+    macOS,
+    deprecated: 9999.0,
+    message: "Use 'init(_:observe:content:)' to make state observation explicit."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999.0,
+    message: "Use 'init(_:observe:content:)' to make state observation explicit."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999.0,
+    message: "Use 'init(_:observe:content:)' to make state observation explicit."
+  )
   public init(
-    _ store: Store<State, Action>,
+    _ store: Store<ViewState, ViewAction>,
+    @ViewBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
     file: StaticString = #fileID,
-    line: UInt = #line,
-    @ViewBuilder content: @escaping (ViewStore<State, Action>) -> Content
+    line: UInt = #line
   ) {
-    self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
+    self.init(store, removeDuplicates: ==, content: content, file: file, line: line)
   }
 }
 
-extension WithViewStore where State == Void, Content: View {
+extension WithViewStore where ViewState == Void, Content: View {
   /// Initializes a structure that transforms a store into an observable view store in order to
   /// compute views from void store state.
   ///
   /// - Parameters:
   ///   - store: A store of equatable state.
   ///   - content: A function that can generate content from a view store.
+  @available(
+    iOS,
+    deprecated: 9999.0,
+    message: "Use 'ViewStore(store).send(action)' instead of observing stateless stores."
+  )
+  @available(
+    macOS,
+    deprecated: 9999.0,
+    message: "Use 'ViewStore(store).send(action)' instead of observing stateless stores."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999.0,
+    message: "Use 'ViewStore(store).send(action)' instead of observing stateless stores."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999.0,
+    message: "Use 'ViewStore(store).send(action)' instead of observing stateless stores."
+  )
   public init(
-    _ store: Store<State, Action>,
+    _ store: Store<ViewState, ViewAction>,
+    @ViewBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
     file: StaticString = #fileID,
-    line: UInt = #line,
-    @ViewBuilder content: @escaping (ViewStore<State, Action>) -> Content
+    line: UInt = #line
   ) {
-    self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
+    self.init(store, removeDuplicates: ==, content: content, file: file, line: line)
   }
 }
 
-extension WithViewStore: DynamicViewContent where State: Collection, Content: DynamicViewContent {
-  public typealias Data = State
+extension WithViewStore: DynamicViewContent where ViewState: Collection, Content: DynamicViewContent {
+  public typealias Data = ViewState
 
-  public var data: State {
+  public var data: ViewState {
     self.viewStore.state
   }
 }
@@ -262,8 +428,8 @@ extension WithViewStore: AccessibilityRotorContent where Content: AccessibilityR
   ///
   /// - Parameters:
   ///   - store: A store.
-  ///   - isDuplicate: A function to determine when two `State` values are equal. When values are
-  ///     equal, repeat view computations are removed,
+  ///   - isDuplicate: A function to determine when two `ViewState` values are equal. When values
+  ///     are equal, repeat view computations are removed,
   ///   - content: A function that can generate content from a view store.
   @available(
     *,
@@ -276,24 +442,24 @@ extension WithViewStore: AccessibilityRotorContent where Content: AccessibilityR
       """
   )
   public init(
-    _ store: Store<State, Action>,
-    removeDuplicates isDuplicate: @escaping (State, State) -> Bool,
+    _ store: Store<ViewState, ViewAction>,
+    removeDuplicates isDuplicate: @escaping (ViewState, ViewState) -> Bool,
+    @AccessibilityRotorContentBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
     file: StaticString = #fileID,
-    line: UInt = #line,
-    @AccessibilityRotorContentBuilder content: @escaping (ViewStore<State, Action>) -> Content
+    line: UInt = #line
   ) {
     self.init(
       store: store,
       removeDuplicates: isDuplicate,
+      content: content,
       file: file,
-      line: line,
-      content: content
+      line: line
     )
   }
 }
 
 @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
-extension WithViewStore where State: Equatable, Content: AccessibilityRotorContent {
+extension WithViewStore where ViewState: Equatable, Content: AccessibilityRotorContent {
   /// Initializes a structure that transforms a store into an observable view store in order to
   /// compute accessibility rotor content from equatable store state.
   ///
@@ -311,17 +477,17 @@ extension WithViewStore where State: Equatable, Content: AccessibilityRotorConte
       """
   )
   public init(
-    _ store: Store<State, Action>,
+    _ store: Store<ViewState, ViewAction>,
+    @AccessibilityRotorContentBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
     file: StaticString = #fileID,
-    line: UInt = #line,
-    @AccessibilityRotorContentBuilder content: @escaping (ViewStore<State, Action>) -> Content
+    line: UInt = #line
   ) {
-    self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
+    self.init(store, removeDuplicates: ==, content: content, file: file, line: line)
   }
 }
 
 @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
-extension WithViewStore where State == Void, Content: AccessibilityRotorContent {
+extension WithViewStore where ViewState == Void, Content: AccessibilityRotorContent {
   /// Initializes a structure that transforms a store into an observable view store in order to
   /// compute accessibility rotor content from void store state.
   ///
@@ -339,12 +505,12 @@ extension WithViewStore where State == Void, Content: AccessibilityRotorContent 
       """
   )
   public init(
-    _ store: Store<State, Action>,
+    _ store: Store<ViewState, ViewAction>,
     file: StaticString = #fileID,
     line: UInt = #line,
-    @AccessibilityRotorContentBuilder content: @escaping (ViewStore<State, Action>) -> Content
+    @AccessibilityRotorContentBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content
   ) {
-    self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
+    self.init(store, removeDuplicates: ==, content: content, file: file, line: line)
   }
 }
 
@@ -359,8 +525,8 @@ extension WithViewStore: Commands where Content: Commands {
   ///
   /// - Parameters:
   ///   - store: A store.
-  ///   - isDuplicate: A function to determine when two `State` values are equal. When values are
-  ///     equal, repeat view computations are removed,
+  ///   - isDuplicate: A function to determine when two `ViewState` values are equal. When values
+  ///     are equal, repeat view computations are removed,
   ///   - content: A function that can generate content from a view store.
   @available(
     *,
@@ -373,18 +539,18 @@ extension WithViewStore: Commands where Content: Commands {
       """
   )
   public init(
-    _ store: Store<State, Action>,
-    removeDuplicates isDuplicate: @escaping (State, State) -> Bool,
+    _ store: Store<ViewState, ViewAction>,
+    removeDuplicates isDuplicate: @escaping (ViewState, ViewState) -> Bool,
+    @CommandsBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
     file: StaticString = #fileID,
-    line: UInt = #line,
-    @CommandsBuilder content: @escaping (ViewStore<State, Action>) -> Content
+    line: UInt = #line
   ) {
     self.init(
       store: store,
       removeDuplicates: isDuplicate,
+      content: content,
       file: file,
-      line: line,
-      content: content
+      line: line
     )
   }
 }
@@ -392,7 +558,7 @@ extension WithViewStore: Commands where Content: Commands {
 @available(iOS 14, macOS 11, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-extension WithViewStore where State: Equatable, Content: Commands {
+extension WithViewStore where ViewState: Equatable, Content: Commands {
   /// Initializes a structure that transforms a store into an observable view store in order to
   /// compute commands from equatable store state.
   ///
@@ -410,19 +576,19 @@ extension WithViewStore where State: Equatable, Content: Commands {
       """
   )
   public init(
-    _ store: Store<State, Action>,
+    _ store: Store<ViewState, ViewAction>,
+    @CommandsBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
     file: StaticString = #fileID,
-    line: UInt = #line,
-    @CommandsBuilder content: @escaping (ViewStore<State, Action>) -> Content
+    line: UInt = #line
   ) {
-    self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
+    self.init(store, removeDuplicates: ==, content: content, file: file, line: line)
   }
 }
 
 @available(iOS 14, macOS 11, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-extension WithViewStore where State == Void, Content: Commands {
+extension WithViewStore where ViewState == Void, Content: Commands {
   /// Initializes a structure that transforms a store into an observable view store in order to
   /// compute commands from void store state.
   ///
@@ -440,12 +606,12 @@ extension WithViewStore where State == Void, Content: Commands {
       """
   )
   public init(
-    _ store: Store<State, Action>,
+    _ store: Store<ViewState, ViewAction>,
     file: StaticString = #fileID,
     line: UInt = #line,
-    @CommandsBuilder content: @escaping (ViewStore<State, Action>) -> Content
+    @CommandsBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content
   ) {
-    self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
+    self.init(store, removeDuplicates: ==, content: content, file: file, line: line)
   }
 }
 
@@ -458,8 +624,8 @@ extension WithViewStore: Scene where Content: Scene {
   ///
   /// - Parameters:
   ///   - store: A store.
-  ///   - isDuplicate: A function to determine when two `State` values are equal. When values are
-  ///     equal, repeat view computations are removed,
+  ///   - isDuplicate: A function to determine when two `ViewState` values are equal. When values
+  ///     are equal, repeat view computations are removed,
   ///   - content: A function that can generate content from a view store.
   @available(
     *,
@@ -472,24 +638,24 @@ extension WithViewStore: Scene where Content: Scene {
       """
   )
   public init(
-    _ store: Store<State, Action>,
-    removeDuplicates isDuplicate: @escaping (State, State) -> Bool,
+    _ store: Store<ViewState, ViewAction>,
+    removeDuplicates isDuplicate: @escaping (ViewState, ViewState) -> Bool,
+    @SceneBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
     file: StaticString = #fileID,
-    line: UInt = #line,
-    @SceneBuilder content: @escaping (ViewStore<State, Action>) -> Content
+    line: UInt = #line
   ) {
     self.init(
       store: store,
       removeDuplicates: isDuplicate,
+      content: content,
       file: file,
-      line: line,
-      content: content
+      line: line
     )
   }
 }
 
 @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
-extension WithViewStore where State: Equatable, Content: Scene {
+extension WithViewStore where ViewState: Equatable, Content: Scene {
   /// Initializes a structure that transforms a store into an observable view store in order to
   /// compute scenes from equatable store state.
   ///
@@ -507,17 +673,17 @@ extension WithViewStore where State: Equatable, Content: Scene {
       """
   )
   public init(
-    _ store: Store<State, Action>,
+    _ store: Store<ViewState, ViewAction>,
+    @SceneBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
     file: StaticString = #fileID,
-    line: UInt = #line,
-    @SceneBuilder content: @escaping (ViewStore<State, Action>) -> Content
+    line: UInt = #line
   ) {
-    self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
+    self.init(store, removeDuplicates: ==, content: content, file: file, line: line)
   }
 }
 
 @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
-extension WithViewStore where State == Void, Content: Scene {
+extension WithViewStore where ViewState == Void, Content: Scene {
   /// Initializes a structure that transforms a store into an observable view store in order to
   /// compute scenes from void store state.
   ///
@@ -535,12 +701,12 @@ extension WithViewStore where State == Void, Content: Scene {
       """
   )
   public init(
-    _ store: Store<State, Action>,
+    _ store: Store<ViewState, ViewAction>,
     file: StaticString = #fileID,
     line: UInt = #line,
-    @SceneBuilder content: @escaping (ViewStore<State, Action>) -> Content
+    @SceneBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content
   ) {
-    self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
+    self.init(store, removeDuplicates: ==, content: content, file: file, line: line)
   }
 }
 
@@ -553,8 +719,8 @@ extension WithViewStore: ToolbarContent where Content: ToolbarContent {
   ///
   /// - Parameters:
   ///   - store: A store.
-  ///   - isDuplicate: A function to determine when two `State` values are equal. When values are
-  ///     equal, repeat view computations are removed,
+  ///   - isDuplicate: A function to determine when two `ViewState` values are equal. When values
+  ///     are equal, repeat view computations are removed,
   ///   - content: A function that can generate content from a view store.
   @available(
     *,
@@ -567,24 +733,24 @@ extension WithViewStore: ToolbarContent where Content: ToolbarContent {
       """
   )
   public init(
-    _ store: Store<State, Action>,
-    removeDuplicates isDuplicate: @escaping (State, State) -> Bool,
+    _ store: Store<ViewState, ViewAction>,
+    removeDuplicates isDuplicate: @escaping (ViewState, ViewState) -> Bool,
     file: StaticString = #fileID,
     line: UInt = #line,
-    @ToolbarContentBuilder content: @escaping (ViewStore<State, Action>) -> Content
+    @ToolbarContentBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content
   ) {
     self.init(
       store: store,
       removeDuplicates: isDuplicate,
+      content: content,
       file: file,
-      line: line,
-      content: content
+      line: line
     )
   }
 }
 
 @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
-extension WithViewStore where State: Equatable, Content: ToolbarContent {
+extension WithViewStore where ViewState: Equatable, Content: ToolbarContent {
   /// Initializes a structure that transforms a store into an observable view store in order to
   /// compute toolbar content from equatable store state.
   ///
@@ -602,17 +768,17 @@ extension WithViewStore where State: Equatable, Content: ToolbarContent {
       """
   )
   public init(
-    _ store: Store<State, Action>,
+    _ store: Store<ViewState, ViewAction>,
     file: StaticString = #fileID,
     line: UInt = #line,
-    @ToolbarContentBuilder content: @escaping (ViewStore<State, Action>) -> Content
+    @ToolbarContentBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content
   ) {
     self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
   }
 }
 
 @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
-extension WithViewStore where State == Void, Content: ToolbarContent {
+extension WithViewStore where ViewState == Void, Content: ToolbarContent {
   /// Initializes a structure that transforms a store into an observable view store in order to
   /// compute toolbar content from void store state.
   ///
@@ -630,10 +796,10 @@ extension WithViewStore where State == Void, Content: ToolbarContent {
       """
   )
   public init(
-    _ store: Store<State, Action>,
+    _ store: Store<ViewState, ViewAction>,
     file: StaticString = #fileID,
     line: UInt = #line,
-    @ToolbarContentBuilder content: @escaping (ViewStore<State, Action>) -> Content
+    @ToolbarContentBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content
   ) {
     self.init(store, removeDuplicates: ==, file: file, line: line, content: content)
   }

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -11,7 +11,7 @@ import SwiftUI
 ///
 /// ```swift
 /// var body: some View {
-///   WithViewStore(self.store) { viewStore in
+///   WithViewStore(self.store, observe: { $0 }) { viewStore in
 ///     VStack {
 ///       Text("Current count: \(viewStore.count)")
 ///       Button("Increment") { viewStore.send(.incrementButtonTapped) }
@@ -227,7 +227,7 @@ public final class ViewStore<State, Action>: ObservableObject {
   ///   let store: Store<State, Action>
   ///
   ///   var body: some View {
-  ///     WithViewStore(self.store) { viewStore in
+  ///     WithViewStore(self.store, observe: { $0 }) { viewStore in
   ///       List {
   ///         if let response = viewStore.response {
   ///           Text(response)


### PR DESCRIPTION
The existing `WithViewStore` initializers make it far too easy to introduce performance problems into an application as it grows, and not easy to understand what's going wrong without more intimate knowledge of the framework and its documentation.

Because of this, we'd like to deprecate the existing initializers and introduce new initializers that make view state observation very explicit:

```swift
// Before:

WithViewStore(self.store) { viewStore in
  // ...
}

// After:

WithViewStore(self.store, observe: { $0 }) { viewStore in
  // ...
}
```

It is now very explicit what state a view is observing, and we think it will stand out more when users encounter performance issues. It is something that is easier to teach and learn.

Instead of scoping stores and then handing them to `WithViewStore`, you can pass state and action transformations directly, which even saves a few keystrokes:

```swift
// Before:

WithViewStore(self.store.scope(state: ViewState.init, action: Action.init)) { viewStore in
  // ...
}

// After:

WithViewStore(self.store, observe: ViewState.init, send: Action.init) { viewStore in
  // ...
}
```

So in short, instead of reusing `Store.scope` for two different kinds of transformations, we have separated them out to be more specific. The general rules:

- Use `Store.scope` to pass a child store to a child view
- Use `WithViewStore(_:observe:)` from a child view to observe view state

The deprecations in this PR are soft and should not cause warnings or churn in your applications, but you will start to be able to use the new APIs as soon as they are released. Then in the future we will deprecate the old APIs with a little more fanfare.

Please let us know if you have any feedback!