### PR TITLE
Make `Reducer` actually deprecated

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -11,6 +11,7 @@ import XCTestDynamicOverlay
 /// A type alias to ``AnyReducer`` for source compatibility. This alias will be removed.
 @available(
   *,
+  deprecated,
   renamed: "AnyReducer",
   message:
     """


### PR DESCRIPTION
> https://github.com/pointfreeco/swift-composable-architecture/releases/tag/0.43.0
> The Reducer type alias is now hard-deprecated to be renamed to AnyReducer

But it is not actually hard-deprecated.