### PR TITLE
Do more to avoid concurrency flakiness in tests

### DIFF
--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -573,7 +573,9 @@
       if "\(self.file)" == "\(file)" {
         self.line = line
       }
-      await Task.megaYield()
+      // NB: Give concurrency runtime more time to kick off effects so users don't need to manually
+      //     instrument their effects.
+      await Task.megaYield(count: 20)
       return .init(rawValue: task, timeout: self.timeout)
     }
 
@@ -1041,7 +1043,7 @@
   }
 
   extension Task where Success == Never, Failure == Never {
-    static func megaYield(count: Int = 6) async {
+    static func megaYield(count: Int = 10) async {
       for _ in 1...count {
         await Task<Void, Never>.detached(priority: .low) { await Task.yield() }.value
       }


### PR DESCRIPTION
Unfortunately for us, Swift does not offer a [reliable way to test integrated concurrency](https://forums.swift.org/t/reliably-testing-code-that-adopts-swift-concurrency/57304). Because of this, the Composable Architecture does what it can to insert instructions to the runtime to yield for some time and allow the work of an effect to get kicked off. We do this to try to simplify things for end-TCA users so that they don't need to manually instrument their own dependencies with async streams and channels for simple async work.

It's not perfect, though, especially when CI machines are typically underpowered virtual boxes that perform differently than what we expect locally. There are a couple tests in TCA that are flakey on GitHub CI that we could instrument to prevent flakiness, but instead let's use them to continuously tweak our yield logic.

In the future, hopefully with custom executors and some other tools provided by Swift, we can avoid these workarounds, but for now... 🤞