### PR TITLE
Simplify re-entrant tests

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -332,8 +332,8 @@ public final class Store<State, Action> {
       withExtendedLifetime(self.bufferedActions) {
         self.bufferedActions.removeAll()
       }
-      self.isSending = false
       self.state.value = currentState
+      self.isSending = false
       if !self.bufferedActions.isEmpty {
         if let task = self.send(
           self.bufferedActions.removeLast(), originatingFrom: originatingAction

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -329,26 +329,11 @@ public final class Store<State, Action> {
     var currentState = self.state.value
     let tasks = Box<[Task<Void, Never>]>(wrappedValue: [])
     defer {
-      // NB: Handle any potential re-entrant actions.
-      //
-      // 1. After all buffered actions have been processed, we clear them out, but this can lead to
-      //    re-entrant actions if a cleared action holds onto an object that sends an additional
-      //    action during "deinit".
-      //
-      //    We use "withExtendedLifetime" to prevent simultaneous access exceptions for this case,
-      //    which otherwise would try to append an action while removal is still in-process.
       withExtendedLifetime(self.bufferedActions) {
         self.bufferedActions.removeAll()
       }
-      // 2. Updating state can also lead to re-entrant actions if the emission of a downstream store
-      //    publisher sends an action back into the store.
-      //
-      //    We update "state" _before_ flipping "isSending" to false to ensure these actions are
-      //    appended to the buffer and not processed immediately.
-      self.state.value = currentState
       self.isSending = false
-      // Should either of the above steps send re-entrant actions back into the store, we handle
-      // them recursively.
+      self.state.value = currentState
       if !self.bufferedActions.isEmpty {
         if let task = self.send(
           self.bufferedActions.removeLast(), originatingFrom: originatingAction

--- a/Tests/ComposableArchitectureTests/CompatibilityTests.swift
+++ b/Tests/ComposableArchitectureTests/CompatibilityTests.swift
@@ -75,55 +75,40 @@ final class CompatibilityTests: XCTestCase {
     )
   }
 
-  func testCaseStudy_ReentrantActionsFromPublisher() {
-    struct State: Equatable {
-      var city: String
-      var country: String
-    }
-
-    enum Action: Equatable {
-      case updateCity(String)
-      case updateCountry(String)
-    }
-
-    let reducer = Reducer<State, Action, Void> { state, action, _ in
-      switch action {
-      case let .updateCity(city):
-        state.city = city
+  // Actions can be re-entrantly sent into the store while observing changes to the store's state.
+  // In such cases we need to take special care that those re-entrant actions are handled _after_
+  // the original action.
+  //
+  // In particular, this means that in the implementation of `Store.send` we need to flip
+  // `isSending` to false _after_ the store's state mutation is made so that re-entrant actions
+  // are buffered rather than immediately handled.
+  func testActionReentranceFromStateObservation() {
+    let store = Store<Int, Int>(
+      initialState: 0,
+      reducer: .init { state, action, _ in
+        state = action
         return .none
-      case let .updateCountry(country):
-        state.country = country
-        return .none
-      }
-    }
-
-    let store = Store(
-      initialState: State(city: "New York", country: "USA"),
-      reducer: reducer,
+      },
       environment: ()
     )
+
     let viewStore = ViewStore(store)
 
     var cancellables: Set<AnyCancellable> = []
-
-    viewStore.publisher.city
-      .sink { city in
-        if city == "London" {
-          viewStore.send(.updateCountry("UK"))
-        }
+    viewStore.publisher
+      .sink { value in
+        if value == 1 { viewStore.send(0) }
       }
       .store(in: &cancellables)
 
-    var countryUpdates = [String]()
-    viewStore.publisher.country
-      .sink { country in
-        countryUpdates.append(country)
-      }
+    var stateChanges: [Int] = []
+    viewStore.publisher
+      .sink { stateChanges.append($0) }
       .store(in: &cancellables)
 
-    viewStore.send(.updateCity("London"))
-
-    XCTAssertEqual(countryUpdates, ["USA", "UK"])
+    XCTAssertEqual(stateChanges, [0])
+    viewStore.send(1)
+    XCTAssertEqual(stateChanges, [0, 1, 0])
   }
 }
 

--- a/Tests/ComposableArchitectureTests/CompatibilityTests.swift
+++ b/Tests/ComposableArchitectureTests/CompatibilityTests.swift
@@ -8,7 +8,7 @@ final class CompatibilityTests: XCTestCase {
   // Actions can be re-entrantly sent into the store if an action is sent that holds an object
   // which sends an action on deinit. In order to prevent a simultaneous access exception for this
   // case we need to use `withExtendedLifetime` on the buffered actions when clearing them out.
-  func testCaseStudy_ReentrantActionsOnDeinitFromClearingBuffer() {
+  func testCaseStudy_ActionReentranceFromClearedBufferCausingDeinitAction() {
     let cancelID = UUID()
 
     struct State: Equatable {}
@@ -85,7 +85,7 @@ final class CompatibilityTests: XCTestCase {
   // In particular, this means that in the implementation of `Store.send` we need to flip
   // `isSending` to false _after_ the store's state mutation is made so that re-entrant actions
   // are buffered rather than immediately handled.
-  func testActionReentranceFromStateObservation() {
+  func testCaseStudy_ActionReentranceFromStateObservation() {
     let store = Store<Int, Int>(
       initialState: 0,
       reducer: .init { state, action, _ in

--- a/Tests/ComposableArchitectureTests/CompatibilityTests.swift
+++ b/Tests/ComposableArchitectureTests/CompatibilityTests.swift
@@ -5,7 +5,10 @@ import XCTest
 
 @MainActor
 final class CompatibilityTests: XCTestCase {
-  func testCaseStudy_ReentrantActionsFromBuffer() {
+  // Actions can be re-entrantly sent into the store if an action is sent that holds an object
+  // which sends an action on deinit. In order to prevent a simultaneous access exception for this
+  // case we need to use `withExtendedLifetime` on the buffered actions when clearing them out.
+  func testCaseStudy_ReentrantActionsOnDeinitFromClearingBuffer() {
     let cancelID = UUID()
 
     struct State: Equatable {}


### PR DESCRIPTION
Simplified the test case for what we expect to happen with re-entrant actions from state observations, and moved the comments in Store.swift over to the test file.