### PR TITLE
Fixes main thread check in scoped stores

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -133,7 +133,7 @@ public final class Store<State, Action> {
   #endif
   var state: CurrentValueSubject<State, Never>
   #if DEBUG
-    private let mainThreadChecksEnabled: Bool
+    let mainThreadChecksEnabled: Bool
   #endif
 
   /// Initializes a store from an initial state and a reducer.
@@ -639,10 +639,20 @@ public typealias StoreOf<R: ReducerProtocol> = Store<R.State, R.Action>
         action: { fromScopedAction(fromRescopedAction($0)) },
         parentStores: self.parentStores + [store]
       )
+      #if DEBUG
+      let childStore = Store<RescopedState, RescopedAction>(
+        initialState: toRescopedState(store.state.value),
+        reducer: reducer,
+        mainThreadChecksEnabled: store.mainThreadChecksEnabled
+      )
+      #else
       let childStore = Store<RescopedState, RescopedAction>(
         initialState: toRescopedState(store.state.value),
         reducer: reducer
       )
+      #endif
+      
+      
       childStore.parentCancellable = store.state
         .dropFirst()
         .sink { [weak childStore] newValue in

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -1,5 +1,5 @@
 import Combine
-@_spi(Internals) import ComposableArchitecture
+@_spi(Internals) @testable import ComposableArchitecture
 import XCTest
 
 @MainActor
@@ -509,5 +509,17 @@ final class StoreTests: XCTestCase {
     try await XCTUnwrap(sendTask).value
     XCTAssertEqual(store.effectCancellables.count, 0)
     XCTAssertEqual(scopedStore.effectCancellables.count, 0)
+  }
+
+  func testScopeStoreFromParentWithDisabledMainThreadChecks() async throws {
+    let store = Store(
+      initialState: (),
+      reducer: EmptyReducer<Void, Void>(),
+      mainThreadChecksEnabled: false
+    )
+    
+    let scopedStore = store.scope(state: { $0 })
+    
+    XCTAssertFalse(scopedStore.mainThreadChecksEnabled)
   }
 }


### PR DESCRIPTION
I migrated an application to use the `.task { ... }` view modifier to setup value subscriptions and ran into some issues with the `Store`'s main thread checker. 

```swift
struct DemoView: View {
  let store: Store<State, Action>
  
  var body: some View {
    WithViewStore(store) { viewStore in 
      Text("Demo")
        .task { await viewStore.send(.initialise).finish() }
    }
  }
}
```

In snapshot tests, the action sent in `.task { ... }` is called on a background thread, triggering the main thread checker in a scoped ViewStore and leading to a failing test. I decided to disable the main thread checker in the snapshot tests as all state is defined in the test setup and snapshots do not depend on any subscriptions. The tests kept failing.

I investigated a little and found out that scoped stores do not inherit the parent store's `mainThreadCheckerEnabled` field. From my perspective, it makes sense to hand down this parameter to scoped stores.

Looking forward to some feedback. Maybe I'm holding it wrong.