### PR TITLE
Fixes for the 'Basic Usage' to allow project to build and run

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ struct MyApp: App {
 }
 ```
 
-You may also find that the HTTP API request to numbersapi.com is blocked by the OS as only HTTPS connections are permitted.  If this happens you can add an exception to the project settings to allow HTTP requests just for the numbersapi.com domain.
+You may also find that the HTTP API request to numbersapi.com is blocked as only HTTPS connections are permitted.  If this happens you can add an exception to the project settings to allow HTTP requests just for the numbersapi.com domain.
 
 ```
 <key>NSAppTransportSecurity</key>

--- a/README.md
+++ b/README.md
@@ -123,38 +123,38 @@ struct Feature: ReducerProtocol {
   
   func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
     switch action {
-    case .factAlertDismissed:
-      state.numberFactAlert = nil
-      return .none
-      
-    case .decrementButtonTapped:
-      state.count -= 1
-      return .none
-      
-    case .incrementButtonTapped:
-      state.count += 1
-      return .none
-      
-    case .numberFactButtonTapped:
-      return .task { [number = state.count] in
-        await .numberFactResponse(
-          TaskResult {
-            String(
-              decoding: try await URLSession.shared
-                .data(from: URL(string: "http://numbersapi.com/\(number)/trivia")!).0,
-              as: UTF8.self
-            )
-          }
-        )
-      }
-      
-    case let .numberFactResponse(.success(fact)):
-      state.numberFactAlert = fact
-      return .none
-      
-    case .numberFactResponse(.failure):
-      state.numberFactAlert = "Could not load a number fact :("
-      return .none
+      case .factAlertDismissed:
+        state.numberFactAlert = nil
+        return .none
+        
+      case .decrementButtonTapped:
+        state.count -= 1
+        return .none
+        
+      case .incrementButtonTapped:
+        state.count += 1
+        return .none
+        
+      case .numberFactButtonTapped:
+        return .task { [number = state.count] in
+          await .numberFactResponse(
+            TaskResult {
+              String(
+                decoding: try await URLSession.shared
+                  .data(from: URL(string: "http://numbersapi.com/\(number)/trivia")!).0,
+                as: UTF8.self
+              )
+            }
+          )
+        }
+        
+      case let .numberFactResponse(.success(fact)):
+        state.numberFactAlert = fact
+        return .none
+        
+      case .numberFactResponse(.failure):
+        state.numberFactAlert = "Could not load a number fact :("
+        return .none
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -118,44 +118,52 @@ And then we implement the `reduce` method which is responsible for handling the 
 
 ```swift
 struct Feature: ReducerProtocol {
-  struct State: Equatable { … }
-  enum Action: Equatable { … }
+  struct State: Equatable {
+    var count = 0
+    var numberFactAlert: String?
+  }
+  enum Action: Equatable {
+    case factAlertDismissed
+    case decrementButtonTapped
+    case incrementButtonTapped
+    case numberFactButtonTapped
+    case numberFactResponse(TaskResult<String>)
+  }
   
   func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
     switch action {
-      case .factAlertDismissed:
-        state.numberFactAlert = nil
-        return .none
-
-      case .decrementButtonTapped:
-        state.count -= 1
-        return .none
-
-      case .incrementButtonTapped:
-        state.count += 1
-        return .none
-
-      case .numberFactButtonTapped:
-        return .task { [number = state.count] in 
-          await .numberFactResponse(
-            TaskResult { 
-              String(
-                decoding: try await URLSession.shared
-                  .data(from: URL(string: "http://numbersapi.com/\(number)/trivia")!).0,
-                as: UTF8.self
-              )
-            }
-          )
-        }
-
-      case let .numberFactResponse(.success(fact)):
-        state.numberFactAlert = fact
-        return .none
-
-      case .numberFactResponse(.failure):
-        state.numberFactAlert = "Could not load a number fact :("
-        return .none
-      } 
+    case .factAlertDismissed:
+      state.numberFactAlert = nil
+      return .none
+      
+    case .decrementButtonTapped:
+      state.count -= 1
+      return .none
+      
+    case .incrementButtonTapped:
+      state.count += 1
+      return .none
+      
+    case .numberFactButtonTapped:
+      return .task { [number = state.count] in
+        await .numberFactResponse(
+          TaskResult {
+            String(
+              decoding: try await URLSession.shared
+                .data(from: URL(string: "http://numbersapi.com/\(number)/trivia")!).0,
+              as: UTF8.self
+            )
+          }
+        )
+      }
+      
+    case let .numberFactResponse(.success(fact)):
+      state.numberFactAlert = fact
+      return .none
+      
+    case .numberFactResponse(.failure):
+      state.numberFactAlert = "Could not load a number fact :("
+      return .none
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -118,17 +118,8 @@ And then we implement the `reduce` method which is responsible for handling the 
 
 ```swift
 struct Feature: ReducerProtocol {
-  struct State: Equatable {
-    var count = 0
-    var numberFactAlert: String?
-  }
-  enum Action: Equatable {
-    case factAlertDismissed
-    case decrementButtonTapped
-    case incrementButtonTapped
-    case numberFactButtonTapped
-    case numberFactResponse(TaskResult<String>)
-  }
+  struct State: Equatable { … }
+  enum Action: Equatable { … }
   
   func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
     switch action {

--- a/README.md
+++ b/README.md
@@ -136,12 +136,12 @@ struct Feature: ReducerProtocol {
         return .none
 
       case .numberFactButtonTapped:
-        return .task { [number = state.count] in
+        return .task { [count = state.count] in
           await .numberFactResponse(
             TaskResult {
               String(
                 decoding: try await URLSession.shared
-                  .data(from: URL(string: "http://numbersapi.com/\(number)/trivia")!).0,
+                  .data(from: URL(string: "http://numbersapi.com/\(count)/trivia")!).0,
                 as: UTF8.self
               )
             }
@@ -276,28 +276,6 @@ struct MyApp: App {
     }
   }
 }
-```
-
-You may also find that the HTTP API request to numbersapi.com is blocked as only HTTPS connections are permitted.  If this happens you can add an exception to the project settings to allow HTTP requests just for the numbersapi.com domain.
-
-```
-<key>NSAppTransportSecurity</key>
-<dict>
-  <key>NSAllowsArbitraryLoads</key>
-  <false/>
-  <key>NSExceptionDomains</key>
-  <dict>
-    <key>numbersapi.com</key>
-    <dict>
-      <key>NSIncludesSubdomains</key>
-      <true/>
-      <key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
-      <true/>
-      <key>NSTemporaryExceptionMinimumTLSVersion</key>
-      <string>TLSv1.1</string>
-    </dict>
-  </dict>
-</dict>
 ```
 
 And that is enough to get something on the screen to play around with. It's definitely a few more steps than if you were to do this in a vanilla SwiftUI way, but there are a few benefits. It gives us a consistent manner to apply state mutations, instead of scattering logic in some observable objects and in various action closures of UI components. It also gives us a concise way of expressing side effects. And we can immediately test this logic, including the effects, without doing much additional work.

--- a/README.md
+++ b/README.md
@@ -126,15 +126,15 @@ struct Feature: ReducerProtocol {
       case .factAlertDismissed:
         state.numberFactAlert = nil
         return .none
-        
+
       case .decrementButtonTapped:
         state.count -= 1
         return .none
-        
+
       case .incrementButtonTapped:
         state.count += 1
         return .none
-        
+
       case .numberFactButtonTapped:
         return .task { [number = state.count] in
           await .numberFactResponse(
@@ -147,11 +147,11 @@ struct Feature: ReducerProtocol {
             }
           )
         }
-        
+
       case let .numberFactResponse(.success(fact)):
         state.numberFactAlert = fact
         return .none
-        
+
       case .numberFactResponse(.failure):
         state.numberFactAlert = "Could not load a number fact :("
         return .none


### PR DESCRIPTION
New to TCA (and Swift for that matter) and was just building the Basic Usage section and ran into some minor errors, these minor changes correct the steps so you can build and run the example.

Using the latest Xcode and Swift 5.7 and the new TCA ReducerProtocol builds.  Key changes are:
- 'number' was undefined in the numbersapi.com code and complier flagged 'using' as an error
- wrapping the FeatureView() in a WindowGroup to fix errors
- sample didn't work since my simulator flagged using HTTP, since there is no HTTPS support added an exception to allow API requests to work.