### PR TITLE
Rename `Effect<Output, _>` to `Effect<Action, _>`

### DIFF
--- a/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
@@ -98,11 +98,11 @@ extension Effect where Failure == Never {
             actionOutput
           )
           await operation(
-            Send { output in
+            Send { action in
               os_signpost(
                 .event, log: log, name: "Effect Output", "%sOutput from %s", prefix, actionOutput
               )
-              send(output)
+              send(action)
             }
           )
           if Task.isCancelled {

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -120,10 +120,10 @@ applying it to views closer to the root.
 
 Reducers are run on the main thread and so they are not appropriate for performing intense CPU
 work. If you need to perform lots of CPU-bound work, then it is more appropriate to use an
-``Effect``, which will operate in the cooperative thread pool, and then send it's output back into
-the system via an action. You should also make sure to perform your CPU intensive work in a
-cooperative manner by periodically suspending with `Task.yield()` so that you do not block a thread
-in the cooperative pool for too long.
+``Effect``, which will operate in the cooperative thread pool, and then send actions back into the
+system. You should also make sure to perform your CPU intensive work in a cooperative manner by
+periodically suspending with `Task.yield()` so that you do not block a thread in the cooperative
+pool for too long.
 
 So, instead of performing intense work like this in your reducer:
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectDeprecations.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectDeprecations.md
@@ -28,6 +28,7 @@ Avoid using deprecated APIs in your app. Select a method to see the replacement 
 
 ### Combine Integration
 
+- ``Effect/Output``
 - ``Effect/init(_:)``
 - ``Effect/init(value:)``
 - ``Effect/init(error:)``

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -39,7 +39,7 @@ extension Effect {
             ()
               -> Publishers.HandleEvents<
                 Publishers.PrefixUntilOutput<
-                  AnyPublisher<Output, Failure>, PassthroughSubject<Void, Never>
+                  AnyPublisher<Action, Failure>, PassthroughSubject<Void, Never>
                 >
               > in
             cancellablesLock.lock()

--- a/Sources/ComposableArchitecture/Effects/Publisher.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher.swift
@@ -5,13 +5,15 @@ import Combine
 @available(tvOS, deprecated: 9999.0)
 @available(watchOS, deprecated: 9999.0)
 extension Effect: Publisher {
+  public typealias Output = Action
+
   public func receive<S: Combine.Subscriber>(
     subscriber: S
-  ) where S.Input == Output, S.Failure == Failure {
+  ) where S.Input == Action, S.Failure == Failure {
     self.publisher.subscribe(subscriber)
   }
 
-  var publisher: AnyPublisher<Output, Failure> {
+  var publisher: AnyPublisher<Action, Failure> {
     switch self.operation {
     case .none:
       return Empty().eraseToAnyPublisher()
@@ -75,7 +77,7 @@ extension Effect {
   @available(macOS, deprecated: 9999.0, message: "Wrap the value in 'Effect.task', instead.")
   @available(tvOS, deprecated: 9999.0, message: "Wrap the value in 'Effect.task', instead.")
   @available(watchOS, deprecated: 9999.0, message: "Wrap the value in 'Effect.task', instead.")
-  public init(value: Output) {
+  public init(value: Action) {
     self.init(Just(value).setFailureType(to: Failure.self))
   }
 
@@ -147,7 +149,7 @@ extension Effect {
   @available(tvOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
   @available(watchOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
   public static func future(
-    _ attemptToFulfill: @escaping (@escaping (Result<Output, Failure>) -> Void) -> Void
+    _ attemptToFulfill: @escaping (@escaping (Result<Action, Failure>) -> Void) -> Void
   ) -> Self {
     Deferred { Future(attemptToFulfill) }.eraseToEffect()
   }
@@ -181,7 +183,7 @@ extension Effect {
   @available(macOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
   @available(tvOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
   @available(watchOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
-  public static func result(_ attemptToFulfill: @escaping () -> Result<Output, Failure>) -> Self {
+  public static func result(_ attemptToFulfill: @escaping () -> Result<Action, Failure>) -> Self {
     Deferred { Future { $0(attemptToFulfill()) } }.eraseToEffect()
   }
 
@@ -246,9 +248,9 @@ extension Effect {
     //     due to a bug in iOS 13.2 that publisher will never complete. The bug was fixed in
     //     iOS 13.3, but to remain compatible with iOS 13.2 and higher we need to do a little
     //     trickery to make sure the deferred publisher completes.
-    Deferred { () -> Publishers.CompactMap<Result<Output?, Failure>.Publisher, Output> in
+    Deferred { () -> Publishers.CompactMap<Result<Action?, Failure>.Publisher, Action> in
       try? work()
-      return Just<Output?>(nil)
+      return Just<Action?>(nil)
         .setFailureType(to: Failure.self)
         .compactMap { $0 }
     }
@@ -294,7 +296,7 @@ extension Effect where Failure == Error {
     watchOS, deprecated: 9999.0,
     message: "Throw and catch errors directly in 'Effect.task' and 'Effect.run', instead."
   )
-  public static func catching(_ work: @escaping () throws -> Output) -> Self {
+  public static func catching(_ work: @escaping () throws -> Action) -> Self {
     .future { $0(Result { try work() }) }
   }
 }

--- a/Sources/ComposableArchitecture/Effects/Throttling.swift
+++ b/Sources/ComposableArchitecture/Effects/Throttling.swift
@@ -25,7 +25,7 @@ extension Effect {
       return .none
     case .publisher, .run:
       return self.receive(on: scheduler)
-        .flatMap { value -> AnyPublisher<Output, Failure> in
+        .flatMap { value -> AnyPublisher<Action, Failure> in
           throttleLock.lock()
           defer { throttleLock.unlock() }
 
@@ -35,7 +35,7 @@ extension Effect {
             return Just(value).setFailureType(to: Failure.self).eraseToAnyPublisher()
           }
 
-          let value = latest ? value : (throttleValues[id] as! Output? ?? value)
+          let value = latest ? value : (throttleValues[id] as! Action? ?? value)
           throttleValues[id] = value
 
           guard throttleTime.distance(to: scheduler.now) < interval else {

--- a/Sources/ComposableArchitecture/Effects/Timer.swift
+++ b/Sources/ComposableArchitecture/Effects/Timer.swift
@@ -103,7 +103,7 @@ extension Effect where Failure == Never {
     tolerance: S.SchedulerTimeType.Stride? = nil,
     on scheduler: S,
     options: S.SchedulerOptions? = nil
-  ) -> Self where S.SchedulerTimeType == Output {
+  ) -> Self where S.SchedulerTimeType == Action {
     Publishers.Timer(every: interval, tolerance: tolerance, scheduler: scheduler, options: options)
       .autoconnect()
       .setFailureType(to: Failure.self)
@@ -137,7 +137,7 @@ extension Effect where Failure == Never {
     tolerance: S.SchedulerTimeType.Stride? = nil,
     on scheduler: S,
     options: S.SchedulerOptions? = nil
-  ) -> Self where S.SchedulerTimeType == Output {
+  ) -> Self where S.SchedulerTimeType == Action {
     self.timer(
       id: ObjectIdentifier(id),
       every: interval,

--- a/Sources/ComposableArchitecture/Internal/Create.swift
+++ b/Sources/ComposableArchitecture/Internal/Create.swift
@@ -171,18 +171,18 @@ extension Publishers.Create.Subscription: CustomStringConvertible {
 
 extension Effect {
   public struct Subscriber {
-    private let _send: (Output) -> Void
+    private let _send: (Action) -> Void
     private let _complete: (Subscribers.Completion<Failure>) -> Void
 
     init(
-      send: @escaping (Output) -> Void,
+      send: @escaping (Action) -> Void,
       complete: @escaping (Subscribers.Completion<Failure>) -> Void
     ) {
       self._send = send
       self._complete = complete
     }
 
-    public func send(_ value: Output) {
+    public func send(_ value: Action) {
       self._send(value)
     }
 

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -426,7 +426,7 @@ extension CaseLet {
 
 extension Effect {
   @available(*, deprecated)
-  public var upstream: AnyPublisher<Output, Failure> {
+  public var upstream: AnyPublisher<Action, Failure> {
     self.publisher
   }
 }
@@ -440,10 +440,10 @@ extension Effect where Failure == Error {
   )
   public static func task(
     priority: TaskPriority? = nil,
-    operation: @escaping @Sendable () async throws -> Output
+    operation: @escaping @Sendable () async throws -> Action
   ) -> Self {
-    Deferred<Publishers.HandleEvents<PassthroughSubject<Output, Failure>>> {
-      let subject = PassthroughSubject<Output, Failure>()
+    Deferred<Publishers.HandleEvents<PassthroughSubject<Action, Failure>>> {
+      let subject = PassthroughSubject<Action, Failure>()
       let task = Task(priority: priority) { @MainActor in
         do {
           try Task.checkCancellation()


### PR DESCRIPTION
We'll keep the type alias for the `Publisher` conformance, but given the changes made to TCA for concurrency, `Effect` should typically only be used these days in reducers to feed actions back into the store, and not more generally as publishers of any output.