### PR TITLE
Use opaque reducers in 5.7 to fix builder inference

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
+++ b/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
@@ -7,175 +7,101 @@
 /// See ``CombineReducers`` for an entry point into a reducer builder context.
 @resultBuilder
 public enum ReducerBuilder<State, Action> {
-  @inlinable
-  public static func buildArray<R: ReducerProtocol>(_ reducers: [R]) -> _SequenceMany<R>
-  where R.State == State, R.Action == Action {
-    _SequenceMany(reducers: reducers)
-  }
-
-  @inlinable
-  public static func buildBlock() -> EmptyReducer<State, Action> {
-    EmptyReducer()
-  }
-
-  @inlinable
-  public static func buildBlock<R: ReducerProtocol>(_ reducer: R) -> R
-  where R.State == State, R.Action == Action {
-    reducer
-  }
-
-  @inlinable
-  public static func buildEither<R0: ReducerProtocol, R1: ReducerProtocol>(
-    first reducer: R0
-  ) -> _Conditional<R0, R1>
-  where R0.State == State, R0.Action == Action {
-    .first(reducer)
-  }
-
-  @inlinable
-  public static func buildEither<R0: ReducerProtocol, R1: ReducerProtocol>(
-    second reducer: R1
-  ) -> _Conditional<R0, R1>
-  where R1.State == State, R1.Action == Action {
-    .second(reducer)
-  }
-
-  @inlinable
-  public static func buildExpression<R: ReducerProtocol>(_ expression: R) -> R
-  where R.State == State, R.Action == Action {
-    expression
-  }
-
-  @inlinable
-  public static func buildFinalResult<R: ReducerProtocol>(_ reducer: R) -> R
-  where R.State == State, R.Action == Action {
-    reducer
-  }
-
-  #if swift(<5.7)
-    @_disfavoredOverload
+  #if swift(>=5.7)
     @inlinable
-    public static func buildFinalResult<R: ReducerProtocol>(_ reducer: R) -> Reduce<State, Action>
+    public static func buildArray(
+      _ reducers: [some ReducerProtocol<State, Action>]
+    ) -> some ReducerProtocol<State, Action> {
+      _SequenceMany(reducers: reducers)
+    }
+
+    @inlinable
+    public static func buildBlock() -> some ReducerProtocol<State, Action> {
+      EmptyReducer()
+    }
+
+    @inlinable
+    public static func buildBlock(
+      _ reducer: some ReducerProtocol<State, Action>
+    ) -> some ReducerProtocol<State, Action> {
+      reducer
+    }
+
+    @inlinable
+    public static func buildEither<R0: ReducerProtocol, R1: ReducerProtocol>(
+      first reducer: R0
+    ) -> _Conditional<R0, R1>
+    where R0.State == State, R0.Action == Action, R1.State == State, R1.Action == Action {
+      .first(reducer)
+    }
+
+    @inlinable
+    public static func buildEither<R0: ReducerProtocol, R1: ReducerProtocol>(
+      second reducer: R1
+    ) -> _Conditional<R0, R1>
+    where R0.State == State, R0.Action == Action, R1.State == State, R1.Action == Action {
+      .second(reducer)
+    }
+
+    @inlinable
+    public static func buildExpression(
+      _ expression: some ReducerProtocol<State, Action>
+    ) -> some ReducerProtocol<State, Action> {
+      expression
+    }
+
+    @inlinable
+    public static func buildFinalResult(
+      _ reducer: some ReducerProtocol<State, Action>
+    ) -> some ReducerProtocol<State, Action> {
+      reducer
+    }
+
+    @inlinable
+    public static func buildLimitedAvailability(
+      _ wrapped: some ReducerProtocol<State, Action>
+    ) -> some ReducerProtocol<State, Action> {
+      _Optional(wrapped: wrapped)
+    }
+
+    @inlinable
+    public static func buildOptional(
+      _ wrapped: (some ReducerProtocol<State, Action>)?
+    ) -> some ReducerProtocol<State, Action> {
+      _Optional(wrapped: wrapped)
+    }
+
+    @inlinable
+    public static func buildPartialBlock(
+      first: some ReducerProtocol<State, Action>
+    ) -> some ReducerProtocol<State, Action> {
+      first
+    }
+
+    @inlinable
+    public static func buildPartialBlock(
+      accumulated: some ReducerProtocol<State, Action>, next: some ReducerProtocol<State, Action>
+    ) -> some ReducerProtocol<State, Action> {
+      _Sequence(accumulated, next)
+    }
+  #else
+    @inlinable
+    public static func buildArray<R: ReducerProtocol>(_ reducers: [R]) -> _SequenceMany<R>
     where R.State == State, R.Action == Action {
-      Reduce(reducer)
-    }
-  #endif
-
-  @inlinable
-  public static func buildLimitedAvailability<R: ReducerProtocol>(
-    _ wrapped: R
-  ) -> _Optional<R>
-  where R.State == State, R.Action == Action {
-    _Optional(wrapped: wrapped)
-  }
-
-  @inlinable
-  public static func buildOptional<R: ReducerProtocol>(_ wrapped: R?) -> _Optional<R>
-  where R.State == State, R.Action == Action {
-    _Optional(wrapped: wrapped)
-  }
-
-  @inlinable
-  public static func buildPartialBlock<R: ReducerProtocol>(first: R) -> R
-  where R.State == State, R.Action == Action {
-    first
-  }
-
-  @inlinable
-  public static func buildPartialBlock<R0: ReducerProtocol, R1: ReducerProtocol>(
-    accumulated: R0, next: R1
-  ) -> _Sequence<R0, R1>
-  where R0.State == State, R0.Action == Action {
-    _Sequence(accumulated, next)
-  }
-
-  public enum _Conditional<First: ReducerProtocol, Second: ReducerProtocol>: ReducerProtocol
-  where
-    First.State == Second.State,
-    First.Action == Second.Action
-  {
-    case first(First)
-    case second(Second)
-
-    @inlinable
-    public func reduce(into state: inout First.State, action: First.Action) -> EffectTask<
-      First.Action
-    > {
-      switch self {
-      case let .first(first):
-        return first.reduce(into: &state, action: action)
-
-      case let .second(second):
-        return second.reduce(into: &state, action: action)
-      }
-    }
-  }
-
-  public struct _Optional<Wrapped: ReducerProtocol>: ReducerProtocol {
-    @usableFromInline
-    let wrapped: Wrapped?
-
-    @usableFromInline
-    init(wrapped: Wrapped?) {
-      self.wrapped = wrapped
+      _SequenceMany(reducers: reducers)
     }
 
     @inlinable
-    public func reduce(
-      into state: inout Wrapped.State, action: Wrapped.Action
-    ) -> EffectTask<Wrapped.Action> {
-      switch wrapped {
-      case let .some(wrapped):
-        return wrapped.reduce(into: &state, action: action)
-      case .none:
-        return .none
-      }
-    }
-  }
-
-  public struct _Sequence<R0: ReducerProtocol, R1: ReducerProtocol>: ReducerProtocol
-  where R0.State == R1.State, R0.Action == R1.Action {
-    @usableFromInline
-    let r0: R0
-
-    @usableFromInline
-    let r1: R1
-
-    @usableFromInline
-    init(_ r0: R0, _ r1: R1) {
-      self.r0 = r0
-      self.r1 = r1
+    public static func buildBlock() -> EmptyReducer<State, Action> {
+      EmptyReducer()
     }
 
     @inlinable
-    public func reduce(into state: inout R0.State, action: R0.Action) -> EffectTask<R0.Action> {
-      self.r0.reduce(into: &state, action: action)
-        .merge(with: self.r1.reduce(into: &state, action: action))
-    }
-  }
-
-  public struct _SequenceMany<Element: ReducerProtocol>: ReducerProtocol {
-    @usableFromInline
-    let reducers: [Element]
-
-    @usableFromInline
-    init(reducers: [Element]) {
-      self.reducers = reducers
+    public static func buildBlock<R: ReducerProtocol>(_ reducer: R) -> R
+    where R.State == State, R.Action == Action {
+      reducer
     }
 
-    @inlinable
-    public func reduce(
-      into state: inout Element.State, action: Element.Action
-    ) -> EffectTask<Element.Action> {
-      self.reducers.reduce(.none) { $0.merge(with: $1.reduce(into: &state, action: action)) }
-    }
-  }
-}
-
-public typealias ReducerBuilderOf<R: ReducerProtocol> = ReducerBuilder<R.State, R.Action>
-
-#if swift(<5.7)
-  extension ReducerBuilder {
     @inlinable
     public static func buildBlock<
       R0: ReducerProtocol,
@@ -403,5 +329,138 @@ public typealias ReducerBuilderOf<R: ReducerProtocol> = ReducerBuilder<R.State, 
         r9
       )
     }
+
+    @inlinable
+    public static func buildEither<R0: ReducerProtocol, R1: ReducerProtocol>(
+      first reducer: R0
+    ) -> _Conditional<R0, R1>
+    where R0.State == State, R0.Action == Action {
+      .first(reducer)
+    }
+
+    @inlinable
+    public static func buildEither<R0: ReducerProtocol, R1: ReducerProtocol>(
+      second reducer: R1
+    ) -> _Conditional<R0, R1>
+    where R1.State == State, R1.Action == Action {
+      .second(reducer)
+    }
+
+    @inlinable
+    public static func buildExpression<R: ReducerProtocol>(_ expression: R) -> R
+    where R.State == State, R.Action == Action {
+      expression
+    }
+
+    @inlinable
+    public static func buildFinalResult<R: ReducerProtocol>(_ reducer: R) -> R
+    where R.State == State, R.Action == Action {
+      reducer
+    }
+
+    @_disfavoredOverload
+    @inlinable
+    public static func buildFinalResult<R: ReducerProtocol>(_ reducer: R) -> Reduce<State, Action>
+    where R.State == State, R.Action == Action {
+      Reduce(reducer)
+    }
+
+    @inlinable
+    public static func buildLimitedAvailability<R: ReducerProtocol>(
+      _ wrapped: R
+    ) -> _Optional<R>
+    where R.State == State, R.Action == Action {
+      _Optional(wrapped: wrapped)
+    }
+
+    @inlinable
+    public static func buildOptional<R: ReducerProtocol>(_ wrapped: R?) -> _Optional<R>
+    where R.State == State, R.Action == Action {
+      _Optional(wrapped: wrapped)
+    }
+  #endif
+
+  public enum _Conditional<First: ReducerProtocol, Second: ReducerProtocol>: ReducerProtocol
+  where
+    First.State == Second.State,
+    First.Action == Second.Action
+  {
+    case first(First)
+    case second(Second)
+
+    @inlinable
+    public func reduce(into state: inout First.State, action: First.Action) -> EffectTask<
+      First.Action
+    > {
+      switch self {
+      case let .first(first):
+        return first.reduce(into: &state, action: action)
+
+      case let .second(second):
+        return second.reduce(into: &state, action: action)
+      }
+    }
   }
-#endif
+
+  public struct _Optional<Wrapped: ReducerProtocol>: ReducerProtocol {
+    @usableFromInline
+    let wrapped: Wrapped?
+
+    @usableFromInline
+    init(wrapped: Wrapped?) {
+      self.wrapped = wrapped
+    }
+
+    @inlinable
+    public func reduce(
+      into state: inout Wrapped.State, action: Wrapped.Action
+    ) -> EffectTask<Wrapped.Action> {
+      switch wrapped {
+      case let .some(wrapped):
+        return wrapped.reduce(into: &state, action: action)
+      case .none:
+        return .none
+      }
+    }
+  }
+
+  public struct _Sequence<R0: ReducerProtocol, R1: ReducerProtocol>: ReducerProtocol
+  where R0.State == R1.State, R0.Action == R1.Action {
+    @usableFromInline
+    let r0: R0
+
+    @usableFromInline
+    let r1: R1
+
+    @usableFromInline
+    init(_ r0: R0, _ r1: R1) {
+      self.r0 = r0
+      self.r1 = r1
+    }
+
+    @inlinable
+    public func reduce(into state: inout R0.State, action: R0.Action) -> EffectTask<R0.Action> {
+      self.r0.reduce(into: &state, action: action)
+        .merge(with: self.r1.reduce(into: &state, action: action))
+    }
+  }
+
+  public struct _SequenceMany<Element: ReducerProtocol>: ReducerProtocol {
+    @usableFromInline
+    let reducers: [Element]
+
+    @usableFromInline
+    init(reducers: [Element]) {
+      self.reducers = reducers
+    }
+
+    @inlinable
+    public func reduce(
+      into state: inout Element.State, action: Element.Action
+    ) -> EffectTask<Element.Action> {
+      self.reducers.reduce(.none) { $0.merge(with: $1.reduce(into: &state, action: action)) }
+    }
+  }
+}
+
+public typealias ReducerBuilderOf<R: ReducerProtocol> = ReducerBuilder<R.State, R.Action>

