### PR TITLE
Rename a few new occurrences of `Effect` to `EffectTask` or `EffectPublisher`

### DIFF
--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1891,7 +1891,7 @@ extension TestStore {
     )
 
     for effect in self.reducer.inFlightEffects {
-      _ = Effect<Never, Never>.cancel(id: effect.id).sink { _ in }
+      _ = EffectPublisher<Never, Never>.cancel(id: effect.id).sink { _ in }
     }
     self.reducer.inFlightEffects = []
   }

--- a/Sources/swift-composable-architecture-benchmark/Dependencies.swift
+++ b/Sources/swift-composable-architecture-benchmark/Dependencies.swift
@@ -25,7 +25,7 @@ let dependenciesSuite = BenchmarkSuite(name: "Dependencies") { suite in
 
 private struct BenchmarkReducer: ReducerProtocol {
   @Dependency(\.someValue) var someValue
-  func reduce(into state: inout Int, action: Void) -> Effect<Void, Never> {
+  func reduce(into state: inout Int, action: Void) -> EffectTask<Void> {
     state = self.someValue
     return .none
   }

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -56,7 +56,7 @@ final class EffectTests: XCTestCase {
         let clock = TestClock()
         var values: [Int] = []
 
-        let effect = Effect<Int, Never>.concatenate(
+        let effect = EffectPublisher<Int, Never>.concatenate(
           (1...3).map { count in
             .task {
               try await clock.sleep(for: .seconds(count))
@@ -107,7 +107,7 @@ final class EffectTests: XCTestCase {
       if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
         let clock = TestClock()
 
-        let effect = Effect<Int, Never>.merge(
+        let effect = EffectPublisher<Int, Never>.merge(
           (1...3).map { count in
             .task {
               try await clock.sleep(for: .seconds(count))
@@ -309,7 +309,7 @@ final class EffectTests: XCTestCase {
         case response(Int)
       }
       @Dependency(\.date) var date
-      func reduce(into state: inout Int, action: Action) -> Effect<Action, Never> {
+      func reduce(into state: inout Int, action: Action) -> EffectTask<Action> {
         switch action {
         case .tap:
           return .run { send in

--- a/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
@@ -266,7 +266,7 @@
     func testExpectedStateEqualityMustModify() async {
       let reducer = Reduce<Int, Bool> { state, action in
         switch action {
-        case true: return Effect(value: false)
+        case true: return EffectTask(value: false)
         case false: return .none
         }
       }

--- a/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
@@ -289,14 +289,14 @@
           case increment
           case loggedInResponse(Bool)
         }
-        func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+        func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
           switch action {
           case .decrement:
             state.count -= 1
             return .none
           case .increment:
             state.count += 1
-            return Effect(value: .loggedInResponse(true))
+            return EffectTask(value: .loggedInResponse(true))
           case let .loggedInResponse(response):
             state.isLoggedIn = response
             return .none
@@ -331,11 +331,11 @@
           case increment
           case loggedInResponse(Bool)
         }
-        func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+        func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
           switch action {
           case .increment:
             state.count += 1
-            return Effect(value: .loggedInResponse(true))
+            return EffectTask(value: .loggedInResponse(true))
           case let .loggedInResponse(response):
             state.isLoggedIn = response
             return .none
@@ -463,7 +463,7 @@
           case tap
           case response(Int)
         }
-        func reduce(into state: inout Int, action: Action) -> Effect<Action, Never> {
+        func reduce(into state: inout Int, action: Action) -> EffectTask<Action> {
           switch action {
           case .tap:
             state += 1
@@ -695,7 +695,7 @@
       case increment
       case decrement
     }
-    func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+    func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
       switch action {
       case .increment:
         state.count += 1
@@ -720,7 +720,7 @@
       case response1(Int)
       case response2(String)
     }
-    func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+    func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
       switch action {
       case .onAppear:
         state = State()
@@ -758,7 +758,7 @@
 
     @Dependency(\.mainQueue) var mainQueue
 
-    func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+    func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
       switch action {
       case let .changeIdentity(name, surname):
         state.name = name


### PR DESCRIPTION
Following #1603, this PR renames a few new internal `Effect` introduced in recent changes, as an homogenous adoption will likely make the transition easier. I've kept three `Effect` with `Never` failures as `EffectPublisher`, as they're directly using `Combine` immediately after.
