### PR TITLE
Fix `_printChanges`

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -15,8 +15,8 @@ extension ViewStore {
 
 extension ReducerProtocol {
   @available(*, deprecated, renamed: "_printChanges")
-  public func debug() -> _PrintChangesReducer<Self, _CustomDumpPrinter> {
-    _PrintChangesReducer(base: self, printer: .customDump)
+  public func debug() -> _PrintChangesReducer<Self> {
+    self._printChanges()
   }
 }
 


### PR DESCRIPTION
Our new internal helper for printing is still a work-in-progress, and customizing it was broken on `ReducerProtocol` release, as pointed out in https://github.com/pointfreeco/swift-composable-architecture/discussions/1465. This at least gets things building again.