### PR TITLE
Fix ButtonRole and Button deprecations

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",
       "state" : {
-        "branch" : "fixes",
-        "revision" : "4ab0f87a77d4e1b537fece1f1272b3edc5ce9eed"
+        "revision" : "4b666bcc59ba1711a7543ecb37e1d181963b180c",
+        "version" : "0.4.2"
       }
     },
     {

--- a/Sources/ComposableArchitecture/UIKit/AlertStateUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/AlertStateUIKit.swift
@@ -80,7 +80,7 @@
   @available(tvOS 13, *)
   @available(watchOS, unavailable)
   extension UIAlertAction.Style {
-    init<Action>(_ role: AlertState<Action>.ButtonRole) {
+    init<Action>(_ role: ButtonState<Action>.Role) {
       switch role {
       case .cancel:
         self = .cancel
@@ -97,7 +97,7 @@
   @available(watchOS, unavailable)
   extension UIAlertAction {
     convenience init<Action>(
-      _ button: AlertState<Action>.Button,
+      _ button: ButtonState<Action>,
       action: @escaping (Action) -> Void
     ) {
       self.init(


### PR DESCRIPTION
Replaced AlertState<Action>.ButtonRole with ButtonState<Action>.Role 
Replaced AlertState<Action>.Button with ButtonState<Action>