### PR TITLE
Make TestStore.receive actually match the action predicate

### DIFF
--- a/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
@@ -216,7 +216,7 @@
       XCTExpectFailure {
         store.receive(.action)
       } issueMatcher: { issue in
-        issue.compactDescription == "Expected to receive an action, but received none."
+        issue.compactDescription == #"Expected to receive an action "action", but didn't get one."#
       }
     }
 

--- a/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
@@ -606,7 +606,7 @@
 
       XCTExpectFailure {
         $0.compactDescription == """
-          Expected to receive a matching action, but didn't get one.
+          Expected to receive an action matching case path, but didn't get one.
           """
       }
 
@@ -627,7 +627,7 @@
 
       XCTExpectFailure {
         $0.compactDescription == """
-          Expected to receive an action, but received none.
+          Expected to receive an action matching case path, but didn't get one.
           """
       }
 

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -167,6 +167,41 @@ final class TestStoreTests: XCTestCase {
         }
       }
     }
+
+    func testReceiveActionMatchingPredicate() async {
+      enum Action: Equatable {
+        case noop, finished
+      }
+
+      let reducer = Reduce<Int, Action> { state, action in
+        switch action {
+        case .noop:
+          return EffectTask(value: .finished)
+        case .finished:
+          return .none
+        }
+      }
+
+      let store = TestStore(initialState: 0, reducer: reducer)
+
+      let predicateShouldBeCalledExpectation = expectation(description: "predicate should be called")
+      await store.send(.noop)
+      await store.receive { action in
+        predicateShouldBeCalledExpectation.fulfill()
+        return action == .finished
+      }
+      wait(for: [predicateShouldBeCalledExpectation], timeout: 0)
+
+      XCTExpectFailure {
+        store.send(.noop)
+        store.receive(.noop)
+      }
+
+      XCTExpectFailure {
+        store.send(.noop)
+        store.receive { $0 == .noop }
+      }
+    }
   #endif
 
   func testStateAccess() async {


### PR DESCRIPTION
When calling `TestStore.receive(_:…)` with a predicate or a case path and exhaustivity on, the current code in `main` never actually calls the `matching` predicate. This PR fixes that, with unit tests.