### PR TITLE
Remove unnecessary dependencies in every CaseStudies

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
@@ -1,6 +1,4 @@
-import Combine
 import ComposableArchitecture
-import XCTestDynamicOverlay
 
 struct Root: ReducerProtocol {
   struct State: Equatable {

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import SwiftUI
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -280,6 +280,8 @@ struct RootView: View {
   }
 }
 
+// MARK: - SwiftUI previews
+
 struct RootView_Previews: PreviewProvider {
   static var previews: some View {
     RootView(

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -19,6 +19,8 @@ private let readMe = """
   alerts and dialogs in your application
   """
 
+// MARK: - Feature domain
+
 struct AlertAndConfirmationDialog: ReducerProtocol {
   struct State: Equatable {
     var alert: AlertState<Action>?
@@ -79,6 +81,8 @@ struct AlertAndConfirmationDialog: ReducerProtocol {
   }
 }
 
+// MARK: - Feature view
+
 struct AlertAndConfirmationDialogView: View {
   let store: StoreOf<AlertAndConfirmationDialog>
 
@@ -105,6 +109,8 @@ struct AlertAndConfirmationDialogView: View {
     )
   }
 }
+
+// MARK: - SwiftUI previews
 
 struct AlertAndConfirmationDialog_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -18,6 +18,8 @@ private let readMe = """
   toggle at the bottom of the screen.
   """
 
+// MARK: - Feature domain
+
 struct Animations: ReducerProtocol {
   struct State: Equatable {
     var alert: AlertState<Action>?
@@ -85,6 +87,8 @@ struct Animations: ReducerProtocol {
   }
 }
 
+// MARK: - Feature view
+
 struct AnimationsView: View {
   let store: StoreOf<Animations>
 
@@ -135,6 +139,8 @@ struct AnimationsView: View {
     }
   }
 }
+
+// MARK: - SwiftUI previews
 
 struct AnimationsView_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 @preconcurrency import SwiftUI  // NB: SwiftUI.Color and SwiftUI.Animation are not Sendable yet.
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -18,6 +18,8 @@ private let readMe = """
   component changes, which means you can keep using a unidirectional style for your feature.
   """
 
+// MARK: - Feature domain
+
 struct BindingBasics: ReducerProtocol {
   struct State: Equatable {
     var sliderValue = 5.0
@@ -54,6 +56,8 @@ struct BindingBasics: ReducerProtocol {
     }
   }
 }
+
+// MARK: - Feature view
 
 struct BindingBasicsView: View {
   let store: StoreOf<BindingBasics>
@@ -118,6 +122,8 @@ private func alternate(_ string: String) -> String {
     }
     .joined()
 }
+
+// MARK: - SwiftUI previews
 
 struct BindingBasicsView_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -13,6 +13,8 @@ private let readMe = """
   It is instructive to compare this case study to the "Binding Basics" case study.
   """
 
+// MARK: - Feature domain
+
 struct BindingForm: ReducerProtocol {
   struct State: Equatable {
     @BindableState var sliderValue = 5.0
@@ -44,6 +46,8 @@ struct BindingForm: ReducerProtocol {
     }
   }
 }
+
+// MARK: - Feature view
 
 struct BindingFormView: View {
   let store: StoreOf<BindingForm>
@@ -105,6 +109,8 @@ private func alternate(_ string: String) -> String {
     }
     .joined()
 }
+
+// MARK: - SwiftUI previews
 
 struct BindingFormView_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -8,6 +8,8 @@ private let readMe = """
   It reuses the the domain of the counter screen and embeds it, twice, in a larger domain.
   """
 
+// MARK: - Feature domain
+
 struct TwoCounters: ReducerProtocol {
   struct State: Equatable {
     var counter1 = Counter.State()
@@ -28,6 +30,8 @@ struct TwoCounters: ReducerProtocol {
     }
   }
 }
+
+// MARK: - Feature view
 
 struct TwoCountersView: View {
   let store: StoreOf<TwoCounters>
@@ -58,6 +62,8 @@ struct TwoCountersView: View {
     .navigationTitle("Two counter demo")
   }
 }
+
+// MARK: - SwiftUI previews
 
 struct TwoCountersView_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -9,6 +9,8 @@ private let readMe = """
   state of the application and any actions that can affect that state or the outside world.
   """
 
+// MARK: - Feature domain
+
 struct Counter: ReducerProtocol {
   struct State: Equatable {
     var count = 0
@@ -30,6 +32,8 @@ struct Counter: ReducerProtocol {
     }
   }
 }
+
+// MARK: - Feature view
 
 struct CounterView: View {
   let store: StoreOf<Counter>
@@ -74,6 +78,8 @@ struct CounterDemoView: View {
     .navigationTitle("Counter demo")
   }
 }
+
+// MARK: - SwiftUI previews
 
 struct CounterView_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -6,6 +6,8 @@ private let readMe = """
   If you tap the "Sign in" button while a field is empty, the focus will be changed to that field.
   """
 
+// MARK: - Feature domain
+
 struct FocusDemo: ReducerProtocol {
   struct State: Equatable {
     @BindableState var focusedField: Field?
@@ -40,6 +42,8 @@ struct FocusDemo: ReducerProtocol {
     }
   }
 }
+
+// MARK: - Feature view
 
 struct FocusDemoView: View {
   let store: StoreOf<FocusDemo>
@@ -79,6 +83,8 @@ extension View {
       .onChange(of: second.wrappedValue) { first.wrappedValue = $0 }
   }
 }
+
+// MARK: - SwiftUI previews
 
 struct FocusDemo_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -12,6 +12,8 @@ private let readMe = """
   Tapping "Toggle counter state" will flip between the `nil` and non-`nil` counter states.
   """
 
+// MARK: - Feature domain
+
 struct OptionalBasics: ReducerProtocol {
   struct State: Equatable {
     var optionalCounter: Counter.State?
@@ -40,6 +42,8 @@ struct OptionalBasics: ReducerProtocol {
     }
   }
 }
+
+// MARK: - Feature view
 
 struct OptionalBasicsView: View {
   let store: StoreOf<OptionalBasics>
@@ -75,6 +79,8 @@ struct OptionalBasicsView: View {
     .navigationTitle("Optional state")
   }
 }
+
+// MARK: - SwiftUI previews
 
 struct OptionalBasicsView_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
@@ -14,6 +14,8 @@ private let readMe = """
   can be reset from the other tab.
   """
 
+// MARK: - Feature domain
+
 struct SharedState: ReducerProtocol {
   enum Tab { case counter, profile }
 
@@ -147,6 +149,8 @@ struct SharedState: ReducerProtocol {
     }
   }
 }
+
+// MARK: - Feature view
 
 struct SharedStateView: View {
   let store: StoreOf<SharedState>

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import SwiftUI
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -150,7 +150,7 @@ struct EffectsBasicsView: View {
   }
 }
 
-// MARK: - Feature SwiftUI previews
+// MARK: - SwiftUI previews
 
 struct EffectsBasicsView_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import SwiftUI
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -12,7 +12,7 @@ private let readMe = """
   request is in-flight will also cancel it.
   """
 
-// MARK: - Demo app domain
+// MARK: - Feature domain
 
 struct EffectsCancellation: ReducerProtocol {
   struct State: Equatable {
@@ -64,7 +64,7 @@ struct EffectsCancellation: ReducerProtocol {
   }
 }
 
-// MARK: - Application view
+// MARK: - Feature view
 
 struct EffectsCancellationView: View {
   let store: StoreOf<EffectsCancellation>

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -15,7 +15,7 @@ private let readMe = """
   the screen, and restarted when entering the screen.
   """
 
-// MARK: - Application domain
+// MARK: - Feature domain
 
 struct LongLivingEffects: ReducerProtocol {
   struct State: Equatable {
@@ -66,7 +66,7 @@ private enum ScreenshotsKey: DependencyKey {
   )
 }
 
-// MARK: - SwiftUI view
+// MARK: - Feature view
 
 struct LongLivingEffectsView: View {
   let store: StoreOf<LongLivingEffects>

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import SwiftUI
 import XCTestDynamicOverlay

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -11,6 +11,8 @@ private let readMe = """
   currently fetching data so that it knows to continue showing the loading indicator.
   """
 
+// MARK: - Feature domain
+
 struct Refreshable: ReducerProtocol {
   struct State: Equatable {
     var count = 0
@@ -61,6 +63,8 @@ struct Refreshable: ReducerProtocol {
   }
 }
 
+// MARK: - Feature view
+
 struct RefreshableView: View {
   @State var isLoading = false
   let store: StoreOf<Refreshable>
@@ -109,6 +113,8 @@ struct RefreshableView: View {
     }
   }
 }
+
+// MARK: - SwiftUI previews
 
 struct Refreshable_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -9,7 +9,7 @@ private let readMe = """
   `AsyncSequence`-friendly API for dealing with timers in asynchronous code.
   """
 
-// MARK: - Timer feature domain
+// MARK: - Feature domain
 
 struct Timers: ReducerProtocol {
   struct State: Equatable {
@@ -48,7 +48,7 @@ struct Timers: ReducerProtocol {
   }
 }
 
-// MARK: - Timer feature view
+// MARK: - Feature view
 
 struct TimersView: View {
   let store: StoreOf<Timers>

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 @preconcurrency import SwiftUI  // NB: SwiftUI.Animation is not Sendable yet.
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -10,6 +10,8 @@ private let readMe = """
   message. The socket server should immediately reply with the exact message you send it.
   """
 
+// MARK: - Feature domain
+
 struct WebSocket: ReducerProtocol {
   struct State: Equatable {
     var alert: AlertState<Action>?
@@ -125,6 +127,8 @@ struct WebSocket: ReducerProtocol {
     }
   }
 }
+
+// MARK: - Feature view
 
 struct WebSocketView: View {
   let store: StoreOf<WebSocket>

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import SwiftUI
 import XCTestDynamicOverlay

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -1,5 +1,4 @@
 import ComposableArchitecture
-import Foundation
 import SwiftUI
 
 private let readMe = """

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -9,6 +9,8 @@ private let readMe = """
   depends on this data.
   """
 
+// MARK: - Feature domain
+
 struct LoadThenNavigateList: ReducerProtocol {
   struct State: Equatable {
     var rows: IdentifiedArrayOf<Row> = [
@@ -78,6 +80,8 @@ struct LoadThenNavigateList: ReducerProtocol {
   }
 }
 
+// MARK: - Feature view
+
 struct LoadThenNavigateListView: View {
   let store: StoreOf<LoadThenNavigateList>
 
@@ -118,6 +122,8 @@ struct LoadThenNavigateListView: View {
     }
   }
 }
+
+// MARK: - SwiftUI previews
 
 struct LoadThenNavigateListView_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -8,6 +8,8 @@ private let readMe = """
   and fires off an effect that will load this state a second later.
   """
 
+// MARK: - Feature domain
+
 struct NavigateAndLoadList: ReducerProtocol {
   struct State: Equatable {
     var rows: IdentifiedArrayOf<Row> = [
@@ -68,6 +70,8 @@ struct NavigateAndLoadList: ReducerProtocol {
   }
 }
 
+// MARK: - Feature view
+
 struct NavigateAndLoadListView: View {
   let store: StoreOf<NavigateAndLoadList>
 
@@ -103,6 +107,8 @@ struct NavigateAndLoadListView: View {
     .navigationTitle("Navigate and load")
   }
 }
+
+// MARK: - SwiftUI previews
 
 struct NavigateAndLoadListView_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -9,6 +9,8 @@ private let readMe = """
   that depends on this data.
   """
 
+// MARK: - Feature domain
+
 struct LoadThenNavigate: ReducerProtocol {
   struct State: Equatable {
     var optionalCounter: Counter.State?
@@ -60,6 +62,8 @@ struct LoadThenNavigate: ReducerProtocol {
   }
 }
 
+// MARK: - Feature view
+
 struct LoadThenNavigateView: View {
   let store: StoreOf<LoadThenNavigate>
 
@@ -97,6 +101,8 @@ struct LoadThenNavigateView: View {
     .navigationTitle("Load then navigate")
   }
 }
+
+// MARK: - SwiftUI previews
 
 struct LoadThenNavigateView_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import SwiftUI
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -8,6 +8,8 @@ private let readMe = """
   counter state and fires off an effect that will load this state a second later.
   """
 
+// MARK: - Feature domain
+
 struct NavigateAndLoad: ReducerProtocol {
   struct State: Equatable {
     var isNavigationActive = false
@@ -53,6 +55,8 @@ struct NavigateAndLoad: ReducerProtocol {
   }
 }
 
+// MARK: - Feature view
+
 struct NavigateAndLoadView: View {
   let store: StoreOf<NavigateAndLoad>
 
@@ -85,6 +89,8 @@ struct NavigateAndLoadView: View {
     .navigationTitle("Navigate and load")
   }
 }
+
+// MARK: - SwiftUI previews
 
 struct NavigateAndLoadView_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -9,6 +9,8 @@ private let readMe = """
   depends on this data.
   """
 
+// MARK: - Feature domain
+
 struct LoadThenPresent: ReducerProtocol {
   struct State: Equatable {
     var optionalCounter: Counter.State?
@@ -60,6 +62,8 @@ struct LoadThenPresent: ReducerProtocol {
   }
 }
 
+// MARK: - Feature view
+
 struct LoadThenPresentView: View {
   let store: StoreOf<LoadThenPresent>
 
@@ -99,6 +103,8 @@ struct LoadThenPresentView: View {
     }
   }
 }
+
+// MARK: - SwiftUI previews
 
 struct LoadThenPresentView_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -8,6 +8,8 @@ private let readMe = """
   state and fires off an effect that will load this state a second later.
   """
 
+// MARK: - Feature domain
+
 struct PresentAndLoad: ReducerProtocol {
   struct State: Equatable {
     var optionalCounter: Counter.State?
@@ -53,6 +55,8 @@ struct PresentAndLoad: ReducerProtocol {
   }
 }
 
+// MARK: - Feature view
+
 struct PresentAndLoadView: View {
   let store: StoreOf<PresentAndLoad>
 
@@ -87,6 +91,8 @@ struct PresentAndLoadView: View {
     }
   }
 }
+
+// MARK: - SwiftUI previews
 
 struct PresentAndLoadView_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -34,6 +34,8 @@ extension AnyReducer {
   }
 }
 
+// MARK: - Feature domain
+
 struct ClockState: Equatable {
   var isTimerActive = false
   var secondsElapsed = 0
@@ -71,6 +73,8 @@ let clockReducer = AnyReducer<ClockState, ClockAction, ClockEnvironment>.combine
     ]
   }
 )
+
+// MARK: - Feature view
 
 struct ClockView: View {
   let store: Store<ClockState, ClockAction>
@@ -132,6 +136,8 @@ struct ClockView: View {
     }
   }
 }
+
+// MARK: - SwiftUI previews
 
 struct Subscriptions_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -52,6 +52,8 @@ extension ReducerProtocol {
   }
 }
 
+// MARK: - Feature domain
+
 struct LifecycleDemo: ReducerProtocol {
   struct State: Equatable {
     var count: Int?
@@ -91,6 +93,8 @@ struct LifecycleDemo: ReducerProtocol {
     }
   }
 }
+
+// MARK: - Feature view
 
 struct LifecycleDemoView: View {
   let store: StoreOf<LifecycleDemo>
@@ -158,6 +162,8 @@ private struct TimerView: View {
     }
   }
 }
+
+// MARK: - SwiftUI previews
 
 struct Lifecycle_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -8,6 +8,8 @@ private let readMe = """
   its name, or tap the right-hand side of a row to navigate to its own associated list of rows.
   """
 
+// MARK: - Feature domain
+
 struct Nested: ReducerProtocol {
   struct State: Equatable, Identifiable {
     let id: UUID
@@ -48,6 +50,8 @@ struct Nested: ReducerProtocol {
     }
   }
 }
+
+// MARK: - Feature view
 
 struct NestedView: View {
   let store: StoreOf<Nested>
@@ -115,17 +119,17 @@ extension Nested.State {
   )
 }
 
-#if DEBUG
-  struct NestedView_Previews: PreviewProvider {
-    static var previews: some View {
-      NavigationView {
-        NestedView(
-          store: Store(
-            initialState: .mock,
-            reducer: Nested()
-          )
+// MARK: - SwiftUI previews
+
+struct NestedView_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationView {
+      NestedView(
+        store: Store(
+          initialState: .mock,
+          reducer: Nested()
         )
-      }
+      )
     }
   }
-#endif
+}

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadClient.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadClient.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import Foundation
 import XCTestDynamicOverlay

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import SwiftUI
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -82,7 +82,7 @@ struct FavoriteButton<ID: Hashable & Sendable>: View {
   }
 }
 
-// MARK: Feature domain -
+// MARK: - Feature domain
 
 struct Episode: ReducerProtocol {
   struct State: Equatable, Identifiable {
@@ -107,6 +107,8 @@ struct Episode: ReducerProtocol {
     }
   }
 }
+
+// MARK: - Feature view
 
 struct EpisodeView: View {
   let store: StoreOf<Episode>
@@ -169,6 +171,8 @@ struct EpisodesView: View {
     .navigationTitle("Favoriting")
   }
 }
+
+// MARK: - SwiftUI previews
 
 struct EpisodesView_Previews: PreviewProvider {
   static var previews: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -1,6 +1,4 @@
-import Combine
 import ComposableArchitecture
-import Foundation
 import SwiftUI
 
 private let readMe = """

--- a/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import Foundation
 import XCTestDynamicOverlay

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndConfirmationDialogsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndConfirmationDialogsTests.swift
@@ -1,6 +1,4 @@
-import Combine
 import ComposableArchitecture
-import SwiftUI
 import XCTest
 
 @testable import SwiftUICaseStudies

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import XCTest
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-BindingBasicsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-BindingBasicsTests.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import XCTest
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-SharedStateTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-SharedStateTests.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import XCTest
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-CancellationTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-CancellationTests.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import XCTest
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import XCTest
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import XCTest
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-LifecycleTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-LifecycleTests.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import XCTest
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-RecursionTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-RecursionTests.swift
@@ -1,7 +1,5 @@
-import Combine
 import ComposableArchitecture
 import XCTest
-import XCTestDynamicOverlay
 
 @testable import SwiftUICaseStudies
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import XCTest
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import XCTest
 

--- a/Examples/Search/SearchTests/SearchTests.swift
+++ b/Examples/Search/SearchTests/SearchTests.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import XCTest
 

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Client.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Client.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import Dependencies
 import Speech

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Live.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Live.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import Speech
 

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import Speech
 @preconcurrency import SwiftUI

--- a/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
+++ b/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import XCTest
 

--- a/Examples/TicTacToe/tic-tac-toe/Tests/LoginSwiftUITests/LoginSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/LoginSwiftUITests/LoginSwiftUITests.swift
@@ -1,5 +1,4 @@
 import AuthenticationClient
-import Combine
 import ComposableArchitecture
 import LoginCore
 import XCTest

--- a/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorSwiftUITests/TwoFactorSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorSwiftUITests/TwoFactorSwiftUITests.swift
@@ -1,5 +1,4 @@
 import AuthenticationClient
-import Combine
 import ComposableArchitecture
 import TwoFactorCore
 import XCTest

--- a/Examples/Todos/Todos/Todo.swift
+++ b/Examples/Todos/Todos/Todo.swift
@@ -1,5 +1,4 @@
 import ComposableArchitecture
-import Foundation
 import SwiftUI
 
 struct Todo: ReducerProtocol {

--- a/Examples/VoiceMemos/VoiceMemos/AudioRecorderClient/LiveAudioRecorderClient.swift
+++ b/Examples/VoiceMemos/VoiceMemos/AudioRecorderClient/LiveAudioRecorderClient.swift
@@ -1,6 +1,5 @@
 import AVFoundation
 import ComposableArchitecture  // TODO: Should `UncheckedSendable` live in `Dependencies`?
-import Foundation
 
 extension AudioRecorderClient: DependencyKey {
   static let liveValue: Self = {

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
@@ -1,5 +1,4 @@
 import ComposableArchitecture
-import Foundation
 import SwiftUI
 
 struct VoiceMemo: ReducerProtocol {

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -1,6 +1,5 @@
 import AVFoundation
 import ComposableArchitecture
-import Foundation
 import SwiftUI
 
 struct VoiceMemos: ReducerProtocol {

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemosApp.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemosApp.swift
@@ -1,5 +1,4 @@
 import ComposableArchitecture
-import Foundation
 import SwiftUI
 
 @main

--- a/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
+++ b/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
@@ -1,7 +1,5 @@
-import Combine
 import ComposableArchitecture
 import XCTest
-import XCTestDynamicOverlay
 
 @testable import VoiceMemos
 


### PR DESCRIPTION
Hi! 👋🏻 
I removed imported dependencies that don't affect building and testing in every CaseStudies.
Most of them are `Combine`, but some `Foundation` were added relatively recently at this `Concurrency Beta` #1189 

Removing them didn't have any build issues, but there could be reasons I'm not aware of.
I'll leave comments below. Please check.

and I added `MARK headers` to each file in SwiftUI - CaseStudies for readability, in 3 simple categories.
Please refer to the capture below.

- Feature domain
- Feature view
- SwiftUI previews

<img width="235" alt="MARK headers" src="https://user-images.githubusercontent.com/71127966/195993944-808db8c3-6ea2-46d1-872d-a04925b8263c.png">