### PR TITLE
Improve the layout of `Web Socket` case study

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -171,11 +171,12 @@ struct WebSocketView: View {
           }
         }
 
-        Section(
-          header: Text("Received messages")) {
-            Text("Status: \(viewStore.connectivityState.rawValue)")
-              .foregroundStyle(.secondary)
-            Text(viewStore.receivedMessages.reversed().joined(separator: "\n"))
+        Section {
+          Text("Status: \(viewStore.connectivityState.rawValue)")
+            .foregroundStyle(.secondary)
+          Text(viewStore.receivedMessages.reversed().joined(separator: "\n"))
+        } header: { 
+          Text("Received messages") 
         }
       }
       .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
@@ -91,7 +91,7 @@ final class WebSocketTests: XCTestCase {
       $0.messageToSend = ""
     }
     await store.receive(.sendResponse(didSucceed: false)) {
-      $0.alert = AlertState(title: TextState("Could not send socket message. Try again."))
+      $0.alert = AlertState(title: TextState("Could not send socket message. Connect to the server first, and try again."))
     }
 
     // Disconnect from the socket


### PR DESCRIPTION
Hi, I improved the layout of `Web Socket` case study.
Let me know what you think. Thank you! 😄 

- The layout of the Web Socket was different from that of other cases. I modified it to have the same tone and manner.
- Also, there are multiple blue text buttons clustered together, making it a bit confusing. I modified it so that the roles of buttons are clearly distinguished.
- Messages are now stacking upward. And when re-connecting, the stacked messages are removed.
- I changed some text.

Please check out gif examples below. (1.5x speed)

|as-is|to-be|
|:-:|:-:|
|<img src="https://user-images.githubusercontent.com/71127966/196712568-2b5619ae-8562-4ae0-8177-b250c7906e57.gif" width="250">|<img src="https://user-images.githubusercontent.com/71127966/196712670-8d751c16-379f-4ca9-b4b9-247fa4b23e94.gif" width="250">|