### PR TITLE
Better handling of effect priority

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -385,9 +385,12 @@ extension EffectPublisher {
         await Task(priority: priority) { await operation() }.cancellableValue
       }
 
+      Swift.print(self)
+      Swift.print(other)
+
       let priority: TaskPriority?
-      if let lhsPriority = lhsPriority, let rhsPriority = rhsPriority {
-        priority = Swift.min(lhsPriority, rhsPriority)
+      if let _lhsPriority = lhsPriority, let _rhsPriority = rhsPriority {
+        priority = Swift.min(_lhsPriority, _rhsPriority)
       } else {
         priority = lhsPriority ?? rhsPriority
       }

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -371,4 +371,55 @@ final class EffectTests: XCTestCase {
       await task.finish()
     }
   }
+
+  func testPriority_Merge1() async {
+    let store = Store(
+      initialState: 0,
+      reducer: Reduce<Int, Void> { state, _ in
+        return .merge(
+          .fireAndForget(priority: .low) {
+            XCTAssertEqual(Task.currentPriority, .high)
+          },
+          .fireAndForget(priority: .high) {
+            XCTAssertEqual(Task.currentPriority, .high)
+          }
+        )
+      }
+    )
+    await ViewStore(store).send(()).finish()
+  }
+
+  func testPriority_Merge2() async {
+    let store = Store(
+      initialState: 0,
+      reducer: Reduce<Int, Void> { state, _ in
+        return .merge(
+          .fireAndForget(priority: .low) {
+            XCTAssertEqual(Task.basePriority, .low)
+          },
+          .fireAndForget(priority: .low) {
+            XCTAssertEqual(Task.basePriority, .low)
+          }
+        )
+      }
+    )
+    await ViewStore(store).send(()).finish()
+  }
+
+  func testPriority_Concatenate() async {
+    let store = Store(
+      initialState: 0,
+      reducer: Reduce<Int, Void> { state, _ in
+        return .concatenate(
+          .fireAndForget(priority: .low) {
+            XCTAssertEqual(Task.currentPriority, .high)
+          },
+          .fireAndForget(priority: .high) {
+            XCTAssertEqual(Task.currentPriority, .high)
+          }
+        )
+      }
+    )
+    await ViewStore(store).send(()).finish()
+  }
 }


### PR DESCRIPTION
We realized that we probably weren't propagating task priorities correctly when merging and concatenating effects, so this is an attempt to fix it. We're not sure it's correct, and there are some things we don't fully understand in how Swift deals with priority.

For merging, we decided to abandon `TaskGroup` because it seems that child tasks don't use their priority at all:

```swift
Task(priority: .high) {
  print("outer", Task.currentPriority.rawValue)
  await withTaskGroup(of: Void.self) { group in
    group.addTask(priority: .low) {
      print("inner", Task.currentPriority.rawValue)
    }
  }
}
```

This prints:

> outer 25
> inner 25

We're not sure if this is a bug in Swift or if there is something about this we don't understand.

So, instead of `TaskGroup` we can just use `Task { ... }` and manage the cancellation ourselves. We also make some attempts to leverage `async let` where possible, thinking that may be more efficient, but it's just a guess.

Also, the main `Effect.run` that executes the merge is given a priority that is the minimum of of the two priorities being merged. We think this is the correct decision to prevent priority inversion, although Swift already does work to upgrade low-priority tasks to avoid this.

And then, for concatenate we now set its priority to the minimum like described above, but we also do extra work to avoid spinning up new `Task`'s when not necessary.

Does anyone have any thoughts on this?