### PR TITLE
Add a `EffectTask<Action>` typealias for `Effect<Action, Never>` and rename `Effect` to `EffectPublisher`

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -35,7 +35,7 @@ struct AlertAndConfirmationDialog: ReducerProtocol {
     case incrementButtonTapped
   }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .alertButtonTapped:
       state.alert = AlertState(

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -35,7 +35,7 @@ struct AlertAndConfirmationDialog: ReducerProtocol {
     case incrementButtonTapped
   }
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .alertButtonTapped:
       state.alert = AlertState(

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -39,7 +39,7 @@ struct Animations: ReducerProtocol {
 
   @Dependency(\.mainQueue) var mainQueue
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     enum CancelID {}
 
     switch action {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -39,7 +39,7 @@ struct Animations: ReducerProtocol {
 
   @Dependency(\.mainQueue) var mainQueue
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     enum CancelID {}
 
     switch action {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -33,7 +33,7 @@ struct BindingBasics: ReducerProtocol {
     case toggleChanged(isOn: Bool)
   }
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case let .sliderValueChanged(value):
       state.sliderValue = value

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -33,7 +33,7 @@ struct BindingBasics: ReducerProtocol {
     case toggleChanged(isOn: Bool)
   }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case let .sliderValueChanged(value):
       state.sliderValue = value

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -19,7 +19,7 @@ struct Counter: ReducerProtocol {
     case incrementButtonTapped
   }
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .decrementButtonTapped:
       state.count -= 1

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -19,7 +19,7 @@ struct Counter: ReducerProtocol {
     case incrementButtonTapped
   }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .decrementButtonTapped:
       state.count -= 1

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
@@ -86,7 +86,7 @@ struct SharedState: ReducerProtocol {
       case isPrimeButtonTapped
     }
 
-    func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+    func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
       switch action {
       case .alertDismissed:
         state.alert = nil
@@ -138,7 +138,7 @@ struct SharedState: ReducerProtocol {
       case resetCounterButtonTapped
     }
 
-    func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+    func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
       switch action {
       case .resetCounterButtonTapped:
         state.resetCount()

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
@@ -86,7 +86,7 @@ struct SharedState: ReducerProtocol {
       case isPrimeButtonTapped
     }
 
-    func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+    func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
       switch action {
       case .alertDismissed:
         state.alert = nil
@@ -138,7 +138,7 @@ struct SharedState: ReducerProtocol {
       case resetCounterButtonTapped
     }
 
-    func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+    func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
       switch action {
       case .resetCounterButtonTapped:
         state.resetCount()

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -40,7 +40,7 @@ struct EffectsBasics: ReducerProtocol {
   @Dependency(\.mainQueue) var mainQueue
   private enum DelayID {}
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .decrementButtonTapped:
       state.count -= 1

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -40,7 +40,7 @@ struct EffectsBasics: ReducerProtocol {
   @Dependency(\.mainQueue) var mainQueue
   private enum DelayID {}
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .decrementButtonTapped:
       state.count -= 1

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -32,7 +32,7 @@ struct EffectsCancellation: ReducerProtocol {
   @Dependency(\.factClient) var factClient
   private enum NumberFactRequestID {}
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .cancelButtonTapped:
       state.isFactRequestInFlight = false

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -32,7 +32,7 @@ struct EffectsCancellation: ReducerProtocol {
   @Dependency(\.factClient) var factClient
   private enum NumberFactRequestID {}
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .cancelButtonTapped:
       state.isFactRequestInFlight = false

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -30,7 +30,7 @@ struct LongLivingEffects: ReducerProtocol {
 
   @Dependency(\.screenshots) var screenshots
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .task:
       // When the view appears, start the effect that emits when screenshots are taken.

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -30,7 +30,7 @@ struct LongLivingEffects: ReducerProtocol {
 
   @Dependency(\.screenshots) var screenshots
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .task:
       // When the view appears, start the effect that emits when screenshots are taken.

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -29,7 +29,7 @@ struct Refreshable: ReducerProtocol {
   @Dependency(\.mainQueue) var mainQueue
   private enum FactRequestID {}
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .cancelButtonTapped:
       return .cancel(id: FactRequestID.self)

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -29,7 +29,7 @@ struct Refreshable: ReducerProtocol {
   @Dependency(\.mainQueue) var mainQueue
   private enum FactRequestID {}
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .cancelButtonTapped:
       return .cancel(id: FactRequestID.self)

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -27,7 +27,7 @@ struct Timers: ReducerProtocol {
   @Dependency(\.mainQueue) var mainQueue
   private enum TimerID {}
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .onDisappear:
       return .cancel(id: TimerID.self)

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -27,7 +27,7 @@ struct Timers: ReducerProtocol {
   @Dependency(\.mainQueue) var mainQueue
   private enum TimerID {}
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .onDisappear:
       return .cancel(id: TimerID.self)

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -39,7 +39,7 @@ struct WebSocket: ReducerProtocol {
   @Dependency(\.webSocket) var webSocket
   private enum WebSocketID {}
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .alertDismissed:
       state.alert = nil

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -39,7 +39,7 @@ struct WebSocket: ReducerProtocol {
   @Dependency(\.webSocket) var webSocket
   private enum WebSocketID {}
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .alertDismissed:
       state.alert = nil

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -11,9 +11,9 @@ private let readMe = """
 
 extension AnyReducer {
   static func subscriptions(
-    _ subscriptions: @escaping (State, Environment) -> [AnyHashable: Effect<Action, Never>]
+    _ subscriptions: @escaping (State, Environment) -> [AnyHashable: EffectOf<Action>]
   ) -> Self {
-    var activeSubscriptions: [AnyHashable: Effect<Action, Never>] = [:]
+    var activeSubscriptions: [AnyHashable: EffectOf<Action>] = [:]
 
     return AnyReducer { state, _, environment in
       let currentSubscriptions = subscriptions(state, environment)

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -11,9 +11,9 @@ private let readMe = """
 
 extension AnyReducer {
   static func subscriptions(
-    _ subscriptions: @escaping (State, Environment) -> [AnyHashable: EffectOf<Action>]
+    _ subscriptions: @escaping (State, Environment) -> [AnyHashable: EffectTask<Action>]
   ) -> Self {
-    var activeSubscriptions: [AnyHashable: EffectOf<Action>] = [:]
+    var activeSubscriptions: [AnyHashable: EffectTask<Action>] = [:]
 
     return AnyReducer { state, _, environment in
       let currentSubscriptions = subscriptions(state, environment)

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -19,8 +19,8 @@ struct LifecycleReducer<Wrapped: ReducerProtocol>: ReducerProtocol {
   }
 
   let wrapped: Wrapped
-  let onAppear: Effect<Wrapped.Action, Never>
-  let onDisappear: Effect<Never, Never>
+  let onAppear: EffectOf<Wrapped.Action>
+  let onDisappear: EffectOf<Never>
 
   var body: some ReducerProtocol<Wrapped.State?, Action> {
     Reduce { state, lifecycleAction in
@@ -45,8 +45,8 @@ extension LifecycleReducer.Action: Equatable where Wrapped.Action: Equatable {}
 
 extension ReducerProtocol {
   func lifecycle(
-    onAppear: Effect<Action, Never>,
-    onDisappear: Effect<Never, Never> = .none
+    onAppear: EffectOf<Action>,
+    onDisappear: EffectOf<Never> = .none
   ) -> LifecycleReducer<Self> {
     LifecycleReducer(wrapped: self, onAppear: onAppear, onDisappear: onDisappear)
   }

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -19,8 +19,8 @@ struct LifecycleReducer<Wrapped: ReducerProtocol>: ReducerProtocol {
   }
 
   let wrapped: Wrapped
-  let onAppear: EffectOf<Wrapped.Action>
-  let onDisappear: EffectOf<Never>
+  let onAppear: EffectTask<Wrapped.Action>
+  let onDisappear: EffectTask<Never>
 
   var body: some ReducerProtocol<Wrapped.State?, Action> {
     Reduce { state, lifecycleAction in
@@ -45,8 +45,8 @@ extension LifecycleReducer.Action: Equatable where Wrapped.Action: Equatable {}
 
 extension ReducerProtocol {
   func lifecycle(
-    onAppear: EffectOf<Action>,
-    onDisappear: EffectOf<Never> = .none
+    onAppear: EffectTask<Action>,
+    onDisappear: EffectTask<Never> = .none
   ) -> LifecycleReducer<Self> {
     LifecycleReducer(wrapped: self, onAppear: onAppear, onDisappear: onDisappear)
   }

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
@@ -24,7 +24,7 @@ struct DownloadComponent: ReducerProtocol {
 
   @Dependency(\.downloadClient) var downloadClient
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .alert(.deleteButtonTapped):
       state.alert = nil

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
@@ -24,7 +24,7 @@ struct DownloadComponent: ReducerProtocol {
 
   @Dependency(\.downloadClient) var downloadClient
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .alert(.deleteButtonTapped):
       state.alert = nil

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -42,7 +42,7 @@ struct Favoriting<ID: Hashable & Sendable>: ReducerProtocol {
 
   func reduce(
     into state: inout FavoritingState<ID>, action: FavoritingAction
-  ) -> Effect<FavoritingAction, Never> {
+  ) -> EffectOf<FavoritingAction> {
     switch action {
     case .alertDismissed:
       state.alert = nil

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -42,7 +42,7 @@ struct Favoriting<ID: Hashable & Sendable>: ReducerProtocol {
 
   func reduce(
     into state: inout FavoritingState<ID>, action: FavoritingAction
-  ) -> EffectOf<FavoritingAction> {
+  ) -> EffectTask<FavoritingAction> {
     switch action {
     case .alertDismissed:
       state.alert = nil

--- a/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
@@ -14,7 +14,7 @@ struct Counter: ReducerProtocol {
     case incrementButtonTapped
   }
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .decrementButtonTapped:
       state.count -= 1

--- a/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
@@ -14,7 +14,7 @@ struct Counter: ReducerProtocol {
     case incrementButtonTapped
   }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .decrementButtonTapped:
       state.count -= 1

--- a/Examples/CaseStudies/tvOSCaseStudies/FocusView.swift
+++ b/Examples/CaseStudies/tvOSCaseStudies/FocusView.swift
@@ -21,7 +21,7 @@ struct Focus: ReducerProtocol {
 
   @Dependency(\.withRandomNumberGenerator) var withRandomNumberGenerator
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .randomButtonClicked:
       state.currentFocus = self.withRandomNumberGenerator {

--- a/Examples/CaseStudies/tvOSCaseStudies/FocusView.swift
+++ b/Examples/CaseStudies/tvOSCaseStudies/FocusView.swift
@@ -21,7 +21,7 @@ struct Focus: ReducerProtocol {
 
   @Dependency(\.withRandomNumberGenerator) var withRandomNumberGenerator
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .randomButtonClicked:
       state.currentFocus = self.withRandomNumberGenerator {

--- a/Examples/Search/Search/SearchView.swift
+++ b/Examples/Search/Search/SearchView.swift
@@ -42,7 +42,7 @@ struct Search: ReducerProtocol {
   private enum SearchLocationID {}
   private enum SearchWeatherID {}
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .forecastResponse(_, .failure):
       state.weather = nil

--- a/Examples/Search/Search/SearchView.swift
+++ b/Examples/Search/Search/SearchView.swift
@@ -42,7 +42,7 @@ struct Search: ReducerProtocol {
   private enum SearchLocationID {}
   private enum SearchWeatherID {}
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .forecastResponse(_, .failure):
       state.weather = nil

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
@@ -25,7 +25,7 @@ struct SpeechRecognition: ReducerProtocol {
 
   @Dependency(\.speechClient) var speechClient
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .authorizationStateAlertDismissed:
       state.alert = nil

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
@@ -25,7 +25,7 @@ struct SpeechRecognition: ReducerProtocol {
 
   @Dependency(\.speechClient) var speechClient
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .authorizationStateAlertDismissed:
       state.alert = nil

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameCore/GameCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameCore/GameCore.swift
@@ -29,7 +29,7 @@ public struct Game: ReducerProtocol {
 
   public init() {}
 
-  public func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  public func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case let .cellTapped(row, column):
       guard

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameCore/GameCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameCore/GameCore.swift
@@ -29,7 +29,7 @@ public struct Game: ReducerProtocol {
 
   public init() {}
 
-  public func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  public func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case let .cellTapped(row, column):
       guard

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
@@ -29,7 +29,7 @@ public struct TwoFactor: ReducerProtocol, Sendable {
 
   public init() {}
 
-  public func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  public func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .alertDismissed:
       state.alert = nil

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
@@ -29,7 +29,7 @@ public struct TwoFactor: ReducerProtocol, Sendable {
 
   public init() {}
 
-  public func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  public func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .alertDismissed:
       state.alert = nil

--- a/Examples/Todos/Todos/Todo.swift
+++ b/Examples/Todos/Todos/Todo.swift
@@ -14,7 +14,7 @@ struct Todo: ReducerProtocol {
     case textFieldChanged(String)
   }
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .checkBoxToggled:
       state.isComplete.toggle()

--- a/Examples/Todos/Todos/Todo.swift
+++ b/Examples/Todos/Todos/Todo.swift
@@ -14,7 +14,7 @@ struct Todo: ReducerProtocol {
     case textFieldChanged(String)
   }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .checkBoxToggled:
       state.isComplete.toggle()

--- a/Examples/VoiceMemos/VoiceMemos/RecordingMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/RecordingMemo.swift
@@ -32,7 +32,7 @@ struct RecordingMemo: ReducerProtocol {
   @Dependency(\.audioRecorder) var audioRecorder
   @Dependency(\.mainRunLoop) var mainRunLoop
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .audioRecorderDidFinish(.success(true)):
       return .task { [state] in .delegate(.didFinish(.success(state))) }

--- a/Examples/VoiceMemos/VoiceMemos/RecordingMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/RecordingMemo.swift
@@ -32,7 +32,7 @@ struct RecordingMemo: ReducerProtocol {
   @Dependency(\.audioRecorder) var audioRecorder
   @Dependency(\.mainRunLoop) var mainRunLoop
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .audioRecorderDidFinish(.success(true)):
       return .task { [state] in .delegate(.didFinish(.success(state))) }

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
@@ -40,7 +40,7 @@ struct VoiceMemo: ReducerProtocol {
   @Dependency(\.mainRunLoop) var mainRunLoop
   private enum PlayID {}
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .audioPlayerClient:
       state.mode = .notPlaying

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
@@ -40,7 +40,7 @@ struct VoiceMemo: ReducerProtocol {
   @Dependency(\.mainRunLoop) var mainRunLoop
   private enum PlayID {}
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .audioPlayerClient:
       state.mode = .notPlaying

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ struct Feature: ReducerProtocol {
   struct State: Equatable { … }
   enum Action: Equatable { … }
   
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
       case .factAlertDismissed:
         state.numberFactAlert = nil

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ struct Feature: ReducerProtocol {
   struct State: Equatable { … }
   enum Action: Equatable { … }
   
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
       case .factAlertDismissed:
         state.numberFactAlert = nil

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
@@ -54,7 +54,7 @@ struct Settings: ReducerProtocol {
   
   func reduce(
     into state: inout State, action: Action
-  ) -> EffectOf<Action> {
+  ) -> EffectTask<Action> {
     switch action {
     case let .isHapticFeedbackEnabledChanged(isEnabled):
       state.isHapticFeedbackEnabled = isEnabled
@@ -146,7 +146,7 @@ struct Settings: ReducerProtocol {
 
   func reduce(
     into state: inout State, action: Action
-  ) -> EffectOf<Action> {
+  ) -> EffectTask<Action> {
     switch action {
     case let digestChanged(digest):
       state.digest = digest

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
@@ -54,7 +54,7 @@ struct Settings: ReducerProtocol {
   
   func reduce(
     into state: inout State, action: Action
-  ) -> Effect<Action, Never> {
+  ) -> EffectOf<Action> {
     switch action {
     case let .isHapticFeedbackEnabledChanged(isEnabled):
       state.isHapticFeedbackEnabled = isEnabled
@@ -146,7 +146,7 @@ struct Settings: ReducerProtocol {
 
   func reduce(
     into state: inout State, action: Action
-  ) -> Effect<Action, Never> {
+  ) -> EffectOf<Action> {
     switch action {
     case let digestChanged(digest):
       state.digest = digest

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/DependencyManagement.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/DependencyManagement.md
@@ -48,7 +48,7 @@ struct Todos: ReducerProtocol {
     // ...
   }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .addButtonTapped:
       state.todos.append(Todo(id: UUID())

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/DependencyManagement.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/DependencyManagement.md
@@ -48,7 +48,7 @@ struct Todos: ReducerProtocol {
     // ...
   }
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .addButtonTapped:
       state.todos.append(Todo(id: UUID())

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
@@ -94,7 +94,7 @@ struct Feature: ReducerProtocol {
 }
 ```
 
-And then we implement the ``ReducerProtocol/reduce(into:action:)-4nzr2`` method which is responsible 
+And then we implement the ``ReducerProtocol/reduce(into:action:)-8yinq`` method which is responsible 
 for handling the actual logic and  behavior for the feature. It describes how to change the current 
 state to the next state, and describes what effects need to be executed. Some actions don't need to 
 execute effects, and they can return `.none` to represent that:

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
@@ -42,7 +42,7 @@ your domain:
     user actions, notifications, event sources and more.
 * **Reducer**: A function that describes how to evolve the current state of the app to the next
     state given an action. The reducer is also responsible for returning any effects that should be
-    run, such as API requests, which can be done by returning an `Effect` value.
+    run, such as API requests, which can be done by returning an `EffectTask` value.
 * **Store**: The runtime that actually drives your feature. You send all user actions to the store
     so that the store can run the reducer and effects, and you can observe state changes in the
     store so that you can update UI.

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
@@ -104,7 +104,7 @@ struct Feature: ReducerProtocol {
   struct State: Equatable { … }
   enum Action: Equatable { … }
   
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
       case .factAlertDismissed:
         state.numberFactAlert = nil

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
@@ -104,7 +104,7 @@ struct Feature: ReducerProtocol {
   struct State: Equatable { … }
   enum Action: Equatable { … }
   
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
       case .factAlertDismissed:
         state.numberFactAlert = nil

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToTheReducerProtocol.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToTheReducerProtocol.md
@@ -81,7 +81,7 @@ struct Feature: ReducerProtocol {
 
   let date: () -> Date
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     // ...
     }
@@ -187,7 +187,7 @@ struct TabA: ReducerProtocol {
   enum Action {
     // ...
   }
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     // ...
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToTheReducerProtocol.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToTheReducerProtocol.md
@@ -64,7 +64,7 @@ You can convert this to the protocol style by:
 `Action`.
 1. Move the fields on the environment to be fields on this new reducer type, and delete the 
 environment type.
-1. Move the reducer's closure implementation to the ``ReducerProtocol/reduce(into:action:)-4nzr2`` 
+1. Move the reducer's closure implementation to the ``ReducerProtocol/reduce(into:action:)-8yinq`` 
 method.
 
 Performing these 4 steps on the feature produces the following:

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToTheReducerProtocol.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToTheReducerProtocol.md
@@ -81,7 +81,7 @@ struct Feature: ReducerProtocol {
 
   let date: () -> Date
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     // ...
     }
@@ -187,7 +187,7 @@ struct TabA: ReducerProtocol {
   enum Action {
     // ...
   }
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     // ...
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -236,15 +236,15 @@ struct Feature: ReducerProtocol {
     switch action {
     case .buttonTapped:
       state.count += 1
-      return Effect(value: .sharedComputation)
+      return EffectTask(value: .sharedComputation)
 
     case .toggleChanged:
       state.isEnabled.toggle()
-      return Effect(value: .sharedComputation)
+      return EffectTask(value: .sharedComputation)
 
     case let .textFieldChanged(text):
       state.description = = text
-      return Effect(value: .sharedComputation)
+      return EffectTask(value: .sharedComputation)
 
     case .sharedComputation:
       // Some shared work to compute something.
@@ -382,8 +382,8 @@ store.send(.textFieldChanged("Hello") {
 
 Reducers are run on the main thread and so they are not appropriate for performing intense CPU
 work. If you need to perform lots of CPU-bound work, then it is more appropriate to use an
-``Effect``, which will operate in the cooperative thread pool, and then send actions back into the
-system. You should also make sure to perform your CPU intensive work in a cooperative manner by
+``EffectTask``, which will operate in the cooperative thread pool, and then send actions back into 
+the system. You should also make sure to perform your CPU intensive work in a cooperative manner by
 periodically suspending with `Task.yield()` so that you do not block a thread in the cooperative
 pool for too long.
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -215,7 +215,7 @@ at each layer a reducer can intercept and reinterpret the action.
 
 It is far better to share logic via simple methods on your ``ReducerProtocol`` conformance.
 The helper methods can take `inout State` as an argument if it needs to make mutations, and it
-can return an `Effect<Action, Never>`. This allows you to share logic without incurring the cost
+can return an `EffectOf<Action>`. This allows you to share logic without incurring the cost
 of sending needless actions.
 
 For example, suppose that there are 3 UI components in your feature such that when any is changed
@@ -232,7 +232,7 @@ struct Feature: ReducerProtocol {
     // ...
   }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .buttonTapped:
       state.count += 1
@@ -302,7 +302,7 @@ and executing synchronous effects.
 
 Instead, we recommend sharing logic with methods defined in your feature's reducer. The method has
 full access to all depedencies, it can take an `inout State` if it needs to make mutations to 
-state, and it can return an `Effect<Action, Never>` if it needs to execute effects.
+state, and it can return an `EffectOf<Action>` if it needs to execute effects.
 
 The above example can be refactored like so:
 
@@ -315,7 +315,7 @@ struct Feature: ReducerProtocol {
     // ...
   }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .buttonTapped:
       state.count += 1
@@ -331,7 +331,7 @@ struct Feature: ReducerProtocol {
     }
   }
 
-  func sharedComputation(state: inout State) -> Effect<Action, Never> {
+  func sharedComputation(state: inout State) -> EffectOf<Action> {
     // Some shared work to compute something.
     return .run { send in
       // A shared effect to compute something

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -215,7 +215,7 @@ at each layer a reducer can intercept and reinterpret the action.
 
 It is far better to share logic via simple methods on your ``ReducerProtocol`` conformance.
 The helper methods can take `inout State` as an argument if it needs to make mutations, and it
-can return an `EffectOf<Action>`. This allows you to share logic without incurring the cost
+can return an `EffectTask<Action>`. This allows you to share logic without incurring the cost
 of sending needless actions.
 
 For example, suppose that there are 3 UI components in your feature such that when any is changed
@@ -232,7 +232,7 @@ struct Feature: ReducerProtocol {
     // ...
   }
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .buttonTapped:
       state.count += 1
@@ -302,7 +302,7 @@ and executing synchronous effects.
 
 Instead, we recommend sharing logic with methods defined in your feature's reducer. The method has
 full access to all depedencies, it can take an `inout State` if it needs to make mutations to 
-state, and it can return an `EffectOf<Action>` if it needs to execute effects.
+state, and it can return an `EffectTask<Action>` if it needs to execute effects.
 
 The above example can be refactored like so:
 
@@ -315,7 +315,7 @@ struct Feature: ReducerProtocol {
     // ...
   }
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .buttonTapped:
       state.count += 1
@@ -331,7 +331,7 @@ struct Feature: ReducerProtocol {
     }
   }
 
-  func sharedComputation(state: inout State) -> EffectOf<Action> {
+  func sharedComputation(state: inout State) -> EffectTask<Action> {
     // Some shared work to compute something.
     return .run { send in
       // A shared effect to compute something

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftConcurrency.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftConcurrency.md
@@ -32,7 +32,7 @@ struct Feature: ReducerProtocol {
   struct State { … }
   enum Action { … }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .buttonTapped:
       return .task {

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftConcurrency.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftConcurrency.md
@@ -7,11 +7,11 @@ and functions that are not thread-safe in concurrent contexts. Many of these war
 for the time being, but in Swift 6 most (if not all) of these warnings will become errors, and so
 you will need to know how to prove to the compiler that your types are safe to use concurrently.
 
-There are 3 primary ways to create an ``Effect`` in the library:
+There are 3 primary ways to create an ``EffectTask`` in the library:
 
-  * ``Effect/task(priority:operation:catch:file:fileID:line:)``
-  * ``Effect/run(priority:operation:catch:file:fileID:line:)``
-  * ``Effect/fireAndForget(priority:_:)``
+  * ``EffectPublisher/task(priority:operation:catch:file:fileID:line:)``
+  * ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)``
+  * ``EffectPublisher/fireAndForget(priority:_:)``
 
 Each of these constructors takes a `@Sendable`, asynchronous closure, which restricts the types of
 closures you can use for your effects. In particular, the closure can only capture `Sendable`

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftConcurrency.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftConcurrency.md
@@ -32,7 +32,7 @@ struct Feature: ReducerProtocol {
   struct State { … }
   enum Action { … }
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .buttonTapped:
       return .task {

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
@@ -251,7 +251,7 @@ supposed to be running, or perhaps the data it feeds into the system later is wr
 requires all effects to finish.
 
 To get this test passing we need to assert on the actions that are sent back into the system
-by the effect. We do this by using the ``TestStore/receive(_:timeout:_:file:line:)`` method,
+by the effect. We do this by using the ``TestStore/receive(_:timeout:_:file:line:)-8yd62`` method,
 which allows you to assert which action you expect to receive from an effect, as well as how the
 state changes after receiving that effect:
 
@@ -269,7 +269,7 @@ going to be received, but after waiting around for a small amount of time no act
 ```
 
 This is because our timer is on a 1 second interval, and by default
-``TestStore/receive(_:timeout:_:file:line:)`` only waits for a fraction of a second. This is
+``TestStore/receive(_:timeout:_:file:line:)-8yd62`` only waits for a fraction of a second. This is
 because typically you should not be performing real time-based asynchrony in effects, and instead
 using a controlled entity, such as a scheduler or clock, that can be sped up in tests. We will
 demonstrate this in a moment, so for now let's increase the timeout:
@@ -369,7 +369,7 @@ store.dependencies.mainQueue = .immediate
 ```
 
 With that small change we can drop the `timeout` arguments from the
-``TestStore/receive(_:timeout:_:file:line:)`` invocations:
+``TestStore/receive(_:timeout:_:file:line:)-8yd62`` invocations:
 
 ```swift
 await store.receive(.timerTick) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
@@ -24,7 +24,7 @@ struct Feature: ReducerProtocol {
   struct State: Equatable { var count = 0 }
   enum Action { case incrementButtonTapped, decrementButtonTapped }
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .incrementButtonTapped:
       state.count += 1
@@ -193,7 +193,7 @@ struct Feature: ReducerProtocol {
   enum Action {  case startTimerButtonTapped, timerTick }
   enum TimerID {}
 
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .startTimerButtonTapped:
       state.count = 0

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
@@ -24,7 +24,7 @@ struct Feature: ReducerProtocol {
   struct State: Equatable { var count = 0 }
   enum Action { case incrementButtonTapped, decrementButtonTapped }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .incrementButtonTapped:
       state.count += 1
@@ -193,7 +193,7 @@ struct Feature: ReducerProtocol {
   enum Action {  case startTimerButtonTapped, timerTick }
   enum TimerID {}
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .startTimerButtonTapped:
       state.count = 0

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
@@ -175,8 +175,8 @@ store.send(.incrementButtonTapped) {
 
 Testing state mutations as shown in the previous section is powerful, but is only half the story
 when it comes to testing features built in the Composable Architecture. The second responsibility of
-``Reducer``s, after mutating state from an action, is to return an ``Effect`` that encapsulates a
-unit of work that runs in the outside world and feeds data back into the system.
+``Reducer``s, after mutating state from an action, is to return an ``EffectTask`` that encapsulates 
+a unit of work that runs in the outside world and feeds data back into the system.
 
 Effects form a major part of a feature's logic. They can perform network requests to external
 services, load and save data to disk, start and stop timers, interact with Apple frameworks (Core
@@ -184,7 +184,7 @@ Location, Core Motion, Speech Recognition, etc.), and more.
 
 As a simple example, suppose we have a feature with a button such that when you tap it it starts
 a timer that counts up until you reach 5, and then stops. This can be accomplished using the
-``Effect/run(priority:operation:catch:file:fileID:line:)`` helper, which provides you an
+``EffectPublisher/run(priority:operation:catch:file:fileID:line:)`` helper, which provides you an
 asynchronous context to operate in and can send multiple actions back into the system:
 
 ```swift

--- a/Sources/ComposableArchitecture/Documentation.docc/ComposableArchitecture.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/ComposableArchitecture.md
@@ -60,7 +60,7 @@ day-to-day when building applications, such as:
 ### State management
 
 - ``ReducerProtocol``
-- ``EffectTask``
+- ``EffectPublisher``
 - ``Store``
 - ``ViewStore``
 

--- a/Sources/ComposableArchitecture/Documentation.docc/ComposableArchitecture.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/ComposableArchitecture.md
@@ -60,7 +60,7 @@ day-to-day when building applications, such as:
 ### State management
 
 - ``ReducerProtocol``
-- ``Effect``
+- ``EffectTask``
 - ``Store``
 - ``ViewStore``
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/EffectDeprecations.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/EffectDeprecations.md
@@ -14,12 +14,7 @@ Avoid using deprecated APIs in your app. Select a method to see the replacement 
 
 ### Cancellation
 
-- ``EffectPublisher/cancel(ids:)-9tnmm``
-
-### Composition
-
-- ``EffectPublisher/concatenate(_:)-3awnj``
-- ``EffectPublisher/concatenate(_:)-8x6rz``
+- ``EffectPublisher/cancel(ids:)-8q1hl``
 
 ### Testing
 
@@ -34,17 +29,17 @@ Avoid using deprecated APIs in your app. Select a method to see the replacement 
 - ``EffectPublisher/init(error:)``
 - ``EffectPublisher/upstream``
 - ``EffectPublisher/catching(_:)``
-- ``EffectPublisher/debounce(id:for:scheduler:options:)-8x633``
-- ``EffectPublisher/debounce(id:for:scheduler:options:)-76yye``
+- ``EffectPublisher/debounce(id:for:scheduler:options:)-1xdnj``
+- ``EffectPublisher/debounce(id:for:scheduler:options:)-1oaak``
 - ``EffectPublisher/deferred(for:scheduler:options:)``
 - ``EffectPublisher/fireAndForget(_:)``
 - ``EffectPublisher/future(_:)``
 - ``EffectPublisher/receive(subscriber:)``
 - ``EffectPublisher/result(_:)``
 - ``EffectPublisher/run(_:)``
-- ``EffectPublisher/throttle(id:for:scheduler:latest:)-9kwd5``
-- ``EffectPublisher/throttle(id:for:scheduler:latest:)-5jfpx``
-- ``EffectPublisher/timer(id:every:tolerance:on:options:)-4exe6``
-- ``EffectPublisher/timer(id:every:tolerance:on:options:)-7po0d``
+- ``EffectPublisher/throttle(id:for:scheduler:latest:)-3gibe``
+- ``EffectPublisher/throttle(id:for:scheduler:latest:)-85y01``
+- ``EffectPublisher/timer(id:every:tolerance:on:options:)-6yv2m``
+- ``EffectPublisher/timer(id:every:tolerance:on:options:)-8t3is``
 - ``EffectPublisher/Subscriber``
 <!--DocC: Can't currently document `Publisher` extensions. -->

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/EffectDeprecations.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/EffectDeprecations.md
@@ -10,41 +10,41 @@ Avoid using deprecated APIs in your app. Select a method to see the replacement 
 
 ### Creating an effect
 
-- ``Effect/task(priority:operation:)``
+- ``EffectPublisher/task(priority:operation:)``
 
 ### Cancellation
 
-- ``Effect/cancel(ids:)-9tnmm``
+- ``EffectPublisher/cancel(ids:)-9tnmm``
 
 ### Composition
 
-- ``Effect/concatenate(_:)-3awnj``
-- ``Effect/concatenate(_:)-8x6rz``
+- ``EffectPublisher/concatenate(_:)-3awnj``
+- ``EffectPublisher/concatenate(_:)-8x6rz``
 
 ### Testing
 
-- ``Effect/failing(_:)``
-- ``Effect/unimplemented(_:)``
+- ``EffectPublisher/failing(_:)``
+- ``EffectPublisher/unimplemented(_:)``
 
 ### Combine integration
 
-- ``Effect/Output``
-- ``Effect/init(_:)``
-- ``Effect/init(value:)``
-- ``Effect/init(error:)``
-- ``Effect/upstream``
-- ``Effect/catching(_:)``
-- ``Effect/debounce(id:for:scheduler:options:)-8x633``
-- ``Effect/debounce(id:for:scheduler:options:)-76yye``
-- ``Effect/deferred(for:scheduler:options:)``
-- ``Effect/fireAndForget(_:)``
-- ``Effect/future(_:)``
-- ``Effect/receive(subscriber:)``
-- ``Effect/result(_:)``
-- ``Effect/run(_:)``
-- ``Effect/throttle(id:for:scheduler:latest:)-9kwd5``
-- ``Effect/throttle(id:for:scheduler:latest:)-5jfpx``
-- ``Effect/timer(id:every:tolerance:on:options:)-4exe6``
-- ``Effect/timer(id:every:tolerance:on:options:)-7po0d``
-- ``Effect/Subscriber``
+- ``EffectPublisher/Output``
+- ``EffectPublisher/init(_:)``
+- ``EffectPublisher/init(value:)``
+- ``EffectPublisher/init(error:)``
+- ``EffectPublisher/upstream``
+- ``EffectPublisher/catching(_:)``
+- ``EffectPublisher/debounce(id:for:scheduler:options:)-8x633``
+- ``EffectPublisher/debounce(id:for:scheduler:options:)-76yye``
+- ``EffectPublisher/deferred(for:scheduler:options:)``
+- ``EffectPublisher/fireAndForget(_:)``
+- ``EffectPublisher/future(_:)``
+- ``EffectPublisher/receive(subscriber:)``
+- ``EffectPublisher/result(_:)``
+- ``EffectPublisher/run(_:)``
+- ``EffectPublisher/throttle(id:for:scheduler:latest:)-9kwd5``
+- ``EffectPublisher/throttle(id:for:scheduler:latest:)-5jfpx``
+- ``EffectPublisher/timer(id:every:tolerance:on:options:)-4exe6``
+- ``EffectPublisher/timer(id:every:tolerance:on:options:)-7po0d``
+- ``EffectPublisher/Subscriber``
 <!--DocC: Can't currently document `Publisher` extensions. -->

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/TestStoreDeprecations.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/TestStoreDeprecations.md
@@ -18,12 +18,12 @@ Avoid using deprecated APIs in your app. Select a method to see the replacement 
 
 ### Testing reducers
 
-- ``TestStore/send(_:_:file:line:)-2anca``
-- ``TestStore/receive(_:timeout:_:file:line:)``
+- ``TestStore/send(_:_:file:line:)-4i91s``
+- ``TestStore/receive(_:timeout:_:file:line:)-8huvm``
 - ``TestStore/receive(_:_:file:line:)``
-- ``TestStore/finish(timeout:file:line:)``
-- ``TestStore/assert(_:file:line:)-4n483``
-- ``TestStore/assert(_:file:line:)-5k4u0``
+- ``TestStore/finish(timeout:file:line:)-43l4y``
+- ``TestStore/assert(_:file:line:)-707lb``
+- ``TestStore/assert(_:file:line:)-4gff7``
 - ``TestStore/LocalState``
 - ``TestStore/LocalAction``
 - ``TestStore/Step``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
@@ -1,4 +1,4 @@
-# ``ComposableArchitecture/Effect``
+# ``ComposableArchitecture/EffectPublisher``
 
 ## Topics
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
@@ -12,16 +12,16 @@
 
 ### Cancellation
 
-- ``cancellable(id:cancelInFlight:)-499iv``
-- ``cancel(id:)-7vmd9``
-- ``cancel(ids:)-8gan2``
-- ``withTaskCancellation(id:cancelInFlight:operation:)-88kxz``
+- ``cancellable(id:cancelInFlight:)-29q60``
+- ``cancel(id:)-6hzsl``
+- ``cancel(ids:)-1cqqx``
+- ``withTaskCancellation(id:cancelInFlight:operation:)-4dtr6``
 
 ### Composition
 
-- ``map(_:)-28ghh``
-- ``merge(_:)-3al9f``
-- ``merge(_:)-4n451``
+- ``map(_:)-yn70``
+- ``merge(_:)-45guh``
+- ``merge(_:)-3d54p``
 
 ### Concurrency
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectCancel.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectCancel.md
@@ -1,7 +1,7 @@
-# ``ComposableArchitecture/EffectPublisher/cancel(id:)-7vmd9``
+# ``ComposableArchitecture/EffectPublisher/cancel(id:)-6hzsl``
 
 ## Topics
 
 ### Overloads
 
-- ``cancel(id:)-iun1``
+- ``cancel(id:)-1c1dw``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectCancel.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectCancel.md
@@ -1,4 +1,4 @@
-# ``ComposableArchitecture/Effect/cancel(id:)-7vmd9``
+# ``ComposableArchitecture/EffectPublisher/cancel(id:)-7vmd9``
 
 ## Topics
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectCancelIds.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectCancelIds.md
@@ -4,4 +4,4 @@
 
 ### Overloads
 
-- ``cancel(ids:)-dmwy``
+- ``cancel(ids:)-1cqqx``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectCancelIds.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectCancelIds.md
@@ -1,4 +1,4 @@
-# ``ComposableArchitecture/Effect/cancel(ids:)-8gan2``
+# ``ComposableArchitecture/EffectPublisher/cancel(ids:)-8gan2``
 
 ## Topics
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectCancellable.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectCancellable.md
@@ -1,4 +1,4 @@
-# ``ComposableArchitecture/Effect/cancellable(id:cancelInFlight:)-499iv``
+# ``ComposableArchitecture/EffectPublisher/cancellable(id:cancelInFlight:)-499iv``
 
 ## Topics
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectRun.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectRun.md
@@ -1,4 +1,4 @@
-# ``ComposableArchitecture/Effect/run(priority:operation:catch:file:fileID:line:)``
+# ``ComposableArchitecture/EffectPublisher/run(priority:operation:catch:file:fileID:line:)``
 
 ## Topics
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerProtocol.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerProtocol.md
@@ -7,7 +7,7 @@
 - ``reduce(into:action:)-4nzr2``
 - ``State``
 - ``Action``
-- ``EffectTask``
+- ``EffectPublisher``
 
 ### Reducer composition
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerProtocol.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerProtocol.md
@@ -7,7 +7,7 @@
 - ``reduce(into:action:)-4nzr2``
 - ``State``
 - ``Action``
-- ``Effect``
+- ``EffectTask``
 
 ### Reducer composition
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerProtocol.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerProtocol.md
@@ -4,7 +4,7 @@
 
 ### Implementing a reducer
 
-- ``reduce(into:action:)-4nzr2``
+- ``reduce(into:action:)-8yinq``
 - ``State``
 - ``Action``
 - ``EffectPublisher``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStore.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStore.md
@@ -14,13 +14,13 @@
 ### Testing a reducer
 
 - ``send(_:_:file:line:)-6s1gq``
-- ``receive(_:timeout:_:file:line:)``
-- ``finish(timeout:file:line:)``
+- ``receive(_:timeout:_:file:line:)-8yd62``
+- ``finish(timeout:file:line:)-7pmv3``
 - ``TestStoreTask``
 
 ### Accessing state
 
-While the most common way of interacting with a test store's state is via its ``send(_:_:file:line:)-6s1gq`` and ``receive(_:timeout:_:file:line:)`` methods, you may also access it directly throughout a test.
+While the most common way of interacting with a test store's state is via its ``send(_:_:file:line:)-6s1gq`` and ``receive(_:timeout:_:file:line:)-8yd62`` methods, you may also access it directly throughout a test.
 
 - ``state``
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/WithTaskCancellation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/WithTaskCancellation.md
@@ -1,7 +1,7 @@
-# ``ComposableArchitecture/withTaskCancellation(id:cancelInFlight:operation:)-88kxz``
+# ``ComposableArchitecture/withTaskCancellation(id:cancelInFlight:operation:)-4dtr6``
 
 ## Topics
 
 ### Overloads
 
-- ``withTaskCancellation(id:cancelInFlight:operation:)-4dtr6``
+- ``withTaskCancellation(id:cancelInFlight:operation:)-88kxz``

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -66,7 +66,7 @@ extension Effect {
 /// Instead of specifying `Never` as `Failure`:
 ///
 /// ```swift
-/// func reduce(into state: inout State, action: Action) -> EffectOf<Action> { … }
+/// func reduce(into state: inout State, action: Action) -> Effect<Action, Never> { … }
 /// ```
 ///
 /// You can specify a single generic:

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -60,6 +60,22 @@ extension Effect {
   }
 }
 
+/// A convenience type alias for referring to an effect that can never fail, like the kind of
+/// ``Effect`` returned by a reducer after processing an action.
+///
+/// Instead of specifying `Never` as `Failure`:
+///
+/// ```swift
+/// func reduce(into state: inout State, action: Action) -> EffectOf<Action> { … }
+/// ```
+///
+/// You can specify a single generic:
+///
+/// ```swift
+/// func reduce(into state: inout State, action: Action) -> EffectOf<Action>  { … }
+/// ```
+public typealias EffectOf<Action> = Effect<Action, Never>
+
 extension Effect where Failure == Never {
   /// Wraps an asynchronous unit of work in an effect.
   ///
@@ -79,7 +95,7 @@ extension Effect where Failure == Never {
   ///   }
   ///   @Dependency(\.numberFact) var numberFact
   ///
-  ///   func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
   ///     switch action {
   ///       case .factButtonTapped:
   ///         return .task { [number = state.number] in
@@ -516,7 +532,7 @@ extension Effect {
   ///
   /// ```swift
   /// struct CounterEnvironment {
-  ///   let playAlertSound: () -> Effect<Never, Never>
+  ///   let playAlertSound: () -> EffectOf<Never>
   /// }
   /// ```
   ///

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -619,7 +619,7 @@ extension EffectPublisher {
     `EffectPublisher<Output, Failure>` in general.
     
     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
-    concurrency to model dependencies that can fail.
+    concurrency to model failable streams of values.
 
     See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
     """
@@ -634,7 +634,7 @@ extension EffectPublisher {
     `EffectPublisher<Output, Failure>` in general.
     
     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
-    concurrency to model dependencies that can fail.
+    concurrency to model failable streams of values.
 
     See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
     """
@@ -649,7 +649,7 @@ extension EffectPublisher {
     `EffectPublisher<Output, Failure>` in general.
     
     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
-    concurrency to model dependencies that can fail.
+    concurrency to model failable streams of values.
 
     See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
     """
@@ -664,7 +664,7 @@ extension EffectPublisher {
     `EffectPublisher<Output, Failure>` in general.
     
     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
-    concurrency to model dependencies that can fail.
+    concurrency to model failable streams of values.
 
     See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
     """

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -72,9 +72,9 @@ extension Effect {
 /// You can specify a single generic:
 ///
 /// ```swift
-/// func reduce(into state: inout State, action: Action) -> EffectOf<Action>  { … }
+/// func reduce(into state: inout State, action: Action) -> EffectTask<Action>  { … }
 /// ```
-public typealias EffectOf<Action> = Effect<Action, Never>
+public typealias EffectTask<Action> = Effect<Action, Never>
 
 extension Effect where Failure == Never {
   /// Wraps an asynchronous unit of work in an effect.
@@ -95,7 +95,7 @@ extension Effect where Failure == Never {
   ///   }
   ///   @Dependency(\.numberFact) var numberFact
   ///
-  ///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
   ///     switch action {
   ///       case .factButtonTapped:
   ///         return .task { [number = state.number] in
@@ -532,7 +532,7 @@ extension Effect {
   ///
   /// ```swift
   /// struct CounterEnvironment {
-  ///   let playAlertSound: () -> EffectOf<Never>
+  ///   let playAlertSound: () -> EffectTask<Never>
   /// }
   /// ```
   ///

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -609,10 +609,10 @@ extension EffectPublisher {
 }
 
 // MARK: - Transitory Deprecation
+
 @available(
   iOS,
   deprecated: 9999.0,
-  renamed: "EffectPublisher",
   message:
     """
     'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or
@@ -627,7 +627,6 @@ extension EffectPublisher {
 @available(
   macOS,
   deprecated: 9999.0,
-  renamed: "EffectPublisher",
   message:
     """
     'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or
@@ -642,7 +641,6 @@ extension EffectPublisher {
 @available(
   tvOS,
   deprecated: 9999.0,
-  renamed: "EffectPublisher",
   message:
     """
     'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or
@@ -657,7 +655,6 @@ extension EffectPublisher {
 @available(
   watchOS,
   deprecated: 9999.0,
-  renamed: "EffectPublisher",
   message:
     """
     'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -49,10 +49,6 @@ public struct EffectPublisher<Action, Failure: Error> {
   }
 }
 
-// TODO: Soft deprecation
-@available(*, deprecated)
-public typealias Effect = EffectPublisher
-
 // MARK: - Creating Effects
 
 extension EffectPublisher {
@@ -611,3 +607,66 @@ extension EffectPublisher {
     }
   }
 }
+
+// MARK: - Transitory Deprecation
+@available(
+  iOS,
+  deprecated: 9999.0,
+  renamed: "EffectPublisher",
+  message:
+    """
+    'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or
+    `EffectPublisher<Output, Failure>` in general.
+    
+    You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
+    concurrency to model dependencies that can fail.
+
+    See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
+    """
+)
+@available(
+  macOS,
+  deprecated: 9999.0,
+  renamed: "EffectPublisher",
+  message:
+    """
+    'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or
+    `EffectPublisher<Output, Failure>` in general.
+    
+    You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
+    concurrency to model dependencies that can fail.
+
+    See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
+    """
+)
+@available(
+  tvOS,
+  deprecated: 9999.0,
+  renamed: "EffectPublisher",
+  message:
+    """
+    'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or
+    `EffectPublisher<Output, Failure>` in general.
+    
+    You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
+    concurrency to model dependencies that can fail.
+
+    See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
+    """
+)
+@available(
+  watchOS,
+  deprecated: 9999.0,
+  renamed: "EffectPublisher",
+  message:
+    """
+    'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or
+    `EffectPublisher<Output, Failure>` in general.
+    
+    You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
+    concurrency to model dependencies that can fail.
+
+    See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
+    """
+)
+public typealias Effect = EffectPublisher

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -608,8 +608,6 @@ extension EffectPublisher {
   }
 }
 
-// MARK: - Transitory Deprecation
-
 @available(
   iOS,
   deprecated: 9999.0,

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -16,23 +16,23 @@ import XCTestDynamicOverlay
 /// * If using Swift's native structured concurrency tools then there are 3 main ways to create an
 /// effect, depending on if you want to emit one single action back into the system, or any number
 /// of actions, or just execute some work without emitting any actions:
-///   * ``Effect/task(priority:operation:catch:file:fileID:line:)``
-///   * ``Effect/run(priority:operation:catch:file:fileID:line:)``
-///   * ``Effect/fireAndForget(priority:_:)``
+///   * ``EffectPublisher/task(priority:operation:catch:file:fileID:line:)``
+///   * ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)``
+///   * ``EffectPublisher/fireAndForget(priority:_:)``
 /// * If using Combine in your application, in particular for the dependencies of your feature
 /// then you can create effects by making use of any of Combine's operators, and then erasing the
-/// publisher type to ``Effect`` with either `eraseToEffect` or `catchToEffect`. Note that the
-/// Combine interface to ``Effect`` is considered soft deprecated, and you should eventually port
-/// to Swift's native concurrency tools.
+/// publisher type to ``EffectPublisher`` with either `eraseToEffect` or `catchToEffect`. Note that
+/// the Combine interface to ``EffectPublisher`` is considered soft deprecated, and you should
+/// eventually port to Swift's native concurrency tools.
 ///
 /// > Important: ``Store`` is not thread safe, and so all effects must receive values on the same
 /// thread. This is typically the main thread,  **and** if the store is being used to drive UI then
 /// it must receive values on the main thread.
 /// >
-/// > This is only an issue if using the Combine interface of ``Effect`` as mentioned above. If you
-/// you are using Swift's concurrency tools and the `.task`, `.run` and `.fireAndForget` functions
-/// on ``Effect``, then threading is automatically handled for you.
-public struct Effect<Action, Failure: Error> {
+/// > This is only an issue if using the Combine interface of ``EffectPublisher`` as mentioned
+/// above. If  you are using Swift's concurrency tools and the `.task`, `.run` and `.fireAndForget`
+/// functions on ``EffectTask``, then threading is automatically handled for you.
+public struct EffectPublisher<Action, Failure: Error> {
   @usableFromInline
   enum Operation {
     case none
@@ -49,9 +49,13 @@ public struct Effect<Action, Failure: Error> {
   }
 }
 
+// TODO: Soft deprecation
+@available(*, deprecated)
+public typealias Effect = EffectPublisher
+
 // MARK: - Creating Effects
 
-extension Effect {
+extension EffectPublisher {
   /// An effect that does nothing and completes immediately. Useful for situations where you must
   /// return an effect, but you don't need to do anything.
   @inlinable
@@ -61,12 +65,12 @@ extension Effect {
 }
 
 /// A convenience type alias for referring to an effect that can never fail, like the kind of
-/// ``Effect`` returned by a reducer after processing an action.
+/// ``EffectPublisher`` returned by a reducer after processing an action.
 ///
 /// Instead of specifying `Never` as `Failure`:
 ///
 /// ```swift
-/// func reduce(into state: inout State, action: Action) -> Effect<Action, Never> { … }
+/// func reduce(into state: inout State, action: Action) -> EffectPublisher<Action, Never> { … }
 /// ```
 ///
 /// You can specify a single generic:
@@ -76,11 +80,11 @@ extension Effect {
 /// ```
 public typealias EffectTask<Action> = Effect<Action, Never>
 
-extension Effect where Failure == Never {
+extension EffectPublisher where Failure == Never {
   /// Wraps an asynchronous unit of work in an effect.
   ///
   /// This function is useful for executing work in an asynchronous context and capturing the result
-  /// in an ``Effect`` so that the reducer, a non-asynchronous context, can process it.
+  /// in an ``EffectTask`` so that the reducer, a non-asynchronous context, can process it.
   ///
   /// For example, if your dependency exposes an `async` function, you can use
   /// ``task(priority:operation:catch:file:fileID:line:)`` to provide an asynchronous context for
@@ -152,12 +156,12 @@ extension Effect where Failure == Never {
                 customDump(error, to: &errorDump, indent: 4)
                 runtimeWarn(
                   """
-                  An "Effect.task" returned from "\(fileID):\(line)" threw an unhandled error. …
+                  An "EffectTask.task" returned from "\(fileID):\(line)" threw an unhandled error. …
 
                   \(errorDump)
 
                   All non-cancellation errors must be explicitly handled via the "catch" parameter \
-                  on "Effect.task", or via a "do" block.
+                  on "EffectTask.task", or via a "do" block.
                   """,
                   file: file,
                   line: line
@@ -234,12 +238,12 @@ extension Effect where Failure == Never {
                 customDump(error, to: &errorDump, indent: 4)
                 runtimeWarn(
                   """
-                  An "Effect.run" returned from "\(fileID):\(line)" threw an unhandled error. …
+                  An "EffectTask.run" returned from "\(fileID):\(line)" threw an unhandled error. …
 
                   \(errorDump)
 
                   All non-cancellation errors must be explicitly handled via the "catch" parameter \
-                  on "Effect.run", or via a "do" block.
+                  on "EffectTask.run", or via a "do" block.
                   """,
                   file: file,
                   line: line
@@ -285,7 +289,7 @@ extension Effect where Failure == Never {
 }
 
 /// A type that can send actions back into the system when used from
-/// ``Effect/run(priority:operation:catch:file:fileID:line:)``.
+/// ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)``.
 ///
 /// This type implements [`callAsFunction`][callAsFunction] so that you invoke it as a function
 /// rather than calling methods on it:
@@ -307,7 +311,7 @@ extension Effect where Failure == Never {
 /// defer { send(.finished, animation: .default) }
 /// ```
 ///
-/// See ``Effect/run(priority:operation:catch:file:fileID:line:)`` for more information on how to
+/// See ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)`` for more information on how to
 /// use this value to construct effects that can emit any number of times in an asynchronous
 /// context.
 ///
@@ -343,7 +347,7 @@ public struct Send<Action> {
 
 // MARK: - Composing Effects
 
-extension Effect {
+extension EffectPublisher {
   /// Merges a variadic list of effects together into a single effect, which runs the effects at the
   /// same time.
   ///
@@ -457,7 +461,7 @@ extension Effect {
   /// - Returns: A publisher that uses the provided closure to map elements from the upstream effect
   ///   to new elements that it then publishes.
   @inlinable
-  public func map<T>(_ transform: @escaping (Action) -> T) -> Effect<T, Failure> {
+  public func map<T>(_ transform: @escaping (Action) -> T) -> EffectPublisher<T, Failure> {
     switch self.operation {
     case .none:
       return .none
@@ -485,7 +489,7 @@ extension Effect {
 
 // MARK: - Testing Effects
 
-extension Effect {
+extension EffectPublisher {
   /// An effect that causes a test to fail if it runs.
   ///
   /// > Important: This Combine-based interface has been soft-deprecated in favor of Swift
@@ -532,7 +536,7 @@ extension Effect {
   ///
   /// ```swift
   /// struct CounterEnvironment {
-  ///   let playAlertSound: () -> EffectTask<Never>
+  ///   let playAlertSound: () -> EffectPublisher<Never, Never>
   /// }
   /// ```
   ///

--- a/Sources/ComposableArchitecture/Effects/Animation.swift
+++ b/Sources/ComposableArchitecture/Effects/Animation.swift
@@ -1,7 +1,7 @@
 import Combine
 import SwiftUI
 
-extension Effect {
+extension EffectPublisher {
   /// Wraps the emission of each element with SwiftUI's `withAnimation`.
   ///
   /// ```swift

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -1,12 +1,12 @@
 import Combine
 import Foundation
 
-extension Effect {
+extension EffectPublisher {
   /// Turns an effect into one that is capable of being canceled.
   ///
   /// To turn an effect into a cancellable one you must provide an identifier, which is used in
-  /// ``Effect/cancel(id:)-iun1`` to identify which in-flight effect should be canceled. Any
-  /// hashable value can be used for the identifier, such as a string, but you can add a bit of
+  /// ``EffectPublisher/cancel(id:)-iun1`` to identify which in-flight effect should be canceled.
+  /// Any hashable value can be used for the identifier, such as a string, but you can add a bit of
   /// protection against typos by defining a new type for the identifier:
   ///
   /// ```swift
@@ -93,8 +93,8 @@ extension Effect {
 
   /// Turns an effect into one that is capable of being canceled.
   ///
-  /// A convenience for calling ``Effect/cancellable(id:cancelInFlight:)-17skv`` with a static type
-  /// as the effect's unique identifier.
+  /// A convenience for calling ``EffectPublisher/cancellable(id:cancelInFlight:)-17skv`` with a
+  /// static type as the effect's unique identifier.
   ///
   /// - Parameters:
   ///   - id: A unique type identifying the effect.
@@ -120,8 +120,8 @@ extension Effect {
 
   /// An effect that will cancel any currently in-flight effect with the given identifier.
   ///
-  /// A convenience for calling ``Effect/cancel(id:)-iun1`` with a static type as the effect's
-  /// unique identifier.
+  /// A convenience for calling ``EffectPublisher/cancel(id:)-iun1`` with a static type as the
+  /// effect's unique identifier.
   ///
   /// - Parameter id: A unique type identifying the effect.
   /// - Returns: A new effect that will cancel any currently in-flight effect with the given
@@ -136,19 +136,19 @@ extension Effect {
   /// - Returns: A new effect that will cancel any currently in-flight effects with the given
   ///   identifiers.
   public static func cancel(ids: [AnyHashable]) -> Self {
-    .merge(ids.map(Effect.cancel(id:)))
+    .merge(ids.map(EffectPublisher.cancel(id:)))
   }
 
   /// An effect that will cancel multiple currently in-flight effects with the given identifiers.
   ///
-  /// A convenience for calling ``Effect/cancel(ids:)-dmwy`` with a static type as the effect's
-  /// unique identifier.
+  /// A convenience for calling ``EffectPublisher/cancel(ids:)-dmwy`` with a static type as the
+  /// effect's unique identifier.
   ///
   /// - Parameter ids: An array of unique types identifying the effects.
   /// - Returns: A new effect that will cancel any currently in-flight effects with the given
   ///   identifiers.
   public static func cancel(ids: [Any.Type]) -> Self {
-    .merge(ids.map(Effect.cancel(id:)))
+    .merge(ids.map(EffectPublisher.cancel(id:)))
   }
 }
 

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -5,7 +5,7 @@ extension EffectPublisher {
   /// Turns an effect into one that is capable of being canceled.
   ///
   /// To turn an effect into a cancellable one you must provide an identifier, which is used in
-  /// ``EffectPublisher/cancel(id:)-iun1`` to identify which in-flight effect should be canceled.
+  /// ``EffectPublisher/cancel(id:)-6hzsl`` to identify which in-flight effect should be canceled.
   /// Any hashable value can be used for the identifier, such as a string, but you can add a bit of
   /// protection against typos by defining a new type for the identifier:
   ///
@@ -93,7 +93,7 @@ extension EffectPublisher {
 
   /// Turns an effect into one that is capable of being canceled.
   ///
-  /// A convenience for calling ``EffectPublisher/cancellable(id:cancelInFlight:)-17skv`` with a
+  /// A convenience for calling ``EffectPublisher/cancellable(id:cancelInFlight:)-29q60`` with a
   /// static type as the effect's unique identifier.
   ///
   /// - Parameters:
@@ -120,7 +120,7 @@ extension EffectPublisher {
 
   /// An effect that will cancel any currently in-flight effect with the given identifier.
   ///
-  /// A convenience for calling ``EffectPublisher/cancel(id:)-iun1`` with a static type as the
+  /// A convenience for calling ``EffectPublisher/cancel(id:)-6hzsl`` with a static type as the
   /// effect's unique identifier.
   ///
   /// - Parameter id: A unique type identifying the effect.
@@ -141,7 +141,7 @@ extension EffectPublisher {
 
   /// An effect that will cancel multiple currently in-flight effects with the given identifiers.
   ///
-  /// A convenience for calling ``EffectPublisher/cancel(ids:)-dmwy`` with a static type as the
+  /// A convenience for calling ``EffectPublisher/cancel(ids:)-1cqqx`` with a static type as the
   /// effect's unique identifier.
   ///
   /// - Parameter ids: An array of unique types identifying the effects.

--- a/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift
+++ b/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift
@@ -264,7 +264,7 @@ extension Task where Success == Never, Failure == Never {
 /// ```swift
 /// @Dependency(\.analytics) var analytics
 ///
-/// func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+/// func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
 ///   switch action {
 ///   case .buttonTapped:
 ///     return .fireAndForget { try await self.analytics.track("Button Tapped") }

--- a/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift
+++ b/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift
@@ -264,7 +264,7 @@ extension Task where Success == Never, Failure == Never {
 /// ```swift
 /// @Dependency(\.analytics) var analytics
 ///
-/// func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+/// func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
 ///   switch action {
 ///   case .buttonTapped:
 ///     return .fireAndForget { try await self.analytics.track("Button Tapped") }

--- a/Sources/ComposableArchitecture/Effects/Publisher.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher.swift
@@ -4,7 +4,7 @@ import Combine
 @available(macOS, deprecated: 9999.0)
 @available(tvOS, deprecated: 9999.0)
 @available(watchOS, deprecated: 9999.0)
-extension Effect: Publisher {
+extension EffectPublisher: Publisher {
   public typealias Output = Action
 
   public func receive<S: Combine.Subscriber>(
@@ -34,13 +34,14 @@ extension Effect: Publisher {
   }
 }
 
-extension Effect {
+extension EffectPublisher {
   /// Initializes an effect that wraps a publisher.
   ///
   /// > Important: This Combine interface has been soft-deprecated in favor of Swift concurrency.
   /// > Prefer performing asynchronous work directly in
-  /// > ``Effect/run(priority:operation:catch:file:fileID:line:)`` by adopting a non-Combine
-  /// > interface, or by iterating over the publisher's asynchronous sequence of `values`:
+  /// > ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)`` by adopting a
+  /// > non-Combine interface, or by iterating over the publisher's asynchronous sequence of
+  /// > `values`:
   /// >
   /// > ```swift
   /// > return .run { send in
@@ -52,19 +53,20 @@ extension Effect {
   ///
   /// - Parameter publisher: A publisher.
   @available(
-    iOS, deprecated: 9999.0, message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    iOS, deprecated: 9999.0,
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     macOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     tvOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     watchOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   public init<P: Publisher>(_ publisher: P) where P.Output == Output, P.Failure == Failure {
     self.operation = .publisher(publisher.eraseToAnyPublisher())
@@ -73,10 +75,10 @@ extension Effect {
   /// Initializes an effect that immediately emits the value passed in.
   ///
   /// - Parameter value: The value that is immediately emitted by the effect.
-  @available(iOS, deprecated: 9999.0, message: "Wrap the value in 'Effect.task', instead.")
-  @available(macOS, deprecated: 9999.0, message: "Wrap the value in 'Effect.task', instead.")
-  @available(tvOS, deprecated: 9999.0, message: "Wrap the value in 'Effect.task', instead.")
-  @available(watchOS, deprecated: 9999.0, message: "Wrap the value in 'Effect.task', instead.")
+  @available(iOS, deprecated: 9999.0, message: "Wrap the value in 'EffectTask.task', instead.")
+  @available(macOS, deprecated: 9999.0, message: "Wrap the value in 'EffectTask.task', instead.")
+  @available(tvOS, deprecated: 9999.0, message: "Wrap the value in 'EffectTask.task', instead.")
+  @available(watchOS, deprecated: 9999.0, message: "Wrap the value in 'EffectTask.task', instead.")
   public init(value: Action) {
     self.init(Just(value).setFailureType(to: Failure.self))
   }
@@ -86,19 +88,19 @@ extension Effect {
   /// - Parameter error: The error that is immediately emitted by the effect.
   @available(
     iOS, deprecated: 9999.0,
-    message: "Throw and catch errors directly in 'Effect.task' and 'Effect.run', instead."
+    message: "Throw and catch errors directly in 'EffectTask.task' and 'EffectTask.run', instead."
   )
   @available(
     macOS, deprecated: 9999.0,
-    message: "Throw and catch errors directly in 'Effect.task' and 'Effect.run', instead."
+    message: "Throw and catch errors directly in 'EffectTask.task' and 'EffectTask.run', instead."
   )
   @available(
     tvOS, deprecated: 9999.0,
-    message: "Throw and catch errors directly in 'Effect.task' and 'Effect.run', instead."
+    message: "Throw and catch errors directly in 'EffectTask.task' and 'EffectTask.run', instead."
   )
   @available(
     watchOS, deprecated: 9999.0,
-    message: "Throw and catch errors directly in 'Effect.task' and 'Effect.run', instead."
+    message: "Throw and catch errors directly in 'EffectTask.task' and 'EffectTask.run', instead."
   )
   public init(error: Failure) {
     // NB: Ideally we'd return a `Fail` publisher here, but due to a bug in iOS 13 that publisher
@@ -115,12 +117,12 @@ extension Effect {
   /// Creates an effect that can supply a single value asynchronously in the future.
   ///
   /// This can be helpful for converting APIs that are callback-based into ones that deal with
-  /// ``Effect``s.
+  /// ``EffectPublisher``s.
   ///
   /// For example, to create an effect that delivers an integer after waiting a second:
   ///
   /// ```swift
-  /// EffectTask<Int>.future { callback in
+  /// EffectPublisher<Int, Never>.future { callback in
   ///   DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
   ///     callback(.success(42))
   ///   }
@@ -131,7 +133,7 @@ extension Effect {
   /// discarded:
   ///
   /// ```swift
-  /// EffectTask<Int>.future { callback in
+  /// EffectPublisher<Int, Never>.future { callback in
   ///   DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
   ///     callback(.success(42))
   ///     callback(.success(1729)) // Will not be emitted by the effect
@@ -139,15 +141,15 @@ extension Effect {
   /// }
   /// ```
   ///
-  ///  If you need to deliver more than one value to the effect, you should use the ``Effect``
-  ///  initializer that accepts a ``Subscriber`` value.
+  ///  If you need to deliver more than one value to the effect, you should use the
+  ///  ``EffectPublisher`` initializer that accepts a ``Subscriber`` value.
   ///
   /// - Parameter attemptToFulfill: A closure that takes a `callback` as an argument which can be
   ///   used to feed it `Result<Output, Failure>` values.
-  @available(iOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
-  @available(macOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
-  @available(tvOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
-  @available(watchOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
+  @available(iOS, deprecated: 9999.0, message: "Use 'EffectTask.task', instead.")
+  @available(macOS, deprecated: 9999.0, message: "Use 'EffectTask.task', instead.")
+  @available(tvOS, deprecated: 9999.0, message: "Use 'EffectTask.task', instead.")
+  @available(watchOS, deprecated: 9999.0, message: "Use 'EffectTask.task', instead.")
   public static func future(
     _ attemptToFulfill: @escaping (@escaping (Result<Action, Failure>) -> Void) -> Void
   ) -> Self {
@@ -165,7 +167,7 @@ extension Effect {
   /// For example, to load a user from some JSON on the disk, one can wrap that work in an effect:
   ///
   /// ```swift
-  /// Effect<User, Error>.result {
+  /// EffectPublisher<User, Error>.result {
   ///   let fileUrl = URL(
   ///     fileURLWithPath: NSSearchPathForDirectoriesInDomains(
   ///       .documentDirectory, .userDomainMask, true
@@ -184,10 +186,10 @@ extension Effect {
   ///
   /// - Parameter attemptToFulfill: A closure encapsulating some work to execute in the real world.
   /// - Returns: An effect.
-  @available(iOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
-  @available(macOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
-  @available(tvOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
-  @available(watchOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
+  @available(iOS, deprecated: 9999.0, message: "Use 'EffectTask.task', instead.")
+  @available(macOS, deprecated: 9999.0, message: "Use 'EffectTask.task', instead.")
+  @available(tvOS, deprecated: 9999.0, message: "Use 'EffectTask.task', instead.")
+  @available(watchOS, deprecated: 9999.0, message: "Use 'EffectTask.task', instead.")
   public static func result(_ attemptToFulfill: @escaping () -> Result<Action, Failure>) -> Self {
     .future { $0(attemptToFulfill()) }
   }
@@ -196,15 +198,15 @@ extension Effect {
   /// a completion.
   ///
   /// This initializer is useful for bridging callback APIs, delegate APIs, and manager APIs to the
-  /// ``Effect`` type. One can wrap those APIs in an Effect so that its events are sent through the
-  /// effect, which allows the reducer to handle them.
+  /// ``EffectPublisher`` type. One can wrap those APIs in an Effect so that its events are sent
+  /// through the effect, which allows the reducer to handle them.
   ///
   /// For example, one can create an effect to ask for access to `MPMediaLibrary`. It can start by
   /// sending the current status immediately, and then if the current status is `notDetermined` it
   /// can request authorization, and once a status is received it can send that back to the effect:
   ///
   /// ```swift
-  /// Effect.run { subscriber in
+  /// EffectPublisher.run { subscriber in
   ///   subscriber.send(MPMediaLibrary.authorizationStatus())
   ///
   ///   guard MPMediaLibrary.authorizationStatus() == .notDetermined else {
@@ -224,16 +226,22 @@ extension Effect {
   /// ```
   ///
   /// - Parameter work: A closure that accepts a ``Subscriber`` value and returns a cancellable.
-  ///   When the ``Effect`` is completed, the cancellable will be used to clean up any resources
-  ///   created when the effect was started.
-  @available(iOS, deprecated: 9999.0, message: "Use the async version of 'Effect.run', instead.")
-  @available(macOS, deprecated: 9999.0, message: "Use the async version of 'Effect.run', instead.")
-  @available(tvOS, deprecated: 9999.0, message: "Use the async version of 'Effect.run', instead.")
+  ///   When the ``EffectPublisher`` is completed, the cancellable will be used to clean up any
+  ///   resources created when the effect was started.
+  @available(
+    iOS, deprecated: 9999.0, message: "Use the async version of 'EffectTask.run', instead."
+  )
+  @available(
+    macOS, deprecated: 9999.0, message: "Use the async version of 'EffectTask.run', instead."
+  )
+  @available(
+    tvOS, deprecated: 9999.0, message: "Use the async version of 'EffectTask.run', instead."
+  )
   @available(
     watchOS, deprecated: 9999.0, message: "Use the async version of 'Effect.run', instead."
   )
   public static func run(
-    _ work: @escaping (Effect.Subscriber) -> Cancellable
+    _ work: @escaping (EffectPublisher.Subscriber) -> Cancellable
   ) -> Self {
     let dependencies = DependencyValues._current
     return AnyPublisher.create { subscriber in
@@ -272,14 +280,14 @@ extension Effect {
   }
 }
 
-extension Effect where Failure == Error {
+extension EffectPublisher where Failure == Error {
   /// Initializes an effect that lazily executes some work in the real world and synchronously sends
   /// that data back into the store.
   ///
   /// For example, to load a user from some JSON on the disk, one can wrap that work in an effect:
   ///
   /// ```swift
-  /// Effect<User, Error>.catching {
+  /// EffectPublisher<User, Error>.catching {
   ///   let fileUrl = URL(
   ///     fileURLWithPath: NSSearchPathForDirectoriesInDomains(
   ///       .documentDirectory, .userDomainMask, true
@@ -296,19 +304,19 @@ extension Effect where Failure == Error {
   /// - Returns: An effect.
   @available(
     iOS, deprecated: 9999.0,
-    message: "Throw and catch errors directly in 'Effect.task' and 'Effect.run', instead."
+    message: "Throw and catch errors directly in 'EffectTask.task' and 'EffectTask.run', instead."
   )
   @available(
     macOS, deprecated: 9999.0,
-    message: "Throw and catch errors directly in 'Effect.task' and 'Effect.run', instead."
+    message: "Throw and catch errors directly in 'EffectTask.task' and 'EffectTask.run', instead."
   )
   @available(
     tvOS, deprecated: 9999.0,
-    message: "Throw and catch errors directly in 'Effect.task' and 'Effect.run', instead."
+    message: "Throw and catch errors directly in 'EffectTask.task' and 'EffectTask.run', instead."
   )
   @available(
     watchOS, deprecated: 9999.0,
-    message: "Throw and catch errors directly in 'Effect.task' and 'Effect.run', instead."
+    message: "Throw and catch errors directly in 'EffectTask.task' and 'EffectTask.run', instead."
   )
   public static func catching(_ work: @escaping () throws -> Action) -> Self {
     .future { $0(Result { try work() }) }
@@ -316,7 +324,7 @@ extension Effect where Failure == Error {
 }
 
 extension Publisher {
-  /// Turns any publisher into an ``Effect``.
+  /// Turns any publisher into an ``EffectPublisher``.
   ///
   /// This can be useful for when you perform a chain of publisher transformations in a reducer, and
   /// you need to convert that publisher to an effect so that you can return it from the reducer:
@@ -330,28 +338,29 @@ extension Publisher {
   ///
   /// - Returns: An effect that wraps `self`.
   @available(
-    iOS, deprecated: 9999.0, message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    iOS, deprecated: 9999.0,
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     macOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     tvOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     watchOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
-  public func eraseToEffect() -> Effect<Output, Failure> {
-    Effect(self)
+  public func eraseToEffect() -> EffectPublisher<Output, Failure> {
+    EffectPublisher(self)
   }
 
-  /// Turns any publisher into an ``Effect``.
+  /// Turns any publisher into an ``EffectPublisher``.
   ///
-  /// This is a convenience operator for writing ``Effect/eraseToEffect()`` followed by
-  /// ``Effect/map(_:)-28ghh`.
+  /// This is a convenience operator for writing ``EffectPublisher/eraseToEffect()`` followed by
+  /// ``EffectPublisher/map(_:)-28ghh`.
   ///
   /// ```swift
   /// case .buttonTapped:
@@ -364,29 +373,30 @@ extension Publisher {
   ///   - transform: A mapping function that converts `Output` to another type.
   /// - Returns: An effect that wraps `self` after mapping `Output` values.
   @available(
-    iOS, deprecated: 9999.0, message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    iOS, deprecated: 9999.0,
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     macOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     tvOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     watchOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   public func eraseToEffect<T>(
     _ transform: @escaping (Output) -> T
-  ) -> Effect<T, Failure> {
+  ) -> EffectPublisher<T, Failure> {
     self.map(transform)
       .eraseToEffect()
   }
 
-  /// Turns any publisher into an ``Effect`` that cannot fail by wrapping its output and failure in
-  /// a result.
+  /// Turns any publisher into an ``EffectTask`` that cannot fail by wrapping its output and failure
+  /// in a result.
   ///
   /// This can be useful when you are working with a failing API but want to deliver its data to an
   /// action that handles both success and failure.
@@ -400,29 +410,30 @@ extension Publisher {
   ///
   /// - Returns: An effect that wraps `self`.
   @available(
-    iOS, deprecated: 9999.0, message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    iOS, deprecated: 9999.0,
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     macOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     tvOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     watchOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   public func catchToEffect() -> EffectTask<Result<Output, Failure>> {
     self.catchToEffect { $0 }
   }
 
-  /// Turns any publisher into an ``Effect`` that cannot fail by wrapping its output and failure
+  /// Turns any publisher into an ``EffectTask`` that cannot fail by wrapping its output and failure
   /// into a result and then applying passed in function to it.
   ///
-  /// This is a convenience operator for writing ``Effect/eraseToEffect()`` followed by
-  /// ``Effect/map(_:)-28ghh`.
+  /// This is a convenience operator for writing ``EffectPublisher/eraseToEffect()`` followed by
+  /// ``EffectPublisher/map(_:)-28ghh`.
   ///
   /// ```swift
   /// case .buttonTapped:
@@ -434,19 +445,20 @@ extension Publisher {
   ///   - transform: A mapping function that converts `Result<Output,Failure>` to another type.
   /// - Returns: An effect that wraps `self`.
   @available(
-    iOS, deprecated: 9999.0, message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    iOS, deprecated: 9999.0,
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     macOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     tvOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     watchOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   public func catchToEffect<T>(
     _ transform: @escaping (Result<Output, Failure>) -> T
@@ -464,8 +476,8 @@ extension Publisher {
       .eraseToEffect()
   }
 
-  /// Turns any publisher into an ``Effect`` for any output and failure type by ignoring all output
-  /// and any failure.
+  /// Turns any publisher into an ``EffectPublisher`` for any output and failure type by ignoring
+  /// all output and any failure.
   ///
   /// This is useful for times you want to fire off an effect but don't want to feed any data back
   /// into the system. It can automatically promote an effect to your reducer's domain.
@@ -503,7 +515,7 @@ extension Publisher {
   public func fireAndForget<NewOutput, NewFailure>(
     outputType: NewOutput.Type = NewOutput.self,
     failureType: NewFailure.Type = NewFailure.self
-  ) -> Effect<NewOutput, NewFailure> {
+  ) -> EffectPublisher<NewOutput, NewFailure> {
     return
       self
       .flatMap { _ in Empty<NewOutput, Failure>() }

--- a/Sources/ComposableArchitecture/Effects/Publisher.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher.swift
@@ -120,7 +120,7 @@ extension Effect {
   /// For example, to create an effect that delivers an integer after waiting a second:
   ///
   /// ```swift
-  /// Effect<Int, Never>.future { callback in
+  /// EffectOf<Int>.future { callback in
   ///   DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
   ///     callback(.success(42))
   ///   }
@@ -131,7 +131,7 @@ extension Effect {
   /// discarded:
   ///
   /// ```swift
-  /// Effect<Int, Never>.future { callback in
+  /// EffectOf<Int>.future { callback in
   ///   DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
   ///     callback(.success(42))
   ///     callback(.success(1729)) // Will not be emitted by the effect
@@ -414,7 +414,7 @@ extension Publisher {
     watchOS, deprecated: 9999.0,
     message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
   )
-  public func catchToEffect() -> Effect<Result<Output, Failure>, Never> {
+  public func catchToEffect() -> EffectOf<Result<Output, Failure>> {
     self.catchToEffect { $0 }
   }
 
@@ -450,7 +450,7 @@ extension Publisher {
   )
   public func catchToEffect<T>(
     _ transform: @escaping (Result<Output, Failure>) -> T
-  ) -> Effect<T, Never> {
+  ) -> EffectOf<T> {
     let dependencies = DependencyValues._current
     let transform = { action in
       DependencyValues.$_current.withValue(dependencies) {

--- a/Sources/ComposableArchitecture/Effects/Publisher.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher.swift
@@ -120,7 +120,7 @@ extension Effect {
   /// For example, to create an effect that delivers an integer after waiting a second:
   ///
   /// ```swift
-  /// EffectOf<Int>.future { callback in
+  /// EffectTask<Int>.future { callback in
   ///   DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
   ///     callback(.success(42))
   ///   }
@@ -131,7 +131,7 @@ extension Effect {
   /// discarded:
   ///
   /// ```swift
-  /// EffectOf<Int>.future { callback in
+  /// EffectTask<Int>.future { callback in
   ///   DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
   ///     callback(.success(42))
   ///     callback(.success(1729)) // Will not be emitted by the effect
@@ -414,7 +414,7 @@ extension Publisher {
     watchOS, deprecated: 9999.0,
     message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
   )
-  public func catchToEffect() -> EffectOf<Result<Output, Failure>> {
+  public func catchToEffect() -> EffectTask<Result<Output, Failure>> {
     self.catchToEffect { $0 }
   }
 
@@ -450,7 +450,7 @@ extension Publisher {
   )
   public func catchToEffect<T>(
     _ transform: @escaping (Result<Output, Failure>) -> T
-  ) -> EffectOf<T> {
+  ) -> EffectTask<T> {
     let dependencies = DependencyValues._current
     let transform = { action in
       DependencyValues.$_current.withValue(dependencies) {

--- a/Sources/ComposableArchitecture/Effects/Publisher/Debouncing.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Debouncing.swift
@@ -1,6 +1,6 @@
 import Combine
 
-extension Effect {
+extension EffectPublisher {
   /// Turns an effect into one that can be debounced.
   ///
   /// To turn an effect into a debounce-able one you must provide an identifier, which is used to
@@ -27,22 +27,22 @@ extension Effect {
   @available(
     iOS,
     deprecated: 9999.0,
-    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'Effect.run', instead."
+    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'EffectTask.run', instead."
   )
   @available(
     macOS,
     deprecated: 9999.0,
-    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'Effect.run', instead."
+    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'EffectTask.run', instead."
   )
   @available(
     tvOS,
     deprecated: 9999.0,
-    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'Effect.run', instead."
+    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'EffectTask.run', instead."
   )
   @available(
     watchOS,
     deprecated: 9999.0,
-    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'Effect.run', instead."
+    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'EffectTask.run', instead."
   )
   public func debounce<S: Scheduler>(
     id: AnyHashable,
@@ -69,8 +69,8 @@ extension Effect {
 
   /// Turns an effect into one that can be debounced.
   ///
-  /// A convenience for calling ``Effect/debounce(id:for:scheduler:options:)-76yye`` with a static
-  /// type as the effect's unique identifier.
+  /// A convenience for calling ``EffectPublisher/debounce(id:for:scheduler:options:)-76yye`` with a
+  /// static type as the effect's unique identifier.
   ///
   /// - Parameters:
   ///   - id: A unique type identifying the effect.

--- a/Sources/ComposableArchitecture/Effects/Publisher/Debouncing.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Debouncing.swift
@@ -69,7 +69,7 @@ extension EffectPublisher {
 
   /// Turns an effect into one that can be debounced.
   ///
-  /// A convenience for calling ``EffectPublisher/debounce(id:for:scheduler:options:)-76yye`` with a
+  /// A convenience for calling ``EffectPublisher/debounce(id:for:scheduler:options:)-1xdnj`` with a
   /// static type as the effect's unique identifier.
   ///
   /// - Parameters:

--- a/Sources/ComposableArchitecture/Effects/Publisher/Deferring.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Deferring.swift
@@ -1,6 +1,6 @@
 import Combine
 
-extension Effect {
+extension EffectPublisher {
   /// Returns an effect that will be executed after given `dueTime`.
   ///
   /// ```swift
@@ -15,11 +15,17 @@ extension Effect {
   ///   - scheduler: The scheduler you want to deliver the defer output to.
   ///   - options: Scheduler options that customize the effect's delivery of elements.
   /// - Returns: An effect that will be executed after `dueTime`
-  @available(iOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'Effect.run', instead.")
-  @available(macOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'Effect.run', instead.")
-  @available(tvOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'Effect.run', instead.")
   @available(
-    watchOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'Effect.run', instead."
+    iOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'EffectTask.run', instead."
+  )
+  @available(
+    macOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'EffectTask.run', instead."
+  )
+  @available(
+    tvOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'EffectTask.run', instead."
+  )
+  @available(
+    watchOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'EffectTask.run', instead."
   )
   public func deferred<S: Scheduler>(
     for dueTime: S.SchedulerTimeType.Stride,

--- a/Sources/ComposableArchitecture/Effects/Publisher/Throttling.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Throttling.swift
@@ -67,7 +67,7 @@ extension EffectPublisher {
 
   /// Throttles an effect so that it only publishes one output per given interval.
   ///
-  /// A convenience for calling ``EffectPublisher/throttle(id:for:scheduler:latest:)-5jfpx`` with a
+  /// A convenience for calling ``EffectPublisher/throttle(id:for:scheduler:latest:)-3gibe`` with a
   /// static type as the effect's unique identifier.
   ///
   /// - Parameters:

--- a/Sources/ComposableArchitecture/Effects/Publisher/Throttling.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Throttling.swift
@@ -2,7 +2,7 @@ import Combine
 import Dispatch
 import Foundation
 
-extension Effect {
+extension EffectPublisher {
   /// Throttles an effect so that it only publishes one output per given interval.
   ///
   /// - Parameters:
@@ -67,8 +67,8 @@ extension Effect {
 
   /// Throttles an effect so that it only publishes one output per given interval.
   ///
-  /// A convenience for calling ``Effect/throttle(id:for:scheduler:latest:)-5jfpx`` with a static
-  /// type as the effect's unique identifier.
+  /// A convenience for calling ``EffectPublisher/throttle(id:for:scheduler:latest:)-5jfpx`` with a
+  /// static type as the effect's unique identifier.
   ///
   /// - Parameters:
   ///   - id: The effect's identifier.

--- a/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
@@ -1,7 +1,7 @@
 import Combine
 import CombineSchedulers
 
-extension Effect where Failure == Never {
+extension EffectPublisher where Failure == Never {
   /// Returns an effect that repeatedly emits the current time of the given scheduler on the given
   /// interval.
   ///
@@ -15,12 +15,12 @@ extension Effect where Failure == Never {
   /// we can see how effects emit. However, because `Timer.publish` takes a concrete `RunLoop` as
   /// its scheduler, we can't substitute in a `TestScheduler` during tests`.
   ///
-  /// That is why we provide `Effect.timer`. It allows you to create a timer that works with any
+  /// That is why we provide `EffectTask.timer`. It allows you to create a timer that works with any
   /// scheduler, not just a run loop, which means you can use a `DispatchQueue` or `RunLoop` when
   /// running your live app, but use a `TestScheduler` in tests.
   ///
   /// To start and stop a timer in your feature you can create the timer effect from an action
-  /// and then use the ``Effect/cancel(id:)-iun1`` effect to stop the timer:
+  /// and then use the ``EffectPublisher/cancel(id:)-iun1`` effect to stop the timer:
   ///
   /// ```swift
   /// struct Feature: ReducerProtocol {
@@ -32,7 +32,7 @@ extension Effect where Failure == Never {
   ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
   ///     switch action {
   ///     case .startButtonTapped:
-  ///       return Effect.timer(id: TimerID(), every: 1, on: self.mainQueue)
+  ///       return EffectTask.timer(id: TimerID(), every: 1, on: self.mainQueue)
   ///         .map { _ in .timerTicked }
   ///
   ///     case .stopButtonTapped:
@@ -89,11 +89,17 @@ extension Effect where Failure == Never {
   ///   - tolerance: The allowed timing variance when emitting events. Defaults to `nil`, which
   ///     allows any variance.
   ///   - options: Scheduler options passed to the timer. Defaults to `nil`.
-  @available(iOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead.")
-  @available(macOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead.")
-  @available(tvOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead.")
   @available(
-    watchOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead."
+    iOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'EffectTask.run', instead."
+  )
+  @available(
+    macOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'EffectTask.run', instead."
+  )
+  @available(
+    tvOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'EffectTask.run', instead."
+  )
+  @available(
+    watchOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'EffectTask.run', instead."
   )
   public static func timer<S: Scheduler>(
     id: AnyHashable,
@@ -112,8 +118,8 @@ extension Effect where Failure == Never {
   /// Returns an effect that repeatedly emits the current time of the given scheduler on the given
   /// interval.
   ///
-  /// A convenience for calling ``Effect/timer(id:every:tolerance:on:options:)-4exe6`` with a
-  /// static type as the effect's unique identifier.
+  /// A convenience for calling ``EffectPublisher/timer(id:every:tolerance:on:options:)-4exe6`` with
+  /// a static type as the effect's unique identifier.
   ///
   /// - Parameters:
   ///   - id: A unique type identifying the effect.
@@ -123,11 +129,17 @@ extension Effect where Failure == Never {
   ///   - tolerance: The allowed timing variance when emitting events. Defaults to `nil`, which
   ///     allows any variance.
   ///   - options: Scheduler options passed to the timer. Defaults to `nil`.
-  @available(iOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead.")
-  @available(macOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead.")
-  @available(tvOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead.")
   @available(
-    watchOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead."
+    iOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'EffectTask.run', instead."
+  )
+  @available(
+    macOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'EffectTask.run', instead."
+  )
+  @available(
+    tvOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'EffectTask.run', instead."
+  )
+  @available(
+    watchOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'EffectTask.run', instead."
   )
   public static func timer<S: Scheduler>(
     id: Any.Type,

--- a/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
@@ -29,7 +29,7 @@ extension Effect where Failure == Never {
   ///   @Dependency(\.mainQueue) var mainQueue
   ///   struct TimerID: Hashable {}
   ///
-  ///   func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
   ///     switch action {
   ///     case .startButtonTapped:
   ///       return Effect.timer(id: TimerID(), every: 1, on: self.mainQueue)

--- a/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
@@ -20,7 +20,7 @@ extension EffectPublisher where Failure == Never {
   /// running your live app, but use a `TestScheduler` in tests.
   ///
   /// To start and stop a timer in your feature you can create the timer effect from an action
-  /// and then use the ``EffectPublisher/cancel(id:)-iun1`` effect to stop the timer:
+  /// and then use the ``EffectPublisher/cancel(id:)-6hzsl`` effect to stop the timer:
   ///
   /// ```swift
   /// struct Feature: ReducerProtocol {
@@ -118,7 +118,7 @@ extension EffectPublisher where Failure == Never {
   /// Returns an effect that repeatedly emits the current time of the given scheduler on the given
   /// interval.
   ///
-  /// A convenience for calling ``EffectPublisher/timer(id:every:tolerance:on:options:)-4exe6`` with
+  /// A convenience for calling ``EffectPublisher/timer(id:every:tolerance:on:options:)-6yv2m`` with
   /// a static type as the effect's unique identifier.
   ///
   /// - Parameters:

--- a/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
@@ -29,7 +29,7 @@ extension Effect where Failure == Never {
   ///   @Dependency(\.mainQueue) var mainQueue
   ///   struct TimerID: Hashable {}
   ///
-  ///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
   ///     switch action {
   ///     case .startButtonTapped:
   ///       return Effect.timer(id: TimerID(), every: 1, on: self.mainQueue)

--- a/Sources/ComposableArchitecture/Effects/TaskResult.swift
+++ b/Sources/ComposableArchitecture/Effects/TaskResult.swift
@@ -31,9 +31,9 @@ import XCTestDynamicOverlay
 /// }
 /// ```
 ///
-/// And finally you can use ``Effect/task(priority:operation:catch:file:fileID:line:)`` to construct
-/// an effect in the reducer that invokes the `numberFact` endpoint and wraps its response in a
-/// ``TaskResult`` by using its catching initializer, ``TaskResult/init(catching:)``:
+/// And finally you can use ``EffectPublisher/task(priority:operation:catch:file:fileID:line:)`` to
+/// construct an effect in the reducer that invokes the `numberFact` endpoint and wraps its response
+/// in a ``TaskResult`` by using its catching initializer, ``TaskResult/init(catching:)``:
 ///
 /// ```swift
 /// case .factButtonTapped:

--- a/Sources/ComposableArchitecture/Internal/Create.swift
+++ b/Sources/ComposableArchitecture/Internal/Create.swift
@@ -105,13 +105,13 @@ final class DemandBuffer<S: Subscriber>: @unchecked Sendable {
 
 extension AnyPublisher {
   private init(
-    _ callback: @escaping (Effect<Output, Failure>.Subscriber) -> Cancellable
+    _ callback: @escaping (EffectPublisher<Output, Failure>.Subscriber) -> Cancellable
   ) {
     self = Publishers.Create(callback: callback).eraseToAnyPublisher()
   }
 
   static func create(
-    _ factory: @escaping (Effect<Output, Failure>.Subscriber) -> Cancellable
+    _ factory: @escaping (EffectPublisher<Output, Failure>.Subscriber) -> Cancellable
   ) -> AnyPublisher<Output, Failure> {
     AnyPublisher(factory)
   }
@@ -119,9 +119,9 @@ extension AnyPublisher {
 
 extension Publishers {
   fileprivate class Create<Output, Failure: Swift.Error>: Publisher {
-    private let callback: (Effect<Output, Failure>.Subscriber) -> Cancellable
+    private let callback: (EffectPublisher<Output, Failure>.Subscriber) -> Cancellable
 
-    init(callback: @escaping (Effect<Output, Failure>.Subscriber) -> Cancellable) {
+    init(callback: @escaping (EffectPublisher<Output, Failure>.Subscriber) -> Cancellable) {
       self.callback = callback
     }
 
@@ -138,7 +138,7 @@ extension Publishers.Create {
     private var cancellable: Cancellable?
 
     init(
-      callback: @escaping (Effect<Output, Failure>.Subscriber) -> Cancellable,
+      callback: @escaping (EffectPublisher<Output, Failure>.Subscriber) -> Cancellable,
       downstream: Downstream
     ) {
       self.buffer = DemandBuffer(subscriber: downstream)
@@ -169,7 +169,7 @@ extension Publishers.Create.Subscription: CustomStringConvertible {
   }
 }
 
-extension Effect {
+extension EffectPublisher {
   public struct Subscriber {
     private let _send: (Action) -> Void
     private let _complete: (Subscribers.Completion<Failure>) -> Void

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -464,19 +464,19 @@ extension TestStore {
 
 // MARK: - Deprecated after 0.38.2:
 
-extension Effect {
+extension EffectPublisher {
   @available(*, deprecated)
   public var upstream: AnyPublisher<Action, Failure> {
     self.publisher
   }
 }
 
-extension Effect where Failure == Error {
+extension EffectPublisher where Failure == Error {
   @_disfavoredOverload
   @available(
     *,
     deprecated,
-    message: "Use the non-failing version of 'Effect.task'"
+    message: "Use the non-failing version of 'EffectTask.task'"
   )
   public static func task(
     priority: TaskPriority? = nil,
@@ -534,7 +534,7 @@ extension Store {
 
 // MARK: - Deprecated after 0.38.0:
 
-extension Effect {
+extension EffectPublisher {
   @available(iOS, deprecated: 9999.0, renamed: "unimplemented")
   @available(macOS, deprecated: 9999.0, renamed: "unimplemented")
   @available(tvOS, deprecated: 9999.0, renamed: "unimplemented")
@@ -556,7 +556,7 @@ extension ViewStore {
 
 // MARK: - Deprecated after 0.34.0:
 
-extension Effect {
+extension EffectPublisher {
   @available(
     *,
     deprecated,

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
@@ -107,7 +107,7 @@ public typealias Reducer = AnyReducer
     """
 )
 public struct AnyReducer<State, Action, Environment> {
-  private let reducer: (inout State, Action, Environment) -> Effect<Action, Never>
+  private let reducer: (inout State, Action, Environment) -> EffectOf<Action>
 
   /// > This API has been soft-deprecated in favor of ``ReducerProtocol``.
   /// Read <doc:MigratingToTheReducerProtocol> for more information.
@@ -173,7 +173,7 @@ public struct AnyReducer<State, Action, Environment> {
       This API has been soft-deprecated in favor of 'ReducerProtocol'. Read the migration guide for more information: https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/reducerprotocol
       """
   )
-  public init(_ reducer: @escaping (inout State, Action, Environment) -> Effect<Action, Never>) {
+  public init(_ reducer: @escaping (inout State, Action, Environment) -> EffectOf<Action>) {
     self.reducer = reducer
   }
 
@@ -1230,7 +1230,7 @@ public struct AnyReducer<State, Action, Environment> {
     _ state: inout State,
     _ action: Action,
     _ environment: Environment
-  ) -> Effect<Action, Never> {
+  ) -> EffectOf<Action> {
     self.reducer(&state, action, environment)
   }
 
@@ -1272,7 +1272,7 @@ public struct AnyReducer<State, Action, Environment> {
     _ state: inout State,
     _ action: Action,
     _ environment: Environment
-  ) -> Effect<Action, Never> {
+  ) -> EffectOf<Action> {
     self.reducer(&state, action, environment)
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
@@ -107,7 +107,7 @@ public typealias Reducer = AnyReducer
     """
 )
 public struct AnyReducer<State, Action, Environment> {
-  private let reducer: (inout State, Action, Environment) -> EffectOf<Action>
+  private let reducer: (inout State, Action, Environment) -> EffectTask<Action>
 
   /// > This API has been soft-deprecated in favor of ``ReducerProtocol``.
   /// Read <doc:MigratingToTheReducerProtocol> for more information.
@@ -173,7 +173,7 @@ public struct AnyReducer<State, Action, Environment> {
       This API has been soft-deprecated in favor of 'ReducerProtocol'. Read the migration guide for more information: https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/reducerprotocol
       """
   )
-  public init(_ reducer: @escaping (inout State, Action, Environment) -> EffectOf<Action>) {
+  public init(_ reducer: @escaping (inout State, Action, Environment) -> EffectTask<Action>) {
     self.reducer = reducer
   }
 
@@ -1230,7 +1230,7 @@ public struct AnyReducer<State, Action, Environment> {
     _ state: inout State,
     _ action: Action,
     _ environment: Environment
-  ) -> EffectOf<Action> {
+  ) -> EffectTask<Action> {
     self.reducer(&state, action, environment)
   }
 
@@ -1272,7 +1272,7 @@ public struct AnyReducer<State, Action, Environment> {
     _ state: inout State,
     _ action: Action,
     _ environment: Environment
-  ) -> EffectOf<Action> {
+  ) -> EffectTask<Action> {
     self.reducer(&state, action, environment)
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
@@ -55,15 +55,15 @@ public typealias Reducer = AnyReducer
 /// Read <doc:MigratingToTheReducerProtocol> for more information.
 ///
 /// A reducer describes how to evolve the current state of an application to the next state, given
-/// an action, and describes what ``Effect``s should be executed later by the store, if any.
+/// an action, and describes what ``EffectTask``s should be executed later by the store, if any.
 ///
 /// Reducers have 3 generics:
 ///
 ///   * `State`: A type that holds the current state of the application.
 ///   * `Action`: A type that holds all possible actions that cause the state of the application to
 ///     change.
-///   * `Environment`: A type that holds all dependencies needed in order to produce ``Effect``s,
-///     such as API clients, analytics clients, random number generators, etc.
+///   * `Environment`: A type that holds all dependencies needed in order to produce
+///     ``EffectTask``s, such as API clients, analytics clients, random number generators, etc.
 ///
 /// > Important: The thread on which effects output is important. An effect's output is immediately
 ///   sent back into the store, and ``Store`` is not thread safe. This means all effects must
@@ -71,9 +71,10 @@ public typealias Reducer = AnyReducer
 ///   output must be on the main thread. You can use the `Publisher` method `receive(on:)` for make
 ///   the effect output its values on the thread of your choice.
 /// >
-/// > This is only an issue if using the Combine interface of ``Effect`` as mentioned above. If you
-///   you are only using Swift's concurrency tools and the `.task`, `.run` and `.fireAndForget`
-///   functions on ``Effect``, then the threading is automatically handled for you.
+/// > This is only an issue if using the Combine interface of ``EffectPublisher`` as mentioned
+///   above. If you are only using Swift's concurrency tools and the `.task`, `.run` and
+///   `.fireAndForget` functions on ``EffectTask``, then the threading is automatically handled for
+///   you.
 @available(
   iOS,
   deprecated: 9999.0,
@@ -117,7 +118,7 @@ public struct AnyReducer<State, Action, Environment> {
   /// The reducer takes three arguments: state, action and environment. The state is `inout` so that
   /// you can make any changes to it directly inline. The reducer must return an effect, which
   /// typically would be constructed by using the dependencies inside the `environment` value. If
-  /// no effect needs to be executed, a ``Effect/none`` effect can be returned.
+  /// no effect needs to be executed, a ``EffectPublisher/none`` effect can be returned.
   ///
   /// For example:
   ///

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
@@ -1185,7 +1185,7 @@ public struct AnyReducer<State, Action, Environment> {
     }
   }
 
-  /// This API has been soft-deprecated in favor of ``ReducerProtocol/reduce(into:action:)-4nzr2``.
+  /// This API has been soft-deprecated in favor of ``ReducerProtocol/reduce(into:action:)-8yinq``.
   /// Read <doc:MigratingToTheReducerProtocol> for more information.
   ///
   /// Runs the reducer.
@@ -1235,7 +1235,7 @@ public struct AnyReducer<State, Action, Environment> {
     self.reducer(&state, action, environment)
   }
 
-  /// This API has been soft-deprecated in favor of ``ReducerProtocol/reduce(into:action:)-4nzr2``.
+  /// This API has been soft-deprecated in favor of ``ReducerProtocol/reduce(into:action:)-8yinq``.
   /// Read <doc:MigratingToTheReducerProtocol> for more information.
   @available(
     iOS,

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerSignpost.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerSignpost.swift
@@ -85,7 +85,7 @@ extension AnyReducer {
   }
 }
 
-extension Effect where Failure == Never {
+extension EffectPublisher where Failure == Never {
   @usableFromInline
   func effectSignpost(
     _ prefix: String,

--- a/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
+++ b/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
@@ -98,7 +98,7 @@ public enum ReducerBuilder<State, Action> {
     case second(Second)
 
     @inlinable
-    public func reduce(into state: inout First.State, action: First.Action) -> EffectOf<
+    public func reduce(into state: inout First.State, action: First.Action) -> EffectTask<
       First.Action
     > {
       switch self {
@@ -123,7 +123,7 @@ public enum ReducerBuilder<State, Action> {
     @inlinable
     public func reduce(
       into state: inout Wrapped.State, action: Wrapped.Action
-    ) -> EffectOf<Wrapped.Action> {
+    ) -> EffectTask<Wrapped.Action> {
       switch wrapped {
       case let .some(wrapped):
         return wrapped.reduce(into: &state, action: action)
@@ -148,7 +148,7 @@ public enum ReducerBuilder<State, Action> {
     }
 
     @inlinable
-    public func reduce(into state: inout R0.State, action: R0.Action) -> EffectOf<R0.Action> {
+    public func reduce(into state: inout R0.State, action: R0.Action) -> EffectTask<R0.Action> {
       self.r0.reduce(into: &state, action: action)
         .merge(with: self.r1.reduce(into: &state, action: action))
     }
@@ -166,7 +166,7 @@ public enum ReducerBuilder<State, Action> {
     @inlinable
     public func reduce(
       into state: inout Element.State, action: Element.Action
-    ) -> EffectOf<Element.Action> {
+    ) -> EffectTask<Element.Action> {
       self.reducers.reduce(.none) { $0.merge(with: $1.reduce(into: &state, action: action)) }
     }
   }

--- a/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
+++ b/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
@@ -98,8 +98,8 @@ public enum ReducerBuilder<State, Action> {
     case second(Second)
 
     @inlinable
-    public func reduce(into state: inout First.State, action: First.Action) -> Effect<
-      First.Action, Never
+    public func reduce(into state: inout First.State, action: First.Action) -> EffectOf<
+      First.Action
     > {
       switch self {
       case let .first(first):
@@ -123,7 +123,7 @@ public enum ReducerBuilder<State, Action> {
     @inlinable
     public func reduce(
       into state: inout Wrapped.State, action: Wrapped.Action
-    ) -> Effect<Wrapped.Action, Never> {
+    ) -> EffectOf<Wrapped.Action> {
       switch wrapped {
       case let .some(wrapped):
         return wrapped.reduce(into: &state, action: action)
@@ -148,7 +148,7 @@ public enum ReducerBuilder<State, Action> {
     }
 
     @inlinable
-    public func reduce(into state: inout R0.State, action: R0.Action) -> Effect<R0.Action, Never> {
+    public func reduce(into state: inout R0.State, action: R0.Action) -> EffectOf<R0.Action> {
       self.r0.reduce(into: &state, action: action)
         .merge(with: self.r1.reduce(into: &state, action: action))
     }
@@ -166,7 +166,7 @@ public enum ReducerBuilder<State, Action> {
     @inlinable
     public func reduce(
       into state: inout Element.State, action: Element.Action
-    ) -> Effect<Element.Action, Never> {
+    ) -> EffectOf<Element.Action> {
       self.reducers.reduce(.none) { $0.merge(with: $1.reduce(into: &state, action: action)) }
     }
   }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
@@ -15,7 +15,7 @@ where Action: BindableAction, State == Action.State {
   @inlinable
   public func reduce(
     into state: inout State, action: Action
-  ) -> EffectOf<Action> {
+  ) -> EffectTask<Action> {
     guard let bindingAction = (/Action.binding).extract(from: action)
     else { return .none }
 

--- a/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
@@ -15,7 +15,7 @@ where Action: BindableAction, State == Action.State {
   @inlinable
   public func reduce(
     into state: inout State, action: Action
-  ) -> Effect<Action, Never> {
+  ) -> EffectOf<Action> {
     guard let bindingAction = (/Action.binding).extract(from: action)
     else { return .none }
 

--- a/Sources/ComposableArchitecture/Reducer/Reducers/CombineReducers.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/CombineReducers.swift
@@ -37,7 +37,7 @@ public struct CombineReducers<Reducers: ReducerProtocol>: ReducerProtocol {
   @inlinable
   public func reduce(
     into state: inout Reducers.State, action: Reducers.Action
-  ) -> EffectOf<Reducers.Action> {
+  ) -> EffectTask<Reducers.Action> {
     self.reducers.reduce(into: &state, action: action)
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/CombineReducers.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/CombineReducers.swift
@@ -37,7 +37,7 @@ public struct CombineReducers<Reducers: ReducerProtocol>: ReducerProtocol {
   @inlinable
   public func reduce(
     into state: inout Reducers.State, action: Reducers.Action
-  ) -> Effect<Reducers.Action, Never> {
+  ) -> EffectOf<Reducers.Action> {
     self.reducers.reduce(into: &state, action: action)
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
@@ -66,7 +66,7 @@ public struct _PrintChangesReducer<Base: ReducerProtocol>: ReducerProtocol {
   @inlinable
   public func reduce(
     into state: inout Base.State, action: Base.Action
-  ) -> EffectOf<Base.Action> {
+  ) -> EffectTask<Base.Action> {
     #if DEBUG
       if self.context != .test, let printer = self.printer {
         let oldState = state

--- a/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
@@ -66,7 +66,7 @@ public struct _PrintChangesReducer<Base: ReducerProtocol>: ReducerProtocol {
   @inlinable
   public func reduce(
     into state: inout Base.State, action: Base.Action
-  ) -> Effect<Base.Action, Never> {
+  ) -> EffectOf<Base.Action> {
     #if DEBUG
       if self.context != .test, let printer = self.printer {
         let oldState = state

--- a/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
@@ -131,7 +131,7 @@ public struct _DependencyKeyWritingReducer<Base: ReducerProtocol>: ReducerProtoc
   @inlinable
   public func reduce(
     into state: inout Base.State, action: Base.Action
-  ) -> Effect<Base.Action, Never> {
+  ) -> EffectOf<Base.Action> {
     DependencyValues.withValues {
       self.update(&$0)
     } operation: {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
@@ -131,7 +131,7 @@ public struct _DependencyKeyWritingReducer<Base: ReducerProtocol>: ReducerProtoc
   @inlinable
   public func reduce(
     into state: inout Base.State, action: Base.Action
-  ) -> EffectOf<Base.Action> {
+  ) -> EffectTask<Base.Action> {
     DependencyValues.withValues {
       self.update(&$0)
     } operation: {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/EmptyReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/EmptyReducer.swift
@@ -13,7 +13,7 @@ public struct EmptyReducer<State, Action>: ReducerProtocol {
   init(internal: Void) {}
 
   @inlinable
-  public func reduce(into _: inout State, action _: Action) -> EffectOf<Action> {
+  public func reduce(into _: inout State, action _: Action) -> EffectTask<Action> {
     .none
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/EmptyReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/EmptyReducer.swift
@@ -13,7 +13,7 @@ public struct EmptyReducer<State, Action>: ReducerProtocol {
   init(internal: Void) {}
 
   @inlinable
-  public func reduce(into _: inout State, action _: Action) -> Effect<Action, Never> {
+  public func reduce(into _: inout State, action _: Action) -> EffectOf<Action> {
     .none
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -140,7 +140,7 @@ public struct _ForEachReducer<
   @inlinable
   public func reduce(
     into state: inout Parent.State, action: Parent.Action
-  ) -> EffectOf<Parent.Action> {
+  ) -> EffectTask<Parent.Action> {
     self.reduceForEach(into: &state, action: action)
       .merge(with: self.parent.reduce(into: &state, action: action))
   }
@@ -148,7 +148,7 @@ public struct _ForEachReducer<
   @inlinable
   func reduceForEach(
     into state: inout Parent.State, action: Parent.Action
-  ) -> EffectOf<Parent.Action> {
+  ) -> EffectTask<Parent.Action> {
     guard let (id, elementAction) = self.toElementAction.extract(from: action) else { return .none }
     if state[keyPath: self.toElementsState][id: id] == nil {
       runtimeWarn(

--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -140,7 +140,7 @@ public struct _ForEachReducer<
   @inlinable
   public func reduce(
     into state: inout Parent.State, action: Parent.Action
-  ) -> Effect<Parent.Action, Never> {
+  ) -> EffectOf<Parent.Action> {
     self.reduceForEach(into: &state, action: action)
       .merge(with: self.parent.reduce(into: &state, action: action))
   }
@@ -148,7 +148,7 @@ public struct _ForEachReducer<
   @inlinable
   func reduceForEach(
     into state: inout Parent.State, action: Parent.Action
-  ) -> Effect<Parent.Action, Never> {
+  ) -> EffectOf<Parent.Action> {
     guard let (id, elementAction) = self.toElementAction.extract(from: action) else { return .none }
     if state[keyPath: self.toElementsState][id: id] == nil {
       runtimeWarn(

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
@@ -134,7 +134,7 @@ public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>
   @inlinable
   public func reduce(
     into state: inout Parent.State, action: Parent.Action
-  ) -> EffectOf<Parent.Action> {
+  ) -> EffectTask<Parent.Action> {
     self.reduceChild(into: &state, action: action)
       .merge(with: self.parent.reduce(into: &state, action: action))
   }
@@ -142,7 +142,7 @@ public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>
   @inlinable
   func reduceChild(
     into state: inout Parent.State, action: Parent.Action
-  ) -> EffectOf<Parent.Action> {
+  ) -> EffectTask<Parent.Action> {
     guard let childAction = self.toChildAction.extract(from: action)
     else { return .none }
     guard var childState = self.toChildState.extract(from: state) else {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
@@ -134,7 +134,7 @@ public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>
   @inlinable
   public func reduce(
     into state: inout Parent.State, action: Parent.Action
-  ) -> Effect<Parent.Action, Never> {
+  ) -> EffectOf<Parent.Action> {
     self.reduceChild(into: &state, action: action)
       .merge(with: self.parent.reduce(into: &state, action: action))
   }
@@ -142,7 +142,7 @@ public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>
   @inlinable
   func reduceChild(
     into state: inout Parent.State, action: Parent.Action
-  ) -> Effect<Parent.Action, Never> {
+  ) -> EffectOf<Parent.Action> {
     guard let childAction = self.toChildAction.extract(from: action)
     else { return .none }
     guard var childState = self.toChildState.extract(from: state) else {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
@@ -131,7 +131,7 @@ public struct _IfLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: Re
   @inlinable
   public func reduce(
     into state: inout Parent.State, action: Parent.Action
-  ) -> Effect<Parent.Action, Never> {
+  ) -> EffectOf<Parent.Action> {
     self.reduceChild(into: &state, action: action)
       .merge(with: self.parent.reduce(into: &state, action: action))
   }
@@ -139,7 +139,7 @@ public struct _IfLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: Re
   @inlinable
   func reduceChild(
     into state: inout Parent.State, action: Parent.Action
-  ) -> Effect<Parent.Action, Never> {
+  ) -> EffectOf<Parent.Action> {
     guard let childAction = self.toChildAction.extract(from: action)
     else { return .none }
     guard state[keyPath: self.toChildState] != nil else {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
@@ -131,7 +131,7 @@ public struct _IfLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: Re
   @inlinable
   public func reduce(
     into state: inout Parent.State, action: Parent.Action
-  ) -> EffectOf<Parent.Action> {
+  ) -> EffectTask<Parent.Action> {
     self.reduceChild(into: &state, action: action)
       .merge(with: self.parent.reduce(into: &state, action: action))
   }
@@ -139,7 +139,7 @@ public struct _IfLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: Re
   @inlinable
   func reduceChild(
     into state: inout Parent.State, action: Parent.Action
-  ) -> EffectOf<Parent.Action> {
+  ) -> EffectTask<Parent.Action> {
     guard let childAction = self.toChildAction.extract(from: action)
     else { return .none }
     guard state[keyPath: self.toChildState] != nil else {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Reduce.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Reduce.swift
@@ -4,11 +4,11 @@
 /// a new type that conforms to ``ReducerProtocol``.
 public struct Reduce<State, Action>: ReducerProtocol {
   @usableFromInline
-  let reduce: (inout State, Action) -> Effect<Action, Never>
+  let reduce: (inout State, Action) -> EffectOf<Action>
 
   @usableFromInline
   init(
-    internal reduce: @escaping (inout State, Action) -> Effect<Action, Never>
+    internal reduce: @escaping (inout State, Action) -> EffectOf<Action>
   ) {
     self.reduce = reduce
   }
@@ -17,7 +17,7 @@ public struct Reduce<State, Action>: ReducerProtocol {
   ///
   /// - Parameter reduce: A function that is called when ``reduce(into:action:)`` is invoked.
   @inlinable
-  public init(_ reduce: @escaping (inout State, Action) -> Effect<Action, Never>) {
+  public init(_ reduce: @escaping (inout State, Action) -> EffectOf<Action>) {
     self.init(internal: reduce)
   }
 
@@ -31,7 +31,7 @@ public struct Reduce<State, Action>: ReducerProtocol {
   }
 
   @inlinable
-  public func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  public func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     self.reduce(&state, action)
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Reduce.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Reduce.swift
@@ -4,11 +4,11 @@
 /// a new type that conforms to ``ReducerProtocol``.
 public struct Reduce<State, Action>: ReducerProtocol {
   @usableFromInline
-  let reduce: (inout State, Action) -> EffectOf<Action>
+  let reduce: (inout State, Action) -> EffectTask<Action>
 
   @usableFromInline
   init(
-    internal reduce: @escaping (inout State, Action) -> EffectOf<Action>
+    internal reduce: @escaping (inout State, Action) -> EffectTask<Action>
   ) {
     self.reduce = reduce
   }
@@ -17,7 +17,7 @@ public struct Reduce<State, Action>: ReducerProtocol {
   ///
   /// - Parameter reduce: A function that is called when ``reduce(into:action:)`` is invoked.
   @inlinable
-  public init(_ reduce: @escaping (inout State, Action) -> EffectOf<Action>) {
+  public init(_ reduce: @escaping (inout State, Action) -> EffectTask<Action>) {
     self.init(internal: reduce)
   }
 
@@ -31,7 +31,7 @@ public struct Reduce<State, Action>: ReducerProtocol {
   }
 
   @inlinable
-  public func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  public func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     self.reduce(&state, action)
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
@@ -233,7 +233,7 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
   @inlinable
   public func reduce(
     into state: inout ParentState, action: ParentAction
-  ) -> EffectOf<ParentAction> {
+  ) -> EffectTask<ParentAction> {
     guard let childAction = self.toChildAction.extract(from: action)
     else { return .none }
     switch self.toChildState {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
@@ -233,7 +233,7 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
   @inlinable
   public func reduce(
     into state: inout ParentState, action: ParentAction
-  ) -> Effect<ParentAction, Never> {
+  ) -> EffectOf<ParentAction> {
     guard let childAction = self.toChildAction.extract(from: action)
     else { return .none }
     switch self.toChildState {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/SignpostReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/SignpostReducer.swift
@@ -58,7 +58,7 @@ public struct _SignpostReducer<Base: ReducerProtocol>: ReducerProtocol {
   @inlinable
   public func reduce(
     into state: inout Base.State, action: Base.Action
-  ) -> Effect<Base.Action, Never> {
+  ) -> EffectOf<Base.Action> {
     var actionOutput: String!
     if self.log.signpostsEnabled {
       actionOutput = debugCaseOutput(action)

--- a/Sources/ComposableArchitecture/Reducer/Reducers/SignpostReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/SignpostReducer.swift
@@ -58,7 +58,7 @@ public struct _SignpostReducer<Base: ReducerProtocol>: ReducerProtocol {
   @inlinable
   public func reduce(
     into state: inout Base.State, action: Base.Action
-  ) -> EffectOf<Base.Action> {
+  ) -> EffectTask<Base.Action> {
     var actionOutput: String!
     if self.log.signpostsEnabled {
       actionOutput = debugCaseOutput(action)

--- a/Sources/ComposableArchitecture/ReducerProtocol.swift
+++ b/Sources/ComposableArchitecture/ReducerProtocol.swift
@@ -23,7 +23,7 @@
   ///
   /// The logic of your feature is implemented by mutating the feature's current state when an action
   /// comes into the system. This is most easily done by implementing the
-  /// ``ReducerProtocol/reduce(into:action:)-4nzr2`` method of the protocol.
+  /// ``ReducerProtocol/reduce(into:action:)-8yinq`` method of the protocol.
   ///
   /// ```swift
   /// struct Feature: ReducerProtocol {
@@ -105,7 +105,7 @@
   /// That is the basics of implementing a feature as a conformance to ``ReducerProtocol``. There are
   /// actually two ways to define a reducer:
   ///
-  ///   1. You can either implement the ``reduce(into:action:)-4nzr2`` method, as shown above, which
+  ///   1. You can either implement the ``reduce(into:action:)-8yinq`` method, as shown above, which
   ///   is given direct mutable access to application ``State`` whenever an ``Action`` is fed into
   ///   the system, and returns an ``EffectTask`` that can communicate with the outside world and
   ///   feed additional ``Action``s back into the system.
@@ -114,7 +114,7 @@
   ///   more reducers together.
   ///
   /// At most one of these requirements should be implemented. If a conformance implements both
-  /// requirements, only ``reduce(into:action:)-4nzr2`` will be called by the ``Store``. If your
+  /// requirements, only ``reduce(into:action:)-8yinq`` will be called by the ``Store``. If your
   /// reducer assembles a body from other reducers _and_ has additional business logic it needs to
   /// layer onto the feature, introduce this logic into the body instead, either with ``Reduce``:
   ///
@@ -145,7 +145,7 @@
   /// ```
   ///
   /// If you are implementing a custom reducer operator that transforms an existing reducer,
-  /// _always_ invoke the ``reduce(into:action:)-4nzr2`` method, never the
+  /// _always_ invoke the ``reduce(into:action:)-8yinq`` method, never the
   /// ``body-swift.property-7foai``. For example, this operator that logs all actions sent to the
   /// reducer:
   ///
@@ -177,7 +177,7 @@
     /// When you create a custom reducer by implementing the ``body-swift.property-7foai``, Swift
     /// infers this type from the value returned.
     ///
-    /// If you create a custom reducer by implementing the ``reduce(into:action:)-4nzr2``, Swift
+    /// If you create a custom reducer by implementing the ``reduce(into:action:)-8yinq``, Swift
     /// infers this type to be `Never`.
     typealias Body = _Body
 
@@ -202,8 +202,8 @@
     ///
     /// Do not invoke this property directly.
     ///
-    /// > Important: if your reducer implements the ``reduce(into:action:)-4nzr2`` method, it will
-    /// > take precedence over this property, and only ``reduce(into:action:)-4nzr2`` will be called
+    /// > Important: if your reducer implements the ``reduce(into:action:)-8yinq`` method, it will
+    /// > take precedence over this property, and only ``reduce(into:action:)-8yinq`` will be called
     /// > by the ``Store``. If your reducer assembles a body from other reducers and has additional
     /// > business logic it needs to layer into the system, introduce this logic into the body
     /// > instead, either with ``Reduce``, or with a separate, dedicated conformance.
@@ -217,7 +217,7 @@
   ///
   /// There are two ways to define a reducer:
   ///
-  ///   1. You can either implement the ``reduce(into:action:)-4nzr2`` method, which is given direct
+  ///   1. You can either implement the ``reduce(into:action:)-8yinq`` method, which is given direct
   ///      mutable access to application ``State`` whenever an ``Action`` is fed into the system,
   ///      and returns an ``EffectTask`` that can communicate with the outside world and feed
 ///        additional ``Action``s back into the system.
@@ -226,7 +226,7 @@
   ///      more reducers together.
   ///
   /// At most one of these requirements should be implemented. If a conformance implements both
-  /// requirements, only ``reduce(into:action:)-4nzr2`` will be called by the ``Store``. If your
+  /// requirements, only ``reduce(into:action:)-8yinq`` will be called by the ``Store``. If your
   /// reducer assembles a body from other reducers _and_ has additional business logic it needs to
   /// layer onto the feature, introduce this logic into the body instead, either with ``Reduce``:
   ///
@@ -256,7 +256,7 @@
   /// ```
   ///
   /// If you are implementing a custom reducer operator that transforms an existing reducer,
-  /// _always_ invoke the ``reduce(into:action:)-4nzr2`` method, never the
+  /// _always_ invoke the ``reduce(into:action:)-8yinq`` method, never the
   /// ``body-swift.property-7foai``. For example, this operator that logs all actions sent to the
   /// reducer:
   ///
@@ -287,7 +287,7 @@
     /// When you create a custom reducer by implementing the ``body-swift.property-7foai``, Swift
     /// infers this type from the value returned.
     ///
-    /// If you create a custom reducer by implementing the ``reduce(into:action:)-4nzr2``, Swift
+    /// If you create a custom reducer by implementing the ``reduce(into:action:)-8yinq``, Swift
     /// infers this type to be `Never`.
     typealias Body = _Body
 
@@ -312,8 +312,8 @@
     ///
     /// Do not invoke this property directly.
     ///
-    /// > Important: if your reducer implements the ``reduce(into:action:)-4nzr2`` method, it will
-    /// > take precedence over this property, and only ``reduce(into:action:)-4nzr2`` will be called
+    /// > Important: if your reducer implements the ``reduce(into:action:)-8yinq`` method, it will
+    /// > take precedence over this property, and only ``reduce(into:action:)-8yinq`` will be called
     /// > by the ``Store``. If your reducer assembles a body from other reducers and has additional
     /// > business logic it needs to layer into the system, introduce this logic into the body
     /// > instead, either with ``Reduce``, or with a separate, dedicated conformance.
@@ -340,7 +340,7 @@ extension ReducerProtocol where Body == Never {
 }
 
 extension ReducerProtocol where Body: ReducerProtocol, Body.State == State, Body.Action == Action {
-  /// Invokes the ``Body-40qdd``'s implementation of ``reduce(into:action:)-4nzr2``.
+  /// Invokes the ``Body-40qdd``'s implementation of ``reduce(into:action:)-8yinq``.
   @inlinable
   public func reduce(
     into state: inout Body.State, action: Body.Action

--- a/Sources/ComposableArchitecture/ReducerProtocol.swift
+++ b/Sources/ComposableArchitecture/ReducerProtocol.swift
@@ -28,7 +28,7 @@
   /// struct Feature: ReducerProtocol {
   ///   // ...
   ///
-  ///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
   ///     switch action {
   ///     case .decrementButtonTapped:
   ///       state.count -= 1
@@ -65,7 +65,7 @@
   ///   }
   ///   enum TimerID {}
   ///
-  ///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
   ///     switch action {
   ///     case .decrementButtonTapped:
   ///       state.count -= 1
@@ -138,7 +138,7 @@
   ///   Settings()
   /// }
   ///
-  /// func core(state: inout State, action: Action) -> EffectOf<Action> {
+  /// func core(state: inout State, action: Action) -> EffectTask<Action> {
   ///   // extra logic
   /// }
   /// ```
@@ -192,7 +192,7 @@
     ///     side effect that can communicate with the outside world.
     /// - Returns: An effect that can communicate with the outside world and feed actions back into
     ///   the system.
-    func reduce(into state: inout State, action: Action) -> EffectOf<Action>
+    func reduce(into state: inout State, action: Action) -> EffectTask<Action>
 
     /// The content and behavior of a reducer that is composed from other reducers.
     ///
@@ -301,7 +301,7 @@
     ///     a side effect that can communicate with the outside world.
     /// - Returns: An effect that can communicate with the outside world and feed actions back into
     ///   the system.
-    func reduce(into state: inout State, action: Action) -> EffectOf<Action>
+    func reduce(into state: inout State, action: Action) -> EffectTask<Action>
 
     /// The content and behavior of a reducer that is composed from other reducers.
     ///
@@ -342,7 +342,7 @@ extension ReducerProtocol where Body: ReducerProtocol, Body.State == State, Body
   @inlinable
   public func reduce(
     into state: inout Body.State, action: Body.Action
-  ) -> EffectOf<Body.Action> {
+  ) -> EffectTask<Body.Action> {
     self.body.reduce(into: &state, action: action)
   }
 }

--- a/Sources/ComposableArchitecture/ReducerProtocol.swift
+++ b/Sources/ComposableArchitecture/ReducerProtocol.swift
@@ -1,6 +1,7 @@
 #if compiler(>=5.7)
   /// A protocol that describes how to evolve the current state of an application to the next state,
-  /// given an action, and describes what ``Effect``s should be executed later by the store, if any.
+  /// given an action, and describes what ``EffectTask``s should be executed later by the store, if
+  /// any.
   ///
   /// Conform types to this protocol to represent the domain, logic and behavior for your feature.
   /// The domain is specified by the "state" and "actions", which can be nested types inside the
@@ -45,7 +46,7 @@
   /// The `reduce` method's first responsibility is to mutate the feature's current state given an
   /// action. It's second responsibility is to return effects that will be executed asynchronously
   /// and feed their data back into the system. Currently `Feature` does not need to run any effects,
-  /// and so ``Effect/none`` is returned.
+  /// and so ``EffectPublisher/none`` is returned.
   ///
   /// If the feature does need to do effectful work, then more would need to be done. For example,
   /// suppose the feature has the ability to start and stop a timer, and with each tick of the timer
@@ -106,8 +107,8 @@
   ///
   ///   1. You can either implement the ``reduce(into:action:)-4nzr2`` method, as shown above, which
   ///   is given direct mutable access to application ``State`` whenever an ``Action`` is fed into
-  ///   the system, and returns an ``Effect`` that can communicate with the outside world and feed
-  ///   additional ``Action``s back into the system.
+  ///   the system, and returns an ``EffectTask`` that can communicate with the outside world and
+  ///   feed additional ``Action``s back into the system.
   ///
   ///   2. Or you can implement the ``body-swift.property-7foai`` property, which combines one or
   ///   more reducers together.
@@ -164,7 +165,7 @@
     associatedtype State
 
     /// A type that holds all possible actions that cause the ``State`` of the reducer to change
-    /// and/or kick off a side ``Effect`` that can communicate with the outside world.
+    /// and/or kick off a side ``EffectTask`` that can communicate with the outside world.
     associatedtype Action
 
     // NB: For Xcode to favor autocompleting `var body: Body` over `var body: Never` we must use a
@@ -211,14 +212,15 @@
   }
 #else
   /// A protocol that describes how to evolve the current state of an application to the next state,
-  /// given an action, and describes what ``Effect``s should be executed later by the store, if any.
+  /// given an action, and describes what ``EffectTask``s should be executed later by the store, if
+  /// any.
   ///
   /// There are two ways to define a reducer:
   ///
   ///   1. You can either implement the ``reduce(into:action:)-4nzr2`` method, which is given direct
   ///      mutable access to application ``State`` whenever an ``Action`` is fed into the system,
-  ///      and returns an ``Effect`` that can communicate with the outside world and feed additional
-  ///      ``Action``s back into the system.
+  ///      and returns an ``EffectTask`` that can communicate with the outside world and feed
+///        additional ``Action``s back into the system.
   ///
   ///   2. Or you can implement the ``body-swift.property-7foai`` property, which combines one or
   ///      more reducers together.
@@ -273,7 +275,7 @@
     associatedtype State
 
     /// A type that holds all possible actions that cause the ``State`` of the reducer to change
-    /// and/or kick off a side ``Effect`` that can communicate with the outside world.
+    /// and/or kick off a side ``EffectTask`` that can communicate with the outside world.
     associatedtype Action
 
     // NB: For Xcode to favor autocompleting `var body: Body` over `var body: Never` we must use a

--- a/Sources/ComposableArchitecture/ReducerProtocol.swift
+++ b/Sources/ComposableArchitecture/ReducerProtocol.swift
@@ -28,7 +28,7 @@
   /// struct Feature: ReducerProtocol {
   ///   // ...
   ///
-  ///   func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
   ///     switch action {
   ///     case .decrementButtonTapped:
   ///       state.count -= 1
@@ -65,7 +65,7 @@
   ///   }
   ///   enum TimerID {}
   ///
-  ///   func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
   ///     switch action {
   ///     case .decrementButtonTapped:
   ///       state.count -= 1
@@ -138,7 +138,7 @@
   ///   Settings()
   /// }
   ///
-  /// func core(state: inout State, action: Action) -> Effect<Action, Never> {
+  /// func core(state: inout State, action: Action) -> EffectOf<Action> {
   ///   // extra logic
   /// }
   /// ```
@@ -192,7 +192,7 @@
     ///     side effect that can communicate with the outside world.
     /// - Returns: An effect that can communicate with the outside world and feed actions back into
     ///   the system.
-    func reduce(into state: inout State, action: Action) -> Effect<Action, Never>
+    func reduce(into state: inout State, action: Action) -> EffectOf<Action>
 
     /// The content and behavior of a reducer that is composed from other reducers.
     ///
@@ -301,7 +301,7 @@
     ///     a side effect that can communicate with the outside world.
     /// - Returns: An effect that can communicate with the outside world and feed actions back into
     ///   the system.
-    func reduce(into state: inout State, action: Action) -> Effect<Action, Never>
+    func reduce(into state: inout State, action: Action) -> EffectOf<Action>
 
     /// The content and behavior of a reducer that is composed from other reducers.
     ///
@@ -342,7 +342,7 @@ extension ReducerProtocol where Body: ReducerProtocol, Body.State == State, Body
   @inlinable
   public func reduce(
     into state: inout Body.State, action: Body.Action
-  ) -> Effect<Body.Action, Never> {
+  ) -> EffectOf<Body.Action> {
     self.body.reduce(into: &state, action: action)
   }
 }

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -128,7 +128,7 @@ public final class Store<State, Action> {
   #if swift(>=5.7)
     private let reducer: any ReducerProtocol<State, Action>
   #else
-    private let reducer: (inout State, Action) -> EffectOf<Action>
+    private let reducer: (inout State, Action) -> EffectTask<Action>
     fileprivate var scope: AnyStoreScope?
   #endif
   var state: CurrentValueSubject<State, Never>
@@ -603,7 +603,7 @@ public typealias StoreOf<R: ReducerProtocol> = Store<R.State, R.Action>
     @inlinable
     func reduce(
       into state: inout ScopedState, action: ScopedAction
-    ) -> EffectOf<ScopedAction> {
+    ) -> EffectTask<ScopedAction> {
       self.isSending = true
       defer {
         state = self.toScopedState(self.rootStore.state.value)

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -128,7 +128,7 @@ public final class Store<State, Action> {
   #if swift(>=5.7)
     private let reducer: any ReducerProtocol<State, Action>
   #else
-    private let reducer: (inout State, Action) -> Effect<Action, Never>
+    private let reducer: (inout State, Action) -> EffectOf<Action>
     fileprivate var scope: AnyStoreScope?
   #endif
   var state: CurrentValueSubject<State, Never>
@@ -603,7 +603,7 @@ public typealias StoreOf<R: ReducerProtocol> = Store<R.State, R.Action>
     @inlinable
     func reduce(
       into state: inout ScopedState, action: ScopedAction
-    ) -> Effect<ScopedAction, Never> {
+    ) -> EffectOf<ScopedAction> {
       self.isSending = true
       defer {
         state = self.toScopedState(self.rootStore.state.value)

--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -39,7 +39,7 @@ import SwiftUI
 /// to show to the user:
 ///
 /// ```swift
-/// func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+/// func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
 ///   switch action {
 ///   case .cancelTapped:
 ///     state.alert = nil

--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -39,7 +39,7 @@ import SwiftUI
 /// to show to the user:
 ///
 /// ```swift
-/// func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+/// func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
 ///   switch action {
 ///   case .cancelTapped:
 ///     state.alert = nil

--- a/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
@@ -40,7 +40,7 @@ import SwiftUI
 /// you want to show to the user:
 ///
 /// ```swift
-/// func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+/// func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
 ///   switch action {
 ///   case .cancelTapped:
 ///     state.confirmationDialog = nil

--- a/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
@@ -40,7 +40,7 @@ import SwiftUI
 /// you want to show to the user:
 ///
 /// ```swift
-/// func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+/// func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
 ///   switch action {
 ///   case .cancelTapped:
 ///     state.confirmationDialog = nil

--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -23,7 +23,7 @@ import SwiftUI
 ///     case descriptionChanged(String)
 ///   }
 ///
-///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> { ... }
+///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> { ... }
 /// }
 /// ```
 ///

--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -23,7 +23,7 @@ import SwiftUI
 ///     case descriptionChanged(String)
 ///   }
 ///
-///   func reduce(into state: inout State, action: Action) -> Effect<Action, Never> { ... }
+///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> { ... }
 /// }
 /// ```
 ///

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -469,8 +469,8 @@ extension TestStore where ScopedState: Equatable {
   /// Sends an action to the store and asserts when state changes.
   ///
   /// This method suspends in order to allow any effects to start. For example, if you
-  /// track an analytics event in a ``Effect/fireAndForget(priority:_:)`` when an action is sent,
-  /// you can assert on that behavior immediately after awaiting `store.send`:
+  /// track an analytics event in a ``EffectPublisher/fireAndForget(priority:_:)`` when an action is
+  /// sent, you can assert on that behavior immediately after awaiting `store.send`:
   ///
   /// ```swift
   /// @MainActor

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -51,7 +51,7 @@ import XCTestDynamicOverlay
 ///
 ///   func reduce(
 ///     into state: inout State, action: Action
-///   ) -> Effect<Action, Never> {
+///   ) -> EffectOf<Action> {
 ///     switch action {
 ///     case .decrementButtonTapped:
 ///       state.count -= 1
@@ -110,7 +110,7 @@ import XCTestDynamicOverlay
 ///
 ///   func reduce(
 ///     into state: inout State, action: Action
-///   ) -> Effect<Action, Never> {
+///   ) -> EffectOf<Action> {
 ///     switch action {
 ///     case let .queryChanged(query):
 ///       enum SearchID {}
@@ -1063,10 +1063,10 @@ class TestReducer<State, Action>: ReducerProtocol {
     self.state = initialState
   }
 
-  func reduce(into state: inout State, action: TestAction) -> Effect<TestAction, Never> {
+  func reduce(into state: inout State, action: TestAction) -> EffectOf<TestAction> {
     let reducer = self.base.dependency(\.self, self.dependencies)
 
-    let effects: Effect<Action, Never>
+    let effects: EffectOf<Action>
     switch action.origin {
     case let .send(action):
       effects = reducer.reduce(into: &state, action: action)

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -51,7 +51,7 @@ import XCTestDynamicOverlay
 ///
 ///   func reduce(
 ///     into state: inout State, action: Action
-///   ) -> EffectOf<Action> {
+///   ) -> EffectTask<Action> {
 ///     switch action {
 ///     case .decrementButtonTapped:
 ///       state.count -= 1
@@ -110,7 +110,7 @@ import XCTestDynamicOverlay
 ///
 ///   func reduce(
 ///     into state: inout State, action: Action
-///   ) -> EffectOf<Action> {
+///   ) -> EffectTask<Action> {
 ///     switch action {
 ///     case let .queryChanged(query):
 ///       enum SearchID {}
@@ -1063,10 +1063,10 @@ class TestReducer<State, Action>: ReducerProtocol {
     self.state = initialState
   }
 
-  func reduce(into state: inout State, action: TestAction) -> EffectOf<TestAction> {
+  func reduce(into state: inout State, action: TestAction) -> EffectTask<TestAction> {
     let reducer = self.base.dependency(\.self, self.dependencies)
 
-    let effects: EffectOf<Action>
+    let effects: EffectTask<Action>
     switch action.origin {
     case let .send(action):
       effects = reducer.reduce(into: &state, action: action)

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -221,7 +221,7 @@ public final class TestStore<State, Action, ScopedState, ScopedAction, Environme
   /// The current state.
   ///
   /// When read from a trailing closure assertion in ``send(_:_:file:line:)-6s1gq`` or
-  /// ``receive(_:timeout:_:file:line:)``, it will equal the `inout` state passed to the closure.
+  /// ``receive(_:timeout:_:file:line:)-8yd62``, it will equal the `inout` state passed to the closure.
   public var state: State {
     self.reducer.state
   }
@@ -229,7 +229,7 @@ public final class TestStore<State, Action, ScopedState, ScopedAction, Environme
   /// The timeout to await for in-flight effects.
   ///
   /// This is the default timeout used in all methods that take an optional timeout, such as
-  /// ``receive(_:timeout:_:file:line:)`` and ``finish(timeout:file:line:)``.
+  /// ``receive(_:timeout:_:file:line:)-8yd62`` and ``finish(timeout:file:line:)-7pmv3``.
   public var timeout: UInt64
 
   private var _environment: Box<Environment>
@@ -955,7 +955,7 @@ extension TestStore {
 /// await store.send(.stopTimerButtonTapped).finish()
 /// ```
 ///
-/// See ``TestStore/finish(timeout:file:line:)`` for the ability to await all in-flight effects in
+/// See ``TestStore/finish(timeout:file:line:)-7pmv3`` for the ability to await all in-flight effects in
 /// the test store.
 ///
 /// See ``ViewStoreTask`` for the analog provided to ``ViewStore``.

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -316,7 +316,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
   ///   }
   ///   @Dependency(\.fetch) var fetch
   ///
-  ///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
   ///     switch action {
   ///     case .pulledToRefresh:
   ///       state.isLoading = true

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -270,8 +270,8 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
   /// > Important: ``ViewStore`` is not thread safe and you should only send actions to it from the
   /// > main thread. If you want to send actions on background threads due to the fact that the
   /// > reducer is performing computationally expensive work, then a better way to handle this is to
-  /// > wrap that work in an ``Effect`` that is performed on a background thread so that the result
-  /// > can be fed back into the store.
+  /// > wrap that work in an ``EffectTask`` that is performed on a background thread so that the
+  /// > result can be fed back into the store.
   ///
   /// - Parameter action: An action.
   /// - Returns: A ``ViewStoreTask`` that represents the lifecycle of the effect executed when

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -316,7 +316,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
   ///   }
   ///   @Dependency(\.fetch) var fetch
   ///
-  ///   func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
   ///     switch action {
   ///     case .pulledToRefresh:
   ///       state.isLoading = true

--- a/Sources/Dependencies/Dependencies/MainQueue.swift
+++ b/Sources/Dependencies/Dependencies/MainQueue.swift
@@ -26,7 +26,7 @@
     ///
     ///   @Dependency(\.mainQueue) var mainQueue
     ///
-    ///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+    ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     ///     switch action {
     ///     case .task:
     ///       return .run { send in

--- a/Sources/Dependencies/Dependencies/MainQueue.swift
+++ b/Sources/Dependencies/Dependencies/MainQueue.swift
@@ -26,7 +26,7 @@
     ///
     ///   @Dependency(\.mainQueue) var mainQueue
     ///
-    ///   func reduce(into state: inout State, action: Action) -> Effect<Action> {
+    ///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     ///     switch action {
     ///     case .task:
     ///       return .run { send in

--- a/Sources/Dependencies/Dependencies/MainRunLoop.swift
+++ b/Sources/Dependencies/Dependencies/MainRunLoop.swift
@@ -26,7 +26,7 @@
     ///
     ///   @Dependency(\.mainRunLoop) var mainRunLoop
     ///
-    ///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+    ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     ///     switch action {
     ///     case .task:
     ///       return .run { send in

--- a/Sources/Dependencies/Dependencies/MainRunLoop.swift
+++ b/Sources/Dependencies/Dependencies/MainRunLoop.swift
@@ -26,7 +26,7 @@
     ///
     ///   @Dependency(\.mainRunLoop) var mainRunLoop
     ///
-    ///   func reduce(into state: inout State, action: Action) -> Effect<Action> {
+    ///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     ///     switch action {
     ///     case .task:
     ///       return .run { send in

--- a/Sources/Dependencies/Dependencies/RandomNumberGenerator.swift
+++ b/Sources/Dependencies/Dependencies/RandomNumberGenerator.swift
@@ -26,7 +26,7 @@ extension DependencyValues {
   ///
   ///   @Dependency(\.withRandomNumberGenerator) var withRandomNumberGenerator
   ///
-  ///   func reduce(into state: inout State, action: Action) -> Effect<Action> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
   ///     switch action {
   ///     case .rollDice:
   ///       self.withRandomNumberGenerator { generator in

--- a/Sources/Dependencies/Dependencies/RandomNumberGenerator.swift
+++ b/Sources/Dependencies/Dependencies/RandomNumberGenerator.swift
@@ -26,7 +26,7 @@ extension DependencyValues {
   ///
   ///   @Dependency(\.withRandomNumberGenerator) var withRandomNumberGenerator
   ///
-  ///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
   ///     switch action {
   ///     case .rollDice:
   ///       self.withRandomNumberGenerator { generator in

--- a/Sources/Dependencies/Dependencies/UUID.swift
+++ b/Sources/Dependencies/Dependencies/UUID.swift
@@ -30,7 +30,7 @@ extension DependencyValues {
   ///
   ///   @Dependency(\.uuid) var uuid
   ///
-  ///   func reduce(into state: inout State, action: Action) -> Effect<Action> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
   ///     switch action {
   ///     case .create:
   ///       state.append(Todo(id: self.uuid())

--- a/Sources/Dependencies/Dependencies/UUID.swift
+++ b/Sources/Dependencies/Dependencies/UUID.swift
@@ -30,7 +30,7 @@ extension DependencyValues {
   ///
   ///   @Dependency(\.uuid) var uuid
   ///
-  ///   func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
   ///     switch action {
   ///     case .create:
   ///       state.append(Todo(id: self.uuid())

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -12,7 +12,7 @@ import XCTestDynamicOverlay
 /// ```
 ///
 /// To change a dependency for a well-defined scope you can use the
-/// ``withValues(_:operation:file:line:)-2atnb`` method:
+/// ``withValues(_:operation:)-1oaja`` method:
 ///
 /// ```swift
 /// @Dependency(\.date) var date

--- a/Sources/swift-composable-architecture-benchmark/Effects.swift
+++ b/Sources/swift-composable-architecture-benchmark/Effects.swift
@@ -5,18 +5,18 @@ import Foundation
 
 let effectSuite = BenchmarkSuite(name: "Effects") {
   $0.benchmark("Merged Effect.none (create, flat)") {
-    doNotOptimizeAway(EffectOf<Int>.merge((1...100).map { _ in .none }))
+    doNotOptimizeAway(EffectTask<Int>.merge((1...100).map { _ in .none }))
   }
 
   $0.benchmark("Merged Effect.none (create, nested)") {
-    var effect = EffectOf<Int>.none
+    var effect = EffectTask<Int>.none
     for _ in 1...100 {
       effect = effect.merge(with: .none)
     }
     doNotOptimizeAway(effect)
   }
 
-  let effect = EffectOf<Int>.merge((1...100).map { _ in .none })
+  let effect = EffectTask<Int>.merge((1...100).map { _ in .none })
   var didComplete = false
   $0.benchmark("Merged Effect.none (sink)") {
     doNotOptimizeAway(

--- a/Sources/swift-composable-architecture-benchmark/Effects.swift
+++ b/Sources/swift-composable-architecture-benchmark/Effects.swift
@@ -5,18 +5,18 @@ import Foundation
 
 let effectSuite = BenchmarkSuite(name: "Effects") {
   $0.benchmark("Merged Effect.none (create, flat)") {
-    doNotOptimizeAway(Effect<Int, Never>.merge((1...100).map { _ in .none }))
+    doNotOptimizeAway(EffectOf<Int>.merge((1...100).map { _ in .none }))
   }
 
   $0.benchmark("Merged Effect.none (create, nested)") {
-    var effect = Effect<Int, Never>.none
+    var effect = EffectOf<Int>.none
     for _ in 1...100 {
       effect = effect.merge(with: .none)
     }
     doNotOptimizeAway(effect)
   }
 
-  let effect = Effect<Int, Never>.merge((1...100).map { _ in .none })
+  let effect = EffectOf<Int>.merge((1...100).map { _ in .none })
   var didComplete = false
   $0.benchmark("Merged Effect.none (sink)") {
     doNotOptimizeAway(

--- a/Sources/swift-composable-architecture-benchmark/StoreScope.swift
+++ b/Sources/swift-composable-architecture-benchmark/StoreScope.swift
@@ -4,7 +4,7 @@ import ComposableArchitecture
 private struct Counter: ReducerProtocol {
   typealias State = Int
   typealias Action = Bool
-  func reduce(into state: inout Int, action: Bool) -> Effect<Bool, Never> {
+  func reduce(into state: inout Int, action: Bool) -> EffectOf<Bool> {
     if action {
       state += 1
       return .none

--- a/Sources/swift-composable-architecture-benchmark/StoreScope.swift
+++ b/Sources/swift-composable-architecture-benchmark/StoreScope.swift
@@ -4,7 +4,7 @@ import ComposableArchitecture
 private struct Counter: ReducerProtocol {
   typealias State = Int
   typealias Action = Bool
-  func reduce(into state: inout Int, action: Bool) -> EffectOf<Bool> {
+  func reduce(into state: inout Int, action: Bool) -> EffectTask<Bool> {
     if action {
       state += 1
       return .none

--- a/Tests/ComposableArchitectureTests/CompatibilityTests.swift
+++ b/Tests/ComposableArchitectureTests/CompatibilityTests.swift
@@ -48,7 +48,7 @@ final class CompatibilityTests: XCTestCase {
           .cancellable(id: cancelID)
 
       case .kickOffAction:
-        return Effect(value: .actionSender(OnDeinit { passThroughSubject.send(.stop) }))
+        return EffectTask(value: .actionSender(OnDeinit { passThroughSubject.send(.stop) }))
 
       case .actionSender:
         return .none

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -20,13 +20,13 @@ final class ComposableArchitectureTests: XCTestCase {
         switch action {
         case .incrAndSquareLater:
           return .merge(
-            Effect(value: .incrNow)
+            EffectTask(value: .incrNow)
               .delay(for: 2, scheduler: self.mainQueue)
               .eraseToEffect(),
-            Effect(value: .squareNow)
+            EffectTask(value: .squareNow)
               .delay(for: 1, scheduler: self.mainQueue)
               .eraseToEffect(),
-            Effect(value: .squareNow)
+            EffectTask(value: .squareNow)
               .delay(for: 2, scheduler: self.mainQueue)
               .eraseToEffect()
           )

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -16,7 +16,7 @@ final class ComposableArchitectureTests: XCTestCase {
         case squareNow
       }
       @Dependency(\.mainQueue) var mainQueue
-      func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+      func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
         switch action {
         case .incrAndSquareLater:
           return .merge(
@@ -80,8 +80,8 @@ final class ComposableArchitectureTests: XCTestCase {
 
   func testLongLivingEffects() async {
     typealias Environment = (
-      startEffect: EffectOf<Void>,
-      stopEffect: EffectOf<Never>
+      startEffect: EffectTask<Void>,
+      stopEffect: EffectTask<Never>
     )
 
     enum Action { case end, incr, start }

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -16,7 +16,7 @@ final class ComposableArchitectureTests: XCTestCase {
         case squareNow
       }
       @Dependency(\.mainQueue) var mainQueue
-      func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+      func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
         switch action {
         case .incrAndSquareLater:
           return .merge(
@@ -80,8 +80,8 @@ final class ComposableArchitectureTests: XCTestCase {
 
   func testLongLivingEffects() async {
     typealias Environment = (
-      startEffect: Effect<Void, Never>,
-      stopEffect: Effect<Never, Never>
+      startEffect: EffectOf<Void>,
+      stopEffect: EffectOf<Never>
     )
 
     enum Action { case end, incr, start }

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -207,7 +207,7 @@
       struct DebuggedReducer: ReducerProtocol {
         typealias State = Int
         typealias Action = Bool
-        func reduce(into state: inout Int, action: Bool) -> Effect<Bool, Never> {
+        func reduce(into state: inout Int, action: Bool) -> EffectOf<Bool> {
           state += action ? 1 : -1
           return .none
         }

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -207,7 +207,7 @@
       struct DebuggedReducer: ReducerProtocol {
         typealias State = Int
         typealias Action = Bool
-        func reduce(into state: inout Int, action: Bool) -> EffectOf<Bool> {
+        func reduce(into state: inout Int, action: Bool) -> EffectTask<Bool> {
           state += action ? 1 : -1
           return .none
         }

--- a/Tests/ComposableArchitectureTests/DependencyKeyWritingReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/DependencyKeyWritingReducerTests.swift
@@ -56,7 +56,7 @@ final class DependencyKeyWritingReducerTests: XCTestCase {
       }
       @Dependency(\.myValue) var myValue
 
-      func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+      func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
         switch action {
         case .tap:
           state.count += 1
@@ -93,7 +93,7 @@ private struct Feature: ReducerProtocol {
   @Dependency(\.myValue) var myValue
   struct State: Equatable { var value = 0 }
   enum Action { case tap }
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
     switch action {
     case .tap:
       state.value = self.myValue

--- a/Tests/ComposableArchitectureTests/DependencyKeyWritingReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/DependencyKeyWritingReducerTests.swift
@@ -46,7 +46,7 @@ final class DependencyKeyWritingReducerTests: XCTestCase {
     }
   }
 
-  func testDependency_EffectOfEffect() async {
+  func testDependency_EffectTaskEffect() async {
     struct Feature: ReducerProtocol {
       struct State: Equatable { var count = 0 }
       enum Action: Equatable {
@@ -56,7 +56,7 @@ final class DependencyKeyWritingReducerTests: XCTestCase {
       }
       @Dependency(\.myValue) var myValue
 
-      func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+      func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
         switch action {
         case .tap:
           state.count += 1
@@ -93,7 +93,7 @@ private struct Feature: ReducerProtocol {
   @Dependency(\.myValue) var myValue
   struct State: Equatable { var value = 0 }
   enum Action { case tap }
-  func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .tap:
       state.value = self.myValue

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -28,7 +28,7 @@ final class EffectCancellationTests: XCTestCase {
     subject.send(2)
     XCTAssertEqual(values, [1, 2])
 
-    Effect<Never, Never>.cancel(id: CancelID())
+    EffectOf<Never>.cancel(id: CancelID())
       .sink { _ in }
       .store(in: &self.cancellables)
 
@@ -75,7 +75,7 @@ final class EffectCancellationTests: XCTestCase {
     XCTAssertEqual(value, nil)
 
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-      Effect<Never, Never>.cancel(id: CancelID())
+      EffectOf<Never>.cancel(id: CancelID())
         .sink { _ in }
         .store(in: &self.cancellables)
     }
@@ -98,7 +98,7 @@ final class EffectCancellationTests: XCTestCase {
     XCTAssertEqual(value, nil)
 
     mainQueue.advance(by: 1)
-    Effect<Never, Never>.cancel(id: CancelID())
+    EffectOf<Never>.cancel(id: CancelID())
       .sink { _ in }
       .store(in: &self.cancellables)
 
@@ -130,7 +130,7 @@ final class EffectCancellationTests: XCTestCase {
       .sink(receiveValue: { _ in })
       .store(in: &self.cancellables)
 
-    Effect<Int, Never>.cancel(id: id)
+    EffectOf<Int>.cancel(id: id)
       .sink(receiveValue: { _ in })
       .store(in: &self.cancellables)
 
@@ -153,7 +153,7 @@ final class EffectCancellationTests: XCTestCase {
     subject.send(1)
     XCTAssertEqual(values, [1])
 
-    Effect<Never, Never>.cancel(id: CancelID())
+    EffectOf<Never>.cancel(id: CancelID())
       .sink { _ in }
       .store(in: &self.cancellables)
 
@@ -178,7 +178,7 @@ final class EffectCancellationTests: XCTestCase {
     subject.send(completion: .finished)
     XCTAssertEqual(values, [1])
 
-    Effect<Never, Never>.cancel(id: CancelID())
+    EffectOf<Never>.cancel(id: CancelID())
       .sink { _ in }
       .store(in: &self.cancellables)
 
@@ -198,7 +198,7 @@ final class EffectCancellationTests: XCTestCase {
     let ids = (1...10).map { _ in UUID() }
 
     let effect = Effect.merge(
-      (1...1_000).map { idx -> Effect<Int, Never> in
+      (1...1_000).map { idx -> EffectOf<Int> in
         let id = ids[idx % 10]
 
         return Effect.merge(
@@ -298,7 +298,7 @@ final class EffectCancellationTests: XCTestCase {
   }
 
   func testNestedMergeCancellation() {
-    let effect = Effect<Int, Never>.merge(
+    let effect = EffectOf<Int>.merge(
       (1...2).publisher
         .eraseToEffect()
         .cancellable(id: 1)
@@ -329,11 +329,11 @@ final class EffectCancellationTests: XCTestCase {
         .cancellable(id: id)
     }
 
-    Effect<AnyHashable, Never>.merge(effects)
+    EffectOf<AnyHashable>.merge(effects)
       .sink { output.append($0) }
       .store(in: &self.cancellables)
 
-    Effect<AnyHashable, Never>
+    EffectOf<AnyHashable>
       .cancel(ids: [A(), C()])
       .sink { _ in }
       .store(in: &self.cancellables)

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -130,7 +130,7 @@ final class EffectCancellationTests: XCTestCase {
       .sink(receiveValue: { _ in })
       .store(in: &self.cancellables)
 
-    EffectTask<Int>.cancel(id: id)
+    EffectPublisher<Int, Never>.cancel(id: id)
       .sink(receiveValue: { _ in })
       .store(in: &self.cancellables)
 
@@ -198,7 +198,7 @@ final class EffectCancellationTests: XCTestCase {
     let ids = (1...10).map { _ in UUID() }
 
     let effect = EffectPublisher.merge(
-      (1...1_000).map { idx -> EffectTask<Int> in
+      (1...1_000).map { idx -> EffectPublisher<Int, Never> in
         let id = ids[idx % 10]
 
         return EffectPublisher.merge(

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -28,7 +28,7 @@ final class EffectCancellationTests: XCTestCase {
     subject.send(2)
     XCTAssertEqual(values, [1, 2])
 
-    EffectOf<Never>.cancel(id: CancelID())
+    EffectTask<Never>.cancel(id: CancelID())
       .sink { _ in }
       .store(in: &self.cancellables)
 
@@ -75,7 +75,7 @@ final class EffectCancellationTests: XCTestCase {
     XCTAssertEqual(value, nil)
 
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-      EffectOf<Never>.cancel(id: CancelID())
+      EffectTask<Never>.cancel(id: CancelID())
         .sink { _ in }
         .store(in: &self.cancellables)
     }
@@ -98,7 +98,7 @@ final class EffectCancellationTests: XCTestCase {
     XCTAssertEqual(value, nil)
 
     mainQueue.advance(by: 1)
-    EffectOf<Never>.cancel(id: CancelID())
+    EffectTask<Never>.cancel(id: CancelID())
       .sink { _ in }
       .store(in: &self.cancellables)
 
@@ -130,7 +130,7 @@ final class EffectCancellationTests: XCTestCase {
       .sink(receiveValue: { _ in })
       .store(in: &self.cancellables)
 
-    EffectOf<Int>.cancel(id: id)
+    EffectTask<Int>.cancel(id: id)
       .sink(receiveValue: { _ in })
       .store(in: &self.cancellables)
 
@@ -153,7 +153,7 @@ final class EffectCancellationTests: XCTestCase {
     subject.send(1)
     XCTAssertEqual(values, [1])
 
-    EffectOf<Never>.cancel(id: CancelID())
+    EffectTask<Never>.cancel(id: CancelID())
       .sink { _ in }
       .store(in: &self.cancellables)
 
@@ -178,7 +178,7 @@ final class EffectCancellationTests: XCTestCase {
     subject.send(completion: .finished)
     XCTAssertEqual(values, [1])
 
-    EffectOf<Never>.cancel(id: CancelID())
+    EffectTask<Never>.cancel(id: CancelID())
       .sink { _ in }
       .store(in: &self.cancellables)
 
@@ -198,7 +198,7 @@ final class EffectCancellationTests: XCTestCase {
     let ids = (1...10).map { _ in UUID() }
 
     let effect = Effect.merge(
-      (1...1_000).map { idx -> EffectOf<Int> in
+      (1...1_000).map { idx -> EffectTask<Int> in
         let id = ids[idx % 10]
 
         return Effect.merge(
@@ -298,7 +298,7 @@ final class EffectCancellationTests: XCTestCase {
   }
 
   func testNestedMergeCancellation() {
-    let effect = EffectOf<Int>.merge(
+    let effect = EffectTask<Int>.merge(
       (1...2).publisher
         .eraseToEffect()
         .cancellable(id: 1)
@@ -329,11 +329,11 @@ final class EffectCancellationTests: XCTestCase {
         .cancellable(id: id)
     }
 
-    EffectOf<AnyHashable>.merge(effects)
+    EffectTask<AnyHashable>.merge(effects)
       .sink { output.append($0) }
       .store(in: &self.cancellables)
 
-    EffectOf<AnyHashable>
+    EffectTask<AnyHashable>
       .cancel(ids: [A(), C()])
       .sink { _ in }
       .store(in: &self.cancellables)

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -15,7 +15,7 @@ final class EffectCancellationTests: XCTestCase {
     var values: [Int] = []
 
     let subject = PassthroughSubject<Int, Never>()
-    let effect = Effect(subject)
+    let effect = EffectPublisher(subject)
       .cancellable(id: CancelID())
 
     effect
@@ -40,7 +40,7 @@ final class EffectCancellationTests: XCTestCase {
     var values: [Int] = []
 
     let subject = PassthroughSubject<Int, Never>()
-    Effect(subject)
+    EffectPublisher(subject)
       .cancellable(id: CancelID(), cancelInFlight: true)
       .sink { values.append($0) }
       .store(in: &self.cancellables)
@@ -51,7 +51,7 @@ final class EffectCancellationTests: XCTestCase {
     subject.send(2)
     XCTAssertEqual(values, [1, 2])
 
-    Effect(subject)
+    EffectPublisher(subject)
       .cancellable(id: CancelID(), cancelInFlight: true)
       .sink { values.append($0) }
       .store(in: &self.cancellables)
@@ -141,7 +141,7 @@ final class EffectCancellationTests: XCTestCase {
     var values: [Int] = []
 
     let subject = PassthroughSubject<Int, Never>()
-    let effect = Effect(subject)
+    let effect = EffectPublisher(subject)
       .cancellable(id: CancelID())
       .cancellable(id: CancelID())
 
@@ -165,7 +165,7 @@ final class EffectCancellationTests: XCTestCase {
     var values: [Int] = []
 
     let subject = PassthroughSubject<Int, Never>()
-    let effect = Effect(subject)
+    let effect = EffectPublisher(subject)
       .cancellable(id: CancelID())
 
     effect
@@ -197,11 +197,11 @@ final class EffectCancellationTests: XCTestCase {
     ]
     let ids = (1...10).map { _ in UUID() }
 
-    let effect = Effect.merge(
+    let effect = EffectPublisher.merge(
       (1...1_000).map { idx -> EffectTask<Int> in
         let id = ids[idx % 10]
 
-        return Effect.merge(
+        return EffectPublisher.merge(
           Just(idx)
             .delay(
               for: .milliseconds(Int.random(in: 1...100)), scheduler: queues.randomElement()!
@@ -213,7 +213,7 @@ final class EffectCancellationTests: XCTestCase {
             .delay(
               for: .milliseconds(Int.random(in: 1...100)), scheduler: queues.randomElement()!
             )
-            .flatMap { Effect.cancel(id: id) }
+            .flatMap { EffectPublisher.cancel(id: id) }
             .eraseToEffect()
         )
       }
@@ -298,7 +298,7 @@ final class EffectCancellationTests: XCTestCase {
   }
 
   func testNestedMergeCancellation() {
-    let effect = EffectTask<Int>.merge(
+    let effect = EffectPublisher<Int, Never>.merge(
       (1...2).publisher
         .eraseToEffect()
         .cancellable(id: 1)

--- a/Tests/ComposableArchitectureTests/EffectFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectFailureTests.swift
@@ -25,7 +25,7 @@
       }
 
       line = #line
-      let effect = EffectOf<Void>.task {
+      let effect = EffectTask<Void>.task {
         struct Unexpected: Error {}
         throw Unexpected()
       }
@@ -51,7 +51,7 @@
       }
 
       line = #line
-      let effect = EffectOf<Void>.run { _ in
+      let effect = EffectTask<Void>.run { _ in
         struct Unexpected: Error {}
         throw Unexpected()
       }

--- a/Tests/ComposableArchitectureTests/EffectFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectFailureTests.swift
@@ -13,14 +13,14 @@
       var line: UInt!
       XCTExpectFailure {
         $0.compactDescription == """
-          An "Effect.task" returned from \
+          An "EffectTask.task" returned from \
           "ComposableArchitectureTests/EffectFailureTests.swift:\(line+1)" threw an unhandled \
           error. …
 
               EffectFailureTests.Unexpected()
 
           All non-cancellation errors must be explicitly handled via the "catch" parameter on \
-          "Effect.task", or via a "do" block.
+          "EffectTask.task", or via a "do" block.
           """
       }
 
@@ -39,14 +39,14 @@
       var line: UInt!
       XCTExpectFailure {
         $0.compactDescription == """
-          An "Effect.run" returned from \
+          An "EffectTask.run" returned from \
           "ComposableArchitectureTests/EffectFailureTests.swift:\(line+1)" threw an unhandled \
           error. …
 
               EffectFailureTests.Unexpected()
 
           All non-cancellation errors must be explicitly handled via the "catch" parameter on \
-          "Effect.run", or via a "do" block.
+          "EffectTask.run", or via a "do" block.
           """
       }
 

--- a/Tests/ComposableArchitectureTests/EffectFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectFailureTests.swift
@@ -25,7 +25,7 @@
       }
 
       line = #line
-      let effect = Effect<Void, Never>.task {
+      let effect = EffectOf<Void>.task {
         struct Unexpected: Error {}
         throw Unexpected()
       }
@@ -51,7 +51,7 @@
       }
 
       line = #line
-      let effect = Effect<Void, Never>.run { _ in
+      let effect = EffectOf<Void>.run { _ in
         struct Unexpected: Error {}
         throw Unexpected()
       }

--- a/Tests/ComposableArchitectureTests/EffectOperationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectOperationTests.swift
@@ -6,7 +6,7 @@
   @MainActor
   class EffectOperationTests: XCTestCase {
     func testMergeDiscardsNones() async {
-      var effect = Effect<Int, Never>.none
+      var effect = EffectOf<Int>.none
         .merge(with: .none)
       switch effect.operation {
       case .none:
@@ -15,7 +15,7 @@
         XCTFail()
       }
 
-      effect = Effect<Int, Never>.task { 42 }
+      effect = EffectOf<Int>.task { 42 }
         .merge(with: .none)
       switch effect.operation {
       case let .run(_, send):
@@ -24,7 +24,7 @@
         XCTFail()
       }
 
-      effect = Effect<Int, Never>.none
+      effect = EffectOf<Int>.none
         .merge(with: .task { 42 })
       switch effect.operation {
       case let .run(_, send):
@@ -33,7 +33,7 @@
         XCTFail()
       }
 
-      effect = Effect<Int, Never>.run { await $0(42) }
+      effect = EffectOf<Int>.run { await $0(42) }
         .merge(with: .none)
       switch effect.operation {
       case let .run(_, send):
@@ -42,7 +42,7 @@
         XCTFail()
       }
 
-      effect = Effect<Int, Never>.none
+      effect = EffectOf<Int>.none
         .merge(with: .run { await $0(42) })
       switch effect.operation {
       case let .run(_, send):
@@ -53,7 +53,7 @@
     }
 
     func testConcatenateDiscardsNones() async {
-      var effect = Effect<Int, Never>.none
+      var effect = EffectOf<Int>.none
         .concatenate(with: .none)
       switch effect.operation {
       case .none:
@@ -62,7 +62,7 @@
         XCTFail()
       }
 
-      effect = Effect<Int, Never>.task { 42 }
+      effect = EffectOf<Int>.task { 42 }
         .concatenate(with: .none)
       switch effect.operation {
       case let .run(_, send):
@@ -71,7 +71,7 @@
         XCTFail()
       }
 
-      effect = Effect<Int, Never>.none
+      effect = EffectOf<Int>.none
         .concatenate(with: .task { 42 })
       switch effect.operation {
       case let .run(_, send):
@@ -80,7 +80,7 @@
         XCTFail()
       }
 
-      effect = Effect<Int, Never>.run { await $0(42) }
+      effect = EffectOf<Int>.run { await $0(42) }
         .concatenate(with: .none)
       switch effect.operation {
       case let .run(_, send):
@@ -89,7 +89,7 @@
         XCTFail()
       }
 
-      effect = Effect<Int, Never>.none
+      effect = EffectOf<Int>.none
         .concatenate(with: .run { await $0(42) })
       switch effect.operation {
       case let .run(_, send):
@@ -102,7 +102,7 @@
     func testMergeFuses() async {
       var values = [Int]()
 
-      let effect = Effect<Int, Never>.task {
+      let effect = EffectOf<Int>.task {
         try await Task.sleep(nanoseconds: NSEC_PER_SEC / 10)
         return 42
       }
@@ -125,7 +125,7 @@
     func testConcatenateFuses() async {
       var values = [Int]()
 
-      let effect = Effect<Int, Never>.task { 42 }
+      let effect = EffectOf<Int>.task { 42 }
         .concatenate(with: .task { 1729 })
       switch effect.operation {
       case let .run(_, send):
@@ -138,7 +138,7 @@
     }
 
     func testMap() async {
-      let effect = Effect<Int, Never>.task { 42 }
+      let effect = EffectOf<Int>.task { 42 }
         .map { "\($0)" }
 
       switch effect.operation {

--- a/Tests/ComposableArchitectureTests/EffectOperationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectOperationTests.swift
@@ -6,7 +6,7 @@
   @MainActor
   class EffectOperationTests: XCTestCase {
     func testMergeDiscardsNones() async {
-      var effect = EffectOf<Int>.none
+      var effect = EffectTask<Int>.none
         .merge(with: .none)
       switch effect.operation {
       case .none:
@@ -15,7 +15,7 @@
         XCTFail()
       }
 
-      effect = EffectOf<Int>.task { 42 }
+      effect = EffectTask<Int>.task { 42 }
         .merge(with: .none)
       switch effect.operation {
       case let .run(_, send):
@@ -24,7 +24,7 @@
         XCTFail()
       }
 
-      effect = EffectOf<Int>.none
+      effect = EffectTask<Int>.none
         .merge(with: .task { 42 })
       switch effect.operation {
       case let .run(_, send):
@@ -33,7 +33,7 @@
         XCTFail()
       }
 
-      effect = EffectOf<Int>.run { await $0(42) }
+      effect = EffectTask<Int>.run { await $0(42) }
         .merge(with: .none)
       switch effect.operation {
       case let .run(_, send):
@@ -42,7 +42,7 @@
         XCTFail()
       }
 
-      effect = EffectOf<Int>.none
+      effect = EffectTask<Int>.none
         .merge(with: .run { await $0(42) })
       switch effect.operation {
       case let .run(_, send):
@@ -53,7 +53,7 @@
     }
 
     func testConcatenateDiscardsNones() async {
-      var effect = EffectOf<Int>.none
+      var effect = EffectTask<Int>.none
         .concatenate(with: .none)
       switch effect.operation {
       case .none:
@@ -62,7 +62,7 @@
         XCTFail()
       }
 
-      effect = EffectOf<Int>.task { 42 }
+      effect = EffectTask<Int>.task { 42 }
         .concatenate(with: .none)
       switch effect.operation {
       case let .run(_, send):
@@ -71,7 +71,7 @@
         XCTFail()
       }
 
-      effect = EffectOf<Int>.none
+      effect = EffectTask<Int>.none
         .concatenate(with: .task { 42 })
       switch effect.operation {
       case let .run(_, send):
@@ -80,7 +80,7 @@
         XCTFail()
       }
 
-      effect = EffectOf<Int>.run { await $0(42) }
+      effect = EffectTask<Int>.run { await $0(42) }
         .concatenate(with: .none)
       switch effect.operation {
       case let .run(_, send):
@@ -89,7 +89,7 @@
         XCTFail()
       }
 
-      effect = EffectOf<Int>.none
+      effect = EffectTask<Int>.none
         .concatenate(with: .run { await $0(42) })
       switch effect.operation {
       case let .run(_, send):
@@ -102,7 +102,7 @@
     func testMergeFuses() async {
       var values = [Int]()
 
-      let effect = EffectOf<Int>.task {
+      let effect = EffectTask<Int>.task {
         try await Task.sleep(nanoseconds: NSEC_PER_SEC / 10)
         return 42
       }
@@ -125,7 +125,7 @@
     func testConcatenateFuses() async {
       var values = [Int]()
 
-      let effect = EffectOf<Int>.task { 42 }
+      let effect = EffectTask<Int>.task { 42 }
         .concatenate(with: .task { 1729 })
       switch effect.operation {
       case let .run(_, send):
@@ -138,7 +138,7 @@
     }
 
     func testMap() async {
-      let effect = EffectOf<Int>.task { 42 }
+      let effect = EffectTask<Int>.task { 42 }
         .map { "\($0)" }
 
       switch effect.operation {

--- a/Tests/ComposableArchitectureTests/EffectRunTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectRunTests.swift
@@ -46,13 +46,13 @@ final class EffectRunTests: XCTestCase {
       var line: UInt!
       XCTExpectFailure(nil, enabled: nil, strict: nil) {
         $0.compactDescription == """
-          An "Effect.run" returned from \
+          An "EffectTask.run" returned from \
           "ComposableArchitectureTests/EffectRunTests.swift:\(line+1)" threw an unhandled error. …
 
               EffectRunTests.Failure()
 
           All non-cancellation errors must be explicitly handled via the "catch" parameter on \
-          "Effect.run", or via a "do" block.
+          "EffectTask.run", or via a "do" block.
           """
       }
       struct State: Equatable {}

--- a/Tests/ComposableArchitectureTests/EffectTaskTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTaskTests.swift
@@ -46,13 +46,13 @@ final class EffectTaskTests: XCTestCase {
       var line: UInt!
       XCTExpectFailure(nil, enabled: nil, strict: nil) {
         $0.compactDescription == """
-          An "Effect.task" returned from \
+          An "EffectTask.task" returned from \
           "ComposableArchitectureTests/EffectTaskTests.swift:\(line+1)" threw an unhandled error. …
 
               EffectTaskTests.Failure()
 
           All non-cancellation errors must be explicitly handled via the "catch" parameter on \
-          "Effect.task", or via a "do" block.
+          "EffectTask.task", or via a "do" block.
           """
       }
       struct State: Equatable {}

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -54,9 +54,9 @@ final class EffectTests: XCTestCase {
     var values: [Int] = []
 
     let effect = EffectTask<Int>.concatenate(
-      Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect(),
-      Effect(value: 2).delay(for: 2, scheduler: mainQueue).eraseToEffect(),
-      Effect(value: 3).delay(for: 3, scheduler: mainQueue).eraseToEffect()
+      EffectTask(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect(),
+      EffectTask(value: 2).delay(for: 2, scheduler: mainQueue).eraseToEffect(),
+      EffectTask(value: 3).delay(for: 3, scheduler: mainQueue).eraseToEffect()
     )
 
     effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
@@ -80,7 +80,7 @@ final class EffectTests: XCTestCase {
     var values: [Int] = []
 
     let effect = EffectTask<Int>.concatenate(
-      Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect()
+      EffectTask(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect()
     )
 
     effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
@@ -96,9 +96,9 @@ final class EffectTests: XCTestCase {
 
   func testMerge() {
     let effect = EffectTask<Int>.merge(
-      Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect(),
-      Effect(value: 2).delay(for: 2, scheduler: mainQueue).eraseToEffect(),
-      Effect(value: 3).delay(for: 3, scheduler: mainQueue).eraseToEffect()
+      EffectTask(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect(),
+      EffectTask(value: 2).delay(for: 2, scheduler: mainQueue).eraseToEffect(),
+      EffectTask(value: 3).delay(for: 3, scheduler: mainQueue).eraseToEffect()
     )
 
     var values: [Int] = []
@@ -187,7 +187,7 @@ final class EffectTests: XCTestCase {
     let expectation = self.expectation(description: "Complete")
 
     // This crashes on iOS 13 if Effect.init(error:) is implemented using the Fail publisher.
-    Effect<Never, Error>(error: NSError(domain: "", code: 1))
+    EffectPublisher<Never, Error>(error: NSError(domain: "", code: 1))
       .retry(3)
       .catch { _ in Fail(error: NSError(domain: "", code: 1)) }
       .sink(

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -53,7 +53,7 @@ final class EffectTests: XCTestCase {
   func testConcatenate() {
     var values: [Int] = []
 
-    let effect = Effect<Int, Never>.concatenate(
+    let effect = EffectOf<Int>.concatenate(
       Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect(),
       Effect(value: 2).delay(for: 2, scheduler: mainQueue).eraseToEffect(),
       Effect(value: 3).delay(for: 3, scheduler: mainQueue).eraseToEffect()
@@ -79,7 +79,7 @@ final class EffectTests: XCTestCase {
   func testConcatenateOneEffect() {
     var values: [Int] = []
 
-    let effect = Effect<Int, Never>.concatenate(
+    let effect = EffectOf<Int>.concatenate(
       Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect()
     )
 
@@ -95,7 +95,7 @@ final class EffectTests: XCTestCase {
   }
 
   func testMerge() {
-    let effect = Effect<Int, Never>.merge(
+    let effect = EffectOf<Int>.merge(
       Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect(),
       Effect(value: 2).delay(for: 2, scheduler: mainQueue).eraseToEffect(),
       Effect(value: 3).delay(for: 3, scheduler: mainQueue).eraseToEffect()
@@ -117,7 +117,7 @@ final class EffectTests: XCTestCase {
   }
 
   func testEffectSubscriberInitializer() {
-    let effect = Effect<Int, Never>.run { subscriber in
+    let effect = EffectOf<Int>.run { subscriber in
       subscriber.send(1)
       subscriber.send(2)
       self.mainQueue.schedule(after: self.mainQueue.now.advanced(by: .seconds(1))) {
@@ -154,7 +154,7 @@ final class EffectTests: XCTestCase {
   func testEffectSubscriberInitializer_WithCancellation() {
     enum CancelID {}
 
-    let effect = Effect<Int, Never>.run { subscriber in
+    let effect = EffectOf<Int>.run { subscriber in
       subscriber.send(1)
       self.mainQueue.schedule(after: self.mainQueue.now.advanced(by: .seconds(1))) {
         subscriber.send(2)
@@ -173,7 +173,7 @@ final class EffectTests: XCTestCase {
     XCTAssertEqual(values, [1])
     XCTAssertEqual(isComplete, false)
 
-    Effect<Void, Never>.cancel(id: CancelID.self)
+    EffectOf<Void>.cancel(id: CancelID.self)
       .sink(receiveValue: { _ in })
       .store(in: &self.cancellables)
 
@@ -213,7 +213,7 @@ final class EffectTests: XCTestCase {
 
   #if DEBUG
     func testUnimplemented() {
-      let effect = Effect<Never, Never>.unimplemented("unimplemented")
+      let effect = EffectOf<Never>.unimplemented("unimplemented")
       XCTExpectFailure {
         effect
           .sink(receiveValue: { _ in })
@@ -226,7 +226,7 @@ final class EffectTests: XCTestCase {
 
   func testTask() async {
     guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else { return }
-    let effect = Effect<Int, Never>.task { 42 }
+    let effect = EffectOf<Int>.task { 42 }
     for await result in effect.values {
       XCTAssertEqual(result, 42)
     }
@@ -242,7 +242,7 @@ final class EffectTests: XCTestCase {
       return 42
     }
 
-    Effect<Int, Never>.task { await work() }
+    EffectOf<Int>.task { await work() }
       .sink(
         receiveCompletion: { _ in XCTFail() },
         receiveValue: { _ in XCTFail() }
@@ -261,7 +261,7 @@ final class EffectTests: XCTestCase {
         case response(Int)
       }
       @Dependency(\.date) var date
-      func reduce(into state: inout Int, action: Action) -> Effect<Action, Never> {
+      func reduce(into state: inout Int, action: Action) -> EffectOf<Action> {
         switch action {
         case .tap:
           return .merge(
@@ -296,7 +296,7 @@ final class EffectTests: XCTestCase {
     let effect =
       DependencyValues
       .withValue(\.date, .init { Date(timeIntervalSince1970: 1_234_567_890) }) {
-        Effect<Void, Never>(value: ())
+        EffectOf<Void>(value: ())
           .map { date() }
       }
     var output: Date?
@@ -309,7 +309,7 @@ final class EffectTests: XCTestCase {
       let effect =
         DependencyValues
         .withValue(\.date, .init { Date(timeIntervalSince1970: 1_234_567_890) }) {
-          Effect<Void, Never>.task {}
+          EffectOf<Void>.task {}
             .map { date() }
         }
       output = await effect.values.first(where: { _ in true })

--- a/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
@@ -140,7 +140,7 @@ private struct Root: ReducerProtocol {
       case action
     }
 
-    func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+    func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
       .none
     }
   }

--- a/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
@@ -140,7 +140,7 @@ private struct Root: ReducerProtocol {
       case action
     }
 
-    func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+    func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
       .none
     }
   }

--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -34,7 +34,7 @@ final class ReducerTests: XCTestCase {
       let delay: DispatchQueue.SchedulerTimeType.Stride
       let setValue: @Sendable () async -> Void
 
-      func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+      func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
         state += 1
         return .fireAndForget {
           try await self.mainQueue.sleep(for: self.delay)
@@ -81,7 +81,7 @@ final class ReducerTests: XCTestCase {
     struct One: ReducerProtocol {
       typealias State = Int
       let effect: @Sendable () async -> Void
-      func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
+      func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
         state += 1
         return .fireAndForget {
           await self.effect()

--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -34,7 +34,7 @@ final class ReducerTests: XCTestCase {
       let delay: DispatchQueue.SchedulerTimeType.Stride
       let setValue: @Sendable () async -> Void
 
-      func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+      func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
         state += 1
         return .fireAndForget {
           try await self.mainQueue.sleep(for: self.delay)
@@ -81,7 +81,7 @@ final class ReducerTests: XCTestCase {
     struct One: ReducerProtocol {
       typealias State = Int
       let effect: @Sendable () async -> Void
-      func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+      func reduce(into state: inout State, action: Action) -> EffectOf<Action> {
         state += 1
         return .fireAndForget {
           await self.effect()

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -185,13 +185,13 @@ final class StoreTests: XCTestCase {
       switch action {
       case .tap:
         return .merge(
-          Effect(value: .next1),
-          Effect(value: .next2),
+          EffectTask(value: .next1),
+          EffectTask(value: .next2),
           .fireAndForget { values.append(1) }
         )
       case .next1:
         return .merge(
-          Effect(value: .end),
+          EffectTask(value: .end),
           .fireAndForget { values.append(2) }
         )
       case .next2:
@@ -214,7 +214,7 @@ final class StoreTests: XCTestCase {
       switch action {
       case .incr:
         state += 1
-        return state >= 100_000 ? Effect(value: .noop) : Effect(value: .incr)
+        return state >= 100_000 ? EffectTask(value: .noop) : EffectTask(value: .incr)
       case .noop:
         return .none
       }
@@ -355,9 +355,9 @@ final class StoreTests: XCTestCase {
         switch action {
         case 0:
           return .merge(
-            Effect(value: 1),
-            Effect(value: 2),
-            Effect(value: 3)
+            EffectTask(value: 1),
+            EffectTask(value: 2),
+            EffectTask(value: 3)
           )
         default:
           state = action

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -18,7 +18,7 @@ final class StoreTests: XCTestCase {
 
   func testCancellableIsRemovedWhenEffectCompletes() {
     let mainQueue = DispatchQueue.test
-    let effect = Effect<Void, Never>(value: ())
+    let effect = EffectOf<Void>(value: ())
       .delay(for: 1, scheduler: mainQueue)
       .eraseToEffect()
 

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -18,7 +18,7 @@ final class StoreTests: XCTestCase {
 
   func testCancellableIsRemovedWhenEffectCompletes() {
     let mainQueue = DispatchQueue.test
-    let effect = EffectOf<Void>(value: ())
+    let effect = EffectTask<Void>(value: ())
       .delay(for: 1, scheduler: mainQueue)
       .eraseToEffect()
 

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -17,7 +17,7 @@ final class TestStoreTests: XCTestCase {
       switch action {
       case .a:
         return .merge(
-          Effect.concatenate(.init(value: .b1), .init(value: .c1))
+          EffectTask.concatenate(.init(value: .b1), .init(value: .c1))
             .delay(for: 1, scheduler: mainQueue)
             .eraseToEffect(),
           Empty(completeImmediately: false)
@@ -26,11 +26,11 @@ final class TestStoreTests: XCTestCase {
         )
       case .b1:
         return
-          Effect
+          EffectTask
           .concatenate(.init(value: .b2), .init(value: .b3))
       case .c1:
         return
-          Effect
+          EffectTask
           .concatenate(.init(value: .c2), .init(value: .c3))
       case .b2, .b3, .c2, .c3:
         return .none
@@ -100,7 +100,7 @@ final class TestStoreTests: XCTestCase {
         switch action {
         case .increment:
           state.isChanging = true
-          return Effect(value: .changed(from: state.count, to: state.count + 1))
+          return EffectTask(value: .changed(from: state.count, to: state.count + 1))
         case .changed(let from, let to):
           state.isChanging = false
           if state.count == from {
@@ -145,7 +145,7 @@ final class TestStoreTests: XCTestCase {
       let reducer = Reduce<State, Action> { state, action in
         switch action {
         case .noop:
-          return Effect(value: .finished)
+          return EffectTask(value: .finished)
         case .finished:
           return .none
         }

--- a/Tests/ComposableArchitectureTests/TimerTests.swift
+++ b/Tests/ComposableArchitectureTests/TimerTests.swift
@@ -11,7 +11,7 @@ final class TimerTests: XCTestCase {
 
     var count = 0
 
-    Effect.timer(id: 1, every: .seconds(1), on: mainQueue)
+    EffectPublisher.timer(id: 1, every: .seconds(1), on: mainQueue)
       .sink { _ in count += 1 }
       .store(in: &self.cancellables)
 
@@ -34,11 +34,11 @@ final class TimerTests: XCTestCase {
     var count2 = 0
     var count3 = 0
 
-    Effect.merge(
-      Effect.timer(id: 1, every: .seconds(2), on: mainQueue)
+    EffectPublisher.merge(
+      EffectPublisher.timer(id: 1, every: .seconds(2), on: mainQueue)
         .handleEvents(receiveOutput: { _ in count2 += 1 })
         .eraseToEffect(),
-      Effect.timer(id: 2, every: .seconds(3), on: mainQueue)
+      EffectPublisher.timer(id: 2, every: .seconds(3), on: mainQueue)
         .handleEvents(receiveOutput: { _ in count3 += 1 })
         .eraseToEffect()
     )
@@ -67,7 +67,7 @@ final class TimerTests: XCTestCase {
 
     struct CancelToken: Hashable {}
 
-    Effect.timer(id: CancelToken(), every: .seconds(2), on: mainQueue)
+    EffectPublisher.timer(id: CancelToken(), every: .seconds(2), on: mainQueue)
       .handleEvents(receiveOutput: { _ in firstCount += 1 })
       .eraseToEffect()
       .sink { _ in }
@@ -81,7 +81,7 @@ final class TimerTests: XCTestCase {
 
     XCTAssertEqual(firstCount, 2)
 
-    Effect.timer(id: CancelToken(), every: .seconds(2), on: mainQueue)
+    EffectPublisher.timer(id: CancelToken(), every: .seconds(2), on: mainQueue)
       .handleEvents(receiveOutput: { _ in secondCount += 1 })
       .eraseToEffect()
       .sink { _ in }
@@ -103,7 +103,7 @@ final class TimerTests: XCTestCase {
 
     var count = 0
 
-    Effect.timer(id: 1, every: .seconds(1), on: mainQueue)
+    EffectPublisher.timer(id: 1, every: .seconds(1), on: mainQueue)
       .prefix(3)
       .sink { _ in count += 1 }
       .store(in: &self.cancellables)

--- a/Tests/ComposableArchitectureTests/ViewStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/ViewStoreTests.swift
@@ -181,7 +181,7 @@ final class ViewStoreTests: XCTestCase {
           return .none
         case .tapped:
           state = true
-          return Effect(value: .response)
+          return EffectTask(value: .response)
             .receive(on: DispatchQueue.main)
             .eraseToEffect()
         }
@@ -212,7 +212,7 @@ final class ViewStoreTests: XCTestCase {
           return .none
         case .tapped:
           state = true
-          return Effect(value: .response)
+          return EffectTask(value: .response)
             .receive(on: DispatchQueue.main)
             .eraseToEffect()
         }


### PR DESCRIPTION
Specifying `Never` in `Effect<Action, Never>` is slightly inconvenient, and it happens the majority of the times `Effect` is used.

Without changing the shape of `Effect`, this PR introduces:
```swift
typealias EffectOf<Action> = Effect<Action, Never>
```
to remove the mental burden of `Never` and save a few keystrokes.

Now that TCA is slowly moving away from Combine, most dependencies are modeled using `async/await`, and `Effect` is becoming more and more focused on reducer's products. I think that a one-generic `Effect<Action>` was envisaged at some point (there are a few traces in the documentation that are fixed by this PR), but it would be a source-breaking change. If it ever happens someday, this typealias should allow codebases to have smoothly migrated toward this shape already, easing the transition.

An alternative would be to define `EffectOf<R:ReducerProtocol> = Effect<R.Action, Never>`. In both cases, they make sense, as one can see the reducer `Reducer` producing an `EffectOf<Action>` when it receives an `Action`, or an `EffectOf<Reducer>`.

My personal preference goes toward the solution proposed in this PR, which is mentally more lightweight, but the `Reducer` one also packs more information, so that could be useful at some point (although I don't see any real application right now).

What do you think about it?