### PR TITLE
refactor : remove unnecessary conformance to Sendable Protocol

### DIFF
--- a/Examples/Search/Search/WeatherClient.swift
+++ b/Examples/Search/Search/WeatherClient.swift
@@ -38,7 +38,7 @@ struct Forecast: Decodable, Equatable, Sendable {
 // Typically this interface would live in its own module, separate from the live implementation.
 // This allows the search feature to compile faster since it only depends on the interface.
 
-struct WeatherClient: Sendable {
+struct WeatherClient {
   var forecast: @Sendable (GeocodingSearch.Result) async throws -> Forecast
   var search: @Sendable (String) async throws -> GeocodingSearch
 }


### PR DESCRIPTION
Since all the members are sendable, the `WeatherClient` does not need to conform to Sendable Protocol explicitly. It is implicitly Sendable.