### PR TITLE
Fix release builds for case studies.

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
@@ -142,38 +142,42 @@ let nevermindButton = AlertState<DownloadComponentAction.AlertAction>.Button
 
 struct DownloadComponent<ID: Equatable>: View {
   let store: Store<DownloadComponentState<ID>, DownloadComponentAction>
+  @ObservedObject var viewStore: ViewStore<DownloadComponentState<ID>, DownloadComponentAction>
+
+  init(store: Store<DownloadComponentState<ID>, DownloadComponentAction>) {
+    self.store = store
+    self.viewStore = ViewStore(self.store)
+  }
 
   var body: some View {
-    WithViewStore(self.store, observe: { $0 }) { viewStore in
-      Button {
-        viewStore.send(.buttonTapped)
-      } label: {
-        if viewStore.mode == .downloaded {
-          Image(systemName: "checkmark.circle")
-            .tint(.accentColor)
-        } else if viewStore.mode.progress > 0 {
-          ZStack {
-            CircularProgressView(value: viewStore.mode.progress)
-              .frame(width: 16, height: 16)
-            Rectangle()
-              .frame(width: 6, height: 6)
-          }
-        } else if viewStore.mode == .notDownloaded {
-          Image(systemName: "icloud.and.arrow.down")
-        } else if viewStore.mode == .startingToDownload {
-          ZStack {
-            ProgressView()
-            Rectangle()
-              .frame(width: 6, height: 6)
-          }
+    Button {
+      self.viewStore.send(.buttonTapped)
+    } label: {
+      if self.viewStore.mode == .downloaded {
+        Image(systemName: "checkmark.circle")
+          .tint(.accentColor)
+      } else if self.viewStore.mode.progress > 0 {
+        ZStack {
+          CircularProgressView(value: self.viewStore.mode.progress)
+            .frame(width: 16, height: 16)
+          Rectangle()
+            .frame(width: 6, height: 6)
+        }
+      } else if self.viewStore.mode == .notDownloaded {
+        Image(systemName: "icloud.and.arrow.down")
+      } else if self.viewStore.mode == .startingToDownload {
+        ZStack {
+          ProgressView()
+          Rectangle()
+            .frame(width: 6, height: 6)
         }
       }
-      .foregroundStyle(.primary)
-      .alert(
-        self.store.scope(state: \.alert, action: DownloadComponentAction.alert),
-        dismiss: .dismissed
-      )
     }
+    .foregroundStyle(.primary)
+    .alert(
+      self.store.scope(state: \.alert, action: DownloadComponentAction.alert),
+      dismiss: .dismissed
+    )
   }
 }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -83,17 +83,21 @@ extension Reducer {
 
 struct FavoriteButton<ID: Hashable>: View {
   let store: Store<FavoriteState<ID>, FavoriteAction>
+  @ObservedObject var viewStore: ViewStore<Bool, FavoriteAction>
+
+  init(store: Store<FavoriteState<ID>, FavoriteAction>) {
+    self.store = store
+    self.viewStore = ViewStore(self.store.scope(state: \.isFavorite))
+  }
 
   var body: some View {
-    WithViewStore(self.store, observe: { $0 }) { viewStore in
-      Button {
-        viewStore.send(.buttonTapped)
-      } label: {
-        Image(systemName: "heart")
-          .symbolVariant(viewStore.isFavorite ? .fill : .none)
-      }
-      .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
+    Button {
+      self.viewStore.send(.buttonTapped)
+    } label: {
+      Image(systemName: "heart")
+        .symbolVariant(self.viewStore.state ? .fill : .none)
     }
+    .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
   }
 }
 

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -197,10 +197,11 @@ final class EffectCancellationTests: XCTestCase {
       DispatchQueue.global(qos: .userInteractive),
       DispatchQueue.global(qos: .utility),
     ]
+    let ids = (1...10).map { _ in UUID() }
 
     let effect = Effect.merge(
       (1...1_000).map { idx -> Effect<Int, Never> in
-        let id = idx % 10
+        let id = ids[idx % 10]
 
         return Effect.merge(
           Just(idx)
@@ -226,7 +227,12 @@ final class EffectCancellationTests: XCTestCase {
       .store(in: &self.cancellables)
     self.wait(for: [expectation], timeout: 999)
 
-    XCTAssertTrue(cancellationCancellables.isEmpty)
+    for id in ids {
+      XCTAssertNil(
+        cancellationCancellables[CancelToken(id: id)],
+        "cancellationCancellables should not contain id \(id)"
+      )
+    }
   }
 
   func testNestedCancels() {


### PR DESCRIPTION
Somehow the introduction of our own back port of `@StateObject` is causing compile errors in release model when using `WithViewStore` in generic views. For example, when building the case studies target in release mode, the following compiler error happens:

```
Undefined symbols for architecture arm64:
  "_$s22ComposableArchitecture12_StateObjectV7Storage33_BCA98CFE651CB6AE3A3A7598ACD2B887LLCMa", referenced from:
      _$s18SwiftUICaseStudies17DownloadComponentV4bodyQrvg in DownloadComponent.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

It happens in both the reusable download component and favoriting component, both of which use `WithViewStore` in a generic context. We should minimize this a bit and file a bug on the swift repo, but for now we can fix by using an explicit `@ObservedObject`. 🫤
