### PR TITLE
Bump SwiftUINavigation and update examples

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swiftui-navigation",
         "state": {
           "branch": null,
-          "revision": "4b666bcc59ba1711a7543ecb37e1d181963b180c",
-          "version": "0.4.2"
+          "revision": "46acf5ecc1cabdb28d7fe03289f6c8b13a023f52",
+          "version": "0.4.5"
         }
       },
       {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -40,12 +40,18 @@ struct AlertAndConfirmationDialog: ReducerProtocol {
   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .alertButtonTapped:
-      state.alert = AlertState(
-        title: TextState("Alert!"),
-        message: TextState("This is an alert"),
-        primaryButton: .cancel(TextState("Cancel")),
-        secondaryButton: .default(TextState("Increment"), action: .send(.incrementButtonTapped))
-      )
+      state.alert = AlertState {
+        TextState("Alert!")
+      } actions: {
+        ButtonState(role: .cancel) {
+          TextState("Cancel")
+        }
+        ButtonState(action: .incrementButtonTapped) {
+          TextState("Increment")
+        }
+      } message: {
+        TextState("This is an alert")
+      }
       return .none
 
     case .alertDismissed:
@@ -53,15 +59,21 @@ struct AlertAndConfirmationDialog: ReducerProtocol {
       return .none
 
     case .confirmationDialogButtonTapped:
-      state.confirmationDialog = ConfirmationDialogState(
-        title: TextState("Confirmation dialog"),
-        message: TextState("This is a confirmation dialog."),
-        buttons: [
-          .cancel(TextState("Cancel")),
-          .default(TextState("Increment"), action: .send(.incrementButtonTapped)),
-          .default(TextState("Decrement"), action: .send(.decrementButtonTapped)),
-        ]
-      )
+      state.confirmationDialog = ConfirmationDialogState {
+        TextState("Confirmation dialog")
+      } actions: {
+        ButtonState(role: .cancel) {
+          TextState("Cancel")
+        }
+        ButtonState(action: .incrementButtonTapped) {
+          TextState("Increment")
+        }
+        ButtonState(action: .decrementButtonTapped) {
+          TextState("Decrement")
+        }
+      } message: {
+        TextState("This is a confirmation dialog.")
+      }
       return .none
 
     case .confirmationDialogDismissed:
@@ -69,12 +81,12 @@ struct AlertAndConfirmationDialog: ReducerProtocol {
       return .none
 
     case .decrementButtonTapped:
-      state.alert = AlertState(title: TextState("Decremented!"))
+      state.alert = AlertState { TextState("Decremented!") }
       state.count -= 1
       return .none
 
     case .incrementButtonTapped:
-      state.alert = AlertState(title: TextState("Incremented!"))
+      state.alert = AlertState { TextState("Incremented!") }
       state.count += 1
       return .none
     }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -62,14 +62,19 @@ struct Animations: ReducerProtocol {
       .cancellable(id: CancelID.self)
 
     case .resetButtonTapped:
-      state.alert = AlertState(
-        title: TextState("Reset state?"),
-        primaryButton: .destructive(
-          TextState("Reset"),
+      state.alert = AlertState {
+        TextState("Reset state?")
+      } actions: {
+        ButtonState(
+          role: .destructive,
           action: .send(.resetConfirmationButtonTapped, animation: .default)
-        ),
-        secondaryButton: .cancel(TextState("Cancel"))
-      )
+        ) {
+          TextState("Reset")
+        }
+        ButtonState(role: .cancel) {
+          TextState("Cancel")
+        }
+      }
       return .none
 
     case .resetConfirmationButtonTapped:

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
@@ -110,8 +110,8 @@ struct SharedState: ReducerProtocol {
         state.alert = AlertState {
           TextState(
             isPrime(state.count)
-            ? "👍 The number \(state.count) is prime!"
-            : "👎 The number \(state.count) is not prime :("
+              ? "👍 The number \(state.count) is prime!"
+              : "👎 The number \(state.count) is not prime :("
           )
         }
         return .none

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
@@ -107,13 +107,13 @@ struct SharedState: ReducerProtocol {
         return .none
 
       case .isPrimeButtonTapped:
-        state.alert = AlertState(
-          title: TextState(
+        state.alert = AlertState {
+          TextState(
             isPrime(state.count)
-              ? "👍 The number \(state.count) is prime!"
-              : "👎 The number \(state.count) is not prime :("
+            ? "👍 The number \(state.count) is prime!"
+            : "👎 The number \(state.count) is not prime :("
           )
-        )
+        }
         return .none
       }
     }

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -111,9 +111,9 @@ struct WebSocket: ReducerProtocol {
       .cancellable(id: WebSocketID.self)
 
     case .sendResponse(didSucceed: false):
-      state.alert = AlertState(
-        title: TextState(
-          "Could not send socket message. Connect to the server first, and try again."))
+      state.alert = AlertState {
+        TextState("Could not send socket message. Connect to the server first, and try again.")
+      }
       return .none
 
     case .sendResponse(didSucceed: true):

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
@@ -85,29 +85,31 @@ struct DownloadComponent: ReducerProtocol {
   }
 
   private var deleteAlert: AlertState<AlertAction> {
-    AlertState(
-      title: TextState("Do you want to delete this map from your offline storage?"),
-      primaryButton: .destructive(
-        TextState("Delete"),
-        action: .send(.deleteButtonTapped, animation: .default)
-      ),
-      secondaryButton: self.nevermindButton
-    )
+    AlertState {
+      TextState("Do you want to delete this map from your offline storage?")
+    } actions: {
+      ButtonState(role: .destructive, action: .send(.deleteButtonTapped, animation: .default)) {
+        TextState("Delete")
+      }
+      self.nevermindButton
+    }
   }
 
   private var stopAlert: AlertState<AlertAction> {
-    AlertState(
-      title: TextState("Do you want to stop downloading this map?"),
-      primaryButton: .destructive(
-        TextState("Stop"),
-        action: .send(.stopButtonTapped, animation: .default)
-      ),
-      secondaryButton: self.nevermindButton
-    )
+    AlertState {
+      TextState("Do you want to stop downloading this map?")
+    } actions: {
+      ButtonState(role: .destructive, action: .send(.stopButtonTapped, animation: .default)) {
+        TextState("Stop")
+      }
+      self.nevermindButton
+    }
   }
 
-  private var nevermindButton: AlertState<AlertAction>.Button {
-    .cancel(TextState("Nevermind"), action: .send(.nevermindButtonTapped))
+  private var nevermindButton: ButtonState<AlertAction> {
+    ButtonState(role: .cancel, action: .nevermindButtonTapped) {
+      TextState("Nevermind")
+    }
   }
 }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -56,7 +56,7 @@ struct Favoriting<ID: Hashable & Sendable>: ReducerProtocol {
       .cancellable(id: CancelID(id: state.id), cancelInFlight: true)
 
     case let .response(.failure(error)):
-      state.alert = AlertState(title: TextState(error.localizedDescription))
+      state.alert = AlertState { TextState(error.localizedDescription) }
       return .none
 
     case let .response(.success(isFavorite)):

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndConfirmationDialogsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndConfirmationDialogsTests.swift
@@ -12,15 +12,21 @@ final class AlertsAndConfirmationDialogsTests: XCTestCase {
     )
 
     await store.send(.alertButtonTapped) {
-      $0.alert = AlertState(
-        title: TextState("Alert!"),
-        message: TextState("This is an alert"),
-        primaryButton: .cancel(TextState("Cancel")),
-        secondaryButton: .default(TextState("Increment"), action: .send(.incrementButtonTapped))
-      )
+      $0.alert = AlertState {
+        TextState("Alert!")
+      } actions: {
+        ButtonState(role: .cancel) {
+          TextState("Cancel")
+        }
+        ButtonState(action: .incrementButtonTapped) {
+          TextState("Increment")
+        }
+      } message: {
+        TextState("This is an alert")
+      }
     }
     await store.send(.incrementButtonTapped) {
-      $0.alert = AlertState(title: TextState("Incremented!"))
+      $0.alert = AlertState { TextState("Incremented!") }
       $0.count = 1
     }
     await store.send(.alertDismissed) {
@@ -35,18 +41,24 @@ final class AlertsAndConfirmationDialogsTests: XCTestCase {
     )
 
     await store.send(.confirmationDialogButtonTapped) {
-      $0.confirmationDialog = ConfirmationDialogState(
-        title: TextState("Confirmation dialog"),
-        message: TextState("This is a confirmation dialog."),
-        buttons: [
-          .cancel(TextState("Cancel")),
-          .default(TextState("Increment"), action: .send(.incrementButtonTapped)),
-          .default(TextState("Decrement"), action: .send(.decrementButtonTapped)),
-        ]
-      )
+      $0.confirmationDialog = ConfirmationDialogState {
+        TextState("Confirmation dialog")
+      } actions: {
+        ButtonState(role: .cancel) {
+          TextState("Cancel")
+        }
+        ButtonState(action: .incrementButtonTapped) {
+          TextState("Increment")
+        }
+        ButtonState(action: .decrementButtonTapped) {
+          TextState("Decrement")
+        }
+      } message: {
+        TextState("This is a confirmation dialog.")
+      }
     }
     await store.send(.incrementButtonTapped) {
-      $0.alert = AlertState(title: TextState("Incremented!"))
+      $0.alert = AlertState { TextState("Incremented!") }
       $0.count = 1
     }
     await store.send(.confirmationDialogDismissed) {

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
@@ -78,14 +78,19 @@ final class AnimationTests: XCTestCase {
     }
 
     await store.send(.resetButtonTapped) {
-      $0.alert = AlertState(
-        title: TextState("Reset state?"),
-        primaryButton: .destructive(
-          TextState("Reset"),
+      $0.alert = AlertState {
+        TextState("Reset state?")
+      } actions: {
+        ButtonState(
+          role: .destructive,
           action: .send(.resetConfirmationButtonTapped, animation: .default)
-        ),
-        secondaryButton: .cancel(TextState("Cancel"))
-      )
+        ) {
+          TextState("Reset")
+        }
+        ButtonState(role: .cancel) {
+          TextState("Cancel")
+        }
+      }
     }
 
     await store.send(.resetConfirmationButtonTapped) {

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-SharedStateTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-SharedStateTests.swift
@@ -76,9 +76,9 @@ final class SharedStateTests: XCTestCase {
     )
 
     await store.send(.isPrimeButtonTapped) {
-      $0.alert = AlertState(
-        title: TextState("👍 The number \($0.count) is prime!")
-      )
+      $0.alert = AlertState {
+        TextState("👍 The number 3 is prime!")
+      }
     }
     await store.send(.alertDismissed) {
       $0.alert = nil
@@ -94,9 +94,9 @@ final class SharedStateTests: XCTestCase {
     )
 
     await store.send(.isPrimeButtonTapped) {
-      $0.alert = AlertState(
-        title: TextState("👎 The number \($0.count) is not prime :(")
-      )
+      $0.alert = AlertState {
+        TextState("👎 The number 6 is not prime :(")
+      }
     }
     await store.send(.alertDismissed) {
       $0.alert = nil

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
@@ -92,9 +92,9 @@ final class WebSocketTests: XCTestCase {
       $0.messageToSend = ""
     }
     await store.receive(.sendResponse(didSucceed: false)) {
-      $0.alert = AlertState(
-        title: TextState(
-          "Could not send socket message. Connect to the server first, and try again."))
+      $0.alert = AlertState {
+        TextState("Could not send socket message. Connect to the server first, and try again.")
+      }
     }
 
     // Disconnect from the socket

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
@@ -52,8 +52,6 @@ final class ReusableComponentsFavoritingTests: XCTestCase {
   }
 
   func testUnhappyPath() async {
-    let clock = TestClock()
-
     let episodes: IdentifiedArrayOf<Episode.State> = [
       Episode.State(
         id: UUID(uuidString: "00000000-0000-0000-0000-000000000000")!,

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
@@ -76,9 +76,9 @@ final class ReusableComponentsFavoritingTests: XCTestCase {
       .episode(
         id: episodes[0].id, action: .favorite(.response(.failure(FavoriteError()))))
     ) {
-      $0.episodes[id: episodes[0].id]?.alert = AlertState(
-        title: TextState("Favoriting failed.")
-      )
+      $0.episodes[id: episodes[0].id]?.alert = AlertState {
+        TextState("Favoriting failed.")
+      }
     }
 
     await store.send(.episode(id: episodes[0].id, action: .favorite(.alertDismissed))) {

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
@@ -57,14 +57,16 @@ final class ReusableComponentsDownloadComponentTests: XCTestCase {
     }
 
     await store.send(.buttonTapped) {
-      $0.alert = AlertState(
-        title: TextState("Do you want to stop downloading this map?"),
-        primaryButton: .destructive(
-          TextState("Stop"),
-          action: .send(.stopButtonTapped, animation: .default)
-        ),
-        secondaryButton: .cancel(TextState("Nevermind"), action: .send(.nevermindButtonTapped))
-      )
+      $0.alert = AlertState {
+        TextState("Do you want to stop downloading this map?")
+      } actions: {
+        ButtonState(role: .destructive, action: .send(.stopButtonTapped, animation: .default)) {
+          TextState("Stop")
+        }
+        ButtonState(role: .cancel, action: .nevermindButtonTapped) {
+          TextState("Nevermind")
+        }
+      }
     }
 
     await store.send(.alert(.stopButtonTapped)) {
@@ -90,14 +92,16 @@ final class ReusableComponentsDownloadComponentTests: XCTestCase {
     }
 
     await store.send(.buttonTapped) {
-      $0.alert = AlertState(
-        title: TextState("Do you want to stop downloading this map?"),
-        primaryButton: .destructive(
-          TextState("Stop"),
-          action: .send(.stopButtonTapped, animation: .default)
-        ),
-        secondaryButton: .cancel(TextState("Nevermind"), action: .send(.nevermindButtonTapped))
-      )
+      $0.alert = AlertState {
+        TextState("Do you want to stop downloading this map?")
+      } actions: {
+        ButtonState(role: .destructive, action: .send(.stopButtonTapped, animation: .default)) {
+          TextState("Stop")
+        }
+        ButtonState(role: .cancel, action: .nevermindButtonTapped) {
+          TextState("Nevermind")
+        }
+      }
     }
 
     self.download.continuation.yield(.response(Data()))
@@ -123,14 +127,16 @@ final class ReusableComponentsDownloadComponentTests: XCTestCase {
     store.dependencies.downloadClient.download = { _ in self.download.stream }
 
     await store.send(.buttonTapped) {
-      $0.alert = AlertState(
-        title: TextState("Do you want to delete this map from your offline storage?"),
-        primaryButton: .destructive(
-          TextState("Delete"),
-          action: .send(.deleteButtonTapped, animation: .default)
-        ),
-        secondaryButton: .cancel(TextState("Nevermind"), action: .send(.nevermindButtonTapped))
-      )
+      $0.alert = AlertState {
+        TextState("Do you want to delete this map from your offline storage?")
+      } actions: {
+        ButtonState(role: .destructive, action: .send(.deleteButtonTapped, animation: .default)) {
+          TextState("Delete")
+        }
+        ButtonState(role: .cancel, action: .nevermindButtonTapped) {
+          TextState("Nevermind")
+        }
+      }
     }
 
     await store.send(.alert(.deleteButtonTapped)) {

--- a/Examples/Search/Search/SearchView.swift
+++ b/Examples/Search/Search/SearchView.swift
@@ -217,9 +217,11 @@ private let dateFormatter: DateFormatter = {
 
 struct SearchView_Previews: PreviewProvider {
   static var previews: some View {
-    let store = Store(
-      initialState: Search.State(),
-      reducer: Search()
+    SearchView(
+      store: Store(
+        initialState: Search.State(),
+        reducer: Search()
+      )
     )
   }
 }

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
@@ -58,13 +58,13 @@ struct SpeechRecognition: ReducerProtocol {
 
     case .speech(.failure(SpeechClient.Failure.couldntConfigureAudioSession)),
       .speech(.failure(SpeechClient.Failure.couldntStartAudioEngine)):
-      state.alert = AlertState(title: TextState("Problem with audio device. Please try again."))
+      state.alert = AlertState { TextState("Problem with audio device. Please try again.") }
       return .none
 
     case .speech(.failure):
-      state.alert = AlertState(
-        title: TextState("An error occurred while transcribing. Please try again.")
-      )
+      state.alert = AlertState {
+        TextState("An error occurred while transcribing. Please try again.")
+      }
       return .none
 
     case let .speech(.success(transcribedText)):
@@ -79,21 +79,21 @@ struct SpeechRecognition: ReducerProtocol {
         return .none
 
       case .denied:
-        state.alert = AlertState(
-          title: TextState(
+        state.alert = AlertState {
+          TextState(
             """
             You denied access to speech recognition. This app needs access to transcribe your \
             speech.
             """
           )
-        )
+        }
         return .none
 
       case .notDetermined:
         return .none
 
       case .restricted:
-        state.alert = AlertState(title: TextState("Your device does not allow speech recognition."))
+        state.alert = AlertState { TextState("Your device does not allow speech recognition.") }
         return .none
 
       @unknown default:

--- a/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
+++ b/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
@@ -19,13 +19,13 @@ final class SpeechRecognitionTests: XCTestCase {
       $0.isRecording = true
     }
     await store.receive(.speechRecognizerAuthorizationStatusResponse(.denied)) {
-      $0.alert = AlertState(
-        title: TextState(
+      $0.alert = AlertState {
+        TextState(
           """
           You denied access to speech recognition. This app needs access to transcribe your speech.
           """
         )
-      )
+      }
       $0.isRecording = false
     }
   }
@@ -42,7 +42,7 @@ final class SpeechRecognitionTests: XCTestCase {
       $0.isRecording = true
     }
     await store.receive(.speechRecognizerAuthorizationStatusResponse(.restricted)) {
-      $0.alert = AlertState(title: TextState("Your device does not allow speech recognition."))
+      $0.alert = AlertState { TextState("Your device does not allow speech recognition.") }
       $0.isRecording = false
     }
   }
@@ -108,7 +108,7 @@ final class SpeechRecognitionTests: XCTestCase {
 
     recognitionTask.continuation.finish(throwing: SpeechClient.Failure.couldntConfigureAudioSession)
     await store.receive(.speech(.failure(SpeechClient.Failure.couldntConfigureAudioSession))) {
-      $0.alert = AlertState(title: TextState("Problem with audio device. Please try again."))
+      $0.alert = AlertState { TextState("Problem with audio device. Please try again.") }
     }
   }
 
@@ -129,7 +129,7 @@ final class SpeechRecognitionTests: XCTestCase {
 
     recognitionTask.continuation.finish(throwing: SpeechClient.Failure.couldntStartAudioEngine)
     await store.receive(.speech(.failure(SpeechClient.Failure.couldntStartAudioEngine))) {
-      $0.alert = AlertState(title: TextState("Problem with audio device. Please try again."))
+      $0.alert = AlertState { TextState("Problem with audio device. Please try again.") }
     }
   }
 }

--- a/Examples/TicTacToe/tic-tac-toe/Package.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 
 import PackageDescription
 
 let package = Package(
   name: "tic-tac-toe",
   platforms: [
-    .iOS(.v14)
+    .iOS(.v15)
   ],
   products: [
     .library(name: "AppCore", targets: ["AppCore"]),

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginCore/LoginCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginCore/LoginCore.swift
@@ -49,7 +49,7 @@ public struct Login: ReducerProtocol, Sendable {
         return .none
 
       case let .loginResponse(.failure(error)):
-        state.alert = AlertState(title: TextState(error.localizedDescription))
+        state.alert = AlertState { TextState(error.localizedDescription) }
         state.isLoginRequestInFlight = false
         return .none
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginCore/LoginCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginCore/LoginCore.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 import Dispatch
 import TwoFactorCore
 
-public struct Login: ReducerProtocol {
+public struct Login: ReducerProtocol, Sendable {
   public struct State: Equatable {
     public var alert: AlertState<Action>?
     public var email = ""

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
@@ -52,7 +52,7 @@ public struct TwoFactor: ReducerProtocol, Sendable {
       .cancellable(id: TearDownToken.self)
 
     case let .twoFactorResponse(.failure(error)):
-      state.alert = AlertState(title: TextState(error.localizedDescription))
+      state.alert = AlertState { TextState(error.localizedDescription) }
       state.isTwoFactorRequestInFlight = false
       return .none
 

--- a/Examples/TicTacToe/tic-tac-toe/Tests/LoginSwiftUITests/LoginSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/LoginSwiftUITests/LoginSwiftUITests.swift
@@ -98,9 +98,9 @@ final class LoginSwiftUITests: XCTestCase {
       $0.isFormDisabled = true
     }
     await store.receive(.loginResponse(.failure(AuthenticationError.invalidUserPassword))) {
-      $0.alert = AlertState(
-        title: TextState(AuthenticationError.invalidUserPassword.localizedDescription)
-      )
+      $0.alert = AlertState {
+        TextState(AuthenticationError.invalidUserPassword.localizedDescription)
+      }
       $0.isActivityIndicatorVisible = false
       $0.isFormDisabled = false
     }

--- a/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorCoreTests/TwoFactorCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorCoreTests/TwoFactorCoreTests.swift
@@ -58,9 +58,9 @@ final class TwoFactorCoreTests: XCTestCase {
       $0.isTwoFactorRequestInFlight = true
     }
     await store.receive(.twoFactorResponse(.failure(AuthenticationError.invalidTwoFactor))) {
-      $0.alert = AlertState(
-        title: TextState(AuthenticationError.invalidTwoFactor.localizedDescription)
-      )
+      $0.alert = AlertState {
+        TextState(AuthenticationError.invalidTwoFactor.localizedDescription)
+      }
       $0.isTwoFactorRequestInFlight = false
     }
     await store.send(.alertDismissed) {

--- a/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorSwiftUITests/TwoFactorSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorSwiftUITests/TwoFactorSwiftUITests.swift
@@ -67,9 +67,9 @@ final class TwoFactorSwiftUITests: XCTestCase {
       $0.isFormDisabled = true
     }
     await store.receive(.twoFactorResponse(.failure(AuthenticationError.invalidTwoFactor))) {
-      $0.alert = AlertState(
-        title: TextState(AuthenticationError.invalidTwoFactor.localizedDescription)
-      )
+      $0.alert = AlertState {
+        TextState(AuthenticationError.invalidTwoFactor.localizedDescription)
+      }
       $0.isActivityIndicatorVisible = false
       $0.isFormDisabled = false
     }

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -51,9 +51,9 @@ struct VoiceMemos: ReducerProtocol {
           }
 
         case .denied:
-          state.alert = AlertState(
-            title: TextState("Permission is required to record voice memos.")
-          )
+          state.alert = AlertState {
+            TextState("Permission is required to record voice memos.")
+          }
           return .none
 
         case .allowed:
@@ -74,7 +74,7 @@ struct VoiceMemos: ReducerProtocol {
         return .none
 
       case .recordingMemo(.delegate(.didFinish(.failure))):
-        state.alert = AlertState(title: TextState("Voice memo recording failed."))
+        state.alert = AlertState { TextState("Voice memo recording failed.") }
         state.recordingMemo = nil
         return .none
 
@@ -87,14 +87,14 @@ struct VoiceMemos: ReducerProtocol {
           state.recordingMemo = newRecordingMemo
           return .none
         } else {
-          state.alert = AlertState(
-            title: TextState("Permission is required to record voice memos.")
-          )
+          state.alert = AlertState {
+            TextState("Permission is required to record voice memos.")
+          }
           return .none
         }
 
       case .voiceMemo(id: _, action: .audioPlayerClient(.failure)):
-        state.alert = AlertState(title: TextState("Voice memo playback failed."))
+        state.alert = AlertState { TextState("Voice memo playback failed.") }
         return .none
 
       case let .voiceMemo(id: id, action: .delete):

--- a/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
+++ b/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
@@ -88,7 +88,7 @@ final class VoiceMemosTests: XCTestCase {
 
     await store.send(.recordButtonTapped)
     await store.receive(.recordPermissionResponse(false)) {
-      $0.alert = AlertState(title: TextState("Permission is required to record voice memos."))
+      $0.alert = AlertState { TextState("Permission is required to record voice memos.") }
       $0.audioRecorderPermission = .denied
     }
     await store.send(.alertDismissed) {
@@ -131,7 +131,7 @@ final class VoiceMemosTests: XCTestCase {
     didFinish.continuation.finish(throwing: SomeError())
     await store.receive(.recordingMemo(.audioRecorderDidFinish(.failure(SomeError()))))
     await store.receive(.recordingMemo(.delegate(.didFinish(.failure(SomeError()))))) {
-      $0.alert = AlertState(title: TextState("Voice memo recording failed."))
+      $0.alert = AlertState { TextState("Voice memo recording failed.") }
       $0.recordingMemo = nil
     }
 
@@ -164,7 +164,7 @@ final class VoiceMemosTests: XCTestCase {
     await store.send(.recordingMemo(.task))
     didFinish.continuation.finish(throwing: SomeError())
     await store.receive(.recordingMemo(.delegate(.didFinish(.failure(SomeError()))))) {
-      $0.alert = AlertState(title: TextState("Voice memo recording failed."))
+      $0.alert = AlertState { TextState("Voice memo recording failed.") }
       $0.recordingMemo = nil
     }
   }
@@ -236,7 +236,7 @@ final class VoiceMemosTests: XCTestCase {
       $0.voiceMemos[id: url]?.mode = .playing(progress: 0)
     }
     await store.receive(.voiceMemo(id: url, action: .audioPlayerClient(.failure(SomeError())))) {
-      $0.alert = AlertState(title: TextState("Voice memo playback failed."))
+      $0.alert = AlertState { TextState("Voice memo playback failed.") }
       $0.voiceMemos[id: url]?.mode = .notPlaying
     }
     await task.cancel()

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test-docs:
 test-examples:
 	for scheme in "CaseStudies (SwiftUI)" "CaseStudies (UIKit)" Search SpeechRecognition TicTacToe Todos VoiceMemos; do \
 		xcodebuild test \
-			-scheme $$scheme \
+			-scheme "$$scheme" \
 			-destination platform="$(PLATFORM_IOS)"; \
 	done
 

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-clocks", from: "0.1.4"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.6.0"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "0.4.1"),
-    .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "0.4.2"),
+    .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "0.4.5"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.5.0"),
   ],
   targets: [


### PR DESCRIPTION
While updating some examples to use the new `AlertState` and `ConfirmationDialogState` initializers, I thought it would probably be worth bumping [SwiftUINavigation](https://github.com/pointfreeco/swiftui-navigation) to the latest version. 

I had a feeling the examples didn't need to support a minimum version but was unsure. I just updated what I could find. 

In addition to updating the examples I have included some small fixes I noticed along the way. Happy to create separate PRs if needed. 

Summary of changes:
- Updated all examples that use `AlertState` and `ConfirmationDialogState`
- Added missing preview for `Search` example
- Remove unused `TestClock` from `ReusableComponentsFavoritingTests`
- Bumped swift tool version to `5.6` and platform requirement to `.iOS(.v15)` for `TicTacToe` example and made `Login` sendable
- Added double quotes to `scheme` variable in Makefile `test-examples` so `CaseStudies (SwiftUI)` `CaseStudies (UIKit)` are passed correctly to `xcodebuild test -scheme`. Currently being passed as `xcodebuild test -scheme CaseStudies "(SwiftUI)"` which results in `xcodebuild: error: Unknown build action '(SwiftUI)'`