### PR TITLE
Add a `.stream` property to `Publisher` that returns an `Async[Throwing]Stream` of its `Output`

### DIFF
--- a/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift
+++ b/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift
@@ -398,8 +398,6 @@ public struct UncheckedSendable<Value>: @unchecked Sendable {
   }
 }
 
-// Async publishers
-
 extension Publisher where Failure == Never {
   /// This property provides an `AsyncStream`, which allows you to use the Swift
   /// `async`-`await` syntax to receive the publisher's elements.

--- a/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift
+++ b/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift
@@ -155,17 +155,13 @@ extension AsyncStream {
     bufferingPolicy limit: Continuation.BufferingPolicy = .unbounded
   )
   where P.Output == Element, P.Failure == Never {
-    if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
-      self = AsyncStream(publisher.values, bufferingPolicy: limit)
-    } else {
-      self = AsyncStream(bufferingPolicy: limit) { continuation in
-        let subscription = publisher.sink(
-          receiveCompletion: { _ in continuation.finish() },
-          receiveValue: { continuation.yield($0) }
-        )
-        continuation.onTermination = { @Sendable _ in
-          subscription.cancel()
-        }
+    self = AsyncStream(bufferingPolicy: limit) { continuation in
+      let subscription = publisher.sink(
+        receiveCompletion: { _ in continuation.finish() },
+        receiveValue: { continuation.yield($0) }
+      )
+      continuation.onTermination = { @Sendable _ in
+        subscription.cancel()
       }
     }
   }
@@ -281,24 +277,20 @@ extension AsyncThrowingStream {
     bufferingPolicy limit: Continuation.BufferingPolicy = .unbounded
   )
   where P.Output == Element, Failure == any Error {
-    if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
-      self = AsyncThrowingStream(publisher.values, bufferingPolicy: limit)
-    } else {
-      self = AsyncThrowingStream(bufferingPolicy: limit) { continuation in
-        let subscription = publisher.sink(
-          receiveCompletion: {
-            switch $0 {
-            case .finished:
-              continuation.finish()
-            case .failure(let error):
-              continuation.finish(throwing: error)
-            }
-          },
-          receiveValue: { continuation.yield($0) }
-        )
-        continuation.onTermination = { @Sendable _ in
-          subscription.cancel()
-        }
+    self = AsyncThrowingStream(bufferingPolicy: limit) { continuation in
+      let subscription = publisher.sink(
+        receiveCompletion: {
+          switch $0 {
+          case .finished:
+            continuation.finish()
+          case .failure(let error):
+            continuation.finish(throwing: error)
+          }
+        },
+        receiveValue: { continuation.yield($0) }
+      )
+      continuation.onTermination = { @Sendable _ in
+        subscription.cancel()
       }
     }
   }

--- a/Tests/ComposableArchitectureTests/PublishersTests.swift
+++ b/Tests/ComposableArchitectureTests/PublishersTests.swift
@@ -1,0 +1,70 @@
+import Combine
+import ComposableArchitecture
+import XCTest
+
+final class PublishersTests: XCTestCase {
+  func testPublisherStream() async throws {
+    let subject: CurrentValueSubject<Int, Never> = CurrentValueSubject(4)
+    let stream = subject.stream
+    let expectation = self.expectation(description: "subscription")
+    let subscriptionTask = Task {
+      var result = [Int]()
+      for await value in stream {
+        result.append(value)
+        if value == 0 {
+          break
+        }
+      }
+      return result
+    }
+
+    subject.send(3)
+    subject.send(2)
+    subject.send(1)
+    subject.send(0)
+    let check = Task {
+      let result = try await subscriptionTask.result.get()
+      XCTAssertEqual(result, [4, 3, 2, 1, 0])
+      expectation.fulfill()
+    }
+    self.wait(for: [expectation], timeout: 1.0)
+    subscriptionTask.cancel()
+    check.cancel()
+  }
+
+  func testPublisherThrowableStream() async throws {
+    struct StreamError: Error {}
+    let subject: CurrentValueSubject<Int, Error> = CurrentValueSubject(4)
+    let stream = subject.stream
+    let expectation = self.expectation(description: "throwing-subscription")
+
+    let subscriptionTask = Task {
+      var result = [Int]()
+      for try await value in stream {
+        result.append(value)
+        if value == 0 {
+          break
+        }
+      }
+      return result
+    }
+
+    subject.send(3)
+    subject.send(2)
+    subject.send(1)
+    subject.send(completion: .failure(StreamError()))
+
+    let check = Task {
+      switch await subscriptionTask.result {
+      case let .failure(error):
+        XCTAssert(error is StreamError)
+        expectation.fulfill()
+      case .success:
+        XCTFail()
+      }
+    }
+    self.wait(for: [expectation], timeout: 1.0)
+    subscriptionTask.cancel()
+    check.cancel()
+  }
+}


### PR DESCRIPTION
The [`values`](https://developer.apple.com/documentation/combine/publisher/values-v7nz) property of `Publisher` that returns an async sequence of its `Output` is not available on all OSs that TCA currently supports. While it is possible to use third party or in-house backports, this creates some friction for users willing to migrate to swift-concurrency while supporting older OSs.

This PR proposes to add a `.stream` property to any `Publisher` that returns either an `AsyncStream<Output>` if the publisher can never fail, or an `AsyncThrowingStream<Output>` otherwise. `AsyncStream` is already the _de facto_ erased async sequence in TCA, and this PR follows this pattern. 

The new `AsyncStream`'s initializers that accept a publisher are kept internal. They can be made public if preferred, and they are already documented.

I've kept buffering to its default to avoid surprising behaviors.

What do you think about this?