### PR TITLE
Add back ReducerProtocolOf for 5.7.1

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerProtocol.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerProtocol.md
@@ -5,7 +5,6 @@
 ### Implementing a reducer
 
 - ``reduce(into:action:)-4nzr2``
-- ``body-swift.property-97ymy``
 - ``State``
 - ``Action``
 - ``Effect``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerProtocol.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerProtocol.md
@@ -5,6 +5,7 @@
 ### Implementing a reducer
 
 - ``reduce(into:action:)-4nzr2``
+- ``body-swift.property-97ymy``
 - ``State``
 - ``Action``
 - ``Effect``

--- a/Sources/ComposableArchitecture/ReducerProtocol.swift
+++ b/Sources/ComposableArchitecture/ReducerProtocol.swift
@@ -184,7 +184,7 @@
     ///
     /// Implement this requirement for "primitive" reducers, or reducers that work on leaf node
     /// features. To define a reducer by combining the logic of other reducers together, implement
-    /// the ``body-swift.property-7foai`` requirement instead.
+    /// the ``body-swift.property-97ymy`` requirement instead.
     ///
     /// - Parameters:
     ///   - state: The current state of the reducer.
@@ -346,3 +346,27 @@ extension ReducerProtocol where Body: ReducerProtocol, Body.State == State, Body
     self.body.reduce(into: &state, action: action)
   }
 }
+
+// NB: This is available only in Swift 5.7.1 due to the following bug:
+//     https://github.com/apple/swift/issues/60550
+#if swift(>=5.7.1)
+  /// A convenience for constraining a ``ReducerProtocol`` conformance. Available only in Swift
+  /// 5.7.1.
+  ///
+  /// This allows you to specify the `body` of a ``ReducerProtocol`` conformance like so:
+  ///
+  /// ```swift
+  /// var body: some ReducerProtocolOf<Self> {
+  ///   // ...
+  /// }
+  /// ```
+  ///
+  /// …instead of the more verbose:
+  ///
+  /// ```swift
+  /// var body: some ReducerProtocol<State, Action> {
+  ///   // ...
+  /// }
+  /// ```
+  public typealias ReducerProtocolOf<R: ReducerProtocol> = ReducerProtocol<R.State, R.Action>
+#endif


### PR DESCRIPTION
Now that https://github.com/apple/swift/issues/60550 is fixed we can add back `ReducerProtocolOf`.