### PR TITLE
Require Swift 5.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,15 +40,6 @@ jobs:
       - name: Build for library evolution
         run: make build-for-library-evolution
 
-  library-compatibility:
-    runs-on: macos-12
-    steps:
-      - uses: actions/checkout@v3
-      - name: Select Xcode 13.2.1
-        run: sudo xcode-select -s /Applications/Xcode_13.2.1.app
-      - name: Build/test for library compatibility
-        run: swift test
-
   benchmarks:
     runs-on: macos-12
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        xcode: ['13.4.1', '14.0']
+        xcode: ['13.4.1', '14.0.1']
         config: ['debug', 'release']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Select Xcode ${{ matrix.xcode }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Run ${{ matrix.config }} tests
@@ -32,28 +32,37 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        xcode: ['13.4.1', '14.0']
+        xcode: ['13.4.1', '14.0.1']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Select Xcode ${{ matrix.xcode }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Build for library evolution
         run: make build-for-library-evolution
 
+  library-compatibility:
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+      - name: Select Xcode 13.2.1
+        run: sudo xcode-select -s /Applications/Xcode_13.2.1.app
+      - name: Build/test for library compatibility
+        run: swift test
+
   benchmarks:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Select Xcode ${{ matrix.xcode }}
-        run: sudo xcode-select -s /Applications/Xcode_14.0.app
+        run: sudo xcode-select -s /Applications/Xcode_14.0.1.app
       - name: Run benchmark
         run: make benchmark
 
   examples:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Select Xcode ${{ matrix.xcode }}
-        run: sudo xcode-select -s /Applications/Xcode_14.0.app
+        run: sudo xcode-select -s /Applications/Xcode_14.0.1.app
       - name: Run tests
         run: make test-examples

--- a/Examples/CaseStudies/tvOSCaseStudies/FocusView.swift
+++ b/Examples/CaseStudies/tvOSCaseStudies/FocusView.swift
@@ -32,58 +32,56 @@ struct Focus: ReducerProtocol {
   }
 }
 
-#if swift(>=5.3)
-  @available(tvOS 14.0, *)
-  struct FocusView: View {
-    let store: StoreOf<Focus>
+@available(tvOS 14.0, *)
+struct FocusView: View {
+  let store: StoreOf<Focus>
 
-    @Environment(\.resetFocus) var resetFocus
-    @Namespace private var namespace
+  @Environment(\.resetFocus) var resetFocus
+  @Namespace private var namespace
 
-    var body: some View {
-      WithViewStore(self.store, observe: { $0 }) { viewStore in
-        VStack(spacing: 100) {
-          Text(readMe)
-            .font(.headline)
-            .multilineTextAlignment(.leading)
-            .padding()
+  var body: some View {
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
+      VStack(spacing: 100) {
+        Text(readMe)
+          .font(.headline)
+          .multilineTextAlignment(.leading)
+          .padding()
 
-          HStack(spacing: 40) {
-            ForEach(1..<6) { index in
-              Button(numbers[index]) {}
-                .prefersDefaultFocus(viewStore.currentFocus == index, in: self.namespace)
-            }
+        HStack(spacing: 40) {
+          ForEach(1..<6) { index in
+            Button(numbers[index]) {}
+              .prefersDefaultFocus(viewStore.currentFocus == index, in: self.namespace)
           }
-          HStack(spacing: 40) {
-            ForEach(6..<11) { index in
-              Button(numbers[index]) {}
-                .prefersDefaultFocus(viewStore.currentFocus == index, in: self.namespace)
-            }
+        }
+        HStack(spacing: 40) {
+          ForEach(6..<11) { index in
+            Button(numbers[index]) {}
+              .prefersDefaultFocus(viewStore.currentFocus == index, in: self.namespace)
           }
+        }
 
-          Button("Focus Random") { viewStore.send(.randomButtonClicked) }
-        }
-        .onChange(of: viewStore.currentFocus) { _ in
-          // Update the view's focus when the state tells us the focus changed.
-          self.resetFocus(in: self.namespace)
-        }
-        .focusScope(self.namespace)
+        Button("Focus Random") { viewStore.send(.randomButtonClicked) }
       }
+      .onChange(of: viewStore.currentFocus) { _ in
+        // Update the view's focus when the state tells us the focus changed.
+        self.resetFocus(in: self.namespace)
+      }
+      .focusScope(self.namespace)
     }
   }
+}
 
-  @available(tvOS 14.0, *)
-  struct FocusView_Previews: PreviewProvider {
-    static var previews: some View {
-      FocusView(
-        store: Store(
-          initialState: Focus.State(),
-          reducer: Focus()
-        )
+@available(tvOS 14.0, *)
+struct FocusView_Previews: PreviewProvider {
+  static var previews: some View {
+    FocusView(
+      store: Store(
+        initialState: Focus.State(),
+        reducer: Focus()
       )
-    }
+    )
   }
-#endif
+}
 
 private let numbers = [
   "Zero",

--- a/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
+++ b/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
@@ -16,18 +16,14 @@ struct RootView: View {
 
   var focusView: AnyView? {
     if #available(tvOS 14.0, *) {
-      #if swift(>=5.3)
-        return AnyView(
-          NavigationLink(
-            "Focus",
-            destination: FocusView(
-              store: self.store.scope(state: \.focus, action: Root.Action.focus)
-            )
+      return AnyView(
+        NavigationLink(
+          "Focus",
+          destination: FocusView(
+            store: self.store.scope(state: \.focus, action: Root.Action.focus)
           )
         )
-      #else
-        return nil
-      #endif
+      )
     } else {
       return nil
     }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 
 import PackageDescription
 
@@ -21,7 +21,8 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
+    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+    .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "0.7.4"),
     .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.8.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.3.0"),
@@ -64,7 +65,7 @@ let package = Package(
       name: "swift-composable-architecture-benchmark",
       dependencies: [
         "ComposableArchitecture",
-        .product(name: "Benchmark", package: "Benchmark"),
+        .product(name: "Benchmark", package: "swift-benchmark"),
       ]
     ),
   ]
@@ -80,10 +81,3 @@ let package = Package(
 //    ])
 //  )
 //}
-
-#if swift(>=5.6)
-  // Add the documentation compiler plugin if possible
-  package.dependencies.append(
-    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
-  )
-#endif

--- a/Sources/Dependencies/Dependencies/Calendar.swift
+++ b/Sources/Dependencies/Dependencies/Calendar.swift
@@ -1,42 +1,40 @@
 import Foundation
 import XCTestDynamicOverlay
 
-#if swift(>=5.6)
-  extension DependencyValues {
-    /// The current calendar that features should use when handling dates.
-    ///
-    /// By default, the calendar returned from `Calendar.autoupdatingCurrent` is supplied. When used
-    /// in a testing context, access will call to `XCTFail` when invoked, unless explicitly
-    /// overridden using ``withValue(_:_:operation:)-705n``:
-    ///
-    /// ```swift
-    /// DependencyValues.withValue(\.calendar, Calendar(identifier: .gregorian)) {
-    ///   // Assertions...
-    /// }
-    /// ```
-    ///
-    /// Or, if you are using the Composable Architecture, you can override dependencies directly
-    /// on the `TestStore`:
-    ///
-    /// ```swift
-    /// let store = TestStore(
-    ///   initialState: MyFeature.State()
-    ///   reducer: MyFeature()
-    /// )
-    ///
-    /// store.dependencies.calendar = Calendar(identifier: .gregorian)
-    /// ```
-    public var calendar: Calendar {
-      get { self[CalendarKey.self] }
-      set { self[CalendarKey.self] = newValue }
-    }
+extension DependencyValues {
+  /// The current calendar that features should use when handling dates.
+  ///
+  /// By default, the calendar returned from `Calendar.autoupdatingCurrent` is supplied. When used
+  /// in a testing context, access will call to `XCTFail` when invoked, unless explicitly
+  /// overridden using ``withValue(_:_:operation:)-705n``:
+  ///
+  /// ```swift
+  /// DependencyValues.withValue(\.calendar, Calendar(identifier: .gregorian)) {
+  ///   // Assertions...
+  /// }
+  /// ```
+  ///
+  /// Or, if you are using the Composable Architecture, you can override dependencies directly
+  /// on the `TestStore`:
+  ///
+  /// ```swift
+  /// let store = TestStore(
+  ///   initialState: MyFeature.State()
+  ///   reducer: MyFeature()
+  /// )
+  ///
+  /// store.dependencies.calendar = Calendar(identifier: .gregorian)
+  /// ```
+  public var calendar: Calendar {
+    get { self[CalendarKey.self] }
+    set { self[CalendarKey.self] = newValue }
+  }
 
-    private enum CalendarKey: DependencyKey {
-      static let liveValue = Calendar.autoupdatingCurrent
-      static var testValue: Calendar {
-        XCTFail(#"Unimplemented: @Dependency(\.calendar)"#)
-        return .autoupdatingCurrent
-      }
+  private enum CalendarKey: DependencyKey {
+    static let liveValue = Calendar.autoupdatingCurrent
+    static var testValue: Calendar {
+      XCTFail(#"Unimplemented: @Dependency(\.calendar)"#)
+      return .autoupdatingCurrent
     }
   }
-#endif
+}

--- a/Sources/Dependencies/Dependencies/Date.swift
+++ b/Sources/Dependencies/Dependencies/Date.swift
@@ -1,85 +1,83 @@
 import Foundation
 import XCTestDynamicOverlay
 
-#if swift(>=5.6)
-  extension DependencyValues {
-    /// A dependency that returns the current date.
-    ///
-    /// By default, a ``DateGenerator/live`` generator is supplied. When used from a `TestStore`, an
-    /// ``DateGenerator/unimplemented`` generator is supplied, unless explicitly overridden.
-    ///
-    /// You can access the current date from a feature by introducing a ``Dependency`` property
-    /// wrapper to the generator's ``DateGenerator/now`` property:
-    ///
-    /// ```swift
-    /// final class FeatureModel: ReducerProtocol {
-    ///   @Dependency(\.date.now) var now
-    ///   // ...
-    /// }
-    /// ```
-    ///
-    /// To override the current date in tests, you can override the generator using
-    /// ``withValue(_:_:operation:)-705n``:
-    ///
-    /// ```swift
-    /// DependencyValues.withValue(\.date, .constant(Date(timeIntervalSince1970: 0))) {
-    ///   // Assertions...
-    /// }
-    /// ```
-    ///
-    /// Or, if you are using the Composable Architecture, you can override dependencies directly
-    /// on the `TestStore`:
-    ///
-    /// ```swift
-    /// let store = TestStore(
-    ///   initialState: MyFeature.State()
-    ///   reducer: MyFeature()
-    /// )
-    ///
-    /// store.dependencies.date = .constant(Date(timeIntervalSince1970: 0))
-    /// ```
-    public var date: DateGenerator {
-      get { self[DateGeneratorKey.self] }
-      set { self[DateGeneratorKey.self] = newValue }
-    }
-
-    private enum DateGeneratorKey: DependencyKey {
-      static let liveValue = DateGenerator { Date() }
-      static let testValue = DateGenerator {
-        XCTFail(#"Unimplemented: @Dependency(\.date)"#)
-        return Date()
-      }
-    }
-  }
-
-  /// A dependency that generates a date.
+extension DependencyValues {
+  /// A dependency that returns the current date.
   ///
-  /// See ``DependencyValues/date`` for more information.
-  public struct DateGenerator: Sendable {
-    private var generate: @Sendable () -> Date
+  /// By default, a ``DateGenerator/live`` generator is supplied. When used from a `TestStore`, an
+  /// ``DateGenerator/unimplemented`` generator is supplied, unless explicitly overridden.
+  ///
+  /// You can access the current date from a feature by introducing a ``Dependency`` property
+  /// wrapper to the generator's ``DateGenerator/now`` property:
+  ///
+  /// ```swift
+  /// final class FeatureModel: ReducerProtocol {
+  ///   @Dependency(\.date.now) var now
+  ///   // ...
+  /// }
+  /// ```
+  ///
+  /// To override the current date in tests, you can override the generator using
+  /// ``withValue(_:_:operation:)-705n``:
+  ///
+  /// ```swift
+  /// DependencyValues.withValue(\.date, .constant(Date(timeIntervalSince1970: 0))) {
+  ///   // Assertions...
+  /// }
+  /// ```
+  ///
+  /// Or, if you are using the Composable Architecture, you can override dependencies directly
+  /// on the `TestStore`:
+  ///
+  /// ```swift
+  /// let store = TestStore(
+  ///   initialState: MyFeature.State()
+  ///   reducer: MyFeature()
+  /// )
+  ///
+  /// store.dependencies.date = .constant(Date(timeIntervalSince1970: 0))
+  /// ```
+  public var date: DateGenerator {
+    get { self[DateGeneratorKey.self] }
+    set { self[DateGeneratorKey.self] = newValue }
+  }
 
-    /// A generator that returns a constant date.
-    ///
-    /// - Parameter now: A date to return.
-    /// - Returns: A generator that always returns the given date.
-    public static func constant(_ now: Date) -> Self {
-      Self { now }
-    }
-
-    /// The current date.
-    public var now: Date {
-      self.generate()
-    }
-
-    /// Initializes a date generator that generates a date from a closure.
-    ///
-    /// - Parameter generate: A closure that returns the current date when called.
-    public init(_ generate: @escaping @Sendable () -> Date) {
-      self.generate = generate
-    }
-
-    public func callAsFunction() -> Date {
-      self.generate()
+  private enum DateGeneratorKey: DependencyKey {
+    static let liveValue = DateGenerator { Date() }
+    static let testValue = DateGenerator {
+      XCTFail(#"Unimplemented: @Dependency(\.date)"#)
+      return Date()
     }
   }
-#endif
+}
+
+/// A dependency that generates a date.
+///
+/// See ``DependencyValues/date`` for more information.
+public struct DateGenerator: Sendable {
+  private var generate: @Sendable () -> Date
+
+  /// A generator that returns a constant date.
+  ///
+  /// - Parameter now: A date to return.
+  /// - Returns: A generator that always returns the given date.
+  public static func constant(_ now: Date) -> Self {
+    Self { now }
+  }
+
+  /// The current date.
+  public var now: Date {
+    self.generate()
+  }
+
+  /// Initializes a date generator that generates a date from a closure.
+  ///
+  /// - Parameter generate: A closure that returns the current date when called.
+  public init(_ generate: @escaping @Sendable () -> Date) {
+    self.generate = generate
+  }
+
+  public func callAsFunction() -> Date {
+    self.generate()
+  }
+}

--- a/Sources/Dependencies/Dependencies/Locale.swift
+++ b/Sources/Dependencies/Dependencies/Locale.swift
@@ -1,54 +1,52 @@
 import Foundation
 import XCTestDynamicOverlay
 
-#if swift(>=5.6)
-  extension DependencyValues {
-    /// The current locale that features should use.
-    ///
-    /// By default, the locale returned from `Locale.autoupdatingCurrent` is supplied. When used
-    /// from a `TestStore`, access will call to `XCTFail` when invoked, unless explicitly
-    /// overridden.
-    ///
-    /// You can access the current locale from a feature by introducing a ``Dependency`` property
-    /// wrapper to the property:
-    ///
-    /// ```swift
-    /// final class FeatureModel: ReducerProtocol {
-    ///   @Dependency(\.locale) var locale
-    ///   // ...
-    /// }
-    /// ```
-    ///
-    /// To override the current locale in tests, use ``withValue(_:_:operation:)-705n``:
+extension DependencyValues {
+  /// The current locale that features should use.
+  ///
+  /// By default, the locale returned from `Locale.autoupdatingCurrent` is supplied. When used
+  /// from a `TestStore`, access will call to `XCTFail` when invoked, unless explicitly
+  /// overridden.
+  ///
+  /// You can access the current locale from a feature by introducing a ``Dependency`` property
+  /// wrapper to the property:
+  ///
+  /// ```swift
+  /// final class FeatureModel: ReducerProtocol {
+  ///   @Dependency(\.locale) var locale
+  ///   // ...
+  /// }
+  /// ```
+  ///
+  /// To override the current locale in tests, use ``withValue(_:_:operation:)-705n``:
 
-    /// ```swift
-    /// DependencyValues.withValue(\.locale, Locale(identifier: "en_US")) {
-    ///   // Assertions...
-    /// }
-    /// ```
-    ///
-    /// Or, if you are using the Composable Architecture, you can override dependencies directly
-    /// on the `TestStore`:
-    ///
-    /// ```swift
-    /// let store = TestStore(
-    ///   initialState: MyFeature.State()
-    ///   reducer: MyFeature()
-    /// )
-    ///
-    /// store.dependencies.locale = Locale(identifier: "en_US")
-    /// ```
-    public var locale: Locale {
-      get { self[LocaleKey.self] }
-      set { self[LocaleKey.self] = newValue }
-    }
+  /// ```swift
+  /// DependencyValues.withValue(\.locale, Locale(identifier: "en_US")) {
+  ///   // Assertions...
+  /// }
+  /// ```
+  ///
+  /// Or, if you are using the Composable Architecture, you can override dependencies directly
+  /// on the `TestStore`:
+  ///
+  /// ```swift
+  /// let store = TestStore(
+  ///   initialState: MyFeature.State()
+  ///   reducer: MyFeature()
+  /// )
+  ///
+  /// store.dependencies.locale = Locale(identifier: "en_US")
+  /// ```
+  public var locale: Locale {
+    get { self[LocaleKey.self] }
+    set { self[LocaleKey.self] = newValue }
+  }
 
-    private enum LocaleKey: DependencyKey {
-      static let liveValue = Locale.autoupdatingCurrent
-      static var testValue: Locale {
-        XCTFail(#"Unimplemented: @Dependency(\.locale)"#)
-        return .autoupdatingCurrent
-      }
+  private enum LocaleKey: DependencyKey {
+    static let liveValue = Locale.autoupdatingCurrent
+    static var testValue: Locale {
+      XCTFail(#"Unimplemented: @Dependency(\.locale)"#)
+      return .autoupdatingCurrent
     }
   }
-#endif
+}

--- a/Sources/Dependencies/Dependencies/OpenURL.swift
+++ b/Sources/Dependencies/Dependencies/OpenURL.swift
@@ -48,7 +48,7 @@ import XCTestDynamicOverlay
             continuation.finish()
           #endif
         }
-        continuation.onTermination = { _ in
+        continuation.onTermination = { @Sendable _ in
           task.cancel()
         }
       }

--- a/Sources/Dependencies/Dependencies/TimeZone.swift
+++ b/Sources/Dependencies/Dependencies/TimeZone.swift
@@ -1,33 +1,31 @@
 import Foundation
 import XCTestDynamicOverlay
 
-#if swift(>=5.6)
-  extension DependencyValues {
-    /// The current time zone that features should use when handling dates.
-    ///
-    /// By default, the time zone returned from `TimeZone.autoupdatingCurrent` is supplied. When
-    /// used from a `TestStore`, access will call to `XCTFail` when invoked, unless explicitly
-    /// overridden:
-    ///
-    /// ```swift
-    /// let store = TestStore(
-    ///   initialState: MyFeature.State()
-    ///   reducer: MyFeature()
-    /// )
-    ///
-    /// store.dependencies.timeZone = TimeZone(secondsFromGMT: 0)
-    /// ```
-    public var timeZone: TimeZone {
-      get { self[TimeZoneKey.self] }
-      set { self[TimeZoneKey.self] = newValue }
-    }
+extension DependencyValues {
+  /// The current time zone that features should use when handling dates.
+  ///
+  /// By default, the time zone returned from `TimeZone.autoupdatingCurrent` is supplied. When
+  /// used from a `TestStore`, access will call to `XCTFail` when invoked, unless explicitly
+  /// overridden:
+  ///
+  /// ```swift
+  /// let store = TestStore(
+  ///   initialState: MyFeature.State()
+  ///   reducer: MyFeature()
+  /// )
+  ///
+  /// store.dependencies.timeZone = TimeZone(secondsFromGMT: 0)
+  /// ```
+  public var timeZone: TimeZone {
+    get { self[TimeZoneKey.self] }
+    set { self[TimeZoneKey.self] = newValue }
+  }
 
-    private enum TimeZoneKey: DependencyKey {
-      static let liveValue = TimeZone.autoupdatingCurrent
-      static var testValue: TimeZone {
-        XCTFail(#"Unimplemented: @Dependency(\.timeZone)"#)
-        return .autoupdatingCurrent
-      }
+  private enum TimeZoneKey: DependencyKey {
+    static let liveValue = TimeZone.autoupdatingCurrent
+    static var testValue: TimeZone {
+      XCTFail(#"Unimplemented: @Dependency(\.timeZone)"#)
+      return .autoupdatingCurrent
     }
   }
-#endif
+}

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -231,7 +231,7 @@ public struct DependencyValues: Sendable {
     file: StaticString = #file,
     function: StaticString = #function,
     line: UInt = #line
-  ) -> Key.Value where Key.Value: Sendable {
+  ) -> Key.Value where Key.Value: _Sendable {
     get {
       guard let dependency = self.storage[ObjectIdentifier(key)]?.base as? Key.Value
       else {
@@ -313,7 +313,7 @@ public struct DependencyValues: Sendable {
 private struct AnySendable: @unchecked Sendable {
   let base: Any
 
-  init<Base: Sendable>(_ base: Base) {
+  init<Base: _Sendable>(_ base: Base) {
     self.base = base
   }
 }
@@ -336,3 +336,9 @@ private let defaultContext: DependencyContext = {
 }()
 
 // TODO: should we have `@Dependency(\.runtimeWarningsEnabled)` and/or `@Dependency(\.treatWarningsAsErrors)`?
+
+#if swift(>=5.6)
+  public typealias _Sendable = Sendable
+#else
+  public typealias _Sendable = Any
+#endif

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -231,7 +231,7 @@ public struct DependencyValues: Sendable {
     file: StaticString = #file,
     function: StaticString = #function,
     line: UInt = #line
-  ) -> Key.Value where Key.Value: _Sendable {
+  ) -> Key.Value where Key.Value: Sendable {
     get {
       guard let dependency = self.storage[ObjectIdentifier(key)]?.base as? Key.Value
       else {
@@ -313,7 +313,7 @@ public struct DependencyValues: Sendable {
 private struct AnySendable: @unchecked Sendable {
   let base: Any
 
-  init<Base: _Sendable>(_ base: Base) {
+  init<Base: Sendable>(_ base: Base) {
     self.base = base
   }
 }
@@ -334,12 +334,3 @@ private let defaultContext: DependencyContext = {
     return .live
   }
 }()
-
-// NB: Swift 5.5 shipped with fewer sendable types, so sendable checking should be more lenient
-#if swift(>=5.6)
-  /// A type alias to Swift's `Sendable` protocol used to maintain backwards compatibility with
-  /// Swift 5.5.
-  public typealias _Sendable = Sendable
-#else
-  public typealias _Sendable = Any
-#endif

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -337,6 +337,8 @@ private let defaultContext: DependencyContext = {
 
 // NB: Swift 5.5 shipped with fewer sendable types, so sendable checking should be more lenient
 #if swift(>=5.6)
+  /// A type alias to Swift's `Sendable` protocol used to maintain backwards compatibility with
+  /// Swift 5.5.
   public typealias _Sendable = Sendable
 #else
   public typealias _Sendable = Any

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -335,8 +335,7 @@ private let defaultContext: DependencyContext = {
   }
 }()
 
-// TODO: should we have `@Dependency(\.runtimeWarningsEnabled)` and/or `@Dependency(\.treatWarningsAsErrors)`?
-
+// NB: Swift 5.5 shipped with fewer sendable types, so sendable checking should be more lenient
 #if swift(>=5.6)
   public typealias _Sendable = Sendable
 #else


### PR DESCRIPTION
~~As pointed out in #1489, we somehow lost compatibility with Swift 5.5 (Xcode 13.2). While we hope to drop support when we hit 1.0, let's try to keep compatibility in the meantime.~~

Unfortunately, it does not appear that Swift 5.5 is up to task when it comes to the new `ReducerProtocol`. While we'd be happy to support it for folks that are stuck building on Xcode <=13.2.1, we personally don't have the bandwidth to investigate the problem. I've opened #1494 to track this.