### PR TITLE
added Self as default associatedtype value for TestDependencyKey.value

### DIFF
--- a/Sources/Dependencies/DependencyKey.swift
+++ b/Sources/Dependencies/DependencyKey.swift
@@ -40,7 +40,7 @@ extension DependencyKey {
 /// See ``DependencyKey`` to define a static, default value for the live application.
 public protocol TestDependencyKey {
   /// The associated type representing the type of the dependency key's value.
-  associatedtype Value
+  associatedtype Value = Self
   // NB: This associated type should be constrained to `Sendable` when this bug is fixed:
   //     https://github.com/apple/swift/issues/60649
 

--- a/Tests/ComposableArchitectureTests/DependencyKeyTests.swift
+++ b/Tests/ComposableArchitectureTests/DependencyKeyTests.swift
@@ -30,4 +30,17 @@ final class DependencyKeyTests: XCTestCase {
 
     XCTAssertEqual(42, Key.previewValue)
   }
+  
+  //TODO: intentionally long naming. I think we don't need this test. Its just there to prove that the improved TestDependencyKey protocol now compiles without a typealias when `Value == Self`
+  func testDependencyKeyThatsItsOwnValueDefaultValues() {
+    struct Key: DependencyKey {
+//      typealias Value = Int
+      static let liveValue = Self()
+      var intValue: Int = 42
+    }
+
+    XCTAssertEqual(42, Key.previewValue.intValue)
+    XCTAssertEqual(42, Key.testValue.intValue)
+  }
+
 }

--- a/Tests/ComposableArchitectureTests/DependencyKeyTests.swift
+++ b/Tests/ComposableArchitectureTests/DependencyKeyTests.swift
@@ -30,17 +30,4 @@ final class DependencyKeyTests: XCTestCase {
 
     XCTAssertEqual(42, Key.previewValue)
   }
-  
-  //TODO: intentionally long naming. I think we don't need this test. Its just there to prove that the improved TestDependencyKey protocol now compiles without a typealias when `Value == Self`
-  func testDependencyKeyThatsItsOwnValueDefaultValues() {
-    struct Key: DependencyKey {
-//      typealias Value = Int
-      static let liveValue = Self()
-      var intValue: Int = 42
-    }
-
-    XCTAssertEqual(42, Key.previewValue.intValue)
-    XCTAssertEqual(42, Key.testValue.intValue)
-  }
-
 }


### PR DESCRIPTION
Hey pointfreeguys,

This is a 1 line PR to slightly improve ergonomics of conforming to `DependencyKey` protocol. By choosing a default type for the `Value` associated type, we can omit the typealias when defining a key with only a `liveValue`.

The choice of default type is kinda arbitrary, but imho its quite common (at least in my codebases, hope Im not alone 😅) to want to use `Self`. E.g. `struct API: Dependency { static var liveValue: Self { .init() } }`. For that reason, this is an actual improvement to the everyday ergonomics.

Afaik the change is purely additive, I can't think of any existing valid Swift code that breaks as a result of the change. Can't speak for future Swift code 🤷‍♂️😅 but I think we should be fine.

I've started a [discussion](https://github.com/pointfreeco/swift-composable-architecture/discussions/1396) alongside this draft PR. Before merging, I would personally remove the newly added test, unless you feel like we should keep it.