### PR TITLE
Deprecate 'Effect' for 'EffectTask'

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -614,14 +614,15 @@ extension EffectPublisher {
     """
     'Effect' has been deprecated in favor of 'EffectTask' when 'Failure == Never', or 'EffectPublisher<Output, Failure>' in general.
     
-    You are encouraged to use 'EffectTask<Action>' to model the output of your reducers, and to Swift concurrency to model failable streams of values.
+    You are encouraged to use 'EffectTask<Action>' to model the output of your reducers, and to use Swift concurrency to model failable streams of values.
 
     To find and replace instances of 'Effect<Action, Never>' to 'EffectTask<Action, Never>' in your codebase, use the following regular expression:
 
-    Find:
-      Effect<([^,]+), Never>
-    Replace:
-      EffectTask<$1>
+      Find:
+        Effect<([^,]+), Never>
+
+      Replace:
+        EffectTask<$1>
 
     See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
     """

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -609,57 +609,19 @@ extension EffectPublisher {
 }
 
 @available(
-  iOS,
-  deprecated: 9999.0,
+  *,
   message:
     """
-    'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or
-    `EffectPublisher<Output, Failure>` in general.
+    'Effect' has been deprecated in favor of 'EffectTask' when 'Failure == Never', or 'EffectPublisher<Output, Failure>' in general.
     
-    You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
-    concurrency to model failable streams of values.
+    You are encouraged to use 'EffectTask<Action>' to model the output of your reducers, and to Swift concurrency to model failable streams of values.
 
-    See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
-    """
-)
-@available(
-  macOS,
-  deprecated: 9999.0,
-  message:
-    """
-    'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or
-    `EffectPublisher<Output, Failure>` in general.
-    
-    You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
-    concurrency to model failable streams of values.
+    To find and replace instances of 'Effect<Action, Never>' to 'EffectTask<Action, Never>' in your codebase, use the following regular expression:
 
-    See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
-    """
-)
-@available(
-  tvOS,
-  deprecated: 9999.0,
-  message:
-    """
-    'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or
-    `EffectPublisher<Output, Failure>` in general.
-    
-    You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
-    concurrency to model failable streams of values.
-
-    See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
-    """
-)
-@available(
-  watchOS,
-  deprecated: 9999.0,
-  message:
-    """
-    'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or
-    `EffectPublisher<Output, Failure>` in general.
-    
-    You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
-    concurrency to model failable streams of values.
+    Find:
+      Effect<([^,]+), Never>
+    Replace:
+      EffectTask<$1>
 
     See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
     """


### PR DESCRIPTION
This is to allow reclaiming 'Effect' at a later time without the 'Failure' generic in the near future.