### PR TITLE
Fix code typo in the article 'Migrating to the reducer protocol'

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToTheReducerProtocol.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToTheReducerProtocol.md
@@ -355,7 +355,7 @@ let parentReducer = Reducer<
   .pullback(
     state: \.feature, 
     action: /ParentAction.feature, 
-    environment: { FeatureEnvironment(date: $0.date) }
+    environment: { $0 }
   ),
 
   Reducer { state, action, environment in


### PR DESCRIPTION
On my way of `migrating to the reducer protocol`, I've found this small typo in the 4th code snippet of [Optional and pullback reducers section](https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/migratingtothereducerprotocol/#Optional-and-pullback-reducers).