### PR TITLE
Add equatable conformance to UncheckedSendable when value is equatable

### DIFF
--- a/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift
+++ b/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift
@@ -395,3 +395,9 @@ public struct UncheckedSendable<Value>: @unchecked Sendable {
     _modify { yield &self.value[keyPath: keyPath] }
   }
 }
+
+extension UncheckedSendable: Equatable where Value: Equatable {
+  public static func == (lhs: UncheckedSendable, rhs: UncheckedSendable) -> Bool {
+    lhs.value == rhs.value
+  }
+}


### PR DESCRIPTION
This change makes it easier to have unchecked types (eg, Color, Image) in State objects. 

- [x] `swift test` passed without issue.