### PR TITLE
Avoid failure when setting test dependency values

### DIFF
--- a/Examples/TicTacToe/tic-tac-toe/Sources/AuthenticationClient/AuthenticationClient.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/AuthenticationClient/AuthenticationClient.swift
@@ -72,7 +72,7 @@ public struct AuthenticationClient: Sendable {
 }
 
 extension AuthenticationClient: TestDependencyKey {
-  public static var testValue = Self(
+  public static let testValue = Self(
     login: unimplemented("\(Self.self).login"),
     twoFactor: unimplemented("\(Self.self).twoFactor")
   )

--- a/Sources/Dependencies/Dependencies/Calendar.swift
+++ b/Sources/Dependencies/Dependencies/Calendar.swift
@@ -33,7 +33,9 @@ extension DependencyValues {
   private enum CalendarKey: DependencyKey {
     static let liveValue = Calendar.autoupdatingCurrent
     static var testValue: Calendar {
-      XCTFail(#"Unimplemented: @Dependency(\.calendar)"#)
+      if !DependencyValues.isSetting {
+        XCTFail(#"Unimplemented: @Dependency(\.calendar)"#)
+      }
       return .autoupdatingCurrent
     }
   }

--- a/Sources/Dependencies/Dependencies/Locale.swift
+++ b/Sources/Dependencies/Dependencies/Locale.swift
@@ -45,7 +45,9 @@ extension DependencyValues {
   private enum LocaleKey: DependencyKey {
     static let liveValue = Locale.autoupdatingCurrent
     static var testValue: Locale {
-      XCTFail(#"Unimplemented: @Dependency(\.locale)"#)
+      if !DependencyValues.isSetting {
+        XCTFail(#"Unimplemented: @Dependency(\.locale)"#)
+      }
       return .autoupdatingCurrent
     }
   }

--- a/Sources/Dependencies/Dependencies/TimeZone.swift
+++ b/Sources/Dependencies/Dependencies/TimeZone.swift
@@ -24,7 +24,9 @@ extension DependencyValues {
   private enum TimeZoneKey: DependencyKey {
     static let liveValue = TimeZone.autoupdatingCurrent
     static var testValue: TimeZone {
-      XCTFail(#"Unimplemented: @Dependency(\.timeZone)"#)
+      if !DependencyValues.isSetting {
+        XCTFail(#"Unimplemented: @Dependency(\.timeZone)"#)
+      }
       return .autoupdatingCurrent
     }
   }

--- a/Sources/Dependencies/Dependencies/URLSession.swift
+++ b/Sources/Dependencies/Dependencies/URLSession.swift
@@ -79,7 +79,9 @@ extension DependencyValues {
   private enum URLSessionKey: DependencyKey {
     static let liveValue = URLSession.shared
     static var testValue: URLSession {
-      XCTFail(#"Unimplemented: @Dependency(\.urlSession)"#)
+      if !DependencyValues.isSetting {
+        XCTFail(#"Unimplemented: @Dependency(\.urlSession)"#)
+      }
       let configuration = URLSessionConfiguration.ephemeral
       configuration.protocolClasses = [UnimplementedURLProtocol.self]
       return URLSession(configuration: configuration)

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -55,7 +55,7 @@ import XCTestDynamicOverlay
 /// ```
 public struct DependencyValues: Sendable {
   @TaskLocal public static var _current = Self()
-  @TaskLocal fileprivate static var isSetting = false
+  @TaskLocal static var isSetting = false
   @TaskLocal static var currentDependency = CurrentDependency()
 
   private var cachedValues = CachedValues()

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -528,7 +528,7 @@ final class StoreTests: XCTestCase {
       }
     }
 
-    let store = Store(
+    let store = TestStore(
       initialState: 0,
       reducer: Counter()
         .dependency(\.calendar, Calendar(identifier: .gregorian))
@@ -537,6 +537,6 @@ final class StoreTests: XCTestCase {
         .dependency(\.urlSession, URLSession(configuration: .ephemeral))
     )
 
-    ViewStore(store).send(true)
+    store.send(true) { $0 = 1 }
   }
 }

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -510,4 +510,33 @@ final class StoreTests: XCTestCase {
     XCTAssertEqual(store.effectCancellables.count, 0)
     XCTAssertEqual(scopedStore.effectCancellables.count, 0)
   }
+
+  func testDependencies() {
+    struct Counter: ReducerProtocol {
+      @Dependency(\.calendar) var calendar
+      @Dependency(\.locale) var locale
+      @Dependency(\.timeZone) var timeZone
+      @Dependency(\.urlSession) var urlSession
+
+      func reduce(into state: inout Int, action: Bool) -> EffectTask<Bool> {
+        _ = self.calendar
+        _ = self.locale
+        _ = self.timeZone
+        _ = self.urlSession
+        state += action ? 1 : -1
+        return .none
+      }
+    }
+
+    let store = Store(
+      initialState: 0,
+      reducer: Counter()
+        .dependency(\.calendar, Calendar(identifier: .gregorian))
+        .dependency(\.locale, Locale(identifier: "en_US"))
+        .dependency(\.timeZone, TimeZone(secondsFromGMT: 0)!)
+        .dependency(\.urlSession, URLSession(configuration: .ephemeral))
+    )
+
+    ViewStore(store).send(true)
+  }
 }

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -511,7 +511,7 @@ final class StoreTests: XCTestCase {
     XCTAssertEqual(scopedStore.effectCancellables.count, 0)
   }
 
-  func testDependencies() {
+  func testOverrideDependenciesDirectlyOnReducer() {
     struct Counter: ReducerProtocol {
       @Dependency(\.calendar) var calendar
       @Dependency(\.locale) var locale
@@ -528,7 +528,7 @@ final class StoreTests: XCTestCase {
       }
     }
 
-    let store = TestStore(
+    let store = Store(
       initialState: 0,
       reducer: Counter()
         .dependency(\.calendar, Calendar(identifier: .gregorian))
@@ -537,6 +537,6 @@ final class StoreTests: XCTestCase {
         .dependency(\.urlSession, URLSession(configuration: .ephemeral))
     )
 
-    store.send(true) { $0 = 1 }
+    ViewStore(store).send(true)
   }
 }

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -206,4 +206,62 @@ final class TestStoreTests: XCTestCase {
     }
     XCTAssertEqual(store.state, 4)
   }
+
+  func testOverrideDependenciesDirectlyOnReducer() {
+    struct Counter: ReducerProtocol {
+      @Dependency(\.calendar) var calendar
+      @Dependency(\.locale) var locale
+      @Dependency(\.timeZone) var timeZone
+      @Dependency(\.urlSession) var urlSession
+
+      func reduce(into state: inout Int, action: Bool) -> EffectTask<Bool> {
+        _ = self.calendar
+        _ = self.locale
+        _ = self.timeZone
+        _ = self.urlSession
+        state += action ? 1 : -1
+        return .none
+      }
+    }
+
+    let store = TestStore(
+      initialState: 0,
+      reducer: Counter()
+        .dependency(\.calendar, Calendar(identifier: .gregorian))
+        .dependency(\.locale, Locale(identifier: "en_US"))
+        .dependency(\.timeZone, TimeZone(secondsFromGMT: 0)!)
+        .dependency(\.urlSession, URLSession(configuration: .ephemeral))
+    )
+
+    store.send(true) { $0 = 1 }
+  }
+
+  func testOverrideDependenciesOnTestStore() {
+    struct Counter: ReducerProtocol {
+      @Dependency(\.calendar) var calendar
+      @Dependency(\.locale) var locale
+      @Dependency(\.timeZone) var timeZone
+      @Dependency(\.urlSession) var urlSession
+
+      func reduce(into state: inout Int, action: Bool) -> EffectTask<Bool> {
+        _ = self.calendar
+        _ = self.locale
+        _ = self.timeZone
+        _ = self.urlSession
+        state += action ? 1 : -1
+        return .none
+      }
+    }
+
+    let store = TestStore(
+      initialState: 0,
+      reducer: Counter()
+    )
+    store.dependencies.calendar =  Calendar(identifier: .gregorian)
+    store.dependencies.locale =  Locale(identifier: "en_US")
+    store.dependencies.timeZone =  TimeZone(secondsFromGMT: 0)!
+    store.dependencies.urlSession =  URLSession(configuration: .ephemeral)
+
+    store.send(true) { $0 = 1 }
+  }
 }


### PR DESCRIPTION
It's currently possible to emit XCTest failures when testing reducers that access dependency values that emit failure upon access, which includes the calendar, locale, time zone, and URL session dependencies.

We may need a more holistic solution for folks that define these kinds of dependencies outside the library, but this will make the library-level failures a bit more lenient.