### PR TITLE
Add support for Filter Reducer

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "branch" : "main",
-        "revision" : "fd12efe73828fce14f2c1ed895107cf3ff9cae0e"
+        "revision" : "7379ef30c447ea6060bfa5ae7fab77d0d6e47866",
+        "version" : "0.1.1"
       }
     },
     {

--- a/Sources/ComposableArchitecture/Effects/Animation.swift
+++ b/Sources/ComposableArchitecture/Effects/Animation.swift
@@ -16,7 +16,7 @@ extension EffectPublisher {
   /// - Returns: A publisher.
   public func animation(_ animation: Animation? = .default) -> Self {
     switch self.operation {
-    case .none:
+    case .none, .passthrough:
       return .none
     case let .publisher(publisher):
       return Self(

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -30,7 +30,7 @@ extension EffectPublisher {
   /// - Returns: A new effect that is capable of being canceled by an identifier.
   public func cancellable(id: AnyHashable, cancelInFlight: Bool = false) -> Self {
     switch self.operation {
-    case .none:
+    case .none, .passthrough:
       return .none
     case let .publisher(publisher):
       return Self(

--- a/Sources/ComposableArchitecture/Effects/Publisher.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher.swift
@@ -15,7 +15,7 @@ extension EffectPublisher: Publisher {
 
   var publisher: AnyPublisher<Action, Failure> {
     switch self.operation {
-    case .none:
+    case .none, .passthrough:
       return Empty().eraseToAnyPublisher()
     case let .publisher(publisher):
       return publisher

--- a/Sources/ComposableArchitecture/Effects/Publisher/Debouncing.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Debouncing.swift
@@ -51,7 +51,7 @@ extension EffectPublisher {
     options: S.SchedulerOptions? = nil
   ) -> Self {
     switch self.operation {
-    case .none:
+    case .none, .passthrough:
       return .none
     case .publisher, .run:
       return Self(

--- a/Sources/ComposableArchitecture/Effects/Publisher/Deferring.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Deferring.swift
@@ -36,7 +36,7 @@ extension EffectPublisher {
     options: S.SchedulerOptions? = nil
   ) -> Self {
     switch self.operation {
-    case .none:
+    case .none, .passthrough:
       return .none
     case .publisher, .run:
       return Self(

--- a/Sources/ComposableArchitecture/Effects/Publisher/Throttling.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Throttling.swift
@@ -21,7 +21,7 @@ extension EffectPublisher {
     latest: Bool
   ) -> Self {
     switch self.operation {
-    case .none:
+    case .none, .passthrough:
       return .none
     case .publisher, .run:
       return self.receive(on: scheduler)

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerDebug.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerDebug.swift
@@ -215,7 +215,7 @@ extension AnyReducer {
         }
 
         switch effects.operation {
-        case .none:
+        case .none, .passthrough:
           return .fireAndForget { print() }
         case .publisher:
           return .fireAndForget { print() }.merge(with: effects)

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerSignpost.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerSignpost.swift
@@ -95,7 +95,7 @@ extension EffectPublisher where Failure == Never {
     let sid = OSSignpostID(log: log)
 
     switch self.operation {
-    case .none:
+    case .none, .passthrough:
       return self
     case let .publisher(publisher):
       return .init(

--- a/Sources/ComposableArchitecture/Reducer/Reducers/FilterReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/FilterReducer.swift
@@ -1,0 +1,109 @@
+extension ReducerProtocol {
+#if swift(>=5.7)
+  @inlinable
+  public func filter<WrappedState, WrappedAction>(
+    _ toWrappedState: WritableKeyPath<State, WrappedState>,
+    action toWrappedAction: CasePath<Action, WrappedAction>,
+    @ReducerBuilder<WrappedState, WrappedAction> then wrapped: () -> some ReducerProtocol<WrappedState, WrappedAction>,
+    file: StaticString = #file,
+    fileID: StaticString = #fileID,
+    line: UInt = #line
+  ) -> some ReducerProtocol<State, Action> {
+    _Filter(
+      parent: self,
+      child: wrapped(),
+      toChildState: toWrappedState,
+      toChildAction: toWrappedAction,
+      file: file,
+      fileID: fileID,
+      line: line
+    )
+  }
+#else
+  @inlinable
+  public func filter<Case: ReducerProtocol>(
+    _ toCaseState: CasePath<State, Case.State>,
+    action toCaseAction: CasePath<Action, Case.Action>,
+    @ReducerBuilderOf<Case> then case: () -> Case,
+    file: StaticString = #file,
+    fileID: StaticString = #fileID,
+    line: UInt = #line
+  ) -> _Filter<Self, Case> {
+    .init(
+      parent: self,
+      child: `case`(),
+      toChildState: toCaseState,
+      toChildAction: toCaseAction,
+      file: file,
+      fileID: fileID,
+      line: line
+    )
+  }
+#endif
+}
+
+public struct _Filter<Parent: ReducerProtocol, Child: ReducerProtocol>: ReducerProtocol {
+  @usableFromInline
+  let parent: Parent
+  
+  @usableFromInline
+  let child: Child
+  
+  @usableFromInline
+  let toChildState: WritableKeyPath<Parent.State, Child.State>
+  
+  @usableFromInline
+  let toChildAction: CasePath<Parent.Action, Child.Action>
+  
+  @usableFromInline
+  let file: StaticString
+  
+  @usableFromInline
+  let fileID: StaticString
+  
+  @usableFromInline
+  let line: UInt
+  
+  @usableFromInline
+  init(
+    parent: Parent,
+    child: Child,
+    toChildState: WritableKeyPath<Parent.State, Child.State>,
+    toChildAction: CasePath<Parent.Action, Child.Action>,
+    file: StaticString,
+    fileID: StaticString,
+    line: UInt
+  ) {
+    self.parent = parent
+    self.child = child
+    self.toChildState = toChildState
+    self.toChildAction = toChildAction
+    self.file = file
+    self.fileID = fileID
+    self.line = line
+  }
+  
+  @inlinable
+  public func reduce(
+    into state: inout Parent.State, action: Parent.Action
+  ) -> EffectTask<Parent.Action> {
+    let effect = self.reduceChild(into: &state, action: action)
+    switch effect.operation {
+    case .none:
+      return effect.merge(with: self.parent.reduce(into: &state, action: action))
+    default:
+      return effect
+    }
+  }
+  
+  @inlinable
+  func reduceChild(
+    into state: inout Parent.State, action: Parent.Action
+  ) -> EffectTask<Parent.Action> {
+    
+    guard let childAction = self.toChildAction.extract(from: action)
+    else { return .none }
+    return self.child.reduce(into: &state[keyPath: self.toChildState], action: childAction)
+      .map(self.toChildAction.embed)
+  }
+}

--- a/Sources/ComposableArchitecture/Reducer/Reducers/FilterReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/FilterReducer.swift
@@ -2,10 +2,10 @@ extension ReducerProtocol {
 #if swift(>=5.7)
   @inlinable
   public func filter<WrappedState, WrappedAction>(
+    behaviour: FilterBehaviour = .filter,
     _ toWrappedState: WritableKeyPath<State, WrappedState>,
     action toWrappedAction: CasePath<Action, WrappedAction>,
     @ReducerBuilder<WrappedState, WrappedAction> then wrapped: () -> some ReducerProtocol<WrappedState, WrappedAction>,
-    behaviour: FilterBehaviour = .filter,
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
@@ -23,20 +23,20 @@ extension ReducerProtocol {
   }
 #else
   @inlinable
-  public func filter<Case: ReducerProtocol>(
-    _ toCaseState: CasePath<State, Case.State>,
-    action toCaseAction: CasePath<Action, Case.Action>,
-    @ReducerBuilderOf<Case> then case: () -> Case,
+  public func filter<Wrapped: ReducerProtocol>(
     behaviour: FilterBehaviour = .filter,
+    _ toWrappedState: WritableKeyPath<State, Wrapped.State>,
+    action toWrappedAction: CasePath<Action, Wrapped.Action>,
+    @ReducerBuilderOf<Wrapped> then wrapped: () -> Wrapped,
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
-  ) -> _Filter<Self, Case> {
+  ) -> _Filter<Self, Wrapped> {
     .init(
       parent: self,
-      child: `case`(),
-      toChildState: toCaseState,
-      toChildAction: toCaseAction,
+      child: wrapped(),
+      toChildState: toWrappedState,
+      toChildAction: toWrappedAction,
       behaviour: behaviour,
       file: file,
       fileID: fileID,

--- a/Sources/ComposableArchitecture/Reducer/Reducers/FilterReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/FilterReducer.swift
@@ -5,6 +5,7 @@ extension ReducerProtocol {
     _ toWrappedState: WritableKeyPath<State, WrappedState>,
     action toWrappedAction: CasePath<Action, WrappedAction>,
     @ReducerBuilder<WrappedState, WrappedAction> then wrapped: () -> some ReducerProtocol<WrappedState, WrappedAction>,
+    behaviour: FilterBehaviour = .filter,
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
@@ -14,6 +15,7 @@ extension ReducerProtocol {
       child: wrapped(),
       toChildState: toWrappedState,
       toChildAction: toWrappedAction,
+      behaviour: behaviour,
       file: file,
       fileID: fileID,
       line: line
@@ -25,6 +27,7 @@ extension ReducerProtocol {
     _ toCaseState: CasePath<State, Case.State>,
     action toCaseAction: CasePath<Action, Case.Action>,
     @ReducerBuilderOf<Case> then case: () -> Case,
+    behaviour: FilterBehaviour = .filter,
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
@@ -34,12 +37,29 @@ extension ReducerProtocol {
       child: `case`(),
       toChildState: toCaseState,
       toChildAction: toCaseAction,
+      behaviour: behaviour,
       file: file,
       fileID: fileID,
       line: line
     )
   }
 #endif
+}
+
+public enum FilterBehaviour {
+  case filter // if filter reducer return .none it let parent reducer do it work
+  case block // if filter reducer return .none it stop the let parent reducer from doing it's work
+}
+
+extension EffectPublisher.Operation {
+  public var isNone: Bool {
+    switch self {
+    case .none:
+      return true
+    default:
+      return false
+    }
+  }
 }
 
 public struct _Filter<Parent: ReducerProtocol, Child: ReducerProtocol>: ReducerProtocol {
@@ -65,11 +85,15 @@ public struct _Filter<Parent: ReducerProtocol, Child: ReducerProtocol>: ReducerP
   let line: UInt
   
   @usableFromInline
+  let behaviour: FilterBehaviour
+  
+  @usableFromInline
   init(
     parent: Parent,
     child: Child,
     toChildState: WritableKeyPath<Parent.State, Child.State>,
     toChildAction: CasePath<Parent.Action, Child.Action>,
+    behaviour: FilterBehaviour = .filter,
     file: StaticString,
     fileID: StaticString,
     line: UInt
@@ -78,6 +102,7 @@ public struct _Filter<Parent: ReducerProtocol, Child: ReducerProtocol>: ReducerP
     self.child = child
     self.toChildState = toChildState
     self.toChildAction = toChildAction
+    self.behaviour = behaviour
     self.file = file
     self.fileID = fileID
     self.line = line
@@ -88,10 +113,15 @@ public struct _Filter<Parent: ReducerProtocol, Child: ReducerProtocol>: ReducerP
     into state: inout Parent.State, action: Parent.Action
   ) -> EffectTask<Parent.Action> {
     let effect = self.reduceChild(into: &state, action: action)
-    switch effect.operation {
-    case .none:
+    let shouldBlock = self.behaviour == .block
+    switch (shouldBlock, effect.operation.isNone) {
+    case (true, true):
+      return effect
+    case (true, false):
+      return effect
+    case (false, true):
       return effect.merge(with: self.parent.reduce(into: &state, action: action))
-    default:
+    case (false, false):
       return effect
     }
   }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/FilterReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/FilterReducer.swift
@@ -47,14 +47,23 @@ extension ReducerProtocol {
 }
 
 public enum FilterBehaviour {
-  case filter // if filter reducer return .none it let parent reducer do it work
-  case block // if filter reducer return .none it stop the let parent reducer from doing it's work
+  case filter // if child reducer return .none it let parent reducer do it work
+  case block // if child reducer return .none it stop the let parent reducer from doing it's work
 }
 
 extension EffectPublisher.Operation {
   public var isNone: Bool {
     switch self {
     case .none:
+      return true
+    default:
+      return false
+    }
+  }
+  
+  public var isPassthrough: Bool {
+    switch self {
+    case .passthrough:
       return true
     default:
       return false
@@ -118,6 +127,9 @@ public struct _Filter<Parent: ReducerProtocol, Child: ReducerProtocol>: ReducerP
     case (true, true):
       return effect
     case (true, false):
+      if effect.operation.isPassthrough {
+        return effect.merge(with: self.parent.reduce(into: &state, action: action))
+      }
       return effect
     case (false, true):
       return effect.merge(with: self.parent.reduce(into: &state, action: action))

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -355,7 +355,7 @@ public final class Store<State, Action> {
       #endif
 
       switch effect.operation {
-      case .none:
+      case .none, .passthrough:
         break
       case let .publisher(publisher):
         var didComplete = false

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1084,7 +1084,7 @@ class TestReducer<State, Action>: ReducerProtocol {
     }
 
     switch effects.operation {
-    case .none:
+    case .none, .passthrough:
       self.effectDidSubscribe.continuation.yield()
       return .none
 

--- a/Tests/ComposableArchitectureTests/FilterReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/FilterReducerTests.swift
@@ -72,7 +72,7 @@ final class FilterReducerTests: XCTestCase {
   }
   
   func testBlockAction() async {
-    let store = TestStore(initialState: MainReducer.State(), reducer: MainReducer().filter(\.self, action: /.self, then: { BlockReducer() }, behaviour: .block))
+    let store = TestStore(initialState: MainReducer.State(), reducer: MainReducer().filter(behaviour: .block, \.self, action: /.self, then: { BlockReducer() }))
     _ = await store.send(.notLimitedAction)
     await store.receive(.alert)
     

--- a/Tests/ComposableArchitectureTests/FilterReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/FilterReducerTests.swift
@@ -41,7 +41,7 @@ final class FilterReducerTests: XCTestCase {
     }
   }
   
-  func testLimitedAction() async {
+  func testFilterAction() async {
     let store = TestStore(initialState: MainReducer.State(), reducer: MainReducer().filter(\.self, action: /.self, then: { FilterReducer() }))
     _ = await store.send(.limitedAction)
     await store.receive(.alert)
@@ -49,6 +49,16 @@ final class FilterReducerTests: XCTestCase {
     _ = await store.send(.notLimitedAction)
     await store.receive(.anotherAction)
     
+    _ = await store.send(.alert)
+    _ = await store.send(.anotherAction)
+  }
+  
+  func testBlockAction() async {
+    let store = TestStore(initialState: MainReducer.State(), reducer: MainReducer().filter(\.self, action: /.self, then: { FilterReducer() }, behaviour: .block))
+    _ = await store.send(.limitedAction)
+    await store.receive(.alert)
+    
+    _ = await store.send(.notLimitedAction)
     _ = await store.send(.alert)
     _ = await store.send(.anotherAction)
   }

--- a/Tests/ComposableArchitectureTests/FilterReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/FilterReducerTests.swift
@@ -1,0 +1,55 @@
+import ComposableArchitecture
+import XCTest
+
+@MainActor
+final class FilterReducerTests: XCTestCase {
+  
+  struct MainReducer: ReducerProtocol {
+    struct State: Equatable { }
+    
+    enum Action {
+      case limitedAction
+      case notLimitedAction
+      case anotherAction
+      case alert
+    }
+    
+    func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+      switch action {
+      case .limitedAction:
+        return Effect(value: .notLimitedAction)
+      case .notLimitedAction:
+        return Effect(value: .anotherAction)
+      case .anotherAction:
+        return .none
+      case .alert:
+        return .none
+      }
+    }
+  }
+  
+  struct FilterReducer: ReducerProtocol {
+    typealias State = MainReducer.State
+    typealias Action = MainReducer.Action
+    
+    func reduce(into state: inout FilterReducerTests.MainReducer.State, action: FilterReducerTests.MainReducer.Action) -> EffectTask<FilterReducerTests.MainReducer.Action> {
+      switch action {
+      case .limitedAction:
+        return Effect(value: .alert)
+      default: return .none
+      }
+    }
+  }
+  
+  func testLimitedAction() async {
+    let store = TestStore(initialState: MainReducer.State(), reducer: MainReducer().filter(\.self, action: /.self, then: { FilterReducer() }))
+    _ = await store.send(.limitedAction)
+    await store.receive(.alert)
+    
+    _ = await store.send(.notLimitedAction)
+    await store.receive(.anotherAction)
+    
+    _ = await store.send(.alert)
+    _ = await store.send(.anotherAction)
+  }
+}


### PR DESCRIPTION
## Filter Reducer

_Filter name is not final as mentioned by @tgrapperon it is not clear enough._

Sometimes it can be pretty useful to change the behavior of a reducer without modifying it. The goal of this feature is to allow or disallow another reducer to run its actions. With `.filter` applied on a Reducer we can use another reducer output to decide what to do.

Before ReducerProtocol we could do something like this and `reducerB` could use `self(&state, action, env)` to change if `reducerA` can do its actions.
```swift
  reducerA
    .reducerB()
    .optional()
    .pullback(
...
    ),
```

This PR try to restore this feature and can be done like this.

```swift
ReducerA()// <-- Parent
  .filter(\.self, action: /.self) {
    ReducerB() // <-- Child
  }
```

This is great for handling authorization/role mechanism for example (my app use this for the demo mode which allow us to use all the app features in read-only and in the onboarding to limit certain actions).

The child reducer `ReducerB` can allow/disallow or force another action on `ReducerA` actions.

I did observe that I needed at least two different `FilterBehaviour`.
```swift
public enum FilterBehaviour {
  case filter // default behavior - if child reducer return .none it let parent reducer do its work
  case block // if the child reducer return .none it stops the parent reducer from doing its work
}
```