### PR TITLE
`XCTUnimplemented` -> `unimplemented`

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
         "state": {
           "branch": null,
-          "revision": "7346701ea29da0a85d4403cf3d7a589a58ae3dee",
-          "version": "0.9.2"
+          "revision": "15bba50ebf3a2065388c8d12210debe4f6ada202",
+          "version": "0.10.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
         "state": {
           "branch": null,
-          "revision": "c9b6b940d95c0a925c63f6858943415714d8a981",
-          "version": "0.5.2"
+          "revision": "819d9d370cd721c9d87671e29d947279292e4541",
+          "version": "0.6.0"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
         "state": {
           "branch": null,
-          "revision": "30314f1ece684dd60679d598a9b89107557b67d9",
-          "version": "0.4.1"
+          "revision": "16e6409ee82e1b81390bdffbf217b9c08ab32784",
+          "version": "0.5.0"
         }
       }
     ]

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -61,7 +61,7 @@ private enum ScreenshotsKey: DependencyKey {
         .map { _ in }
     )
   }
-  static let testValue: @Sendable () async -> AsyncStream<Void> = XCTUnimplemented(
+  static let testValue: @Sendable () async -> AsyncStream<Void> = unimplemented(
     #"@Dependency(\.screenshots)"#, placeholder: .finished
   )
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -315,10 +315,10 @@ extension WebSocketClient: DependencyKey {
   }
 
   static let testValue = Self(
-    open: XCTUnimplemented("\(Self.self).open", placeholder: AsyncStream.never),
-    receive: XCTUnimplemented("\(Self.self).receive"),
-    send: XCTUnimplemented("\(Self.self).send"),
-    sendPing: XCTUnimplemented("\(Self.self).sendPing")
+    open: unimplemented("\(Self.self).open", placeholder: AsyncStream.never),
+    receive: unimplemented("\(Self.self).receive"),
+    send: unimplemented("\(Self.self).send"),
+    sendPing: unimplemented("\(Self.self).sendPing")
   )
 }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadClient.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadClient.swift
@@ -47,6 +47,6 @@ extension DownloadClient: DependencyKey {
   )
 
   static let testValue = Self(
-    download: XCTUnimplemented("\(Self.self).download")
+    download: unimplemented("\(Self.self).download")
   )
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
@@ -29,6 +29,6 @@ extension FactClient: DependencyKey {
   /// This is the "unimplemented" fact dependency that is useful to plug into tests that you want
   /// to prove do not need the dependency.
   static let testValue = Self(
-    fetch: XCTUnimplemented("\(Self.self).fetch")
+    fetch: unimplemented("\(Self.self).fetch")
   )
 }

--- a/Examples/Search/Search/WeatherClient.swift
+++ b/Examples/Search/Search/WeatherClient.swift
@@ -50,8 +50,8 @@ extension WeatherClient: TestDependencyKey {
   )
 
   static let testValue = Self(
-    forecast: XCTUnimplemented("\(Self.self).forecast"),
-    search: XCTUnimplemented("\(Self.self).search")
+    forecast: unimplemented("\(Self.self).forecast"),
+    search: unimplemented("\(Self.self).search")
   )
 }
 

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Client.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Client.swift
@@ -67,11 +67,11 @@ extension SpeechClient: TestDependencyKey {
   }
 
   static let testValue = Self(
-    finishTask: XCTUnimplemented("\(Self.self).finishTask"),
-    requestAuthorization: XCTUnimplemented(
+    finishTask: unimplemented("\(Self.self).finishTask"),
+    requestAuthorization: unimplemented(
       "\(Self.self).requestAuthorization", placeholder: .notDetermined
     ),
-    startTask: XCTUnimplemented("\(Self.self).recognitionTask", placeholder: .never)
+    startTask: unimplemented("\(Self.self).recognitionTask", placeholder: .never)
   )
 }
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/AuthenticationClient/AuthenticationClient.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/AuthenticationClient/AuthenticationClient.swift
@@ -73,8 +73,8 @@ public struct AuthenticationClient: Sendable {
 
 extension AuthenticationClient: TestDependencyKey {
   public static var testValue = Self(
-    login: XCTUnimplemented("\(Self.self).login"),
-    twoFactor: XCTUnimplemented("\(Self.self).twoFactor")
+    login: unimplemented("\(Self.self).login"),
+    twoFactor: unimplemented("\(Self.self).twoFactor")
   )
 }
 

--- a/Examples/VoiceMemos/VoiceMemos/AudioPlayerClient/AudioPlayerClient.swift
+++ b/Examples/VoiceMemos/VoiceMemos/AudioPlayerClient/AudioPlayerClient.swift
@@ -15,7 +15,7 @@ extension AudioPlayerClient: TestDependencyKey {
   )
 
   static let testValue = Self(
-    play: XCTUnimplemented("\(Self.self).play")
+    play: unimplemented("\(Self.self).play")
   )
 }
 

