### PR TITLE
Make ViewStore.yield(while:) main actor.

### DIFF
--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -406,6 +406,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
   ///
   /// - Parameter predicate: A predicate on `ViewState` that determines for how long this method
   ///                        should suspend.
+  @MainActor
   public func yield(while predicate: @escaping (ViewState) -> Bool) async {
     if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
       _ = await self.publisher


### PR DESCRIPTION
Considering that `viewStore.send(_:while:)` is `@MainActor`, it seems this one should be too.