### PR TITLE
Fix for Xcode 14 RC

### DIFF
--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -269,7 +269,7 @@
       )
     }
 
-    #if swift(>=5.7)
+    #if swift(>=5.7) && !os(macOS) && !targetEnvironment(macCatalyst)
       /// Suspends until all in-flight effects have finished, or until it times out.
       ///
       /// Can be used to assert that all effects have finished.
@@ -753,7 +753,7 @@
       }
     }
 
-    #if swift(>=5.7)
+    #if swift(>=5.7) && !os(macOS) && !targetEnvironment(macCatalyst)
       /// Asserts an action was received from an effect and asserts how the state changes.
       ///
       /// - Parameters:
@@ -940,7 +940,7 @@
       await self.rawValue?.cancellableValue
     }
 
-    #if swift(>=5.7)
+    #if swift(>=5.7) && !os(macOS) && !targetEnvironment(macCatalyst)
       /// Asserts the underlying task finished.
       ///
       /// - Parameter duration: The amount of time to wait before asserting.
@@ -1020,7 +1020,7 @@
     }
   }
 
-  #if swift(>=5.7)
+  #if swift(>=5.7) && !os(macOS) && !targetEnvironment(macCatalyst)
     @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
     extension Duration {
       fileprivate var nanoseconds: UInt64 {

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -269,6 +269,8 @@
       )
     }
 
+    // NB: Only needed until Xcode ships a macOS SDK that uses the 5.7 standard library.
+    // See: https://forums.swift.org/t/xcode-14-rc-cannot-specialize-protocol-type/60171/15
     #if swift(>=5.7) && !os(macOS) && !targetEnvironment(macCatalyst)
       /// Suspends until all in-flight effects have finished, or until it times out.
       ///
@@ -753,6 +755,8 @@
       }
     }
 
+    // NB: Only needed until Xcode ships a macOS SDK that uses the 5.7 standard library.
+    // See: https://forums.swift.org/t/xcode-14-rc-cannot-specialize-protocol-type/60171/15
     #if swift(>=5.7) && !os(macOS) && !targetEnvironment(macCatalyst)
       /// Asserts an action was received from an effect and asserts how the state changes.
       ///
@@ -940,6 +944,8 @@
       await self.rawValue?.cancellableValue
     }
 
+    // NB: Only needed until Xcode ships a macOS SDK that uses the 5.7 standard library.
+    // See: https://forums.swift.org/t/xcode-14-rc-cannot-specialize-protocol-type/60171/15
     #if swift(>=5.7) && !os(macOS) && !targetEnvironment(macCatalyst)
       /// Asserts the underlying task finished.
       ///
@@ -1020,6 +1026,8 @@
     }
   }
 
+  // NB: Only needed until Xcode ships a macOS SDK that uses the 5.7 standard library.
+  // See: https://forums.swift.org/t/xcode-14-rc-cannot-specialize-protocol-type/60171/15
   #if swift(>=5.7) && !os(macOS) && !targetEnvironment(macCatalyst)
     @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
     extension Duration {


### PR DESCRIPTION
[It turns out][xcode-14-stdlib] that Xcode 14 RC shipped with a macOS 12 SDK that uses the 5.6 version of the standard library instead of 5.7. This means `Duration` is not accessible when building for macOS but is fine to use with iOS. So, let's conditionally compile the few APIs that use `Duration` until it is available.

[xcode-14-stdlib]: https://forums.swift.org/t/xcode-14-rc-cannot-specialize-protocol-type/60171/15