### PR TITLE
Fix missing parameter in code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ struct MyApp: App {
       store: Store(
         initialState: Feature.State(),
         reducer: Feature(
-          numberFact: {
+          numberFact: { number in
             let (data, _) = try await URLSession.shared
               .data(from: .init(string: "http://numbersapi.com/\(number)")!)
             return String(decoding: data, using: UTF8.self)


### PR DESCRIPTION
The `number` closure parameter was erroneously deleted after a migration of the code sample.
This PR adds it back.