### PR TITLE
Add soft-deprecated warning message to Effect

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -609,50 +609,9 @@ extension EffectPublisher {
 }
 
 @available(
-  iOS,
-  deprecated: 9999.0,
-  message:
-    """
-    'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or
-    `EffectPublisher<Output, Failure>` in general.
-    
-    You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
-    concurrency to model failable streams of values.
-
-    See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
-    """
-)
-@available(
-  macOS,
-  deprecated: 9999.0,
-  message:
-    """
-    'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or
-    `EffectPublisher<Output, Failure>` in general.
-    
-    You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
-    concurrency to model failable streams of values.
-
-    See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
-    """
-)
-@available(
-  tvOS,
-  deprecated: 9999.0,
-  message:
-    """
-    'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or
-    `EffectPublisher<Output, Failure>` in general.
-    
-    You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
-    concurrency to model failable streams of values.
-
-    See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
-    """
-)
-@available(
-  watchOS,
-  deprecated: 9999.0,
+  *,
+  deprecated,
+  renamed: "EffectPublisher",
   message:
     """
     'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -74,7 +74,7 @@ extension EffectPublisher {
 /// ```swift
 /// func reduce(into state: inout State, action: Action) -> EffectTask<Action>  { … }
 /// ```
-public typealias EffectTask<Action> = Effect<Action, Never>
+public typealias EffectTask<Action> = EffectPublisher<Action, Never>
 
 extension EffectPublisher where Failure == Never {
   /// Wraps an asynchronous unit of work in an effect.

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1891,7 +1891,7 @@ extension TestStore {
     )
 
     for effect in self.reducer.inFlightEffects {
-      _ = Effect<Never, Never>.cancel(id: effect.id).sink { _ in }
+      _ = EffectPublisher<Never, Never>.cancel(id: effect.id).sink { _ in }
     }
     self.reducer.inFlightEffects = []
   }

--- a/Sources/swift-composable-architecture-benchmark/Dependencies.swift
+++ b/Sources/swift-composable-architecture-benchmark/Dependencies.swift
@@ -25,7 +25,7 @@ let dependenciesSuite = BenchmarkSuite(name: "Dependencies") { suite in
 
 private struct BenchmarkReducer: ReducerProtocol {
   @Dependency(\.someValue) var someValue
-  func reduce(into state: inout Int, action: Void) -> Effect<Void, Never> {
+  func reduce(into state: inout Int, action: Void) -> EffectPublisher<Void, Never> {
     state = self.someValue
     return .none
   }

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -309,7 +309,7 @@ final class EffectTests: XCTestCase {
         case response(Int)
       }
       @Dependency(\.date) var date
-      func reduce(into state: inout Int, action: Action) -> Effect<Action, Never> {
+      func reduce(into state: inout Int, action: Action) -> EffectPublisher<Action, Never> {
         switch action {
         case .tap:
           return .run { send in

--- a/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
@@ -266,7 +266,7 @@
     func testExpectedStateEqualityMustModify() async {
       let reducer = Reduce<Int, Bool> { state, action in
         switch action {
-        case true: return Effect(value: false)
+        case true: return EffectPublisher(value: false)
         case false: return .none
         }
       }

--- a/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
@@ -289,14 +289,14 @@
           case increment
           case loggedInResponse(Bool)
         }
-        func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+        func reduce(into state: inout State, action: Action) -> EffectPublisher<Action, Never> {
           switch action {
           case .decrement:
             state.count -= 1
             return .none
           case .increment:
             state.count += 1
-            return Effect(value: .loggedInResponse(true))
+            return EffectPublisher(value: .loggedInResponse(true))
           case let .loggedInResponse(response):
             state.isLoggedIn = response
             return .none
@@ -331,11 +331,11 @@
           case increment
           case loggedInResponse(Bool)
         }
-        func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+        func reduce(into state: inout State, action: Action) -> EffectPublisher<Action, Never> {
           switch action {
           case .increment:
             state.count += 1
-            return Effect(value: .loggedInResponse(true))
+            return EffectPublisher(value: .loggedInResponse(true))
           case let .loggedInResponse(response):
             state.isLoggedIn = response
             return .none
@@ -695,7 +695,7 @@
       case increment
       case decrement
     }
-    func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+    func reduce(into state: inout State, action: Action) -> EffectPublisher<Action, Never> {
       switch action {
       case .increment:
         state.count += 1
@@ -720,7 +720,7 @@
       case response1(Int)
       case response2(String)
     }
-    func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+    func reduce(into state: inout State, action: Action) -> EffectPublisher<Action, Never> {
       switch action {
       case .onAppear:
         state = State()
@@ -758,7 +758,7 @@
 
     @Dependency(\.mainQueue) var mainQueue
 
-    func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+    func reduce(into state: inout State, action: Action) -> EffectPublisher<Action, Never> {
       switch action {
       case let .changeIdentity(name, surname):
         state.name = name


### PR DESCRIPTION
As I understand, currently used Effect is going to be deprecated, and renamed to EffectPublisher. However, after I upgraded TCA dependency in our project to latest 0.45.0, there were no soft-deprecated messages for Effect, similar to Reducer naming. 