### PR TITLE
Fix `AsyncThrowingStream` documentation typo

### DIFF
--- a/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift
+++ b/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift
@@ -141,7 +141,7 @@ extension AsyncStream {
 }
 
 extension AsyncThrowingStream where Failure == Error {
-  /// Initializes an `AsyncStream` from any `AsyncSequence`.
+  /// Initializes an `AsyncThrowingStream` from any `AsyncSequence`.
   ///
   /// - Parameters:
   ///   - sequence: An `AsyncSequence`.


### PR DESCRIPTION
This would have been fixed with #1566.