### PR TITLE
Remove not used let keyword in Timer Use Example comment.

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
@@ -38,7 +38,7 @@ extension Effect where Failure == Never {
   ///     case .stopButtonTapped:
   ///       return .cancel(id: TimerID())
   ///
-  ///     case let .timerTicked:
+  ///     case .timerTicked:
   ///       state.count += 1
   ///       return .none
   ///   }


### PR DESCRIPTION
Removed the unused `let` keyword from the Timer Use Example comment.