### PR TITLE
Hard-deprecate `Reducer` struct type alias

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -3,6 +3,24 @@ import Combine
 import SwiftUI
 import XCTestDynamicOverlay
 
+// MARK: - Deprecated after 0.42.0:
+
+/// This API has been soft-deprecated in favor of ``ReducerProtocol``.
+/// Read <doc:MigratingToTheReducerProtocol> for more information.
+///
+/// A type alias to ``AnyReducer`` for source compatibility. This alias will be removed.
+@available(
+  *,
+  renamed: "AnyReducer",
+  message:
+    """
+    'Reducer' has been deprecated in favor of 'ReducerProtocol'.
+
+    See the migration guide for more information: https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/reducerprotocol
+    """
+)
+public typealias Reducer = AnyReducer
+
 // MARK: - Deprecated after 0.41.0:
 
 extension ViewStore {

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
@@ -4,56 +4,6 @@ import Combine
 /// This API has been soft-deprecated in favor of ``ReducerProtocol``.
 /// Read <doc:MigratingToTheReducerProtocol> for more information.
 ///
-/// A type alias to ``AnyReducer`` for source compatibility. This alias will be removed.
-@available(
-  iOS,
-  deprecated: 9999.0,
-  renamed: "AnyReducer",
-  message:
-    """
-    'Reducer' has been deprecated in favor of 'ReducerProtocol'.
-
-    See the migration guide for more information: https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/reducerprotocol
-    """
-)
-@available(
-  macOS,
-  deprecated: 9999.0,
-  renamed: "AnyReducer",
-  message:
-    """
-    'Reducer' has been deprecated in favor of 'ReducerProtocol'.
-
-    See the migration guide for more information: https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/reducerprotocol
-    """
-)
-@available(
-  tvOS,
-  deprecated: 9999.0,
-  renamed: "AnyReducer",
-  message:
-    """
-    'Reducer' has been deprecated in favor of 'ReducerProtocol'.
-
-    See the migration guide for more information: https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/reducerprotocol
-    """
-)
-@available(
-  watchOS,
-  deprecated: 9999.0,
-  renamed: "AnyReducer",
-  message:
-    """
-    'Reducer' has been deprecated in favor of 'ReducerProtocol'.
-
-    See the migration guide for more information: https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/reducerprotocol
-    """
-)
-public typealias Reducer = AnyReducer
-
-/// This API has been soft-deprecated in favor of ``ReducerProtocol``.
-/// Read <doc:MigratingToTheReducerProtocol> for more information.
-///
 /// A reducer describes how to evolve the current state of an application to the next state, given
 /// an action, and describes what ``Effect``s should be executed later by the store, if any.
 ///

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -838,7 +838,7 @@ extension TestStore where ScopedState: Equatable, Action: Equatable {
     await Task.megaYield()
     let start = DispatchTime.now().uptimeNanoseconds
     while !Task.isCancelled {
-      await Task.detached(priority: .low) { await Task.yield() }.value
+      await Task.detached(priority: .background) { await Task.yield() }.value
 
       guard self.reducer.receivedActions.isEmpty
       else { break }
@@ -1131,7 +1131,7 @@ class TestReducer<State, Action>: ReducerProtocol {
 extension Task where Success == Never, Failure == Never {
   @_spi(Internals) public static func megaYield(count: Int = 10) async {
     for _ in 1...count {
-      await Task<Void, Never>.detached(priority: .low) { await Task.yield() }.value
+      await Task<Void, Never>.detached(priority: .background) { await Task.yield() }.value
     }
   }
 }


### PR DESCRIPTION
One step from our roadmap: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477