### PR TITLE
Fix a few flakey tests

### DIFF
--- a/Examples/TicTacToe/tic-tac-toe/Tests/AppCoreTests/AppCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/AppCoreTests/AppCoreTests.swift
@@ -124,7 +124,5 @@ final class AppCoreTests: XCTestCase {
     ) {
       $0 = .newGame(NewGameState())
     }
-
-    await store.finish()
   }
 }

--- a/Examples/TicTacToe/tic-tac-toe/Tests/AppCoreTests/AppCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/AppCoreTests/AppCoreTests.swift
@@ -54,6 +54,8 @@ final class AppCoreTests: XCTestCase {
     await store.send(.newGame(.logoutButtonTapped)) {
       $0 = .login(LoginState())
     }
+
+    await store.finish()
   }
 
   func testIntegration_TwoFactor() async {
@@ -124,5 +126,7 @@ final class AppCoreTests: XCTestCase {
     ) {
       $0 = .newGame(NewGameState())
     }
+
+    await store.finish()
   }
 }

--- a/Examples/TicTacToe/tic-tac-toe/Tests/AppCoreTests/AppCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/AppCoreTests/AppCoreTests.swift
@@ -54,8 +54,6 @@ final class AppCoreTests: XCTestCase {
     await store.send(.newGame(.logoutButtonTapped)) {
       $0 = .login(LoginState())
     }
-
-    await store.finish()
   }
 
   func testIntegration_TwoFactor() async {

--- a/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorSwiftUITests/TwoFactorSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorSwiftUITests/TwoFactorSwiftUITests.swift
@@ -86,5 +86,7 @@ final class TwoFactorSwiftUITests: XCTestCase {
     await store.send(.alertDismissed) {
       $0.alert = nil
     }
+
+    await store.finish()
   }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
   ],
   dependencies: [
     .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
-    .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "0.7.3"),
+    .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "0.7.4"),
     .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.8.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.3.0"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "0.3.2"),

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -274,11 +274,11 @@
       @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
       @MainActor
       public func finish(
-        timeout duration: Duration,
+        timeout duration: Duration? = nil,
         file: StaticString = #file,
         line: UInt = #line
       ) async {
-        await self.finish(timeout: duration.nanoseconds, file: file, line: line)
+        await self.finish(timeout: duration?.nanoseconds, file: file, line: line)
       }
     #endif
 
@@ -287,6 +287,7 @@
     /// Can be used to assert that all effects have finished.
     ///
     /// - Parameter nanoseconds: The amount of time to wait before asserting.
+    @_disfavoredOverload
     @MainActor
     public func finish(
       timeout nanoseconds: UInt64? = nil,
@@ -936,22 +937,23 @@
     }
 
     #if swift(>=5.7)
-      @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
       /// Asserts the underlying task finished.
       ///
       /// - Parameter duration: The amount of time to wait before asserting.
+      @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
       public func finish(
-        timeout duration: Duration,
+        timeout duration: Duration? = nil,
         file: StaticString = #file,
         line: UInt = #line
       ) async {
-        await self.finish(timeout: duration.nanoseconds, file: file, line: line)
+        await self.finish(timeout: duration?.nanoseconds, file: file, line: line)
       }
     #endif
 
     /// Asserts the underlying task finished.
     ///
     /// - Parameter nanoseconds: The amount of time to wait before asserting.
+    @_disfavoredOverload
     public func finish(
       timeout nanoseconds: UInt64? = nil,
       file: StaticString = #file,

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -851,7 +851,7 @@
       else { return }
 
       { self.receive(expectedAction, updateExpectingResult, file: file, line: line) }()
-      await Task.megaYield()
+      await Task.megaYield(count: 6)
     }
   }
 

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -234,7 +234,7 @@
       self.reducer = reducer
       self.state = initialState
       self.toScopedState = toScopedState
-      self.timeout = 100 * NSEC_PER_MSEC
+      self.timeout = NSEC_PER_SEC
 
       self.store = Store(
         initialState: initialState,

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -852,7 +852,7 @@
       else { return }
 
       { self.receive(expectedAction, updateExpectingResult, file: file, line: line) }()
-      await Task.megaYield(count: 6)
+      await Task.megaYield()
     }
   }
 
