### PR TITLE
remove unknown suffix at documentation

### DIFF
--- a/Sources/Dependencies/Dependencies/Calendar.swift
+++ b/Sources/Dependencies/Dependencies/Calendar.swift
@@ -6,7 +6,7 @@ extension DependencyValues {
   ///
   /// By default, the calendar returned from `Calendar.autoupdatingCurrent` is supplied. When used
   /// in a testing context, access will call to `XCTFail` when invoked, unless explicitly
-  /// overridden using ``withValue(_:_:operation:)-705n``:
+  /// overridden using ``withValue(_:_:operation:)``:
   ///
   /// ```swift
   /// DependencyValues.withValue(\.calendar, Calendar(identifier: .gregorian)) {

--- a/Sources/Dependencies/Dependencies/Context.swift
+++ b/Sources/Dependencies/Dependencies/Context.swift
@@ -4,7 +4,7 @@ extension DependencyValues {
   /// The current ``DependencyContext`` can be used to determine how dependencies are loaded by the
   /// current runtime.
   ///
-  /// It can also be overridden, for example via ``withValue(_:_:operation:)-705n``, to control how
+  /// It can also be overridden, for example via ``withValue(_:_:operation:)``, to control how
   /// dependencies will be loaded by the runtime for the duration of the override.
   ///
   /// ```swift

--- a/Sources/Dependencies/Dependencies/Date.swift
+++ b/Sources/Dependencies/Dependencies/Date.swift
@@ -18,7 +18,7 @@ extension DependencyValues {
   /// ```
   ///
   /// To override the current date in tests, you can override the generator using
-  /// ``withValue(_:_:operation:)-705n``:
+  /// ``withValue(_:_:operation:)``:
   ///
   /// ```swift
   /// DependencyValues.withValue(\.date, .constant(Date(timeIntervalSince1970: 0))) {

--- a/Sources/Dependencies/Dependencies/Locale.swift
+++ b/Sources/Dependencies/Dependencies/Locale.swift
@@ -18,7 +18,7 @@ extension DependencyValues {
   /// }
   /// ```
   ///
-  /// To override the current locale in tests, use ``withValue(_:_:operation:)-705n``:
+  /// To override the current locale in tests, use ``withValue(_:_:operation:)``:
 
   /// ```swift
   /// DependencyValues.withValue(\.locale, Locale(identifier: "en_US")) {

--- a/Sources/Dependencies/DependencyContext.swift
+++ b/Sources/Dependencies/DependencyContext.swift
@@ -18,7 +18,7 @@ public enum DependencyContext: Sendable {
   ///
   /// This context is the default when run from an Xcode preview.
   ///
-  /// Dependencies accessed from a preview context will use ``TestDependencyKey/previewValue-8u2sy``
+  /// Dependencies accessed from a preview context will use ``TestDependencyKey/previewValue``
   /// to request a default value.
   case preview
 

--- a/Sources/Dependencies/DependencyKey.swift
+++ b/Sources/Dependencies/DependencyKey.swift
@@ -51,7 +51,7 @@ import XCTestDynamicOverlay
 ///
 /// `DependencyKey` inherits from ``TestDependencyKey``, which has two other overridable
 /// requirements: ``TestDependencyKey/testValue``, which should return a default value for the
-/// purpose of testing, and ``TestDependencyKey/previewValue-8u2sy``, which can return a default
+/// purpose of testing, and ``TestDependencyKey/previewValue``, which can return a default
 /// value suitable for Xcode previews. When left unimplemented, these endpoints will return the
 /// ``liveValue``, instead.
 ///
@@ -66,7 +66,7 @@ public protocol DependencyKey: TestDependencyKey {
   /// your dependencies for tests.
   ///
   /// To automatically supply a test dependency in a test context, consider implementing the
-  /// ``testValue-535kh`` requirement.
+  /// ``testValue`` requirement.
   static var liveValue: Value { get }
 
   // NB: The associated type and requirements of TestDependencyKey are repeated in this protocol
@@ -114,7 +114,7 @@ public protocol DependencyKey: TestDependencyKey {
 /// interface from its live implementation.
 ///
 /// ``TestDependencyKey`` has one main requirement, ``testValue``, which must return a default value
-/// for the purposes of testing, and one optional requirement, ``previewValue-8u2sy``, which can
+/// for the purposes of testing, and one optional requirement, ``previewValue``, which can
 /// return a default value suitable for Xcode previews, or the ``testValue``, if left unimplemented.
 ///
 /// See ``DependencyKey`` to define a static, default value for the live application.

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -12,7 +12,7 @@ import XCTestDynamicOverlay
 /// ```
 ///
 /// To change a dependency for a well-defined scope you can use the
-/// ``withValues(_:operation:)-1oaja`` method:
+/// ``withValues(_:operation:)`` method:
 ///
 /// ```swift
 /// @Dependency(\.date) var date
@@ -79,7 +79,7 @@ public struct DependencyValues: Sendable {
   /// }
   /// ```
   ///
-  /// See ``withValues(_:operation:)-9prz8`` to update multiple dependencies at once without nesting
+  /// See ``withValues(_:operation:)`` to update multiple dependencies at once without nesting
   /// calls to `withValue`.
   ///
   /// - Parameters:
@@ -115,7 +115,7 @@ public struct DependencyValues: Sendable {
   /// }
   /// ```
   ///
-  /// See ``withValues(_:operation:)-1oaja`` to update multiple dependencies at once without nesting
+  /// See ``withValues(_:operation:)`` to update multiple dependencies at once without nesting
   /// calls to `withValue`.
   ///
   /// - Parameters:
@@ -154,7 +154,7 @@ public struct DependencyValues: Sendable {
   /// }
   /// ```
   ///
-  /// See ``withValue(_:_:operation:)-3yj9d`` to update a single dependency with a constant value.
+  /// See ``withValue(_:_:operation:)`` to update a single dependency with a constant value.
   ///
   /// - Parameters:
   ///   - updateValuesForOperation: A closure for updating the current dependency values for the
@@ -190,7 +190,7 @@ public struct DependencyValues: Sendable {
   /// }
   /// ```
   ///
-  /// See ``withValue(_:_:operation:)-705n`` to update a single dependency with a constant value.
+  /// See ``withValue(_:_:operation:)`` to update a single dependency with a constant value.
   ///
   /// - Parameters:
   ///   - updateValuesForOperation: A closure for updating the current dependency values for the
@@ -232,7 +232,7 @@ public struct DependencyValues: Sendable {
   /// ```
   ///
   /// You use custom dependency values the same way you use system-provided values, setting a value
-  /// with ``withValue(_:_:operation:)-705n``, and reading values with the ``Dependency`` property
+  /// with ``withValue(_:_:operation:)``, and reading values with the ``Dependency`` property
   /// wrapper.
   public subscript<Key: TestDependencyKey>(
     key: Key.Type,

--- a/Sources/Dependencies/Documentation.docc/Extensions/DependencyKey.md
+++ b/Sources/Dependencies/Documentation.docc/Extensions/DependencyKey.md
@@ -6,8 +6,8 @@
 
 - ``Value``
 - ``liveValue``
-- ``testValue-535kh``
-- ``previewValue-36s5j``
+- ``testValue``
+- ``previewValue``
 
 ### Modularizing a dependency
 

--- a/Sources/Dependencies/Documentation.docc/Extensions/DependencyValues.md
+++ b/Sources/Dependencies/Documentation.docc/Extensions/DependencyValues.md
@@ -9,8 +9,8 @@
 
 ### Overriding values
 
-- ``withValue(_:_:operation:)-3yj9d``
-- ``withValues(_:operation:)-1oaja``
+- ``withValue(_:_:operation:)``
+- ``withValues(_:operation:)``
 
 ### Dependency values
 

--- a/Sources/Dependencies/Documentation.docc/Extensions/DependencyValuesWithValue.md
+++ b/Sources/Dependencies/Documentation.docc/Extensions/DependencyValuesWithValue.md
@@ -1,7 +1,7 @@
-# ``Dependencies/DependencyValues/withValue(_:_:operation:)-705n``
+# ``Dependencies/DependencyValues/withValue(_:_:operation:)``
 
 ## Topics
 
 ### Overloads
 
-- ``DependencyValues/withValue(_:_:operation:)-3yj9d``
+- ``DependencyValues/withValue(_:_:operation:)``

--- a/Sources/Dependencies/Documentation.docc/Extensions/DependencyValuesWithValues.md
+++ b/Sources/Dependencies/Documentation.docc/Extensions/DependencyValuesWithValues.md
@@ -1,7 +1,7 @@
-# ``Dependencies/DependencyValues/withValues(_:operation:)-1oaja``
+# ``Dependencies/DependencyValues/withValues(_:operation:)``
 
 ## Topics
 
 ### Overloads
 
-- ``DependencyValues/withValues(_:operation:)-9prz8``
+- ``DependencyValues/withValues(_:operation:)``

--- a/Sources/Dependencies/Documentation.docc/Extensions/TestDependencyKey.md
+++ b/Sources/Dependencies/Documentation.docc/Extensions/TestDependencyKey.md
@@ -6,4 +6,4 @@
 
 - ``Value``
 - ``testValue``
-- ``previewValue-8u2sy``
+- ``previewValue``


### PR DESCRIPTION
I found some unknown suffixes in Dependency library's documentations. OR, Are they has any functionality or meaning I did not know?