### PR TITLE
Close TestStore.

### DIFF
--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -422,7 +422,7 @@ import XCTestDynamicOverlay
 /// [merowing.info]: https://www.merowing.info
 /// [exhaustive-testing-in-tca]: https://www.merowing.info/exhaustive-testing-in-tca/
 /// [Composable-Architecture-at-Scale]: https://vimeo.com/751173570
-open class TestStore<State, Action, ScopedState, ScopedAction, Environment> {
+public final class TestStore<State, Action, ScopedState, ScopedAction, Environment> {
 
   /// The current dependencies of the test store.
   ///


### PR DESCRIPTION
In an early prototype for non-exhaustive test stores we explored an API that would allow subclassing `TestStore`. We abandoned that approach, but accidentally left the class open. So let's close it.