### PR TITLE
Fixes a small typo in concurrency docs

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftConcurrency.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftConcurrency.md
@@ -89,7 +89,7 @@ extension DependencyValues {
 If `FactClient` is not `Sendable`, for whatever reason, you will get a warning in the `get`
 and `set` lines:
 
->⚠️ Type 'AudioPlayerClient' does not conform to the 'Sendable' protocol
+>⚠️ Type 'FactClient' does not conform to the 'Sendable' protocol
 
 To fix this you need to make each dependency `Sendable`. This usually just means making sure 
 that the interface type only holds onto `Sendable` data, and in particular, any closure-based 


### PR DESCRIPTION
Noticed a simple typo on a read through of the concurrency migration docs. Hope the tiny PR is kosher!