### PR TITLE
Loosen platform requirements for Dependencies library

### DIFF
--- a/ComposableArchitecture.xcworkspace/contents.xcworkspacedata
+++ b/ComposableArchitecture.xcworkspace/contents.xcworkspacedata
@@ -2,9 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Sources/Dependencies/Documentation.docc/Extensions/DependencyValuesWithValue.md">
-   </FileRef>
-   <FileRef
       location = "group:">
    </FileRef>
    <FileRef

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -134,20 +134,15 @@ extension Effect where Failure == Never {
               #if DEBUG
                 var errorDump = ""
                 customDump(error, to: &errorDump, indent: 4)
-                runtimeWarning(
+                runtimeWarn(
                   """
-                  An 'Effect.task' returned from "%@:%d" threw an unhandled error. …
+                  An "Effect.task" returned from "\(fileID):\(line)" threw an unhandled error. …
 
-                  %@
+                  \(errorDump)
 
-                  All non-cancellation errors must be explicitly handled via the 'catch' parameter \
-                  on 'Effect.task', or via a 'do' block.
+                  All non-cancellation errors must be explicitly handled via the "catch" parameter \
+                  on "Effect.task", or via a "do" block.
                   """,
-                  [
-                    "\(fileID)",
-                    line,
-                    errorDump,
-                  ],
                   file: file,
                   line: line
                 )
@@ -221,20 +216,15 @@ extension Effect where Failure == Never {
               #if DEBUG
                 var errorDump = ""
                 customDump(error, to: &errorDump, indent: 4)
-                runtimeWarning(
+                runtimeWarn(
                   """
-                  An 'Effect.run' returned from "%@:%d" threw an unhandled error. …
+                  An "Effect.run" returned from "\(fileID):\(line)" threw an unhandled error. …
 
-                  %@
+                  \(errorDump)
 
-                  All non-cancellation errors must be explicitly handled via the 'catch' parameter \
-                  on 'Effect.run', or via a 'do' block.
+                  All non-cancellation errors must be explicitly handled via the "catch" parameter \
+                  on "Effect.run", or via a "do" block.
                   """,
-                  [
-                    "\(fileID)",
-                    line,
-                    errorDump,
-                  ],
                   file: file,
                   line: line
                 )

--- a/Sources/ComposableArchitecture/Effects/TaskResult.swift
+++ b/Sources/ComposableArchitecture/Effects/TaskResult.swift
@@ -213,21 +213,20 @@ extension TaskResult: Equatable where Success: Equatable {
     case let (.failure(lhs), .failure(rhs)):
       return _isEqual(lhs, rhs) ?? {
         #if DEBUG
-          if TaskResultDebugging.emitRuntimeWarnings, type(of: lhs) == type(of: rhs) {
-            runtimeWarning(
+          let lhsType = type(of: lhs)
+          if TaskResultDebugging.emitRuntimeWarnings, lhsType == type(of: rhs) {
+            let lhsTypeName = typeName(lhsType)
+            runtimeWarn(
               """
-              '%1$@' is not equatable. …
+              "\(lhsTypeName)" is not equatable. …
 
-              To test two values of this type, it must conform to the 'Equatable' protocol. For \
+              To test two values of this type, it must conform to the "Equatable" protocol. For \
               example:
 
-                  extension %1$@: Equatable {}
+                  extension \(lhsTypeName): Equatable {}
 
-              See the documentation of 'TaskResult' for more information.
-              """,
-              [
-                "\(type(of: lhs))",
-              ]
+              See the documentation of "TaskResult" for more information.
+              """
             )
           }
         #endif
@@ -252,19 +251,17 @@ extension TaskResult: Hashable where Success: Hashable {
       } else {
         #if DEBUG
           if TaskResultDebugging.emitRuntimeWarnings {
-            runtimeWarning(
+            let errorType = typeName(type(of: error))
+            runtimeWarn(
               """
-              '%1$@' is not hashable. …
+              "\(errorType)" is not hashable. …
 
-              To hash a value of this type, it must conform to the 'Hashable' protocol. For example:
+              To hash a value of this type, it must conform to the "Hashable" protocol. For example:
 
-                  extension %1$@: Hashable {}
+                  extension \(errorType): Hashable {}
 
-              See the documentation of 'TaskResult' for more information.
-              """,
-              [
-                "\(type(of: error))",
-              ]
+              See the documentation of "TaskResult" for more information.
+              """
             )
           }
         #endif

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -1071,15 +1071,15 @@ extension AnyReducer {
         return .none
       }
       if index >= parentState[keyPath: toElementsState].endIndex {
-        runtimeWarning(
+        runtimeWarn(
           """
-          A "forEach" reducer at "%@:%d" received an action when state contained no element at \
-          that index. …
+          A "forEach" reducer at "\(fileID):\(line)" received an action when state contained no \
+          element at that index. …
 
             Action:
-              %@
+              \(debugCaseOutput(action))
             Index:
-              %d
+              \(index)
 
           This is generally considered an application logic error, and can happen for a few \
           reasons:
@@ -1101,12 +1101,6 @@ extension AnyReducer {
           when its state contains an element at this index. In SwiftUI applications, use \
           "ForEachStore".
           """,
-          [
-            "\(fileID)",
-            line,
-            debugCaseOutput(action),
-            index,
-          ],
           file: file,
           line: line
         )

--- a/Sources/ComposableArchitecture/Internal/RuntimeWarnings.swift
+++ b/Sources/ComposableArchitecture/Internal/RuntimeWarnings.swift
@@ -26,7 +26,7 @@ func runtimeWarn(
           message
         )
       #else
-        fputs("\(formatter.string(from: Date())) [\(category)] \(message)", stderr)
+        fputs("\(formatter.string(from: Date())) [\(category)] \(message)\n", stderr)
       #endif
     }
   #endif

--- a/Sources/ComposableArchitecture/Internal/RuntimeWarnings.swift
+++ b/Sources/ComposableArchitecture/Internal/RuntimeWarnings.swift
@@ -1,15 +1,50 @@
+@_transparent
+@usableFromInline
+@inline(__always)
+func runtimeWarn(
+  _ message: @autoclosure () -> String,
+  category: String? = "ComposableArchitecture",
+  file: StaticString? = nil,
+  line: UInt? = nil
+) {
+  #if DEBUG
+    let message = message()
+    let category = category ?? "Runtime Warning"
+    if _XCTIsTesting {
+      if let file = file, let line = line {
+        XCTFail(message, file: file, line: line)
+      } else {
+        XCTFail(message)
+      }
+    } else {
+      #if canImport(os)
+        os_log(
+          .fault,
+          dso: dso,
+          log: OSLog(subsystem: "com.apple.runtime-issues", category: category),
+          "%@",
+          message
+        )
+      #else
+        fputs("\(formatter.string(from: Date())) [\(category)] \(message)", stderr)
+      #endif
+    }
+  #endif
+}
+
 #if DEBUG
-  import os
   import XCTestDynamicOverlay
 
-  // NB: Xcode runtime warnings offer a much better experience than traditional assertions and
-  //     breakpoints, but Apple provides no means of creating custom runtime warnings ourselves.
-  //     To work around this, we hook into SwiftUI's runtime issue delivery mechanism, instead.
-  //
-  // Feedback filed: https://gist.github.com/stephencelis/a8d06383ed6ccde3e5ef5d1b3ad52bbc
-  @usableFromInline
-  let rw = (
-    dso: { () -> UnsafeMutableRawPointer in
+  #if canImport(os)
+    import os
+
+    // NB: Xcode runtime warnings offer a much better experience than traditional assertions and
+    //     breakpoints, but Apple provides no means of creating custom runtime warnings ourselves.
+    //     To work around this, we hook into SwiftUI's runtime issue delivery mechanism, instead.
+    //
+    // Feedback filed: https://gist.github.com/stephencelis/a8d06383ed6ccde3e5ef5d1b3ad52bbc
+    @usableFromInline
+    let dso = { () -> UnsafeMutableRawPointer in
       let count = _dyld_image_count()
       for i in 0..<count {
         if let name = _dyld_get_image_name(i) {
@@ -22,33 +57,15 @@
         }
       }
       return UnsafeMutableRawPointer(mutating: #dsohandle)
-    }(),
-    log: OSLog(subsystem: "com.apple.runtime-issues", category: "ComposableArchitecture")
-  )
-#endif
+    }()
+  #else
+    import Foundation
 
-@_transparent
-@usableFromInline
-@inline(__always)
-func runtimeWarning(
-  _ message: @autoclosure () -> StaticString,
-  _ args: @autoclosure () -> [CVarArg] = [],
-  file: StaticString? = nil,
-  line: UInt? = nil
-) {
-  #if DEBUG
-    let message = message()
-    if _XCTIsTesting {
-      if let file = file, let line = line {
-        XCTFail(String(format: "\(message)", arguments: args()), file: file, line: line)
-      } else {
-        XCTFail(String(format: "\(message)", arguments: args()))
-      }
-    } else {
-      unsafeBitCast(
-        os_log as (OSLogType, UnsafeRawPointer, OSLog, StaticString, CVarArg...) -> Void,
-        to: ((OSLogType, UnsafeRawPointer, OSLog, StaticString, [CVarArg]) -> Void).self
-      )(.fault, rw.dso, rw.log, message, args())
-    }
+    @usableFromInline
+    let formatter: DateFormatter = {
+      let formatter = DateFormatter()
+      formatter.dateFormat = "yyyy-MM-dd HH:MM:SS.sssZ"
+      return formatter
+    }()
   #endif
-}
+#endif

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
@@ -716,22 +716,22 @@ public struct AnyReducer<State, Action, Environment> {
       guard let childAction = toChildAction.extract(from: parentAction) else { return .none }
 
       guard var childState = toChildState.extract(from: parentState) else {
-        runtimeWarning(
+        runtimeWarn(
           """
-          A reducer pulled back from "%@:%d" received an action when child state was \
+          A reducer pulled back from "\(fileID):\(line)" received an action when child state was \
           unavailable. …
 
             Action:
-              %@
+              \(debugCaseOutput(childAction))
 
           This is generally considered an application logic error, and can happen for a few \
           reasons:
 
           • The reducer for a particular case of state was combined with or run from another \
-          reducer that set "%@" to another case before the reducer ran. Combine or run \
-          case-specific reducers before reducers that may set their state to another case. This \
-          ensures that case-specific reducers can handle their actions while their state is \
-          available.
+          reducer that set "\(typeName(State.self))" to another case before the reducer ran. \
+          Combine or run case-specific reducers before reducers that may set their state to \
+          another case. This ensures that case-specific reducers can handle their actions while \
+          their state is available.
 
           • An in-flight effect emitted this action when state was unavailable. While it may be \
           perfectly reasonable to ignore this action, you may want to cancel the associated \
@@ -741,12 +741,6 @@ public struct AnyReducer<State, Action, Environment> {
           actions for this reducer can only be sent to a view store when state is non-"nil". \
           In SwiftUI applications, use "SwitchStore".
           """,
-          [
-            "\(fileID)",
-            line,
-            debugCaseOutput(childAction),
-            typeName(State.self),
-          ],
           file: file,
           line: line
         )
@@ -964,20 +958,20 @@ public struct AnyReducer<State, Action, Environment> {
   > {
     .init { state, action, environment in
       guard state != nil else {
-        runtimeWarning(
+        runtimeWarn(
           """
-          An "optional" reducer at "%@:%d" received an action when state was "nil". …
+          An "optional" reducer at "\(fileID):\(line)" received an action when state was "nil". …
 
             Action:
-              %@
+              \(debugCaseOutput(action))
 
           This is generally considered an application logic error, and can happen for a few \
           reasons:
 
-          • The optional reducer was combined with or run from another reducer that set "%@" to \
-          "nil" before the optional reducer ran. Combine or run optional reducers before \
-          reducers that can set their state to "nil". This ensures that optional reducers can \
-          handle their actions while their state is still non-"nil".
+          • The optional reducer was combined with or run from another reducer that set \
+          "\(typeName(State.self))" to "nil" before the optional reducer ran. Combine or run \
+          optional reducers before reducers that can set their state to "nil". This ensures that \
+          optional reducers can handle their actions while their state is still non-"nil".
 
           • An in-flight effect emitted this action while state was "nil". While it may be \
           perfectly reasonable to ignore this action, you may want to cancel the associated \
@@ -987,12 +981,6 @@ public struct AnyReducer<State, Action, Environment> {
           this reducer can only be sent to a view store when state is non-"nil". In SwiftUI \
           applications, use "IfLetStore".
           """,
-          [
-            "\(fileID)",
-            line,
-            debugCaseOutput(action),
-            typeName(State.self),
-          ],
           file: file,
           line: line
         )
@@ -1085,15 +1073,15 @@ public struct AnyReducer<State, Action, Environment> {
       else { return .none }
 
       if parentState[keyPath: toElementsState][id: id] == nil {
-        runtimeWarning(
+        runtimeWarn(
           """
-          A "forEach" reducer at "%@:%d" received an action when state contained no element with \
-          that id. …
+          A "forEach" reducer at "\(fileID):\(line)" received an action when state contained no \
+          element with that id. …
 
             Action:
-              %@
+              \(debugCaseOutput(action))
             ID:
-              %@
+              \(id)
 
           This is generally considered an application logic error, and can happen for a few \
           reasons:
@@ -1114,12 +1102,6 @@ public struct AnyReducer<State, Action, Environment> {
           when its state contains an element at this id. In SwiftUI applications, use \
           "ForEachStore".
           """,
-          [
-            "\(fileID)",
-            line,
-            debugCaseOutput(action),
-            "\(id)",
-          ],
           file: file,
           line: line
         )
@@ -1160,15 +1142,15 @@ public struct AnyReducer<State, Action, Environment> {
       guard let (key, action) = toKeyedAction.extract(from: parentAction) else { return .none }
 
       if parentState[keyPath: toDictionaryState][key] == nil {
-        runtimeWarning(
+        runtimeWarn(
           """
-          A "forEach" reducer at "%@:%d" received an action when state contained no value at \
-          that key. …
+          A "forEach" reducer at "\(fileID):\(line)" received an action when state contained no \
+          value at that key. …
 
             Action:
-              %@
+              \(debugCaseOutput(action))
             Key:
-              %@
+              \(key)
 
           This is generally considered an application logic error, and can happen for a few \
           reasons:
@@ -1188,12 +1170,6 @@ public struct AnyReducer<State, Action, Environment> {
           key. To fix this make sure that actions for this reducer can only be sent to a view \
           store when its state contains an element at this key.
           """,
-          [
-            "\(fileID)",
-            line,
-            debugCaseOutput(action),
-            "\(key)",
-          ],
           file: file,
           line: line
         )

--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -127,12 +127,12 @@ public struct _ForEachReducer<
   ) -> Effect<Parent.Action, Never> {
     guard let (id, elementAction) = self.toElementAction.extract(from: action) else { return .none }
     if state[keyPath: self.toElementsState][id: id] == nil {
-      runtimeWarning(
+      runtimeWarn(
         """
-        A "forEach" at "%@:%d" received an action for a missing element.
+        A "forEach" at "\(self.fileID):\(self.line)" received an action for a missing element.
 
           Action:
-            %@
+            \(debugCaseOutput(action))
 
         This is generally considered an application logic error, and can happen for a few reasons:
 
@@ -148,11 +148,6 @@ public struct _ForEachReducer<
         fix this make sure that actions for this reducer can only be sent from a view store when \
         its state contains an element at this id. In SwiftUI applications, use "ForEachStore".
         """,
-        [
-          "\(self.fileID)",
-          line,
-          debugCaseOutput(action),
-        ],
         file: self.file,
         line: self.line
       )

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
@@ -122,21 +122,22 @@ public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>
     guard let childAction = self.toChildAction.extract(from: action)
     else { return .none }
     guard var childState = self.toChildState.extract(from: state) else {
-      runtimeWarning(
+      runtimeWarn(
         """
-        An "ifCaseLet" at "%@:%d" received a child action when child state was set to a different \
-        case. …
+        An "ifCaseLet" at "\(self.fileID):\(self.line)" received a child action when child state \
+        was set to a different case. …
 
           Action:
-            %@
+            \(debugCaseOutput(action))
           State:
-            %@
+            \(debugCaseOutput(state))
 
         This is generally considered an application logic error, and can happen for a few reasons:
 
-        • A parent reducer set "%@" to a different case before this reducer ran. This reducer must \
-        run before any other reducer sets child state to a different case. This ensures that child \
-        reducers can handle their actions while their state is still available.
+        • A parent reducer set "\(typeName(Parent.State.self))" to a different case before this \
+        reducer ran. This reducer must run before any other reducer sets child state to a \
+        different case. This ensures that child reducers can handle their actions while their \
+        state is still available.
 
         • An in-flight effect emitted this action when child state was unavailable. While it may \
         be perfectly reasonable to ignore this action, consider canceling the associated effect \
@@ -146,13 +147,6 @@ public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>
         for this reducer can only be sent from a view store when state is set to the appropriate \
         case. In SwiftUI applications, use "SwitchStore".
         """,
-        [
-          "\(self.fileID)",
-          self.line,
-          debugCaseOutput(action),
-          debugCaseOutput(state),
-          typeName(Parent.State.self),
-        ],
         file: self.file,
         line: self.line
       )

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
@@ -119,12 +119,13 @@ public struct _IfLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: Re
     guard let childAction = self.toChildAction.extract(from: action)
     else { return .none }
     guard state[keyPath: self.toChildState] != nil else {
-      runtimeWarning(
+      runtimeWarn(
         """
-        An "ifLet" at "%@:%d" received a child action when child state was "nil". …
+        An "ifLet" at "\(self.fileID):\(self.line)" received a child action when child state was \
+        "nil". …
 
           Action:
-            %@
+            \(debugCaseOutput(action))
 
         This is generally considered an application logic error, and can happen for a few reasons:
 
@@ -140,12 +141,6 @@ public struct _IfLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: Re
         reducer can only be sent from a view store when state is non-"nil". In SwiftUI \
         applications, use "IfLetStore".
         """,
-        [
-          "\(self.fileID)",
-          self.line,
-          debugCaseOutput(action),
-          typeName(Child.State.self),
-        ],
         file: self.file,
         line: self.line
       )

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
@@ -239,24 +239,25 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
     switch self.toChildState {
     case let .casePath(toChildState, file, fileID, line):
       guard var childState = toChildState.extract(from: state) else {
-        runtimeWarning(
+        runtimeWarn(
           """
-          A "Scope" at "%@:%d" received a child action when child state was set to a different \
-          case. …
+          A "Scope" at "\(fileID):\(line)" received a child action when child state was set to a \
+          different case. …
 
             Action:
-              %@
+              \(debugCaseOutput(action))
             State:
-              %@
+              \(debugCaseOutput(state))
 
           This is generally considered an application logic error, and can happen for a few \
           reasons:
 
-          • A parent reducer set "%@" to a different case before the scoped reducer ran. Child \
-          reducers must run before any parent reducer sets child state to a different case. This \
-          ensures that child reducers can handle their actions while their state is still \
-          available. Consider using "ReducerProtocol.ifCaseLet" to embed this child reducer in the \
-          parent reducer that change its state to ensure the child reducer runs first.
+          • A parent reducer set "\(typeName(ParentState.self))" to a different case before the \
+          scoped reducer ran. Child reducers must run before any parent reducer sets child state \
+          to a different case. This ensures that child reducers can handle their actions while \
+          their state is still available. Consider using "ReducerProtocol.ifCaseLet" to embed this \
+          child reducer in the parent reducer that change its state to ensure the child reducer \
+          runs first.
 
           • An in-flight effect emitted this action when child state was unavailable. While it may \
           be perfectly reasonable to ignore this action, consider canceling the associated effect \
@@ -266,13 +267,6 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
           for this reducer can only be sent from a view store when state is set to the appropriate \
           case. In SwiftUI applications, use "SwitchStore".
           """,
-          [
-            "\(fileID)",
-            line,
-            debugCaseOutput(action),
-            debugCaseOutput(state),
-            typeName(ParentState.self),
-          ],
           file: file,
           line: line
         )

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -452,12 +452,12 @@ public final class Store<State, Action> {
 
       switch status {
       case let .effectCompletion(action):
-        runtimeWarning(
+        runtimeWarn(
           """
           An effect completed on a non-main thread. …
 
             Effect returned from:
-              %@
+              \(debugCaseOutput(action))
 
           Make sure to use ".receive(on:)" on any effects that execute on background threads to \
           receive their output on the main thread.
@@ -465,12 +465,11 @@ public final class Store<State, Action> {
           The "Store" class is not thread-safe, and so all interactions with an instance of \
           "Store" (including all of its scopes and derived view stores) must be done on the main \
           thread.
-          """,
-          [debugCaseOutput(action)]
+          """
         )
 
       case .`init`:
-        runtimeWarning(
+        runtimeWarn(
           """
           A store initialized on a non-main thread. …
 
@@ -481,7 +480,7 @@ public final class Store<State, Action> {
         )
 
       case .scope:
-        runtimeWarning(
+        runtimeWarn(
           """
           "Store.scope" was called on a non-main thread. …
 
@@ -492,27 +491,26 @@ public final class Store<State, Action> {
         )
 
       case let .send(action, originatingAction: nil):
-        runtimeWarning(
+        runtimeWarn(
           """
-          "ViewStore.send" was called on a non-main thread with: %@ …
+          "ViewStore.send" was called on a non-main thread with: \(debugCaseOutput(action)) …
 
           The "Store" class is not thread-safe, and so all interactions with an instance of \
           "Store" (including all of its scopes and derived view stores) must be done on the main \
           thread.
-          """,
-          [debugCaseOutput(action)]
+          """
         )
 
       case let .send(action, originatingAction: .some(originatingAction)):
-        runtimeWarning(
+        runtimeWarn(
           """
           An effect published an action on a non-main thread. …
 
             Effect published:
-              %@
+              \(debugCaseOutput(action))
 
             Effect returned from:
-              %@
+              \(debugCaseOutput(originatingAction))
 
           Make sure to use ".receive(on:)" on any effects that execute on background threads to \
           receive their output on the main thread.
@@ -520,11 +518,7 @@ public final class Store<State, Action> {
           The "Store" class is not thread-safe, and so all interactions with an instance of \
           "Store" (including all of its scopes and derived view stores) must be done on the main \
           thread.
-          """,
-          [
-            debugCaseOutput(action),
-            debugCaseOutput(originatingAction),
-          ]
+          """
         )
       }
     #endif

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -394,20 +394,16 @@ extension BindingAction: CustomDumpReflectable {
 
     deinit {
       guard self.wasCalled else {
-        runtimeWarning(
+        runtimeWarn(
           """
-          A binding action sent from a view store at "%@:%d" was not handled. …
+          A binding action sent from a view store at "\(self.fileID):\(self.line)" was not \
+          handled. …
 
             Action:
-              %@
+              \(typeName(self.bindableActionType)).binding(.set(_, \(self.value)))
 
           To fix this, invoke "BindingReducer()" from your feature reducer's "body".
           """,
-          [
-            "\(self.fileID)",
-            self.line,
-            "\(typeName(self.bindableActionType)).binding(.set(_, \(self.value)))",
-          ],
           file: self.file,
           line: self.line
         )

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -1208,21 +1208,16 @@ public struct _ExhaustivityCheckView<State, Action>: View {
       .padding()
       .background(Color.red.edgesIgnoringSafeArea(.all))
       .onAppear {
-        runtimeWarning(
+        runtimeWarn(
           """
-          SwitchStore@%@:%d does not handle the current case. …
+          A "SwitchStore" at "\(self.fileID):\(self.line)" does not handle the current case. …
 
             Unhandled case:
-              %@
+              \(debugCaseOutput(self.store.wrappedValue.state.value))
 
           Make sure that you exhaustively provide a "CaseLet" view for each case in your state, \
           or provide a "Default" view at the end of the "SwitchStore".
           """,
-          [
-            "\(self.fileID)",
-            self.line,
-            debugCaseOutput(self.store.wrappedValue.state.value),
-          ],
           file: self.file,
           line: self.line
         )

--- a/Sources/Dependencies/Dependencies/OpenURL.swift
+++ b/Sources/Dependencies/Dependencies/OpenURL.swift
@@ -10,68 +10,70 @@ import XCTestDynamicOverlay
   import SwiftUI
 #endif
 
-extension DependencyValues {
-  /// A dependency that opens a URL.
-  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 7, *)
-  public var openURL: OpenURLEffect {
-    get { self[OpenURLKey.self] }
-    set { self[OpenURLKey.self] = newValue }
+#if canImport(AppKit) || canImport(UIKit) || canImport(SwiftUI)
+  extension DependencyValues {
+    /// A dependency that opens a URL.
+    @available(iOS 13, macOS 10.15, tvOS 13, watchOS 7, *)
+    public var openURL: OpenURLEffect {
+      get { self[OpenURLKey.self] }
+      set { self[OpenURLKey.self] = newValue }
+    }
   }
-}
 
-private enum OpenURLKey: DependencyKey {
-  static let liveValue = OpenURLEffect { url in
-    let stream = AsyncStream<Bool> { continuation in
-      let task = Task { @MainActor in
-        #if canImport(AppKit) && !targetEnvironment(macCatalyst)
-          NSWorkspace.shared.open(url, configuration: .init()) { app, error in
-            continuation.yield(app != nil && error == nil)
-            continuation.finish()
-          }
-        #elseif canImport(UIKit) && !os(watchOS)
-          UIApplication.shared.open(url) { canOpen in
-            continuation.yield(canOpen)
-            continuation.finish()
-          }
-        #elseif canImport(SwiftUI)
-          if #available(watchOS 7, *) {
-            EnvironmentValues().openURL(url)
-            continuation.yield(true)
-            continuation.finish()
-          } else {
+  private enum OpenURLKey: DependencyKey {
+    static let liveValue = OpenURLEffect { url in
+      let stream = AsyncStream<Bool> { continuation in
+        let task = Task { @MainActor in
+          #if canImport(AppKit) && !targetEnvironment(macCatalyst)
+            NSWorkspace.shared.open(url, configuration: .init()) { app, error in
+              continuation.yield(app != nil && error == nil)
+              continuation.finish()
+            }
+          #elseif canImport(UIKit) && !os(watchOS)
+            UIApplication.shared.open(url) { canOpen in
+              continuation.yield(canOpen)
+              continuation.finish()
+            }
+          #elseif canImport(SwiftUI)
+            if #available(watchOS 7, *) {
+              EnvironmentValues().openURL(url)
+              continuation.yield(true)
+              continuation.finish()
+            } else {
+              continuation.yield(false)
+              continuation.finish()
+            }
+          #else
             continuation.yield(false)
             continuation.finish()
-          }
-        #else
-          continuation.yield(false)
-          continuation.finish()
-        #endif
+          #endif
+        }
+        continuation.onTermination = { _ in
+          task.cancel()
+        }
       }
-      continuation.onTermination = { _ in
-        task.cancel()
-      }
+      return await stream.first(where: { _ in true }) ?? false
     }
-    return await stream.first(where: { _ in true }) ?? false
-  }
-  static let testValue = OpenURLEffect { _ in
-    XCTFail(#"Unimplemented: @Dependency(\.openURL)"#)
-    return false
-  }
-}
-
-public struct OpenURLEffect: Sendable {
-  private let handler: @Sendable (URL) async -> Bool
-
-  public init(handler: @escaping @Sendable (URL) async -> Bool) {
-    self.handler = handler
+    static let testValue = OpenURLEffect { _ in
+      XCTFail(#"Unimplemented: @Dependency(\.openURL)"#)
+      return false
+    }
   }
 
-  @available(watchOS, unavailable)
-  public func callAsFunction(_ url: URL) async -> Bool {
-    await self.handler(url)
-  }
+  public struct OpenURLEffect: Sendable {
+    private let handler: @Sendable (URL) async -> Bool
 
-  public func callAsFunction(_ url: URL) async {
-    _ = await self.handler(url)
+    public init(handler: @escaping @Sendable (URL) async -> Bool) {
+      self.handler = handler
+    }
+
+    @available(watchOS, unavailable)
+    public func callAsFunction(_ url: URL) async -> Bool {
+      await self.handler(url)
+    }
+
+    public func callAsFunction(_ url: URL) async {
+      _ = await self.handler(url)
+    }
   }
-}
+#endif

--- a/Sources/Dependencies/Dependencies/URLSession.swift
+++ b/Sources/Dependencies/Dependencies/URLSession.swift
@@ -1,6 +1,10 @@
 import Foundation
 import XCTestDynamicOverlay
 
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
 extension DependencyValues {
   /// The URL session that features should use to make URL requests.
   ///

--- a/Sources/Dependencies/Dependencies/UUID.swift
+++ b/Sources/Dependencies/Dependencies/UUID.swift
@@ -126,24 +126,14 @@ public struct UUIDGenerator: Sendable {
 }
 
 private final class IncrementingUUIDGenerator: @unchecked Sendable {
-  private let lock: os_unfair_lock_t
+  private let lock = NSLock()
   private var sequence = 0
 
-  init() {
-    self.lock = os_unfair_lock_t.allocate(capacity: 1)
-    self.lock.initialize(to: os_unfair_lock())
-  }
-
-  deinit {
-    self.lock.deinitialize(count: 1)
-    self.lock.deallocate()
-  }
-
   func callAsFunction() -> UUID {
-    os_unfair_lock_lock(self.lock)
+    self.lock.lock()
     defer {
       self.sequence += 1
-      os_unfair_lock_unlock(self.lock)
+      self.lock.unlock()
     }
     return UUID(uuidString: "00000000-0000-0000-0000-\(String(format: "%012x", self.sequence))")!
   }

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -271,24 +271,20 @@ public struct DependencyValues: Sendable {
                   """
               )
 
-              runtimeWarning(
+              runtimeWarn(
                 """
-                @Dependency(\\.%@) has no live implementation, but was accessed from a live context.
+                "@Dependency(\\.\(function))" has no live implementation, but was accessed from a \
+                live context.
 
-                %@
+                \(dependencyDescription)
 
-                Every dependency registered with the library must conform to 'DependencyKey', and \
+                Every dependency registered with the library must conform to "DependencyKey", and \
                 that conformance must be visible to the running application.
 
-                To fix, make sure that '%@' conforms to 'DependencyKey' by providing a live \
-                implementation of your dependency, and make sure that the conformance is linked \
-                with this current application.
+                To fix, make sure that "\(typeName(Key.self))" conforms to "DependencyKey" by \
+                providing a live implementation of your dependency, and make sure that the \
+                conformance is linked with this current application.
                 """,
-                [
-                  "\(function)",
-                  dependencyDescription,
-                  typeName(Key.self),
-                ],
                 file: Self.currentDependency.file ?? file,
                 line: Self.currentDependency.line ?? line
               )

--- a/Sources/Dependencies/Internal/RuntimeWarnings.swift
+++ b/Sources/Dependencies/Internal/RuntimeWarnings.swift
@@ -26,7 +26,7 @@ func runtimeWarn(
           message
         )
       #else
-        fputs("\(formatter.string(from: Date())) [\(category)] \(message)", stderr)
+        fputs("\(formatter.string(from: Date())) [\(category)] \(message)\n", stderr)
       #endif
     }
   #endif

--- a/Sources/Dependencies/Internal/RuntimeWarnings.swift
+++ b/Sources/Dependencies/Internal/RuntimeWarnings.swift
@@ -1,15 +1,50 @@
+@_transparent
+@usableFromInline
+@inline(__always)
+func runtimeWarn(
+  _ message: @autoclosure () -> String,
+  category: String? = "Dependencies",
+  file: StaticString? = nil,
+  line: UInt? = nil
+) {
+  #if DEBUG
+    let message = message()
+    let category = category ?? "Runtime Warning"
+    if _XCTIsTesting {
+      if let file = file, let line = line {
+        XCTFail(message, file: file, line: line)
+      } else {
+        XCTFail(message)
+      }
+    } else {
+      #if canImport(os)
+        os_log(
+          .fault,
+          dso: dso,
+          log: OSLog(subsystem: "com.apple.runtime-issues", category: category),
+          "%@",
+          message
+        )
+      #else
+        fputs("\(formatter.string(from: Date())) [\(category)] \(message)", stderr)
+      #endif
+    }
+  #endif
+}
+
 #if DEBUG
-  import os
   import XCTestDynamicOverlay
 
-  // NB: Xcode runtime warnings offer a much better experience than traditional assertions and
-  //     breakpoints, but Apple provides no means of creating custom runtime warnings ourselves.
-  //     To work around this, we hook into SwiftUI's runtime issue delivery mechanism, instead.
-  //
-  // Feedback filed: https://gist.github.com/stephencelis/a8d06383ed6ccde3e5ef5d1b3ad52bbc
-  @usableFromInline
-  let rw = (
-    dso: { () -> UnsafeMutableRawPointer in
+  #if canImport(os)
+    import os
+
+    // NB: Xcode runtime warnings offer a much better experience than traditional assertions and
+    //     breakpoints, but Apple provides no means of creating custom runtime warnings ourselves.
+    //     To work around this, we hook into SwiftUI's runtime issue delivery mechanism, instead.
+    //
+    // Feedback filed: https://gist.github.com/stephencelis/a8d06383ed6ccde3e5ef5d1b3ad52bbc
+    @usableFromInline
+    let dso = { () -> UnsafeMutableRawPointer in
       let count = _dyld_image_count()
       for i in 0..<count {
         if let name = _dyld_get_image_name(i) {
@@ -22,33 +57,15 @@
         }
       }
       return UnsafeMutableRawPointer(mutating: #dsohandle)
-    }(),
-    log: OSLog(subsystem: "com.apple.runtime-issues", category: "ComposableArchitecture")
-  )
-#endif
+    }()
+  #else
+    import Foundation
 
-@_transparent
-@usableFromInline
-@inline(__always)
-func runtimeWarning(
-  _ message: @autoclosure () -> StaticString,
-  _ args: @autoclosure () -> [CVarArg] = [],
-  file: StaticString? = nil,
-  line: UInt? = nil
-) {
-  #if DEBUG
-    let message = message()
-    if _XCTIsTesting {
-      if let file = file, let line = line {
-        XCTFail(String(format: "\(message)", arguments: args()), file: file, line: line)
-      } else {
-        XCTFail(String(format: "\(message)", arguments: args()))
-      }
-    } else {
-      unsafeBitCast(
-        os_log as (OSLogType, UnsafeRawPointer, OSLog, StaticString, CVarArg...) -> Void,
-        to: ((OSLogType, UnsafeRawPointer, OSLog, StaticString, [CVarArg]) -> Void).self
-      )(.fault, rw.dso, rw.log, message, args())
-    }
+    @usableFromInline
+    let formatter: DateFormatter = {
+      let formatter = DateFormatter()
+      formatter.dateFormat = "yyyy-MM-dd HH:MM:SS.sssZ"
+      return formatter
+    }()
   #endif
-}
+#endif

--- a/Tests/ComposableArchitectureTests/EffectFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectFailureTests.swift
@@ -13,14 +13,14 @@
       var line: UInt!
       XCTExpectFailure {
         $0.compactDescription == """
-          An 'Effect.task' returned from \
+          An "Effect.task" returned from \
           "ComposableArchitectureTests/EffectFailureTests.swift:\(line+1)" threw an unhandled \
           error. …
 
               EffectFailureTests.Unexpected()
 
-          All non-cancellation errors must be explicitly handled via the 'catch' parameter on \
-          'Effect.task', or via a 'do' block.
+          All non-cancellation errors must be explicitly handled via the "catch" parameter on \
+          "Effect.task", or via a "do" block.
           """
       }
 
@@ -39,14 +39,14 @@
       var line: UInt!
       XCTExpectFailure {
         $0.compactDescription == """
-          An 'Effect.run' returned from \
+          An "Effect.run" returned from \
           "ComposableArchitectureTests/EffectFailureTests.swift:\(line+1)" threw an unhandled \
           error. …
 
               EffectFailureTests.Unexpected()
 
-          All non-cancellation errors must be explicitly handled via the 'catch' parameter on \
-          'Effect.run', or via a 'do' block.
+          All non-cancellation errors must be explicitly handled via the "catch" parameter on \
+          "Effect.run", or via a "do" block.
           """
       }
 

--- a/Tests/ComposableArchitectureTests/EffectRunTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectRunTests.swift
@@ -46,13 +46,13 @@ final class EffectRunTests: XCTestCase {
       var line: UInt!
       XCTExpectFailure(nil, enabled: nil, strict: nil) {
         $0.compactDescription == """
-          An 'Effect.run' returned from \
+          An "Effect.run" returned from \
           "ComposableArchitectureTests/EffectRunTests.swift:\(line+1)" threw an unhandled error. …
 
               EffectRunTests.Failure()
 
-          All non-cancellation errors must be explicitly handled via the 'catch' parameter on \
-          'Effect.run', or via a 'do' block.
+          All non-cancellation errors must be explicitly handled via the "catch" parameter on \
+          "Effect.run", or via a "do" block.
           """
       }
       struct State: Equatable {}

--- a/Tests/ComposableArchitectureTests/EffectTaskTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTaskTests.swift
@@ -46,13 +46,13 @@ final class EffectTaskTests: XCTestCase {
       var line: UInt!
       XCTExpectFailure(nil, enabled: nil, strict: nil) {
         $0.compactDescription == """
-          An 'Effect.task' returned from \
+          An "Effect.task" returned from \
           "ComposableArchitectureTests/EffectTaskTests.swift:\(line+1)" threw an unhandled error. …
 
               EffectTaskTests.Failure()
 
-          All non-cancellation errors must be explicitly handled via the 'catch' parameter on \
-          'Effect.task', or via a 'do' block.
+          All non-cancellation errors must be explicitly handled via the "catch" parameter on \
+          "Effect.task", or via a "do" block.
           """
       }
       struct State: Equatable {}

--- a/Tests/ComposableArchitectureTests/TaskResultTests.swift
+++ b/Tests/ComposableArchitectureTests/TaskResultTests.swift
@@ -15,13 +15,13 @@ final class TaskResultTests: XCTestCase {
         )
       } issueMatcher: {
         $0.compactDescription == """
-          'Failure' is not equatable. …
+          "TaskResultTests.Failure" is not equatable. …
 
-          To test two values of this type, it must conform to the 'Equatable' protocol. For example:
+          To test two values of this type, it must conform to the "Equatable" protocol. For example:
 
-              extension Failure: Equatable {}
+              extension TaskResultTests.Failure: Equatable {}
 
-          See the documentation of 'TaskResult' for more information.
+          See the documentation of "TaskResult" for more information.
           """
       }
     }
@@ -62,13 +62,13 @@ final class TaskResultTests: XCTestCase {
         _ = TaskResult<Never>.failure(Failure(message: "Something went wrong")).hashValue
       } issueMatcher: {
         $0.compactDescription == """
-          'Failure' is not hashable. …
+          "TaskResultTests.Failure" is not hashable. …
 
-          To hash a value of this type, it must conform to the 'Hashable' protocol. For example:
+          To hash a value of this type, it must conform to the "Hashable" protocol. For example:
 
-              extension Failure: Hashable {}
+              extension TaskResultTests.Failure: Hashable {}
 
-          See the documentation of 'TaskResult' for more information.
+          See the documentation of "TaskResult" for more information.
           """
       }
     }

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -26,8 +26,8 @@ final class DependencyValuesTests: XCTestCase {
         }
       } issueMatcher: {
         $0.compactDescription == """
-          @Dependency(\\.missingLiveDependency) has no live implementation, but was accessed from \
-          a live context.
+          "@Dependency(\\.missingLiveDependency)" has no live implementation, but was accessed \
+          from a live context.
 
             Location:
               DependenciesTests/DependencyValuesTests.swift:\(line)
@@ -36,10 +36,10 @@ final class DependencyValuesTests: XCTestCase {
             Value:
               Int
 
-          Every dependency registered with the library must conform to 'DependencyKey', and that \
+          Every dependency registered with the library must conform to "DependencyKey", and that \
           conformance must be visible to the running application.
 
-          To fix, make sure that 'TestKey' conforms to 'DependencyKey' by providing a live \
+          To fix, make sure that "TestKey" conforms to "DependencyKey" by providing a live \
           implementation of your dependency, and make sure that the conformance is linked with \
           this current application.
           """


### PR DESCRIPTION
Dependencies is not currently usable outside Apple platforms due to unrestricted use of platform-only APIs. This PR should guard their availability a bit better and allow for compilation on Linux at the very least, allowing Dependencies code to be written in multiplatform libraries.