### PR TITLE
Link latest version documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,12 +474,14 @@ That is the basics of building and testing a feature in the Composable Architect
 The documentation for releases and `main` are available here:
 
 * [`main`](https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture)
-* [0.46.0](https://pointfreeco.github.io/swift-composable-architecture/0.46.0/documentation/composablearchitecture/)
+* [0.47.0](https://pointfreeco.github.io/swift-composable-architecture/0.47.0/documentation/composablearchitecture/)
+
 <details>
   <summary>
   Other versions
   </summary>
 
+  * [0.46.0](https://pointfreeco.github.io/swift-composable-architecture/0.46.0/documentation/composablearchitecture/)
   * [0.45.0](https://pointfreeco.github.io/swift-composable-architecture/0.45.0/documentation/composablearchitecture/)
   * [0.44.0](https://pointfreeco.github.io/swift-composable-architecture/0.44.0/documentation/composablearchitecture/)
   * [0.43.0](https://pointfreeco.github.io/swift-composable-architecture/0.43.0/documentation/composablearchitecture/)


### PR DESCRIPTION
Link the `0.47.0` documentation in `README.md` and move the `0.46.0` link under the collapsable `Other versions` section.