@@ -1009,7 +1009,7 @@
   }
 
   extension Task where Success == Never, Failure == Never {
-    static func megaYield(count: Int = 3) async {
+    static func megaYield(count: Int = 6) async {
       for _ in 1...count {
         await Task<Void, Never>.detached(priority: .low) { await Task.yield() }.value
       }

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -158,7 +158,7 @@ final class ComposableArchitectureTests: XCTestCase {
 
     await store.send(.incr) { $0 = 1 }
     await mainQueue.advance(by: .seconds(1))
-    await store.receive(.response(1))
+    await store.receive(.response(1), timeout: NSEC_PER_MSEC * 500)
 
     await store.send(.incr) { $0 = 2 }
     await store.send(.cancel)

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -162,5 +162,6 @@ final class ComposableArchitectureTests: XCTestCase {
 
     await store.send(.incr) { $0 = 2 }
     await store.send(.cancel)
+    await store.finish()
   }
 }

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -158,7 +158,7 @@ final class ComposableArchitectureTests: XCTestCase {
 
     await store.send(.incr) { $0 = 1 }
     await mainQueue.advance(by: .seconds(1))
-    await store.receive(.response(1), timeout: NSEC_PER_MSEC * 500)
+    await store.receive(.response(1))
 
     await store.send(.incr) { $0 = 2 }
     await store.send(.cancel)

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import ComposableArchitecture
 
 final class EffectCancellationTests: XCTestCase {
-  struct CancelToken: Hashable {}
+  struct CancelID: Hashable {}
   var cancellables: Set<AnyCancellable> = []
 
   override func tearDown() {
@@ -17,7 +17,7 @@ final class EffectCancellationTests: XCTestCase {
 
     let subject = PassthroughSubject<Int, Never>()
     let effect = Effect(subject)
-      .cancellable(id: CancelToken())
+      .cancellable(id: CancelID())
 
     effect
       .sink { values.append($0) }
@@ -29,7 +29,7 @@ final class EffectCancellationTests: XCTestCase {
     subject.send(2)
     XCTAssertNoDifference(values, [1, 2])
 
-    Effect<Never, Never>.cancel(id: CancelToken())
+    Effect<Never, Never>.cancel(id: CancelID())
       .sink { _ in }
       .store(in: &self.cancellables)
 
@@ -42,7 +42,7 @@ final class EffectCancellationTests: XCTestCase {
 
     let subject = PassthroughSubject<Int, Never>()
     Effect(subject)
-      .cancellable(id: CancelToken(), cancelInFlight: true)
+      .cancellable(id: CancelID(), cancelInFlight: true)
       .sink { values.append($0) }
       .store(in: &self.cancellables)
 
@@ -53,7 +53,7 @@ final class EffectCancellationTests: XCTestCase {
     XCTAssertNoDifference(values, [1, 2])
 
     Effect(subject)
-      .cancellable(id: CancelToken(), cancelInFlight: true)
+      .cancellable(id: CancelID(), cancelInFlight: true)
       .sink { values.append($0) }
       .store(in: &self.cancellables)
 
@@ -69,14 +69,14 @@ final class EffectCancellationTests: XCTestCase {
     Just(1)
       .delay(for: 0.15, scheduler: DispatchQueue.main)
       .eraseToEffect()
-      .cancellable(id: CancelToken())
+      .cancellable(id: CancelID())
       .sink { value = $0 }
       .store(in: &self.cancellables)
 
     XCTAssertNoDifference(value, nil)
 
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-      Effect<Never, Never>.cancel(id: CancelToken())
+      Effect<Never, Never>.cancel(id: CancelID())
         .sink { _ in }
         .store(in: &self.cancellables)
     }
@@ -93,14 +93,14 @@ final class EffectCancellationTests: XCTestCase {
     Just(1)
       .delay(for: 2, scheduler: mainQueue)
       .eraseToEffect()
-      .cancellable(id: CancelToken())
+      .cancellable(id: CancelID())
       .sink { value = $0 }
       .store(in: &self.cancellables)
 
     XCTAssertNoDifference(value, nil)
 
     mainQueue.advance(by: 1)
-    Effect<Never, Never>.cancel(id: CancelToken())
+    Effect<Never, Never>.cancel(id: CancelID())
       .sink { _ in }
       .store(in: &self.cancellables)
 
@@ -110,29 +110,33 @@ final class EffectCancellationTests: XCTestCase {
   }
 
   func testCancellablesCleanUp_OnComplete() {
+    let id = UUID()
+
     Just(1)
       .eraseToEffect()
-      .cancellable(id: 1)
+      .cancellable(id: id)
       .sink(receiveValue: { _ in })
       .store(in: &self.cancellables)
 
-    XCTAssertNoDifference([:], cancellationCancellables)
+    XCTAssertNil(cancellationCancellables[CancelToken(id: id)])
   }
 
   func testCancellablesCleanUp_OnCancel() {
+    let id = UUID()
+
     let mainQueue = DispatchQueue.test
     Just(1)
       .delay(for: 1, scheduler: mainQueue)
       .eraseToEffect()
-      .cancellable(id: 1)
+      .cancellable(id: id)
       .sink(receiveValue: { _ in })
       .store(in: &self.cancellables)
 
-    Effect<Int, Never>.cancel(id: 1)
+    Effect<Int, Never>.cancel(id: id)
       .sink(receiveValue: { _ in })
       .store(in: &self.cancellables)
 
-    XCTAssertNoDifference([:], cancellationCancellables)
+    XCTAssertNil(cancellationCancellables[CancelToken(id: id)])
   }
 
   func testDoubleCancellation() {
@@ -140,8 +144,8 @@ final class EffectCancellationTests: XCTestCase {
 
     let subject = PassthroughSubject<Int, Never>()
     let effect = Effect(subject)
-      .cancellable(id: CancelToken())
-      .cancellable(id: CancelToken())
+      .cancellable(id: CancelID())
+      .cancellable(id: CancelID())
 
     effect
       .sink { values.append($0) }
@@ -151,7 +155,7 @@ final class EffectCancellationTests: XCTestCase {
     subject.send(1)
     XCTAssertNoDifference(values, [1])
 
-    Effect<Never, Never>.cancel(id: CancelToken())
+    Effect<Never, Never>.cancel(id: CancelID())
       .sink { _ in }
       .store(in: &self.cancellables)
 
@@ -164,7 +168,7 @@ final class EffectCancellationTests: XCTestCase {
 
     let subject = PassthroughSubject<Int, Never>()
     let effect = Effect(subject)
-      .cancellable(id: CancelToken())
+      .cancellable(id: CancelID())
 
     effect
       .sink { values.append($0) }
@@ -176,7 +180,7 @@ final class EffectCancellationTests: XCTestCase {
     subject.send(completion: .finished)
     XCTAssertNoDifference(values, [1])
 
-    Effect<Never, Never>.cancel(id: CancelToken())
+    Effect<Never, Never>.cancel(id: CancelID())
       .sink { _ in }
       .store(in: &self.cancellables)
 
@@ -226,12 +230,14 @@ final class EffectCancellationTests: XCTestCase {
   }
 
   func testNestedCancels() {
+    let id = UUID()
+
     var effect = Empty<Void, Never>(completeImmediately: false)
       .eraseToEffect()
       .cancellable(id: 1)
 
-    for _ in 1 ... .random(in: 1...1_000) {
-      effect = effect.cancellable(id: 1)
+    for _ in 1...1_000 {
+      effect = effect.cancellable(id: id)
     }
 
     effect
@@ -240,7 +246,7 @@ final class EffectCancellationTests: XCTestCase {
 
     cancellables.removeAll()
 
-    XCTAssertNoDifference([:], cancellationCancellables)
+    XCTAssertNil(cancellationCancellables[CancelToken(id: id)])
   }
 
   func testSharedId() {


### PR DESCRIPTION
Ever since #1312 we've been getting some intermittent test failures. This is happening because we have a few tests that work directly with effects instead of using a `TestStore`, and those tests are leaving behind some artifacts that are being picked up by other tests.

This will not affect anyone using the library. This is only a problem in the library itself. We should probably audit all of those tests to make sure that things are cleaned up, or even better switch them all to use `TestStore` so that everything remains in a closed system.