### PR TITLE
Don't implicitly infer test context.

### DIFF
--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -298,8 +298,6 @@ struct CurrentDependency {
 private let defaultContext: DependencyContext = {
   if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" {
     return .preview
-  } else if _XCTIsTesting {
-    return .test
   } else {
     return .live
   }

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -66,33 +66,36 @@ final class DependencyValuesTests: XCTestCase {
   }
 
   func testDependencyDefaultIsReused() {
-    DependencyValues.withValue(\.self, .init()) {
-      @Dependency(\.reuseClient) var reuseClient: ReuseClient
+      DependencyValues.withValue(\.self, .init()) {
+        DependencyValues.withValue(\.context, .test) {
+        @Dependency(\.reuseClient) var reuseClient: ReuseClient
 
-      XCTAssertEqual(reuseClient.count(), 0)
-      reuseClient.setCount(42)
-      XCTAssertEqual(reuseClient.count(), 42)
+        XCTAssertEqual(reuseClient.count(), 0)
+        reuseClient.setCount(42)
+        XCTAssertEqual(reuseClient.count(), 42)
+      }
     }
   }
 
   func testDependencyDefaultIsReused_SegmentedByContext() {
     DependencyValues.withValue(\.self, .init()) {
-      @Dependency(\.reuseClient) var reuseClient: ReuseClient
+      DependencyValues.withValue(\.context, .test) {
+        @Dependency(\.reuseClient) var reuseClient: ReuseClient
 
-      XCTAssertEqual(reuseClient.count(), 0)
-      reuseClient.setCount(42)
-      XCTAssertEqual(reuseClient.count(), 42)
-
-      DependencyValues.withValue(\.context, .preview) {
         XCTAssertEqual(reuseClient.count(), 0)
-        reuseClient.setCount(1729)
-        XCTAssertEqual(reuseClient.count(), 1729)
-      }
+        reuseClient.setCount(42)
+        XCTAssertEqual(reuseClient.count(), 42)
 
-      XCTAssertEqual(reuseClient.count(), 42)
+        DependencyValues.withValue(\.context, .preview) {
+          XCTAssertEqual(reuseClient.count(), 0)
+          reuseClient.setCount(1729)
+          XCTAssertEqual(reuseClient.count(), 1729)
+        }
 
-      DependencyValues.withValue(\.context, .live) {
-        #if DEBUG
+        XCTAssertEqual(reuseClient.count(), 42)
+
+        DependencyValues.withValue(\.context, .live) {
+#if DEBUG
           XCTExpectFailure {
             $0.compactDescription.contains(
               """
@@ -101,17 +104,18 @@ final class DependencyValuesTests: XCTestCase {
               """
             )
           }
-        #endif
-        XCTAssertEqual(reuseClient.count(), 0)
-        reuseClient.setCount(-42)
-        XCTAssertEqual(
-          reuseClient.count(),
-          0,
-          "Don't cache dependency when using a test value in a live context"
-        )
-      }
+#endif
+          XCTAssertEqual(reuseClient.count(), 0)
+          reuseClient.setCount(-42)
+          XCTAssertEqual(
+            reuseClient.count(),
+            0,
+            "Don't cache dependency when using a test value in a live context"
+          )
+        }
 
-      XCTAssertEqual(reuseClient.count(), 42)
+        XCTAssertEqual(reuseClient.count(), 42)
+      }
     }
   }
 
@@ -139,41 +143,43 @@ final class DependencyValuesTests: XCTestCase {
   }
 
   func testBinding() {
-    @Dependency(\.childDependencyEarlyBinding) var childDependencyEarlyBinding:
+    DependencyValues.withValue(\.context, .test) {
+      @Dependency(\.childDependencyEarlyBinding) var childDependencyEarlyBinding:
       ChildDependencyEarlyBinding
-    @Dependency(\.childDependencyLateBinding) var childDependencyLateBinding:
+      @Dependency(\.childDependencyLateBinding) var childDependencyLateBinding:
       ChildDependencyLateBinding
-
-    XCTAssertEqual(childDependencyEarlyBinding.fetch(), 42)
-    XCTAssertEqual(childDependencyLateBinding.fetch(), 42)
-
-    DependencyValues.withValue(\.someDependency.fetch, { 1729 }) {
-      XCTAssertEqual(childDependencyEarlyBinding.fetch(), 1729)
-      XCTAssertEqual(childDependencyLateBinding.fetch(), 1729)
-    }
-
-    var childDependencyEarlyBindingEscaped: ChildDependencyEarlyBinding!
-    var childDependencyLateBindingEscaped: ChildDependencyLateBinding!
-
-    DependencyValues.withValue(\.someDependency.fetch, { 999 }) {
-      @Dependency(\.childDependencyEarlyBinding) var childDependencyEarlyBinding2:
+      
+      XCTAssertEqual(childDependencyEarlyBinding.fetch(), 42)
+      XCTAssertEqual(childDependencyLateBinding.fetch(), 42)
+      
+      DependencyValues.withValue(\.someDependency.fetch, { 1729 }) {
+        XCTAssertEqual(childDependencyEarlyBinding.fetch(), 1729)
+        XCTAssertEqual(childDependencyLateBinding.fetch(), 1729)
+      }
+      
+      var childDependencyEarlyBindingEscaped: ChildDependencyEarlyBinding!
+      var childDependencyLateBindingEscaped: ChildDependencyLateBinding!
+      
+      DependencyValues.withValue(\.someDependency.fetch, { 999 }) {
+        @Dependency(\.childDependencyEarlyBinding) var childDependencyEarlyBinding2:
         ChildDependencyEarlyBinding
-      @Dependency(\.childDependencyLateBinding) var childDependencyLateBinding2:
+        @Dependency(\.childDependencyLateBinding) var childDependencyLateBinding2:
         ChildDependencyLateBinding
-
-      childDependencyEarlyBindingEscaped = childDependencyEarlyBinding
-      childDependencyLateBindingEscaped = childDependencyLateBinding
-
-      XCTAssertEqual(childDependencyEarlyBinding2.fetch(), 999)
-      XCTAssertEqual(childDependencyLateBinding2.fetch(), 999)
-    }
-
-    XCTAssertEqual(childDependencyEarlyBindingEscaped.fetch(), 42)
-    XCTAssertEqual(childDependencyLateBindingEscaped.fetch(), 42)
-
-    DependencyValues.withValue(\.someDependency.fetch, { 1_000 }) {
-      XCTAssertEqual(childDependencyEarlyBindingEscaped.fetch(), 1_000)
-      XCTAssertEqual(childDependencyLateBindingEscaped.fetch(), 1_000)
+        
+        childDependencyEarlyBindingEscaped = childDependencyEarlyBinding
+        childDependencyLateBindingEscaped = childDependencyLateBinding
+        
+        XCTAssertEqual(childDependencyEarlyBinding2.fetch(), 999)
+        XCTAssertEqual(childDependencyLateBinding2.fetch(), 999)
+      }
+      
+      XCTAssertEqual(childDependencyEarlyBindingEscaped.fetch(), 42)
+      XCTAssertEqual(childDependencyLateBindingEscaped.fetch(), 42)
+      
+      DependencyValues.withValue(\.someDependency.fetch, { 1_000 }) {
+        XCTAssertEqual(childDependencyEarlyBindingEscaped.fetch(), 1_000)
+        XCTAssertEqual(childDependencyLateBindingEscaped.fetch(), 1_000)
+      }
     }
   }
 


### PR DESCRIPTION
Right now we infer the dependency context from whether or not we think the code is running in a test context. This causes problems when running tests on an application target, because the entry point of the application will actually execute, causing live dependencies to be used in a test context. Those failures bleed over to the test target. This is only an issue when testing application targets. Libraries and SPM modules work just fine.

Now technically it is just really bad that Xcode even runs the entry point of the application. This can cause you to accidentally execute API requests, track analytics, write data to disk, etc. without you knowing. TCA is just warning you that this is happening by yelling loudly and failing the test suite.

I'm starting to think it's not worth implicitly inferring the test context. If we stopped doing that, then the test host could go back to secretly using live dependencies without it failing the test suite.

This has come up a number of times, in both [discussions](https://github.com/pointfreeco/swift-composable-architecture/discussions/1652#discussioncomment-4112291) and on a Slack.