### PR TITLE
Add test for early vs late binding of @Dependency.

### DIFF
--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -149,6 +149,14 @@ final class DependencyValuesTests: XCTestCase {
       XCTAssertEqual(childDependencyEarlyBinding.fetch(), 1729)
       XCTAssertEqual(childDependencyLateBinding.fetch(), 1729)
     }
+
+    DependencyValues.withValue(\.someDependency.fetch, { 999 }) {
+      @Dependency(\.childDependencyEarlyBinding) var childDependencyEarlyBinding2;
+      @Dependency(\.childDependencyLateBinding) var childDependencyLateBinding2;
+
+      XCTAssertEqual(childDependencyEarlyBinding2.fetch(), 999)
+      XCTAssertEqual(childDependencyLateBinding2.fetch(), 999)
+    }
   }
 }
 

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -150,12 +150,26 @@ final class DependencyValuesTests: XCTestCase {
       XCTAssertEqual(childDependencyLateBinding.fetch(), 1729)
     }
 
+    var childDependencyEarlyBindingEscaped: ChildDependencyEarlyBinding!
+    var childDependencyLateBindingEscaped: ChildDependencyLateBinding!
+
     DependencyValues.withValue(\.someDependency.fetch, { 999 }) {
       @Dependency(\.childDependencyEarlyBinding) var childDependencyEarlyBinding2;
       @Dependency(\.childDependencyLateBinding) var childDependencyLateBinding2;
 
+      childDependencyEarlyBindingEscaped = childDependencyEarlyBinding
+      childDependencyLateBindingEscaped = childDependencyLateBinding
+
       XCTAssertEqual(childDependencyEarlyBinding2.fetch(), 999)
       XCTAssertEqual(childDependencyLateBinding2.fetch(), 999)
+    }
+
+    XCTAssertEqual(childDependencyEarlyBindingEscaped.fetch(), 42)
+    XCTAssertEqual(childDependencyLateBindingEscaped.fetch(), 42)
+
+    DependencyValues.withValue(\.someDependency.fetch, { 1_000 }) {
+      XCTAssertEqual(childDependencyEarlyBindingEscaped.fetch(), 1_000)
+      XCTAssertEqual(childDependencyLateBindingEscaped.fetch(), 1_000)
     }
   }
 }

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -139,35 +139,33 @@ final class DependencyValuesTests: XCTestCase {
   }
 
   func testBinding() {
-    DependencyValues.withValue(\.context, .live) {
-      @Dependency(\.childDependencyEarlyBinding) var childDependencyEarlyBinding;
-      @Dependency(\.childDependencyLateBinding) var childDependencyLateBinding;
-      
-      XCTAssertEqual(childDependencyEarlyBinding.fetch(), 42)
-      XCTAssertEqual(childDependencyLateBinding.fetch(), 42)
-      
-      DependencyValues.withValue(\.someDependency.fetch, { 1729 }) {
-        XCTAssertEqual(childDependencyEarlyBinding.fetch(), 1729)
-        XCTAssertEqual(childDependencyLateBinding.fetch(), 1729)
-      }
+    @Dependency(\.childDependencyEarlyBinding) var childDependencyEarlyBinding;
+    @Dependency(\.childDependencyLateBinding) var childDependencyLateBinding;
+
+    XCTAssertEqual(childDependencyEarlyBinding.fetch(), 42)
+    XCTAssertEqual(childDependencyLateBinding.fetch(), 42)
+
+    DependencyValues.withValue(\.someDependency.fetch, { 1729 }) {
+      XCTAssertEqual(childDependencyEarlyBinding.fetch(), 1729)
+      XCTAssertEqual(childDependencyLateBinding.fetch(), 1729)
     }
   }
 }
 
-struct SomeDependency: DependencyKey {
+struct SomeDependency: TestDependencyKey {
   var fetch: () -> Int
-  static let liveValue = Self { 42 }
+  static let testValue = Self { 42 }
 }
-struct ChildDependencyEarlyBinding: DependencyKey {
+struct ChildDependencyEarlyBinding: TestDependencyKey {
   var fetch: () -> Int
-  static var liveValue: Self {
+  static var testValue: Self {
     @Dependency(\.someDependency) var someDependency
     return Self { someDependency.fetch() }
   }
 }
-struct ChildDependencyLateBinding: DependencyKey {
+struct ChildDependencyLateBinding: TestDependencyKey {
   var fetch: () -> Int
-  static var liveValue: Self {
+  static var testValue: Self {
     return Self {
       @Dependency(\.someDependency) var someDependency
       return someDependency.fetch()


### PR DESCRIPTION
While answering a question about `@Dependency` I started to wonder if there really is a difference between using `@Dependency` in an early binding vs a late binding.

For example, is there a difference between these two dependencies that each use a `@Dependency`:

```swift
struct ChildDependencyEarlyBinding: DependencyKey {
  var fetch: () -> Int
  static var liveValue: Self {
    @Dependency(\.someDependency) var someDependency
    return Self { someDependency.fetch() }
  }
}

struct ChildDependencyLateBinding: DependencyKey {
  var fetch: () -> Int
  static var liveValue: Self {
    return Self {
      @Dependency(\.someDependency) var someDependency
      return someDependency.fetch()
    }
  }
}
```

Because accessing `someDependency` goes through the `@Dependency` property wrapper, which then resolves the dependency, it doesn't actually matter if bind early or late.

This is a good thing and makes it that much easier to use `@Dependency` from within other dependencies.