### PR TITLE
More docs for WithViewStore and new observe argument

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -157,15 +157,15 @@ WithViewStore(
 }
 ```
 
-Alternatively, and recommended, you can introduce a lightweight `ViewState` struct nested inside
-your view whose purpose is to transform the `Store`'s full state into the bare essentials of what
-the view needs:
+Alternatively, and recommended, you can introduce a lightweight, equatable `ViewState` struct
+nested inside your view whose purpose is to transform the `Store`'s full state into the bare
+essentials of what the view needs:
 
 ```swift
 struct AppView: View {
   let store: Store<AppState, AppAction>
   
-  struct ViewState {
+  struct ViewState: Equatable {
     let selectedTab: AppState.Tab
     let unreadActivityCount: Int
     init(state: AppState) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -197,7 +197,9 @@ This technique for reducing view re-computations is most effective towards the r
 hierarchy and least effective towards the leaf nodes of your app. Root features tend to hold lots
 of state that its view does not need, such as child features, and leaf features tend to only hold
 what's necessary. If you are going to employ this technique you will get the most benefit by
-applying it to views closer to the root.
+applying it to views closer to the root. At leaf features and views that need access to most
+of the state, it is fine to continue using `observe { $0 }` to observe all of the state in the 
+store.
 
 ### CPU intensive calculations
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -166,8 +166,10 @@ struct AppView: View {
   let store: Store<AppState, AppAction>
   
   struct ViewState {
+    let selectedTab: AppState.Tab
     let unreadActivityCount: Int
     init(state: AppState) {
+      self.selectedTab = state.selectedTab
       self.unreadActivityCount = state.activity.unreadCount
     }
   }

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -74,10 +74,92 @@ This means `AppView` does not actually need to observe any state changes. This v
 created a single time, whereas if we observed the store then it would re-compute every time a single
 thing changed in either the activity, search or profile child features.
 
-If sometime in the future we do actually need some state from the store, we can create a localized
-"view state" struct that holds only the bare essentials of state that the view needs to do its
-job. For example, suppose the activity state holds an integer that represents the number of 
-unread activities. Then we could observe changes to only that piece of state like so:
+If sometime in the future we do actually need some state from the store, we can start to observe
+only the bare essentials of state necessary for the view to do its job. For example, suppose that 
+we need access to the currently selected tab in state:
+
+```swift
+struct AppState {
+  var activity: ActivityState
+  var search: SearchState
+  var profile: ProfileState
+  var selectedTab: Tab
+  enum Tab { case activity, search, profile }
+}
+```
+
+Then we can observe this state so that we can construct a binding to `selectedTab` for the tab view:
+
+```swift
+struct AppView: View {
+  let store: Store<AppState, AppAction>
+
+  var body: some View {
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
+      TabView(selection: viewStore.binding(send: AppAction.tabSelected) {
+        ActivityView(
+          store: self.store.scope(state: \.activity, action: AppAction.activity)
+        )
+        .tag(AppState.Tab.activity)
+        SearchView(
+          store: self.store.scope(state: \.search, action: AppAction.search)
+        )
+        .tag(AppState.Tab.search)
+        ProfileView(
+          store: self.store.scope(state: \.profile, action: AppAction.profile)
+        )
+        .tag(AppState.Tab.profile)
+      }
+    }
+  }
+}
+```
+
+However, this style of state observation is terribly inefficient since _every_ change to `AppState`
+will cause the view to re-compute even though the only piece of state we actually care about is
+the `selectedTab`. The reason we are observing too much state is because we use `observe: { $0 }`
+in the construct of the ``WithViewStore``, which means the view store will observe all of state.
+
+To chisel away at the observed state you can provide a closure for that argument that plucks out
+the state the view needs. In this case the view only needs a single field:
+
+```swift
+WithViewStore(self.store, observe: \.selectedTab) { viewStore in
+  TabView(selection: viewStore.binding(send: AppAction.tabSelected) {
+    // ...
+  }
+}
+```
+
+In the future, the view may need access to more state. For example, suppose `ActivityState` holds
+onto an `unreadCount` integer to represent how many new activities you have. There's no need to
+observe _all_ of `ActivityState` to get access to this one field. You can observe just the one 
+field.
+
+Technically you can do this by mapping your state into a tuple, but because tuples are not 
+`Equatable` you will need to provide an explicit `removeDuplicates` argument:
+
+```swift
+WithViewStore(
+  self.store, 
+  observe: { (selectedTab: $0.selectedTab, unreadActivityCount: $0.activity.unreadCount) },
+  removeDuplicates: ==
+) { viewStore in 
+  TabView(selection: viewStore.binding(\.selectedTab, send: AppAction.tabSelected) {
+    ActivityView(
+      store: self.store.scope(state: \.activity, action: AppAction.activity)
+    )
+    .tag(AppState.Tab.activity)
+    .badge("\(viewStore.state)")
+
+    // ...
+  }
+}
+```
+
+Alternatively, and recommended, you can introduce a lightweight `ViewState` struct nested inside
+your view whose purpose is to transform the `Store`'s full state into the bare essentials of what
+the view needs:
 
 ```swift
 struct AppView: View {
@@ -106,9 +188,8 @@ struct AppView: View {
 }
 ```
 
-Now the `AppView` will re-compute its body only when `activity.unreadCount` changes. In particular,
-no changes to the search or profile features will cause the view to re-compute, and that greatly
-reduces how often the view must re-compute.
+This gives you maximum flexibilty in the future for adding new fields to `ViewState` without making
+your view convoluated.
 
 This technique for reducing view re-computations is most effective towards the root of your app
 hierarchy and least effective towards the leaf nodes of your app. Root features tend to hold lots

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -118,7 +118,7 @@ struct AppView: View {
 However, this style of state observation is terribly inefficient since _every_ change to `AppState`
 will cause the view to re-compute even though the only piece of state we actually care about is
 the `selectedTab`. The reason we are observing too much state is because we use `observe: { $0 }`
-in the construct of the ``WithViewStore``, which means the view store will observe all of state.
+in the construction of the ``WithViewStore``, which means the view store will observe all of state.
 
 To chisel away at the observed state you can provide a closure for that argument that plucks out
 the state the view needs. In this case the view only needs a single field:

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -198,7 +198,7 @@ hierarchy and least effective towards the leaf nodes of your app. Root features 
 of state that its view does not need, such as child features, and leaf features tend to only hold
 what's necessary. If you are going to employ this technique you will get the most benefit by
 applying it to views closer to the root. At leaf features and views that need access to most
-of the state, it is fine to continue using `observe { $0 }` to observe all of the state in the 
+of the state, it is fine to continue using `observe: { $0 }` to observe all of the state in the 
 store.
 
 ### CPU intensive calculations

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftUIDeprecations.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftUIDeprecations.md
@@ -8,6 +8,26 @@ Avoid using deprecated APIs in your app. Select a method to see the replacement 
 
 ## Topics
 
+### `WithViewStore`
+
+- ``WithViewStore/init(_:content:file:line:)-1gjbi``
+- ``WithViewStore/init(_:content:file:line:)-2uj44``
+- ``WithViewStore/init(_:content:file:line:)-5vj3w``
+- ``WithViewStore/init(_:content:file:line:)-5zsmz``
+- ``WithViewStore/init(_:content:file:line:)-7kai``
+- ``WithViewStore/init(_:file:line:content:)-4xog0``
+- ``WithViewStore/init(_:file:line:content:)-55smh``
+- ``WithViewStore/init(_:file:line:content:)-7qkc1``
+- ``WithViewStore/init(_:file:line:content:)-8b21b``
+- ``WithViewStore/init(_:file:line:content:)-9b6e2``
+- ``WithViewStore/init(_:removeDuplicates:content:file:line:)-1lyhl``
+- ``WithViewStore/init(_:removeDuplicates:content:file:line:)-35xje``
+- ``WithViewStore/init(_:removeDuplicates:content:file:line:)-8zzun``
+- ``WithViewStore/init(_:removeDuplicates:content:file:line:)-9atby``
+- ``WithViewStore/init(_:removeDuplicates:file:line:content:)``
+- ``WithViewStore/Action``
+- ``WithViewStore/State``
+
 ### View State
 
 - ``ActionSheetState``

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -336,7 +336,8 @@ extension WithViewStore: View where Content: View {
   ///
   /// - Parameters:
   ///   - store: A store.
-  ///   - toViewState: A function that transforms store state into observable view state.
+  ///   - toViewState: A function that transforms store state into observable view state. All
+  ///   changes to the view state will cause the `WithViewStore` to re-compute its view.
   ///   - isDuplicate: A function to determine when two `ViewState` values are equal. When values
   ///     are equal, repeat view computations are removed,
   ///   - content: A function that can generate content from a view store.
@@ -466,7 +467,8 @@ extension WithViewStore where ViewState: Equatable, Content: View {
   ///
   /// - Parameters:
   ///   - store: A store.
-  ///   - toViewState: A function that transforms store state into observable view state.
+  ///   - toViewState: A function that transforms store state into observable view state. All
+  ///   changes to the view state will cause the `WithViewStore` to re-compute its view.
   ///   - fromViewAction: A function that transforms view actions into store action.
   ///   - isDuplicate: A function to determine when two `ViewState` values are equal. When values
   ///     are equal, repeat view computations are removed,
@@ -551,7 +553,8 @@ extension WithViewStore where ViewState: Equatable, Content: View {
   ///
   /// - Parameters:
   ///   - store: A store.
-  ///   - toViewState: A function that transforms store state into observable view state.
+  ///   - toViewState: A function that transforms store state into observable view state. All
+  ///   changes to the view state will cause the `WithViewStore` to re-compute its view.
   ///   - isDuplicate: A function to determine when two `ViewState` values are equal. When values
   ///     are equal, repeat view computations are removed,
   ///   - content: A function that can generate content from a view store.


### PR DESCRIPTION
Spurred by the discussions in #1340 I've added more documentation to both `WithViewStore` and the new `observe` argument in its initializer.