--- a/Examples/VoiceMemos/VoiceMemos/AudioRecorderClient/AudioRecorderClient.swift
+++ b/Examples/VoiceMemos/VoiceMemos/AudioRecorderClient/AudioRecorderClient.swift
@@ -34,12 +34,12 @@ extension AudioRecorderClient: TestDependencyKey {
   }
 
   static let testValue = Self(
-    currentTime: XCTUnimplemented("\(Self.self).currentTime", placeholder: nil),
-    requestRecordPermission: XCTUnimplemented(
+    currentTime: unimplemented("\(Self.self).currentTime", placeholder: nil),
+    requestRecordPermission: unimplemented(
       "\(Self.self).requestRecordPermission", placeholder: false
     ),
-    startRecording: XCTUnimplemented("\(Self.self).startRecording", placeholder: false),
-    stopRecording: XCTUnimplemented("\(Self.self).stopRecording")
+    startRecording: unimplemented("\(Self.self).startRecording", placeholder: false),
+    stopRecording: unimplemented("\(Self.self).stopRecording")
   )
 }
 

--- a/Examples/VoiceMemos/VoiceMemos/Dependencies.swift
+++ b/Examples/VoiceMemos/VoiceMemos/Dependencies.swift
@@ -16,7 +16,7 @@ extension DependencyValues {
         UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
       }
     }
-    static let testValue: @Sendable () async -> Void = XCTUnimplemented(
+    static let testValue: @Sendable () async -> Void = unimplemented(
       #"@Dependency(\.openSettings)"#
     )
   }
