### PR TITLE
Update case studies/docs for Scope and reducer builders

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -19,7 +19,7 @@ struct RootView: View {
           )
 
           NavigationLink(
-            "Pullback and combine",
+            "Combining reducers",
             destination: TwoCountersView(
               store: self.store.scope(
                 state: \.twoCounters,

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -2,8 +2,7 @@ import ComposableArchitecture
 import SwiftUI
 
 private let readMe = """
-  This screen demonstrates how to take small features and compose them into bigger ones using the \
-  `pullback` and `combine` operators on reducers, and the `scope` operator on stores.
+  This screen demonstrates how to take small features and compose them into bigger ones using reducer builders and the `Scope` reducer, as well as the `scope` operator on stores.
 
   It reuses the the domain of the counter screen and embeds it, twice, in a larger domain.
   """

--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ If you'd like to contribute a translation, please [open a PR](https://github.com
 
     In other ways TCA is a little more lax than the other libraries. For example, Elm controls what kinds of effects can be created via the `Cmd` type, but TCA allows an escape hatch to any kind of effect since `Effect` conforms to the Combine `Publisher` protocol.
 
-    And then there are certain things that TCA prioritizes highly that are not points of focus for Redux, Elm, or most other libraries. For example, composition is very important aspect of TCA, which is the process of breaking down large features into smaller units that can be glued together. This is accomplished with the `pullback` and `combine` operators on reducers, and it aids in handling complex features as well as modularization for a better-isolated code base and improved compile times.
+    And then there are certain things that TCA prioritizes highly that are not points of focus for Redux, Elm, or most other libraries. For example, composition is very important aspect of TCA, which is the process of breaking down large features into smaller units that can be glued together. This is accomplished with reducer builders and operators like `Scope`, and it aids in handling complex features as well as modularization for a better-isolated code base and improved compile times.
   </details>
 
 ## Credits and thanks


### PR DESCRIPTION
We still had some old copy around `pullback` and `combine` that I'm sure are confusing.