### PR TITLE
Remove some escaping closures

### DIFF
--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -123,8 +123,6 @@ struct AppView: View {
     }
   }
 
-  @State var count = 0
-
   var body: some View {
     NavigationView {
       VStack(alignment: .leading) {
@@ -146,17 +144,12 @@ struct AppView: View {
         List {
           ForEachStore(
             self.store.scope(state: \.filteredTodos, action: Todos.Action.todo(id:action:))
-          ) { store in
-            VStack {
-              TodoView(store: store)
-              Text("Count: \(self.count)")
-              Button { self.count += 1 } label: { Text("Increment") }
-            }
+          ) {
+            TodoView(store: $0)
           }
           .onDelete { self.viewStore.send(.delete($0)) }
           .onMove { self.viewStore.send(.move($0, $1)) }
         }
-        .buttonStyle(.borderless)
       }
       .navigationTitle("Todos")
       .navigationBarItems(

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -123,6 +123,8 @@ struct AppView: View {
     }
   }
 
+  @State var count = 0
+
   var body: some View {
     NavigationView {
       VStack(alignment: .leading) {
@@ -144,12 +146,17 @@ struct AppView: View {
         List {
           ForEachStore(
             self.store.scope(state: \.filteredTodos, action: Todos.Action.todo(id:action:))
-          ) {
-            TodoView(store: $0)
+          ) { store in
+            VStack {
+              TodoView(store: store)
+              Text("Count: \(self.count)")
+              Button { self.count += 1 } label: { Text("Increment") }
+            }
           }
           .onDelete { self.viewStore.send(.delete($0)) }
           .onMove { self.viewStore.send(.move($0, $1)) }
         }
+        .buttonStyle(.borderless)
       }
       .navigationTitle("Todos")
       .navigationBarItems(

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -1149,16 +1149,14 @@ extension ForEachStore {
   {
     let data = store.state.value
     self.data = data
-    self.content = {
-      WithViewStore(store.scope(state: { $0.map { $0[keyPath: id] } })) { viewStore in
-        ForEach(Array(viewStore.state.enumerated()), id: \.element) { index, _ in
-          content(
-            store.scope(
-              state: { index < $0.endIndex ? $0[index] : data[index] },
-              action: { (index, $0) }
-            )
+    self.content = WithViewStore(store.scope(state: { $0.map { $0[keyPath: id] } })) { viewStore in
+      ForEach(Array(viewStore.state.enumerated()), id: \.element) { index, _ in
+        content(
+          store.scope(
+            state: { index < $0.endIndex ? $0[index] : data[index] },
+            action: { (index, $0) }
           )
-        }
+        )
       }
     }
   }

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -1134,40 +1134,48 @@ extension AnyReducer {
   }
 }
 
-//extension ForEachStore {
-//  @available(*, deprecated, message: "Use the 'IdentifiedArray'-based version, instead.")
-//  public init(
-//    _ store: Store<Data, (Data.Index, EachAction)>,
-//    id: KeyPath<EachState, ID>,
-//    @ViewBuilder content: @escaping (Store<EachState, EachAction>) -> EachContent
-//  ) {
-//    let data = store.state.value
-//    self.data = data
-//    self.content = WithViewStore(store.scope(state: { $0.map { $0[keyPath: id] } })) { viewStore in
-//      ForEach(Array(viewStore.state.enumerated()), id: \.element) { index, _ in
-//        content(
-//          store.scope(
-//            state: { index < $0.endIndex ? $0[index] : data[index] },
-//            action: { (index, $0) }
-//          )
-//        )
-//      }
-//    }
-//  }
-//
-//  @available(*, deprecated, message: "Use the 'IdentifiedArray'-based version, instead.")
-//  public init<EachContent>(
-//    _ store: Store<Data, (Data.Index, EachAction)>,
-//    @ViewBuilder content: @escaping (Store<EachState, EachAction>) -> EachContent
-//  )
-//  where
-//    Data == [EachState],
-//    Content == WithViewStore<
-//      [ID], (Data.Index, EachAction), ForEach<[(offset: Int, element: ID)], ID, EachContent>
-//    >,
-//    EachState: Identifiable,
-//    EachState.ID == ID
-//  {
-//    self.init(store, id: \.id, content: content)
-//  }
-//}
+extension ForEachStore {
+  @available(*, deprecated, message: "Use the 'IdentifiedArray'-based version, instead.")
+  public init<EachContent>(
+    _ store: Store<Data, (Data.Index, EachAction)>,
+    id: KeyPath<EachState, ID>,
+    @ViewBuilder content: @escaping (Store<EachState, EachAction>) -> EachContent
+  )
+  where
+    Data == [EachState],
+    Content == WithViewStore<
+      [ID], (Data.Index, EachAction), ForEach<[(offset: Int, element: ID)], ID, EachContent>
+    >
+  {
+    let data = store.state.value
+    self.data = data
+    self.content = {
+      WithViewStore(store.scope(state: { $0.map { $0[keyPath: id] } })) { viewStore in
+        ForEach(Array(viewStore.state.enumerated()), id: \.element) { index, _ in
+          content(
+            store.scope(
+              state: { index < $0.endIndex ? $0[index] : data[index] },
+              action: { (index, $0) }
+            )
+          )
+        }
+      }
+    }
+  }
+
+  @available(*, deprecated, message: "Use the 'IdentifiedArray'-based version, instead.")
+  public init<EachContent>(
+    _ store: Store<Data, (Data.Index, EachAction)>,
+    @ViewBuilder content: @escaping (Store<EachState, EachAction>) -> EachContent
+  )
+  where
+    Data == [EachState],
+    Content == WithViewStore<
+      [ID], (Data.Index, EachAction), ForEach<[(offset: Int, element: ID)], ID, EachContent>
+    >,
+    EachState: Identifiable,
+    EachState.ID == ID
+  {
+    self.init(store, id: \.id, content: content)
+  }
+}

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -1134,48 +1134,40 @@ extension AnyReducer {
   }
 }
 
-extension ForEachStore {
-  @available(*, deprecated, message: "Use the 'IdentifiedArray'-based version, instead.")
-  public init<EachContent>(
-    _ store: Store<Data, (Data.Index, EachAction)>,
-    id: KeyPath<EachState, ID>,
-    @ViewBuilder content: @escaping (Store<EachState, EachAction>) -> EachContent
-  )
-  where
-    Data == [EachState],
-    Content == WithViewStore<
-      [ID], (Data.Index, EachAction), ForEach<[(offset: Int, element: ID)], ID, EachContent>
-    >
-  {
-    let data = store.state.value
-    self.data = data
-    self.content = {
-      WithViewStore(store.scope(state: { $0.map { $0[keyPath: id] } })) { viewStore in
-        ForEach(Array(viewStore.state.enumerated()), id: \.element) { index, _ in
-          content(
-            store.scope(
-              state: { index < $0.endIndex ? $0[index] : data[index] },
-              action: { (index, $0) }
-            )
-          )
-        }
-      }
-    }
-  }
-
-  @available(*, deprecated, message: "Use the 'IdentifiedArray'-based version, instead.")
-  public init<EachContent>(
-    _ store: Store<Data, (Data.Index, EachAction)>,
-    @ViewBuilder content: @escaping (Store<EachState, EachAction>) -> EachContent
-  )
-  where
-    Data == [EachState],
-    Content == WithViewStore<
-      [ID], (Data.Index, EachAction), ForEach<[(offset: Int, element: ID)], ID, EachContent>
-    >,
-    EachState: Identifiable,
-    EachState.ID == ID
-  {
-    self.init(store, id: \.id, content: content)
-  }
-}
+//extension ForEachStore {
+//  @available(*, deprecated, message: "Use the 'IdentifiedArray'-based version, instead.")
+//  public init(
+//    _ store: Store<Data, (Data.Index, EachAction)>,
+//    id: KeyPath<EachState, ID>,
+//    @ViewBuilder content: @escaping (Store<EachState, EachAction>) -> EachContent
+//  ) {
+//    let data = store.state.value
+//    self.data = data
+//    self.content = WithViewStore(store.scope(state: { $0.map { $0[keyPath: id] } })) { viewStore in
+//      ForEach(Array(viewStore.state.enumerated()), id: \.element) { index, _ in
+//        content(
+//          store.scope(
+//            state: { index < $0.endIndex ? $0[index] : data[index] },
+//            action: { (index, $0) }
+//          )
+//        )
+//      }
+//    }
+//  }
+//
+//  @available(*, deprecated, message: "Use the 'IdentifiedArray'-based version, instead.")
+//  public init<EachContent>(
+//    _ store: Store<Data, (Data.Index, EachAction)>,
+//    @ViewBuilder content: @escaping (Store<EachState, EachAction>) -> EachContent
+//  )
+//  where
+//    Data == [EachState],
+//    Content == WithViewStore<
+//      [ID], (Data.Index, EachAction), ForEach<[(offset: Int, element: ID)], ID, EachContent>
+//    >,
+//    EachState: Identifiable,
+//    EachState.ID == ID
+//  {
+//    self.init(store, id: \.id, content: content)
+//  }
+//}

--- a/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
@@ -49,9 +49,10 @@ public struct IfLetStore<State, Action, Content: View>: View {
   public init<IfContent, ElseContent>(
     _ store: Store<State?, Action>,
     @ViewBuilder then ifContent: @escaping (Store<State, Action>) -> IfContent,
-    @ViewBuilder else elseContent: @escaping () -> ElseContent
+    @ViewBuilder else elseContent: () -> ElseContent
   ) where Content == _ConditionalContent<IfContent, ElseContent> {
     self.store = store
+    let elseContent = elseContent()
     self.content = { viewStore in
       if var state = viewStore.state {
         return ViewBuilder.buildEither(
@@ -63,7 +64,7 @@ public struct IfLetStore<State, Action, Content: View>: View {
           )
         )
       } else {
-        return ViewBuilder.buildEither(second: elseContent())
+        return ViewBuilder.buildEither(second: elseContent)
       }
     }
   }

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -55,18 +55,18 @@ import SwiftUI
 /// case of an enum in reducers that operate on the entire enum.
 public struct SwitchStore<State, Action, Content: View>: View {
   public let store: Store<State, Action>
-  public let content: () -> Content
+  public let content: Content
 
   init(
     store: Store<State, Action>,
-    @ViewBuilder content: @escaping () -> Content
+    @ViewBuilder content: () -> Content
   ) {
     self.store = store
-    self.content = content
+    self.content = content()
   }
 
   public var body: some View {
-    self.content()
+    self.content
       .environmentObject(StoreObservableObject(store: self.store))
   }
 }

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -135,26 +135,26 @@ extension CaseLet where EnumAction == CaseAction {
 /// a ``CaseLet`` for each case of the enum), then you must insert a ``Default`` view at the end of
 /// the ``SwitchStore``'s body.
 public struct Default<Content: View>: View {
-  private let content: () -> Content
+  private let content: Content
 
   /// Initializes a ``Default`` view that computes content depending on if a store of enum state
   /// does not match a particular case.
   ///
   /// - Parameter content: A function that returns a view that is visible only when the switch
   ///   store's state does not match a preceding ``CaseLet`` view.
-  public init(@ViewBuilder content: @escaping () -> Content) {
-    self.content = content
+  public init(@ViewBuilder content: () -> Content) {
+    self.content = content()
   }
 
   public var body: some View {
-    self.content()
+    self.content
   }
 }
 
 extension SwitchStore {
   public init<State1, Action1, Content1, DefaultContent>(
     _ store: Store<State, Action>,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
         Default<DefaultContent>
@@ -171,8 +171,8 @@ extension SwitchStore {
       >
     >
   {
+    let content = content().value
     self.init(store: store) {
-      let content = content().value
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
@@ -208,7 +208,7 @@ extension SwitchStore {
 
   public init<State1, Action1, Content1, State2, Action2, Content2, DefaultContent>(
     _ store: Store<State, Action>,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
         CaseLet<State, Action, State2, Action2, Content2>,
@@ -229,8 +229,8 @@ extension SwitchStore {
       >
     >
   {
+    let content = content().value
     self.init(store: store) {
-      let content = content().value
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
@@ -248,7 +248,7 @@ extension SwitchStore {
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
         CaseLet<State, Action, State2, Action2, Content2>
@@ -283,7 +283,7 @@ extension SwitchStore {
     DefaultContent
   >(
     _ store: Store<State, Action>,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
         CaseLet<State, Action, State2, Action2, Content2>,
@@ -308,8 +308,8 @@ extension SwitchStore {
       >
     >
   {
+    let content = content().value
     self.init(store: store) {
-      let content = content().value
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
@@ -329,7 +329,7 @@ extension SwitchStore {
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
         CaseLet<State, Action, State2, Action2, Content2>,
@@ -370,7 +370,7 @@ extension SwitchStore {
     DefaultContent
   >(
     _ store: Store<State, Action>,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
         CaseLet<State, Action, State2, Action2, Content2>,
@@ -399,8 +399,8 @@ extension SwitchStore {
       >
     >
   {
+    let content = content().value
     self.init(store: store) {
-      let content = content().value
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
@@ -427,7 +427,7 @@ extension SwitchStore {
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
         CaseLet<State, Action, State2, Action2, Content2>,
@@ -474,7 +474,7 @@ extension SwitchStore {
     DefaultContent
   >(
     _ store: Store<State, Action>,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
         CaseLet<State, Action, State2, Action2, Content2>,
@@ -507,8 +507,8 @@ extension SwitchStore {
       >
     >
   {
+    let content = content().value
     self.init(store: store) {
-      let content = content().value
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
@@ -538,7 +538,7 @@ extension SwitchStore {
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
         CaseLet<State, Action, State2, Action2, Content2>,
@@ -591,7 +591,7 @@ extension SwitchStore {
     DefaultContent
   >(
     _ store: Store<State, Action>,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
         CaseLet<State, Action, State2, Action2, Content2>,
@@ -628,8 +628,8 @@ extension SwitchStore {
       >
     >
   {
+    let content = content().value
     self.init(store: store) {
-      let content = content().value
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
@@ -662,7 +662,7 @@ extension SwitchStore {
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
         CaseLet<State, Action, State2, Action2, Content2>,
@@ -721,7 +721,7 @@ extension SwitchStore {
     DefaultContent
   >(
     _ store: Store<State, Action>,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
         CaseLet<State, Action, State2, Action2, Content2>,
@@ -762,8 +762,8 @@ extension SwitchStore {
       >
     >
   {
+    let content = content().value
     self.init(store: store) {
-      let content = content().value
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
@@ -799,7 +799,7 @@ extension SwitchStore {
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
         CaseLet<State, Action, State2, Action2, Content2>,
@@ -864,7 +864,7 @@ extension SwitchStore {
     DefaultContent
   >(
     _ store: Store<State, Action>,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
         CaseLet<State, Action, State2, Action2, Content2>,
@@ -909,8 +909,8 @@ extension SwitchStore {
       >
     >
   {
+    let content = content().value
     self.init(store: store) {
-      let content = content().value
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
@@ -949,7 +949,7 @@ extension SwitchStore {
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
         CaseLet<State, Action, State2, Action2, Content2>,
@@ -1020,7 +1020,7 @@ extension SwitchStore {
     DefaultContent
   >(
     _ store: Store<State, Action>,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
         CaseLet<State, Action, State2, Action2, Content2>,
@@ -1069,8 +1069,8 @@ extension SwitchStore {
       >
     >
   {
+    let content = content().value
     self.init(store: store) {
-      let content = content().value
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
@@ -1112,7 +1112,7 @@ extension SwitchStore {
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<State, Action, State1, Action1, Content1>,
         CaseLet<State, Action, State2, Action2, Content2>,

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -963,6 +963,11 @@ public struct TestStoreTask: Hashable, Sendable {
   fileprivate let rawValue: Task<Void, Never>?
   fileprivate let timeout: UInt64
 
+  @_spi(Canary) public init(rawValue: Task<Void, Never>?, timeout: UInt64) {
+    self.rawValue = rawValue
+    self.timeout = timeout
+  }
+
   /// Cancels the underlying task and waits for it to finish.
   public func cancel() async {
     self.rawValue?.cancel()

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -1,5 +1,5 @@
 import Combine
-import ComposableArchitecture
+@_spi(Canary) import ComposableArchitecture
 import XCTest
 
 @MainActor
@@ -315,6 +315,7 @@ final class EffectTests: XCTestCase {
       $0 = 1_234_567_890
     }
   }
+
   func testMap() async {
     @Dependency(\.date) var date
     let effect =
@@ -338,6 +339,19 @@ final class EffectTests: XCTestCase {
         }
       output = await effect.values.first(where: { _ in true })
       XCTAssertEqual(output, Date(timeIntervalSince1970: 1_234_567_890))
+    }
+  }
+
+  func testCanary1() async {
+    for _ in 1...100 {
+      let task = TestStoreTask(rawValue: Task {}, timeout: NSEC_PER_SEC)
+      await task.finish()
+    }
+  }
+  func testCanary2() async {
+    for _ in 1...100 {
+      let task = TestStoreTask(rawValue: nil, timeout: NSEC_PER_SEC)
+      await task.finish()
     }
   }
 }


### PR DESCRIPTION
We have 2 unnecessary escaping closures in `ForEachStore` and `SwitchStore`. It's not actually gonna buy us anything in practice, but still they are definitely not needed.