--- a/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
+++ b/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
@@ -60,15 +60,15 @@ public enum ReducerBuilder<State, Action> {
     @inlinable
     public static func buildLimitedAvailability(
       _ wrapped: some ReducerProtocol<State, Action>
-    ) -> some ReducerProtocol<State, Action> {
-      _Optional(wrapped: wrapped)
+    ) -> Reduce<State, Action> {
+      Reduce(wrapped)
     }
 
     @inlinable
     public static func buildOptional(
       _ wrapped: (some ReducerProtocol<State, Action>)?
     ) -> some ReducerProtocol<State, Action> {
-      _Optional(wrapped: wrapped)
+      wrapped
     }
 
     @inlinable
@@ -368,15 +368,15 @@ public enum ReducerBuilder<State, Action> {
     @inlinable
     public static func buildLimitedAvailability<R: ReducerProtocol>(
       _ wrapped: R
-    ) -> _Optional<R>
+    ) -> Reduce<R.State, R.Action>
     where R.State == State, R.Action == Action {
-      _Optional(wrapped: wrapped)
+      Reduce(wrapped)
     }
 
     @inlinable
-    public static func buildOptional<R: ReducerProtocol>(_ wrapped: R?) -> _Optional<R>
+    public static func buildOptional<R: ReducerProtocol>(_ wrapped: R?) -> R?
     where R.State == State, R.Action == Action {
-      _Optional(wrapped: wrapped)
+      wrapped
     }
   #endif
 
@@ -398,28 +398,6 @@ public enum ReducerBuilder<State, Action> {
 
       case let .second(second):
         return second.reduce(into: &state, action: action)
-      }
-    }
-  }
-
-  public struct _Optional<Wrapped: ReducerProtocol>: ReducerProtocol {
-    @usableFromInline
-    let wrapped: Wrapped?
-
-    @usableFromInline
-    init(wrapped: Wrapped?) {
-      self.wrapped = wrapped
-    }
-
-    @inlinable
-    public func reduce(
-      into state: inout Wrapped.State, action: Wrapped.Action
-    ) -> EffectTask<Wrapped.Action> {
-      switch wrapped {
-      case let .some(wrapped):
-        return wrapped.reduce(into: &state, action: action)
-      case .none:
-        return .none
       }
     }
   }