@@ -28,7 +28,7 @@ extension DependencyValues {
 
   private enum TemporaryDirectoryKey: DependencyKey {
     static let liveValue: @Sendable () -> URL = { URL(fileURLWithPath: NSTemporaryDirectory()) }
-    static let testValue: @Sendable () -> URL = XCTUnimplemented(
+    static let testValue: @Sendable () -> URL = unimplemented(
       #"@Dependency(\.temporaryDirectory)"#
     )
   }

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/DependencyManagement.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/DependencyManagement.md
@@ -315,24 +315,17 @@ Unfortunately, `XCTFail` cannot be used in non-test targets, and so this instanc
 in the same file where your dependency is registered. To work around this you can use our
 [XCTestDynamicOverlay][xctest-dynamic-overlay-gh] library that dynamically invokes `XCTFail` and
 it is automatically accessible when using the Composable Architecture. It also comes with some
-helpers to ease the construction of these unimplemented values:
+helpers to ease the construction of these unimplemented values, which we can use when defining the
+`testValue` of your dependency:
 
 ```swift
 import XCTestDynamicOverlay
 
 extension APIClient {
-  static let unimplemented = Self(
-    fetchUser: XCTUnimplemented("APIClient.fetchUser")
-    fetchUsers: XCTUnimplemented("APIClient.fetchUsers")
+  static let testValue = Self(
+    fetchUser: unimplemented("APIClient.fetchUser")
+    fetchUsers: unimplemented("APIClient.fetchUsers")
   )
-}
-```
-
-This is now the value that is most appropriate to use as the `testValue` of your dependency:
-
-```swift
-extension APIClient: TestDependencyKey {
-  static let testValue = APIClient.unimplemented
 }
 ```
 

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -490,7 +490,7 @@ extension EffectPublisher {
   ///
   /// > Important: This Combine-based interface has been soft-deprecated in favor of Swift
   /// > concurrency. Prefer using async functions and `AsyncStream`s directly in your dependencies,
-  /// > and using `XCTUnimplemented` from the [XCTest Dynamic Overlay](gh-xctest-dynamic-overlay)
+  /// > and using `unimplemented` from the [XCTest Dynamic Overlay](gh-xctest-dynamic-overlay)
   /// > library to stub in a function that fails when invoked:
   /// >
   /// > ```swift
@@ -498,9 +498,9 @@ extension EffectPublisher {
   /// >   var fetch: (Int) async throws -> String
   /// > }
   /// >
-  /// > extension NumberFactClient {
-  /// >   static let unimplemented = Self(
-  /// >     fetch: XCTUnimplemented(
+  /// > extension NumberFactClient: TestDependencyKey {
+  /// >   static let testValue = Self(
+  /// >     fetch: unimplemented(
   /// >       "\(Self.self).fetch",
   /// >       placeholder: "Not an interesting number."
   /// >     )
@@ -590,16 +590,16 @@ extension EffectPublisher {
   ///   messages.
   /// - Returns: An effect that causes a test to fail if it runs.
   @available(
-    iOS, deprecated: 9999.0, message: "Call 'XCTUnimplemented' from your dependencies, instead."
+    iOS, deprecated: 9999.0, message: "Call 'unimplemented' from your dependencies, instead."
   )
   @available(
-    macOS, deprecated: 9999.0, message: "Call 'XCTUnimplemented' from your dependencies, instead."
+    macOS, deprecated: 9999.0, message: "Call 'unimplemented' from your dependencies, instead."
   )
   @available(
-    tvOS, deprecated: 9999.0, message: "Call 'XCTUnimplemented' from your dependencies, instead."
+    tvOS, deprecated: 9999.0, message: "Call 'unimplemented' from your dependencies, instead."
   )
   @available(
-    watchOS, deprecated: 9999.0, message: "Call 'XCTUnimplemented' from your dependencies, instead."
+    watchOS, deprecated: 9999.0, message: "Call 'unimplemented' from your dependencies, instead."
   )
   public static func unimplemented(_ prefix: String) -> Self {
     .fireAndForget {


### PR DESCRIPTION
The `XCTUnimplemented` helper is a more general tool than XCTest, and can surface valuable runtime warnings in your application even if you never write a single test. Because of this we'd like to distance our tools from the `XCT` prefix where it feels appropriate.

As a small step, this means renaming `XCTUnimplemented` to `unimplemented`. While `XCTUnimplemented` still works today, it is soft-deprecated to push folks towards `unimplemented`, and assuming this course feels good, we'll eventually hard-deprecate it.

The one repercussion is that folks used to defining "unimplemented" dependencies using `static let unimplemented` will run into circular reference issues:

```swift
extension APIClient {
  static let unimplemented = Self(
    fetchUser: unimplemented("\(Self.self).fetchUser")  // 🛑
  )
}
```

In TCA apps this shouldn't pose a problem as we use `testValue`:

```swift
extension APIClient: TestDependencyKey {
  static let testValue = Self(
    fetchUser: unimplemented("\(Self.self).fetchUser")  // ✅
  )
}
```

In vanilla apps, though, you'll need to adopt a new name or qualify the function call. You could adopt `testValue` to get a jumpstart if you ever plan on any future migration to TCA. Or you can always keep `unimplemented` as the name, it's just a little verbose to fully qualify the function and break the circular reference:

```swift
extension APIClient {
  static let unimplemented = Self(
    fetchUser: XCTestDynamicOverlay.unimplemented("\(Self.self).fetchUser")  // ✅
  )
}
```