### PR TITLE
Add a test that checks that nested dependencies are correctly overridden

### DIFF
--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -176,6 +176,15 @@ final class DependencyValuesTests: XCTestCase {
       XCTAssertEqual(childDependencyLateBindingEscaped.fetch(), 1_000)
     }
   }
+  
+  func testNestedDependencyIsOverridden() {
+    DependencyValues.withValue(\.nestedValue.value, 10) {
+      @Dependency(\.nestedValue) var nestedValue: NestedValue
+      @Dependency(\.nestedValue.value) var value: Int
+      XCTAssertEqual(nestedValue.value, 10)
+      XCTAssertEqual(value, 10)
+    }
+  }
 }
 
 struct SomeDependency: TestDependencyKey {
@@ -198,6 +207,11 @@ struct ChildDependencyLateBinding: TestDependencyKey {
     }
   }
 }
+struct NestedValue: TestDependencyKey {
+  static var testValue: Self { .init() }
+  var value: Int = 0
+}
+
 extension DependencyValues {
   var someDependency: SomeDependency {
     get { self[SomeDependency.self] }
@@ -210,6 +224,10 @@ extension DependencyValues {
   var childDependencyLateBinding: ChildDependencyLateBinding {
     get { self[ChildDependencyLateBinding.self] }
     set { self[ChildDependencyLateBinding.self] = newValue }
+  }
+  var nestedValue: NestedValue {
+    get { self[NestedValue.self] }
+    set { self[NestedValue.self] = newValue }
   }
 }
 


### PR DESCRIPTION
This PR adds a test that covers the case where we override only a property of a `DependencyKey`. It checks that accessing the property from the dependency is producing the same result as directly exposing this property as a dependency.
It didn't seem obvious to me that it would work at first sight, but feel free to close the PR if you think this is superfluous.