--- a/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
+++ b/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
@@ -28,19 +28,19 @@ public enum ReducerBuilder<State, Action> {
     }
 
     @inlinable
-    public static func buildEither<R1: ReducerProtocol>(
-      first reducer: some ReducerProtocol<State, Action>
-    ) -> some ReducerProtocol<State, Action>
-    where R1.State == State, R1.Action == Action {
-      _Conditional.first(reducer, R1.self)
+    public static func buildEither<R0: ReducerProtocol, R1: ReducerProtocol>(
+      first reducer: R0
+    ) -> _Conditional<R0, R1>
+    where R0.State == State, R0.Action == Action, R1.State == State, R1.Action == Action {
+      .first(reducer)
     }
 
     @inlinable
-    public static func buildEither<R0: ReducerProtocol>(
-      second reducer: some ReducerProtocol<State, Action>
-    ) -> some ReducerProtocol<State, Action>
-    where R0.State == State, R0.Action == Action {
-      _Conditional.second(reducer, R0.self)
+    public static func buildEither<R0: ReducerProtocol, R1: ReducerProtocol>(
+      second reducer: R1
+    ) -> _Conditional<R0, R1>
+    where R0.State == State, R0.Action == Action, R1.State == State, R1.Action == Action {
+      .second(reducer)
     }
 
     @inlinable
@@ -385,18 +385,18 @@ public enum ReducerBuilder<State, Action> {
     First.State == Second.State,
     First.Action == Second.Action
   {
-    case first(First, Second.Type = Second.self)
-    case second(Second, First.Type = First.self)
+    case first(First)
+    case second(Second)
 
     @inlinable
     public func reduce(into state: inout First.State, action: First.Action) -> EffectTask<
       First.Action
     > {
       switch self {
-      case let .first(first, _):
+      case let .first(first):
         return first.reduce(into: &state, action: action)
 
-      case let .second(second, _):
+      case let .second(second):
         return second.reduce(into: &state, action: action)
       }
     }

--- a/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
+++ b/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
@@ -28,19 +28,19 @@ public enum ReducerBuilder<State, Action> {
     }
 
     @inlinable
-    public static func buildEither<R0: ReducerProtocol, R1: ReducerProtocol>(
-      first reducer: R0
-    ) -> _Conditional<R0, R1>
-    where R0.State == State, R0.Action == Action, R1.State == State, R1.Action == Action {
-      .first(reducer)
+    public static func buildEither<R1: ReducerProtocol>(
+      first reducer: some ReducerProtocol<State, Action>
+    ) -> some ReducerProtocol<State, Action>
+    where R1.State == State, R1.Action == Action {
+      _Conditional.first(reducer, R1.self)
     }
 
     @inlinable
-    public static func buildEither<R0: ReducerProtocol, R1: ReducerProtocol>(
-      second reducer: R1
-    ) -> _Conditional<R0, R1>
-    where R0.State == State, R0.Action == Action, R1.State == State, R1.Action == Action {
-      .second(reducer)
+    public static func buildEither<R0: ReducerProtocol>(
+      second reducer: some ReducerProtocol<State, Action>
+    ) -> some ReducerProtocol<State, Action>
+    where R0.State == State, R0.Action == Action {
+      _Conditional.second(reducer, R0.self)
     }
 
     @inlinable
@@ -385,18 +385,18 @@ public enum ReducerBuilder<State, Action> {
     First.State == Second.State,
     First.Action == Second.Action
   {
-    case first(First)
-    case second(Second)
+    case first(First, Second.Type = Second.self)
+    case second(Second, First.Type = First.self)
 
     @inlinable
     public func reduce(into state: inout First.State, action: First.Action) -> EffectTask<
       First.Action
     > {
       switch self {
-      case let .first(first):
+      case let .first(first, _):
         return first.reduce(into: &state, action: action)
 
-      case let .second(second):
+      case let .second(second, _):
         return second.reduce(into: &state, action: action)
       }
     }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/CombineReducers.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/CombineReducers.swift
@@ -41,15 +41,3 @@ public struct CombineReducers<Reducers: ReducerProtocol>: ReducerProtocol {
     self.reducers.reduce(into: &state, action: action)
   }
 }
-
-#if swift(>=5.7)
-  extension ReducerProtocol {
-    // NB: This overload is provided to work around https://github.com/apple/swift/issues/60445
-    /// Combines multiple reducers into a single reducer.
-    public func CombineReducers<State, Action>(
-      @ReducerBuilder<State, Action> _ build: () -> some ReducerProtocol<State, Action>
-    ) -> some ReducerProtocol<State, Action> {
-      ComposableArchitecture.CombineReducers(build)
-    }
-  }
-#endif

--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -1,97 +1,73 @@
 extension ReducerProtocol {
-  #if swift(>=5.7)
-    /// Embeds a child reducer in a parent domain that works on elements of a collection in parent
-    /// state.
-    ///
-    /// For example, if a parent feature holds onto an array of child states, then it can perform
-    /// its core logic _and_ the child's logic by using the `forEach` operator:
-    ///
-    /// ```swift
-    /// struct Parent: ReducerProtocol {
-    ///   struct State {
-    ///     var rows: IdentifiedArrayOf<Row.State>
-    ///     // ...
-    ///   }
-    ///   enum Action {
-    ///     case row(id: Row.State.ID, action: Row.Action)
-    ///     // ...
-    ///   }
-    ///
-    ///   var body: some ReducerProtocol<State, Action> {
-    ///     Reduce { state, action in
-    ///       // Core logic for parent feature
-    ///     }
-    ///     .forEach(\.rows, action: /Action.row) {
-    ///       Row()
-    ///     }
-    ///   }
-    /// }
-    /// ```
-    ///
-    /// > Tip: We are using `IdentifiedArray` from our
-    /// [Identified Collections][swift-identified-collections] library because it provides a safe
-    /// and ergonomic API for accessing elements from a stable ID rather than positional indices.
-    ///
-    /// The `forEach` forces a specific order of operations for the child and parent features. It
-    /// runs the child first, and then the parent. If the order was reversed, then it would be
-    /// possible for the parent feature to remove the child state from the array, in which case the
-    /// child feature would not be able to react to that action. That can cause subtle bugs.
-    ///
-    /// It is still possible for a parent feature higher up in the application to remove the child
-    /// state from the array before the child has a chance to react to the action. In such cases a
-    /// runtime warning is shown in Xcode to let you know that there's a potential problem.
-    ///
-    /// [swift-identified-collections]: http://github.com/pointfreeco/swift-identified-collections
-    ///
-    /// - Parameters:
-    ///   - toElementsState: A writable key path from parent state to an `IdentifiedArray` of child
-    ///     state.
-    ///   - toElementAction: A case path from parent action to child identifier and child actions.
-    ///   - element: A reducer that will be invoked with child actions against elements of child
-    ///     state.
-    /// - Returns: A reducer that combines the child reducer with the parent reducer.
-    @inlinable
-    public func forEach<ID: Hashable, ElementState, ElementAction>(
-      _ toElementsState: WritableKeyPath<State, IdentifiedArray<ID, ElementState>>,
-      action toElementAction: CasePath<Action, (ID, ElementAction)>,
-      @ReducerBuilder<ElementState, ElementAction> _ element: () -> some ReducerProtocol<
-        ElementState, ElementAction
-      >,
-      file: StaticString = #file,
-      fileID: StaticString = #fileID,
-      line: UInt = #line
-    ) -> some ReducerProtocol<State, Action> {
-      _ForEachReducer(
-        parent: self,
-        toElementsState: toElementsState,
-        toElementAction: toElementAction,
-        element: element(),
-        file: file,
-        fileID: fileID,
-        line: line
-      )
-    }
-  #else
-    @inlinable
-    public func forEach<ID: Hashable, Element: ReducerProtocol>(
-      _ toElementsState: WritableKeyPath<State, IdentifiedArray<ID, Element.State>>,
-      action toElementAction: CasePath<Action, (ID, Element.Action)>,
-      @ReducerBuilderOf<Element> _ element: () -> Element,
-      file: StaticString = #file,
-      fileID: StaticString = #fileID,
-      line: UInt = #line
-    ) -> _ForEachReducer<Self, ID, Element> {
-      _ForEachReducer(
-        parent: self,
-        toElementsState: toElementsState,
-        toElementAction: toElementAction,
-        element: element(),
-        file: file,
-        fileID: fileID,
-        line: line
-      )
-    }
-  #endif
+  /// Embeds a child reducer in a parent domain that works on elements of a collection in parent
+  /// state.
+  ///
+  /// For example, if a parent feature holds onto an array of child states, then it can perform
+  /// its core logic _and_ the child's logic by using the `forEach` operator:
+  ///
+  /// ```swift
+  /// struct Parent: ReducerProtocol {
+  ///   struct State {
+  ///     var rows: IdentifiedArrayOf<Row.State>
+  ///     // ...
+  ///   }
+  ///   enum Action {
+  ///     case row(id: Row.State.ID, action: Row.Action)
+  ///     // ...
+  ///   }
+  ///
+  ///   var body: some ReducerProtocol<State, Action> {
+  ///     Reduce { state, action in
+  ///       // Core logic for parent feature
+  ///     }
+  ///     .forEach(\.rows, action: /Action.row) {
+  ///       Row()
+  ///     }
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// > Tip: We are using `IdentifiedArray` from our
+  /// [Identified Collections][swift-identified-collections] library because it provides a safe
+  /// and ergonomic API for accessing elements from a stable ID rather than positional indices.
+  ///
+  /// The `forEach` forces a specific order of operations for the child and parent features. It
+  /// runs the child first, and then the parent. If the order was reversed, then it would be
+  /// possible for the parent feature to remove the child state from the array, in which case the
+  /// child feature would not be able to react to that action. That can cause subtle bugs.
+  ///
+  /// It is still possible for a parent feature higher up in the application to remove the child
+  /// state from the array before the child has a chance to react to the action. In such cases a
+  /// runtime warning is shown in Xcode to let you know that there's a potential problem.
+  ///
+  /// [swift-identified-collections]: http://github.com/pointfreeco/swift-identified-collections
+  ///
+  /// - Parameters:
+  ///   - toElementsState: A writable key path from parent state to an `IdentifiedArray` of child
+  ///     state.
+  ///   - toElementAction: A case path from parent action to child identifier and child actions.
+  ///   - element: A reducer that will be invoked with child actions against elements of child
+  ///     state.
+  /// - Returns: A reducer that combines the child reducer with the parent reducer.
+  @inlinable
+  public func forEach<ID: Hashable, Element: ReducerProtocol>(
+    _ toElementsState: WritableKeyPath<State, IdentifiedArray<ID, Element.State>>,
+    action toElementAction: CasePath<Action, (ID, Element.Action)>,
+    @ReducerBuilderOf<Element> _ element: () -> Element,
+    file: StaticString = #file,
+    fileID: StaticString = #fileID,
+    line: UInt = #line
+  ) -> _ForEachReducer<Self, ID, Element> {
+    _ForEachReducer(
+      parent: self,
+      toElementsState: toElementsState,
+      toElementAction: toElementAction,
+      element: element(),
+      file: file,
+      fileID: fileID,
+      line: line
+    )
+  }
 }
 
 public struct _ForEachReducer<

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
@@ -1,93 +1,69 @@
 extension ReducerProtocol {
-  #if swift(>=5.7)
-    /// Embeds a child reducer in a parent domain that works on a case of parent enum state.
-    ///
-    /// For example, if a parent feature's state is expressed as an enum of multiple children
-    /// states, then `ifCaseLet` can run a child reducer on a particular case of the enum:
-    ///
-    /// ```swift
-    /// struct Parent: ReducerProtocol {
-    ///   enum State {
-    ///     case loggedIn(Authenticated.State)
-    ///     case loggedOut(Unauthenticated.State)
-    ///   }
-    ///   enum Action {
-    ///     case loggedIn(Authenticated.Action)
-    ///     case loggedOut(Unauthenticated.Action)
-    ///     // ...
-    ///   }
-    ///
-    ///   var body: some ReducerProtocol<State, Action> {
-    ///     Reduce { state, action in
-    ///       // Core logic for parent feature
-    ///     }
-    ///     .ifCaseLet(/State.loggedIn, action: /Action.loggedIn) {
-    ///       Authenticated()
-    ///     }
-    ///     .ifCaseLet(/State.loggedOut, action: /Action.loggedOut) {
-    ///       Unauthenticated()
-    ///     }
-    ///   }
-    /// }
-    /// ```
-    ///
-    /// The `ifCaseLet` forces a specific order of operations for the child and parent features. It
-    /// runs the child first, and then the parent. If the order was reversed, then it would be
-    /// possible for the parent feature to change the case of the enum, in which case the child
-    /// feature would not be able to react to that action. That can cause subtle bugs.
-    ///
-    /// It is still possible for a parent feature higher up in the application to change the case of
-    /// the enum before the child has a chance to react to the action. In such cases a runtime
-    /// warning is shown in Xcode to let you know that there's a potential problem.
-    ///
-    /// - Parameters:
-    ///   - toCaseState: A case path from parent state to a case containing child state.
-    ///   - toCaseAction: A case path from parent action to a case containing child actions.
-    ///   - case: A reducer that will be invoked with child actions against child state when it is
-    ///     present
-    /// - Returns: A reducer that combines the child reducer with the parent reducer.
-    @inlinable
-    public func ifCaseLet<CaseState, CaseAction>(
-      _ toCaseState: CasePath<State, CaseState>,
-      action toCaseAction: CasePath<Action, CaseAction>,
-      @ReducerBuilder<CaseState, CaseAction> then case: () -> some ReducerProtocol<
-        CaseState, CaseAction
-      >,
-      file: StaticString = #file,
-      fileID: StaticString = #fileID,
-      line: UInt = #line
-    ) -> some ReducerProtocol<State, Action> {
-      _IfCaseLetReducer(
-        parent: self,
-        child: `case`(),
-        toChildState: toCaseState,
-        toChildAction: toCaseAction,
-        file: file,
-        fileID: fileID,
-        line: line
-      )
-    }
-  #else
-    @inlinable
-    public func ifCaseLet<Case: ReducerProtocol>(
-      _ toCaseState: CasePath<State, Case.State>,
-      action toCaseAction: CasePath<Action, Case.Action>,
-      @ReducerBuilderOf<Case> then case: () -> Case,
-      file: StaticString = #file,
-      fileID: StaticString = #fileID,
-      line: UInt = #line
-    ) -> _IfCaseLetReducer<Self, Case> {
-      .init(
-        parent: self,
-        child: `case`(),
-        toChildState: toCaseState,
-        toChildAction: toCaseAction,
-        file: file,
-        fileID: fileID,
-        line: line
-      )
-    }
-  #endif
+  /// Embeds a child reducer in a parent domain that works on a case of parent enum state.
+  ///
+  /// For example, if a parent feature's state is expressed as an enum of multiple children
+  /// states, then `ifCaseLet` can run a child reducer on a particular case of the enum:
+  ///
+  /// ```swift
+  /// struct Parent: ReducerProtocol {
+  ///   enum State {
+  ///     case loggedIn(Authenticated.State)
+  ///     case loggedOut(Unauthenticated.State)
+  ///   }
+  ///   enum Action {
+  ///     case loggedIn(Authenticated.Action)
+  ///     case loggedOut(Unauthenticated.Action)
+  ///     // ...
+  ///   }
+  ///
+  ///   var body: some ReducerProtocol<State, Action> {
+  ///     Reduce { state, action in
+  ///       // Core logic for parent feature
+  ///     }
+  ///     .ifCaseLet(/State.loggedIn, action: /Action.loggedIn) {
+  ///       Authenticated()
+  ///     }
+  ///     .ifCaseLet(/State.loggedOut, action: /Action.loggedOut) {
+  ///       Unauthenticated()
+  ///     }
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// The `ifCaseLet` forces a specific order of operations for the child and parent features. It
+  /// runs the child first, and then the parent. If the order was reversed, then it would be
+  /// possible for the parent feature to change the case of the enum, in which case the child
+  /// feature would not be able to react to that action. That can cause subtle bugs.
+  ///
+  /// It is still possible for a parent feature higher up in the application to change the case of
+  /// the enum before the child has a chance to react to the action. In such cases a runtime
+  /// warning is shown in Xcode to let you know that there's a potential problem.
+  ///
+  /// - Parameters:
+  ///   - toCaseState: A case path from parent state to a case containing child state.
+  ///   - toCaseAction: A case path from parent action to a case containing child actions.
+  ///   - case: A reducer that will be invoked with child actions against child state when it is
+  ///     present
+  /// - Returns: A reducer that combines the child reducer with the parent reducer.
+  @inlinable
+  public func ifCaseLet<Case: ReducerProtocol>(
+    _ toCaseState: CasePath<State, Case.State>,
+    action toCaseAction: CasePath<Action, Case.Action>,
+    @ReducerBuilderOf<Case> then case: () -> Case,
+    file: StaticString = #file,
+    fileID: StaticString = #fileID,
+    line: UInt = #line
+  ) -> _IfCaseLetReducer<Self, Case> {
+    .init(
+      parent: self,
+      child: `case`(),
+      toChildState: toCaseState,
+      toChildAction: toCaseAction,
+      file: file,
+      fileID: fileID,
+      line: line
+    )
+  }
 }
 
 public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: ReducerProtocol {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Optional.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Optional.swift
@@ -1,0 +1,19 @@
+extension Optional: ReducerProtocol where Wrapped: ReducerProtocol {
+  #if swift(<5.7)
+    public typealias State = Wrapped.State
+    public typealias Action = Wrapped.Action
+    public typealias _Body = Never
+  #endif
+
+  @inlinable
+  public func reduce(
+    into state: inout Wrapped.State, action: Wrapped.Action
+  ) -> EffectTask<Wrapped.Action> {
+    switch self {
+    case let .some(wrapped):
+      return wrapped.reduce(into: &state, action: action)
+    case .none:
+      return .none
+    }
+  }
+}

--- a/Tests/ComposableArchitectureTests/CompatibilityTests.swift
+++ b/Tests/ComposableArchitectureTests/CompatibilityTests.swift
@@ -36,7 +36,7 @@ final class CompatibilityTests: XCTestCase {
 
     var handledActions: [String] = []
 
-    let reducer = Reducer<State, Action, Void> { state, action, env in
+    let reducer = AnyReducer<State, Action, Void> { state, action, env in
       handledActions.append(action.description)
 
       switch action {

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -124,7 +124,7 @@ final class ComposableArchitectureTests: XCTestCase {
       case response(Int)
     }
 
-    let reducer = Reducer<Int, Action, Void> { state, action, _ in
+    let reducer = AnyReducer<Int, Action, Void> { state, action, _ in
       enum CancelID {}
 
       switch action {

--- a/Tests/ComposableArchitectureTests/ForEachReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ForEachReducerTests.swift
@@ -83,17 +83,33 @@ struct Elements: ReducerProtocol {
     case buttonTapped
     case row(id: Int, action: String)
   }
-  var body: Reduce<State, Action> {
-    Reduce<State, Action> { state, action in
-      .none
-    }
-    .forEach(\.rows, action: /Action.row) {
-      Reduce { state, action in
-        state.value = action
-        return action.isEmpty
-          ? .run { await $0("Empty") }
-          : .none
+  #if swift(>=5.7)
+    var body: some ReducerProtocol<State, Action> {
+      Reduce<State, Action> { state, action in
+        .none
+      }
+      .forEach(\.rows, action: /Action.row) {
+        Reduce { state, action in
+          state.value = action
+          return action.isEmpty
+            ? .run { await $0("Empty") }
+            : .none
+        }
       }
     }
-  }
+  #else
+    var body: Reduce<State, Action> {
+      Reduce<State, Action> { state, action in
+        .none
+      }
+      .forEach(\.rows, action: /Action.row) {
+        Reduce { state, action in
+          state.value = action
+          return action.isEmpty
+            ? .run { await $0("Empty") }
+            : .none
+        }
+      }
+    }
+  #endif
 }

--- a/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
@@ -54,9 +54,9 @@ private struct Root: ReducerProtocol {
 
     @ReducerBuilder<State, Action>
     var testFlowControl: some ReducerProtocol<State, Action> {
-      if true {
-        Self()
-      }
+//      if true {
+//        Self()
+//      }
 
       if Bool.random() {
         Self()
@@ -64,13 +64,13 @@ private struct Root: ReducerProtocol {
         EmptyReducer()
       }
 
-      for _ in 1...10 {
-        Self()
-      }
-
-      if #available(*) {
-        Self()
-      }
+//      for _ in 1...10 {
+//        Self()
+//      }
+//
+//      if #available(*) {
+//        Self()
+//      }
     }
   #else
     var body: Reduce<State, Action> {
@@ -234,4 +234,32 @@ private struct ForEachExample: ReducerProtocol {
       EmptyReducer().forEach(\.values, action: /Action.value) { EmptyReducer() }
     }
   #endif
+}
+
+private struct ScopeIfLetExample: ReducerProtocol {
+  struct State {
+    var optionalSelf: Self? {
+      get { self }
+      set { newValue.map { self = $0 } }
+    }
+  }
+
+  enum Action {}
+
+  var body: some ReducerProtocol<State, Action> {
+    Scope(state: \.self, action: .self) {
+      EmptyReducer()
+        .ifLet(\.optionalSelf, action: .self) {
+          EmptyReducer()
+        }
+    }
+  }
+}
+
+func _Scope<ParentState, ParentAction, ChildState, ChildAction>(
+  state toChildState: WritableKeyPath<ParentState, ChildState>,
+  action toChildAction: CasePath<ParentAction, ChildAction>,
+  @ReducerBuilder<ChildState, ChildAction> child: () -> some ReducerProtocol<ChildState, ChildAction>
+) -> some ReducerProtocol<ParentState, ParentAction> {
+  Scope(state: toChildState, action: toChildAction, child)
 }

--- a/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
@@ -246,20 +246,23 @@ private struct ScopeIfLetExample: ReducerProtocol {
 
   enum Action {}
 
-  var body: some ReducerProtocol<State, Action> {
-    Scope(state: \.self, action: .self) {
-      EmptyReducer()
-        .ifLet(\.optionalSelf, action: .self) {
-          EmptyReducer()
-        }
+  #if swift(>=5.7)
+    var body: some ReducerProtocol<State, Action> {
+      Scope(state: \.self, action: .self) {
+        EmptyReducer()
+          .ifLet(\.optionalSelf, action: .self) {
+            EmptyReducer()
+          }
+      }
     }
-  }
-}
-
-func _Scope<ParentState, ParentAction, ChildState, ChildAction>(
-  state toChildState: WritableKeyPath<ParentState, ChildState>,
-  action toChildAction: CasePath<ParentAction, ChildAction>,
-  @ReducerBuilder<ChildState, ChildAction> child: () -> some ReducerProtocol<ChildState, ChildAction>
-) -> some ReducerProtocol<ParentState, ParentAction> {
-  Scope(state: toChildState, action: toChildAction, child)
+  #else
+    var body: Reduce<State, Action> {
+      Scope(state: \.self, action: .self) {
+        EmptyReducer()
+          .ifLet(\.optionalSelf, action: .self) {
+            EmptyReducer()
+          }
+      }
+    }
+  #endif
 }

--- a/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
@@ -54,9 +54,9 @@ private struct Root: ReducerProtocol {
 
     @ReducerBuilder<State, Action>
     var testFlowControl: some ReducerProtocol<State, Action> {
-//      if true {
-//        Self()
-//      }
+      if true {
+        Self()
+      }
 
       if Bool.random() {
         Self()
@@ -64,13 +64,13 @@ private struct Root: ReducerProtocol {
         EmptyReducer()
       }
 
-//      for _ in 1...10 {
-//        Self()
-//      }
-//
-//      if #available(*) {
-//        Self()
-//      }
+      for _ in 1...10 {
+        Self()
+      }
+
+      if #available(*) {
+        Self()
+      }
     }
   #else
     var body: Reduce<State, Action> {

--- a/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
@@ -2,6 +2,35 @@
 
 import ComposableArchitecture
 
+import XCTest
+
+private struct Test: ReducerProtocol {
+  struct State {}
+  enum Action { case tap }
+
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+    .none
+  }
+
+  @available(iOS, introduced: 9999.0)
+  struct Unavailable: ReducerProtocol {
+    func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+      .none
+    }
+  }
+}
+
+func testLimitedAvailability() {
+  _ = CombineReducers {
+    Test()
+    if #available(iOS 9999.0, *) {
+      Test.Unavailable()
+    } else if #available(iOS 8888.0, *) {
+      EmptyReducer()
+    }
+  }
+}
+
 private struct Root: ReducerProtocol {
   struct State {
     var feature: Feature.State
@@ -15,6 +44,11 @@ private struct Root: ReducerProtocol {
     case optionalFeature(Feature.Action)
     case enumFeature(Features.Action)
     case features(id: Feature.State.ID, feature: Feature.Action)
+  }
+
+  @available(iOS, introduced: 9999.0)
+  struct Unavailable: ReducerProtocol {
+    let body = EmptyReducer<State, Action>()
   }
 
   #if swift(>=5.7)
@@ -68,8 +102,8 @@ private struct Root: ReducerProtocol {
         Self()
       }
 
-      if #available(*) {
-        Self()
+      if #available(iOS 9999.0, *) {
+        Unavailable()
       }
     }
   #else
@@ -126,8 +160,8 @@ private struct Root: ReducerProtocol {
         Self()
       }
 
-      if #available(*) {
-        Self()
+      if #available(iOS 9999.0, *) {
+        Unavailable()
       }
     }
   #endif

--- a/Tests/ComposableArchitectureTests/ScopeTests.swift
+++ b/Tests/ComposableArchitectureTests/ScopeTests.swift
@@ -89,14 +89,25 @@ private struct Feature: ReducerProtocol {
     case child1(Child1.Action)
     case child2(Child2.Action)
   }
-  var body: Reduce<State, Action> {
-    Scope(state: \.child1, action: /Action.child1) {
-      Child1()
+  #if swift(>=5.7)
+    var body: some ReducerProtocol<State, Action> {
+      Scope(state: \.child1, action: /Action.child1) {
+        Child1()
+      }
+      Scope(state: \.child2, action: /Action.child2) {
+        Child2()
+      }
     }
-    Scope(state: \.child2, action: /Action.child2) {
-      Child2()
+  #else
+    var body: Reduce<State, Action> {
+      Scope(state: \.child1, action: /Action.child1) {
+        Child1()
+      }
+      Scope(state: \.child2, action: /Action.child2) {
+        Child2()
+      }
     }
-  }
+  #endif
 }
 
 private struct Child1: ReducerProtocol {
@@ -130,22 +141,43 @@ private struct Child2: ReducerProtocol {
     case count(Int)
     case name(String)
   }
-  var body: Reduce<State, Action> {
-    Scope(state: /State.count, action: /Action.count) {
-      Reduce { state, action in
-        state = action
-        return state < 0
-          ? .run { await $0(0) }
-          : .none
+  #if swift(>=5.7)
+    var body: some ReducerProtocol<State, Action> {
+      Scope(state: /State.count, action: /Action.count) {
+        Reduce { state, action in
+          state = action
+          return state < 0
+            ? .run { await $0(0) }
+            : .none
+        }
+      }
+      Scope(state: /State.name, action: /Action.name) {
+        Reduce { state, action in
+          state = action
+          return state.isEmpty
+            ? .run { await $0("Empty") }
+            : .none
+        }
       }
     }
-    Scope(state: /State.name, action: /Action.name) {
-      Reduce { state, action in
-        state = action
-        return state.isEmpty
-          ? .run { await $0("Empty") }
-          : .none
+  #else
+    var body: Reduce<State, Action> {
+      Scope(state: /State.count, action: /Action.count) {
+        Reduce { state, action in
+          state = action
+          return state < 0
+            ? .run { await $0(0) }
+            : .none
+        }
+      }
+      Scope(state: /State.name, action: /Action.name) {
+        Reduce { state, action in
+          state = action
+          return state.isEmpty
+            ? .run { await $0("Empty") }
+            : .none
+        }
       }
     }
-  }
+  #endif
 }


### PR DESCRIPTION
Turns out a lot of the bugs we were working around with `CombineReducers` inference, as well as `buildFinalResult` warnings (previously: #1467) go away if we use `some ReducerProtocol<State, Action>` on Swift 5.7 instead of the concrete alternative.

@slavapestov Not sure if you're aware of these functional differences between inference of generics vs. opaque constrained types or would like some fresh bug reports. It can take some time to file them, but if they're not being tracked yet we can try to file down a repro.