### PR TITLE
Remove a few dependencies to UIKit in SwiftUI's CaseStudies

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
@@ -1,6 +1,5 @@
 import Combine
 import ComposableArchitecture
-import UIKit
 import XCTestDynamicOverlay
 
 struct Root: ReducerProtocol {

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -93,6 +93,7 @@ struct EffectsBasics: ReducerProtocol {
 
 struct EffectsBasicsView: View {
   let store: StoreOf<EffectsBasics>
+  @Environment(\.openURL) var openURL
 
   var body: some View {
     WithViewStore(self.store, observe: { $0 }) { viewStore in
@@ -138,7 +139,7 @@ struct EffectsBasicsView: View {
 
         Section {
           Button("Number facts provided by numbersapi.com") {
-            UIApplication.shared.open(URL(string: "http://numbersapi.com")!)
+            openURL(URL(string: "http://numbersapi.com")!)
           }
           .foregroundStyle(.secondary)
           .frame(maxWidth: .infinity)

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -139,7 +139,7 @@ struct EffectsBasicsView: View {
 
         Section {
           Button("Number facts provided by numbersapi.com") {
-            openURL(URL(string: "http://numbersapi.com")!)
+            self.openURL(URL(string: "http://numbersapi.com")!)
           }
           .foregroundStyle(.secondary)
           .frame(maxWidth: .infinity)

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -105,7 +105,7 @@ struct EffectsCancellationView: View {
 
         Section {
           Button("Number facts provided by numbersapi.com") {
-            openURL(URL(string: "http://numbersapi.com")!)
+            self.openURL(URL(string: "http://numbersapi.com")!)
           }
           .foregroundStyle(.secondary)
           .frame(maxWidth: .infinity)

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -69,7 +69,8 @@ struct EffectsCancellation: ReducerProtocol {
 
 struct EffectsCancellationView: View {
   let store: StoreOf<EffectsCancellation>
-
+  @Environment(\.openURL) var openURL
+  
   var body: some View {
     WithViewStore(self.store, observe: { $0 }) { viewStore in
       Form {
@@ -104,7 +105,7 @@ struct EffectsCancellationView: View {
 
         Section {
           Button("Number facts provided by numbersapi.com") {
-            UIApplication.shared.open(URL(string: "http://numbersapi.com")!)
+            openURL(URL(string: "http://numbersapi.com")!)
           }
           .foregroundStyle(.secondary)
           .frame(maxWidth: .infinity)

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -1,7 +1,6 @@
 import Combine
 import ComposableArchitecture
 import SwiftUI
-import UIKit
 
 private let readMe = """
   This screen demonstrates navigation that depends on loading optional state.


### PR DESCRIPTION
A PR about TCA's the `OpenURL` `Dependency` reminded me that we can use the built-in `@Environment(\.openURL)` in `CaseStudies`.