### PR TITLE
`ReducerProtocol.debug` -> `ReducerProtocol._printChanges`

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/CaseStudiesApp.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/CaseStudiesApp.swift
@@ -9,8 +9,8 @@ struct CaseStudiesApp: App {
         store: Store(
           initialState: Root.State(),
           reducer: Root()
-            .debug()
             .signpost()
+            ._printChanges()
         )
       )
     }

--- a/Examples/Search/Search/SearchApp.swift
+++ b/Examples/Search/Search/SearchApp.swift
@@ -8,7 +8,7 @@ struct SearchApp: App {
       SearchView(
         store: Store(
           initialState: Search.State(),
-          reducer: Search().debug()
+          reducer: Search()._printChanges()
         )
       )
     }

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognitionApp.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognitionApp.swift
@@ -8,7 +8,7 @@ struct SpeechRecognitionApp: App {
       SpeechRecognitionView(
         store: Store(
           initialState: SpeechRecognition.State(),
-          reducer: SpeechRecognition().debug()
+          reducer: SpeechRecognition()._printChanges()
         )
       )
     }

--- a/Examples/TicTacToe/App/RootView.swift
+++ b/Examples/TicTacToe/App/RootView.swift
@@ -30,7 +30,7 @@ enum GameType: Identifiable {
 struct RootView: View {
   let store = Store(
     initialState: TicTacToe.State(),
-    reducer: TicTacToe().debug()
+    reducer: TicTacToe()._printChanges()
   )
 
   @State var showGame: GameType?

--- a/Examples/Todos/Todos/TodosApp.swift
+++ b/Examples/Todos/Todos/TodosApp.swift
@@ -8,7 +8,7 @@ struct TodosApp: App {
       AppView(
         store: Store(
           initialState: Todos.State(),
-          reducer: Todos().debug()
+          reducer: Todos()._printChanges()
         )
       )
     }

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemosApp.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemosApp.swift
@@ -9,7 +9,7 @@ struct VoiceMemosApp: App {
       VoiceMemosView(
         store: Store(
           initialState: VoiceMemos.State(),
-          reducer: VoiceMemos().debug()
+          reducer: VoiceMemos()._printChanges()
         )
       )
     }

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -5,6 +5,13 @@ import XCTestDynamicOverlay
 
 // MARK: - Deprecated after 0.41.0:
 
+extension ReducerProtocol {
+  @available(*, deprecated, renamed: "_printChanges")
+  public func debug() -> _PrintChangesReducer<Self, _CustomDumpPrinter> {
+    _PrintChangesReducer(base: self, printer: .customDump)
+  }
+}
+
 #if swift(>=5.7)
   extension ReducerBuilder {
     @_disfavoredOverload

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -213,7 +213,7 @@
         }
       }
 
-      let store = TestStore(initialState: 0, reducer: DebuggedReducer().printChange())
+      let store = TestStore(initialState: 0, reducer: DebuggedReducer()._printChanges())
       await store.send(true) { $0 = 1 }
     }
   }

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -213,7 +213,7 @@
         }
       }
 
-      let store = TestStore(initialState: 0, reducer: DebuggedReducer().debug())
+      let store = TestStore(initialState: 0, reducer: DebuggedReducer().printChange())
       await store.send(true) { $0 = 1 }
     }
   }


### PR DESCRIPTION
We want to revisit some of these debugging APIs in the future, so let's keep them around, but underscore them to allow for more flexible evolution.