### PR TITLE
Remove redundant error type in ReusableFavoritingTests.swift

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -189,7 +189,7 @@ struct EpisodesView_Previews: PreviewProvider {
   }
 }
 
-struct FavoriteError: LocalizedError {
+struct FavoriteError: LocalizedError, Equatable {
   var errorDescription: String? {
     "Favoriting failed."
   }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
@@ -52,11 +52,6 @@ final class ReusableComponentsFavoritingTests: XCTestCase {
   }
 
   func testUnhappyPath() async {
-    struct FavoriteError: Equatable, LocalizedError {
-      var errorDescription: String? {
-        "Favoriting failed."
-      }
-    }
     let scheduler = DispatchQueue.test
 
     let episodes: IdentifiedArrayOf<Episode.State> = [
@@ -82,7 +77,7 @@ final class ReusableComponentsFavoritingTests: XCTestCase {
         id: episodes[0].id, action: .favorite(.response(.failure(FavoriteError()))))
     ) {
       $0.episodes[id: episodes[0].id]?.alert = AlertState(
-        title: TextState("Favoriting failed.")
+        title: TextState(FavoriteError().localizedDescription)
       )
     }
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
@@ -77,7 +77,7 @@ final class ReusableComponentsFavoritingTests: XCTestCase {
         id: episodes[0].id, action: .favorite(.response(.failure(FavoriteError()))))
     ) {
       $0.episodes[id: episodes[0].id]?.alert = AlertState(
-        title: TextState(FavoriteError().localizedDescription)
+        title: TextState("Favoriting failed.")
       )
     }
 


### PR DESCRIPTION
Hi! I removed a redundant `FavoriteError` struct in ReusableFavoritingTests.swift
And changed the hard-coded AlertState's title so that it's easier to maintain.