### PR TITLE
Nudge issue filers to repo in vanilla SwiftUI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,7 @@ body:
   attributes:
     label: Checklist
     options:
-    - label: I have not been able to reproduce this bug in a vanilla SwiftUI project.
+    - label: I have determined whether this bug is also reproducible in a vanilla SwiftUI project.
       required: true
     - label: If possible, I've reproduced the issue using the `main` branch of this package.
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,7 +22,7 @@ body:
     label: Checklist
     options:
     - label: I have determined whether this bug is also reproducible in a vanilla SwiftUI project.
-      required: true
+      required: false
     - label: If possible, I've reproduced the issue using the `main` branch of this package.
       required: false
     - label: This issue hasn't been addressed in an [existing GitHub issue](https://github.com/pointfreeco/swift-composable-architecture/issues) or [discussion](https://github.com/pointfreeco/swift-composable-architecture/discussions).


### PR DESCRIPTION
It's great to remind filers to attempt to reproduce issues in vanilla SwiftUI and include those findings in their initial report. But, the new checklist item may exclude the filing of issues that TCA would want to respond to. In the past, such issues have led to good discussions on GitHub, documentation enhancements, and, I think, even additions to TCA.

_Note_: Despite being wordy, I used "this bug is _also_ reproducible" rather than simply "this bug is reproducible". My intent is to clearly imply that vanilla SwiftUI issues are still welcome, rather than perhaps imply vanilla issues shouldn't be filed.

Thoughts?