### PR TITLE
Allow `BindingReducer` to work with `ViewState`

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -8,7 +8,7 @@ private let readMe = """
   Bindable state and actions allow you to safely eliminate the boilerplate caused by needing to \
   have a unique action for every UI control. Instead, all UI bindings can be consolidated into a \
   single `binding` action that holds onto a `BindingAction` value, and all bindable state can be \
-  safeguarded with the `BindableState` property wrapper.
+  safeguarded with the `BindingState` property wrapper.
 
   It is instructive to compare this case study to the "Binding Basics" case study.
   """
@@ -17,10 +17,10 @@ private let readMe = """
 
 struct BindingForm: ReducerProtocol {
   struct State: Equatable {
-    @BindableState var sliderValue = 5.0
-    @BindableState var stepCount = 10
-    @BindableState var text = ""
-    @BindableState var toggleIsOn = false
+    @BindingState var sliderValue = 5.0
+    @BindingState var stepCount = 10
+    @BindingState var text = ""
+    @BindingState var toggleIsOn = false
   }
 
   enum Action: BindableAction, Equatable {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -21,6 +21,8 @@ struct BindingForm: ReducerProtocol {
     @BindingState var stepCount = 10
     @BindingState var text = ""
     @BindingState var toggleIsOn = false
+    
+    @BindingState var point: CGPoint = .zero
   }
 
   enum Action: BindableAction, Equatable {
@@ -32,6 +34,8 @@ struct BindingForm: ReducerProtocol {
     BindingReducer()
     Reduce { state, action in
       switch action {
+      case .binding(\.$point.x):
+        return .none
       case .binding(\.$stepCount):
         state.sliderValue = .minimum(state.sliderValue, Double(state.stepCount))
         return .none

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -29,7 +29,7 @@ struct BindingForm: ReducerProtocol {
   }
 
   var body: some ReducerProtocol<State, Action> {
-//    BindingReducer()
+    BindingReducer()
     Reduce { state, action in
       switch action {
       case .binding(\.$stepCount):

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -16,7 +16,7 @@ private let readMe = """
 // MARK: - Feature domain
 
 struct BindingForm: ReducerProtocol {
-  struct State: Equatable {
+  struct State: Equatable, BindableStateProtocol {
     @BindingState var sliderValue = 5.0
     @BindingState var stepCount = 10
     @BindingState var text = ""
@@ -60,7 +60,7 @@ struct BindingFormView: View {
         }
 
         HStack {
-          TextField("Type here", text: viewStore.binding(\.$text))
+          TextField("Type here", text: viewStore.$text)
             .disableAutocorrection(true)
             .foregroundStyle(viewStore.toggleIsOn ? Color.secondary : .primary)
           Text(alternate(viewStore.text))
@@ -69,13 +69,12 @@ struct BindingFormView: View {
 
         Toggle(
           "Disable other controls",
-          isOn: viewStore.binding(\.$toggleIsOn)
-            .resignFirstResponder()
+          isOn: viewStore.$toggleIsOn.resignFirstResponder()
         )
 
         Stepper(
           "Max slider value: \(viewStore.stepCount)",
-          value: viewStore.binding(\.$stepCount),
+          value: viewStore.$stepCount,
           in: 0...100
         )
         .disabled(viewStore.toggleIsOn)
@@ -83,7 +82,7 @@ struct BindingFormView: View {
         HStack {
           Text("Slider value: \(Int(viewStore.sliderValue))")
 
-          Slider(value: viewStore.binding(\.$sliderValue), in: 0...Double(viewStore.stepCount))
+          Slider(value: viewStore.$sliderValue, in: 0...Double(viewStore.stepCount))
             .tint(.accentColor)
         }
         .disabled(viewStore.toggleIsOn)

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -29,7 +29,7 @@ struct BindingForm: ReducerProtocol {
   }
 
   var body: some ReducerProtocol<State, Action> {
-    BindingReducer()
+//    BindingReducer()
     Reduce { state, action in
       switch action {
       case .binding(\.$stepCount):

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -73,9 +73,7 @@ struct BindingFormView: View {
         )
 
         Stepper(
-          "Max slider value: \(viewStore.stepCount)",
-          value: viewStore.$stepCount,
-          in: 0...100
+          "Max slider value: \(viewStore.stepCount)", value: viewStore.$stepCount, in: 0...100
         )
         .disabled(viewStore.toggleIsOn)
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -16,13 +16,11 @@ private let readMe = """
 // MARK: - Feature domain
 
 struct BindingForm: ReducerProtocol {
-  struct State: Equatable, BindableStateProtocol {
+  struct State: BindableStateProtocol, Equatable {
     @BindingState var sliderValue = 5.0
     @BindingState var stepCount = 10
     @BindingState var text = ""
     @BindingState var toggleIsOn = false
-    
-    @BindingState var point: CGPoint = .zero
   }
 
   enum Action: BindableAction, Equatable {
@@ -34,8 +32,6 @@ struct BindingForm: ReducerProtocol {
     BindingReducer()
     Reduce { state, action in
       switch action {
-      case .binding(\.$point.x):
-        return .none
       case .binding(\.$stepCount):
         state.sliderValue = .minimum(state.sliderValue, Double(state.stepCount))
         return .none

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -10,9 +10,9 @@ private let readMe = """
 
 struct FocusDemo: ReducerProtocol {
   struct State: Equatable {
-    @BindableState var focusedField: Field?
-    @BindableState var password: String = ""
-    @BindableState var username: String = ""
+    @BindingState var focusedField: Field?
+    @BindingState var password: String = ""
+    @BindingState var username: String = ""
 
     enum Field: String, Hashable {
       case username, password

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -9,7 +9,7 @@ private let readMe = """
 // MARK: - Feature domain
 
 struct FocusDemo: ReducerProtocol {
-  struct State: Equatable {
+  struct State: BindableStateProtocol, Equatable {
     @BindingState var focusedField: Field?
     @BindingState var password: String = ""
     @BindingState var username: String = ""
@@ -55,10 +55,11 @@ struct FocusDemoView: View {
         AboutView(readMe: readMe)
 
         VStack {
-          TextField("Username", text: viewStore.binding(\.$username))
+          
+          TextField("Username", text: viewStore.$username)
             .focused($focusedField, equals: .username)
 
-          SecureField("Password", text: viewStore.binding(\.$password))
+          SecureField("Password", text: viewStore.$password)
             .focused($focusedField, equals: .password)
           Button("Sign In") {
             viewStore.send(.signInButtonTapped)
@@ -67,7 +68,7 @@ struct FocusDemoView: View {
         }
         .textFieldStyle(.roundedBorder)
       }
-      .synchronize(viewStore.binding(\.$focusedField), self.$focusedField)
+      .synchronize(viewStore.$focusedField, self.$focusedField)
     }
     .navigationTitle("Focus demo")
   }

--- a/Examples/Todos/Todos/Todo.swift
+++ b/Examples/Todos/Todos/Todo.swift
@@ -3,26 +3,17 @@ import SwiftUI
 
 struct Todo: ReducerProtocol {
   struct State: Equatable, Identifiable {
-    var description = ""
+    @BindableState var description = ""
     let id: UUID
-    var isComplete = false
+    @BindableState var isComplete = false
   }
 
-  enum Action: Equatable {
-    case checkBoxToggled
-    case textFieldChanged(String)
+  enum Action: BindableAction, Equatable {
+    case binding(BindingAction<State>)
   }
 
-  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
-    switch action {
-    case .checkBoxToggled:
-      state.isComplete.toggle()
-      return .none
-
-    case let .textFieldChanged(description):
-      state.description = description
-      return .none
-    }
+  var body: some ReducerProtocol<State, Action> {
+    BindingReducer()
   }
 }
 
@@ -32,15 +23,12 @@ struct TodoView: View {
   var body: some View {
     WithViewStore(self.store, observe: { $0 }) { viewStore in
       HStack {
-        Button(action: { viewStore.send(.checkBoxToggled) }) {
+        Button(action: { viewStore.$isComplete.wrappedValue.toggle() }) {
           Image(systemName: viewStore.isComplete ? "checkmark.square" : "square")
         }
         .buttonStyle(.plain)
 
-        TextField(
-          "Untitled Todo",
-          text: viewStore.binding(get: \.description, send: Todo.Action.textFieldChanged)
-        )
+        TextField("Untitled Todo", text: viewStore.$description)
       }
       .foregroundColor(viewStore.isComplete ? .gray : nil)
     }

--- a/Examples/Todos/Todos/Todo.swift
+++ b/Examples/Todos/Todos/Todo.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import SwiftUI
 
 struct Todo: ReducerProtocol {
-  struct State: Equatable, Identifiable, BindableStateProtocol {
+  struct State: BindableStateProtocol, Equatable, Identifiable {
     @BindingState var description = ""
     let id: UUID
     @BindingState var isComplete = false

--- a/Examples/Todos/Todos/Todo.swift
+++ b/Examples/Todos/Todos/Todo.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import SwiftUI
 
 struct Todo: ReducerProtocol {
-  struct State: Equatable, Identifiable {
+  struct State: Equatable, Identifiable, BindableStateProtocol {
     @BindingState var description = ""
     let id: UUID
     @BindingState var isComplete = false

--- a/Examples/Todos/Todos/Todo.swift
+++ b/Examples/Todos/Todos/Todo.swift
@@ -3,9 +3,9 @@ import SwiftUI
 
 struct Todo: ReducerProtocol {
   struct State: Equatable, Identifiable {
-    @BindableState var description = ""
+    @BindingState var description = ""
     let id: UUID
-    @BindableState var isComplete = false
+    @BindingState var isComplete = false
   }
 
   enum Action: BindableAction, Equatable {

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -103,14 +103,6 @@ struct Todos: ReducerProtocol {
 struct AppView: View {
   let store: StoreOf<Todos>
 
-  // TODO: Add `ViewStore.init(_,observe:send:removeDuplicates:)`
-//  @ObservedObject var viewStore: ViewStore<ViewState, Todos.Action>
-//
-//  init(store: StoreOf<Todos>) {
-//    self.store = store
-//    self.viewStore = ViewStore(self.store.scope(state: ViewState.init(state:)))
-//  }
-
   struct ViewState: Equatable {
     @BindingViewState var editMode: EditMode
     @BindingViewState var filter: Filter

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -9,8 +9,8 @@ enum Filter: LocalizedStringKey, CaseIterable, Hashable {
 
 struct Todos: ReducerProtocol {
   struct State: Equatable {
-    var editMode: EditMode = .inactive
-    var filter: Filter = .all
+    @BindableState var editMode: EditMode = .inactive
+    @BindableState var filter: Filter = .all
     var todos: IdentifiedArrayOf<Todo.State> = []
 
     var filteredTodos: IdentifiedArrayOf<Todo.State> {
@@ -22,12 +22,11 @@ struct Todos: ReducerProtocol {
     }
   }
 
-  enum Action: Equatable {
+  enum Action: BindableAction, Equatable {
     case addTodoButtonTapped
+    case binding(BindingAction<State>)
     case clearCompletedButtonTapped
     case delete(IndexSet)
-    case editModeChanged(EditMode)
-    case filterPicked(Filter)
     case move(IndexSet, Int)
     case sortCompletedTodos
     case todo(id: Todo.State.ID, action: Todo.Action)
@@ -38,10 +37,14 @@ struct Todos: ReducerProtocol {
   private enum TodoCompletionID {}
 
   var body: some ReducerProtocol<State, Action> {
+    BindingReducer()
     Reduce { state, action in
       switch action {
       case .addTodoButtonTapped:
         state.todos.insert(Todo.State(id: self.uuid()), at: 0)
+        return .none
+
+      case .binding:
         return .none
 
       case .clearCompletedButtonTapped:
@@ -53,14 +56,6 @@ struct Todos: ReducerProtocol {
         for index in indexSet {
           state.todos.remove(id: filteredTodos[index].id)
         }
-        return .none
-
-      case let .editModeChanged(editMode):
-        state.editMode = editMode
-        return .none
-
-      case let .filterPicked(filter):
-        state.filter = filter
         return .none
 
       case var .move(source, destination):
@@ -88,7 +83,7 @@ struct Todos: ReducerProtocol {
         state.todos.sort { $1.isComplete && !$0.isComplete }
         return .none
 
-      case .todo(id: _, action: .checkBoxToggled):
+      case .todo(id: _, action: .binding(\.$isComplete)):
         return .run { send in
           try await self.clock.sleep(for: .seconds(1))
           await send(.sortCompletedTodos, animation: .default)
@@ -107,70 +102,64 @@ struct Todos: ReducerProtocol {
 
 struct AppView: View {
   let store: StoreOf<Todos>
-  @ObservedObject var viewStore: ViewStore<ViewState, Todos.Action>
 
-  init(store: StoreOf<Todos>) {
-    self.store = store
-    self.viewStore = ViewStore(self.store.scope(state: ViewState.init(state:)))
-  }
+  // TODO: Add `ViewStore.init(_,observe:send:removeDuplicates:)`
+//  @ObservedObject var viewStore: ViewStore<ViewState, Todos.Action>
+//
+//  init(store: StoreOf<Todos>) {
+//    self.store = store
+//    self.viewStore = ViewStore(self.store.scope(state: ViewState.init(state:)))
+//  }
 
   struct ViewState: Equatable {
-    let editMode: EditMode
-    let filter: Filter
+    @BindableViewState var editMode: EditMode
+    @BindableViewState var filter: Filter
     let isClearCompletedButtonDisabled: Bool
 
-    init(state: Todos.State) {
-      self.editMode = state.editMode
-      self.filter = state.filter
+    init(state: BindableStore<Todos.State>) {
+      self._editMode = state.$editMode
+      self._filter = state.$filter
       self.isClearCompletedButtonDisabled = !state.todos.contains(where: \.isComplete)
     }
   }
 
   var body: some View {
-    NavigationView {
-      VStack(alignment: .leading) {
-        Picker(
-          "Filter",
-          selection: self.viewStore.binding(
-            get: \.filter,
-            send: Todos.Action.filterPicked
-          )
-          .animation()
-        ) {
-          ForEach(Filter.allCases, id: \.self) { filter in
-            Text(filter.rawValue).tag(filter)
+    WithViewStore(self.store, observe: ViewState.init) { viewStore in
+      NavigationView {
+        VStack(alignment: .leading) {
+          Picker("Filter", selection: viewStore.$filter.animation()) {
+            ForEach(Filter.allCases, id: \.self) { filter in
+              Text(filter.rawValue).tag(filter)
+            }
           }
-        }
-        .pickerStyle(.segmented)
-        .padding(.horizontal)
+          .pickerStyle(.segmented)
+          .padding(.horizontal)
 
-        List {
-          ForEachStore(
-            self.store.scope(state: \.filteredTodos, action: Todos.Action.todo(id:action:))
-          ) {
-            TodoView(store: $0)
+          List {
+            ForEachStore(
+              self.store.scope(state: \.filteredTodos, action: Todos.Action.todo(id:action:))
+            ) {
+              TodoView(store: $0)
+            }
+            .onDelete { viewStore.send(.delete($0)) }
+            .onMove { viewStore.send(.move($0, $1)) }
           }
-          .onDelete { self.viewStore.send(.delete($0)) }
-          .onMove { self.viewStore.send(.move($0, $1)) }
         }
+        .navigationTitle("Todos")
+        .navigationBarItems(
+          trailing: HStack(spacing: 20) {
+            EditButton()
+            Button("Clear Completed") {
+              viewStore.send(.clearCompletedButtonTapped, animation: .default)
+            }
+            .disabled(viewStore.isClearCompletedButtonDisabled)
+            Button("Add Todo") { viewStore.send(.addTodoButtonTapped, animation: .default) }
+          }
+        )
+        .environment(\.editMode, viewStore.$editMode)
       }
-      .navigationTitle("Todos")
-      .navigationBarItems(
-        trailing: HStack(spacing: 20) {
-          EditButton()
-          Button("Clear Completed") {
-            self.viewStore.send(.clearCompletedButtonTapped, animation: .default)
-          }
-          .disabled(self.viewStore.isClearCompletedButtonDisabled)
-          Button("Add Todo") { self.viewStore.send(.addTodoButtonTapped, animation: .default) }
-        }
-      )
-      .environment(
-        \.editMode,
-        self.viewStore.binding(get: \.editMode, send: Todos.Action.editModeChanged)
-      )
+      .navigationViewStyle(.stack)
     }
-    .navigationViewStyle(.stack)
   }
 }
 

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -112,25 +112,19 @@ struct AppView: View {
 //  }
 
   struct ViewState: Equatable {
-    @BindableViewState var editMode: EditMode
-    @BindableViewState var filter: Filter
+    @BindingViewState var editMode: EditMode
+    @BindingViewState var filter: Filter
     let isClearCompletedButtonDisabled: Bool
 
-    init(state: BindingStore<Todos.State>) {
-      self._editMode = state.$editMode
-      self._filter = state.$filter
-      self.isClearCompletedButtonDisabled = !state.todos.contains(where: \.isComplete)
-    }
-
-    init(state: BindingStore<Todos.State>) {
-      self._editMode = state.$editMode
-      self._filter = state.$filter
+    init(@BindingStore state: Todos.State) {
+      self._editMode = $state.$editMode
+      self._filter = $state.$filter
       self.isClearCompletedButtonDisabled = !state.todos.contains(where: \.isComplete)
     }
   }
 
   var body: some View {
-    WithViewStore(self.store, observe: ViewState.init) { viewStore in
+    WithViewStore(self.store, observe: ViewState.init($state:)) { viewStore in
       NavigationView {
         VStack(alignment: .leading) {
           Picker("Filter", selection: viewStore.$filter.animation()) {

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -8,7 +8,7 @@ enum Filter: LocalizedStringKey, CaseIterable, Hashable {
 }
 
 struct Todos: ReducerProtocol {
-  struct State: Equatable {
+  struct State: Equatable, BindableStateProtocol {
     @BindingState var editMode: EditMode = .inactive
     @BindingState var filter: Filter = .all
     var todos: IdentifiedArrayOf<Todo.State> = []
@@ -116,15 +116,15 @@ struct AppView: View {
     @BindingViewState var filter: Filter
     let isClearCompletedButtonDisabled: Bool
 
-    init(@BindingStore state: Todos.State) {
-      self._editMode = $state.$editMode
-      self._filter = $state.$filter
+    init(state: Todos.State) {
+      self._editMode = state.binding.$editMode
+      self._filter = state.binding.$filter
       self.isClearCompletedButtonDisabled = !state.todos.contains(where: \.isComplete)
     }
   }
 
   var body: some View {
-    WithViewStore(self.store, observe: ViewState.init($state:)) { viewStore in
+    WithViewStore(self.store, observe: ViewState.init) { viewStore in
       NavigationView {
         VStack(alignment: .leading) {
           Picker("Filter", selection: viewStore.$filter.animation()) {

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -8,7 +8,7 @@ enum Filter: LocalizedStringKey, CaseIterable, Hashable {
 }
 
 struct Todos: ReducerProtocol {
-  struct State: Equatable, BindableStateProtocol {
+  struct State: BindableStateProtocol, Equatable {
     @BindingState var editMode: EditMode = .inactive
     @BindingState var filter: Filter = .all
     var todos: IdentifiedArrayOf<Todo.State> = []

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -117,8 +117,8 @@ struct AppView: View {
     let isClearCompletedButtonDisabled: Bool
 
     init(state: Todos.State) {
-      self._editMode = state.binding.$editMode
-      self._filter = state.binding.$filter
+      self._editMode = state.bindings.$editMode
+      self._filter = state.bindings.$filter
       self.isClearCompletedButtonDisabled = !state.todos.contains(where: \.isComplete)
     }
   }

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -9,8 +9,8 @@ enum Filter: LocalizedStringKey, CaseIterable, Hashable {
 
 struct Todos: ReducerProtocol {
   struct State: Equatable {
-    @BindableState var editMode: EditMode = .inactive
-    @BindableState var filter: Filter = .all
+    @BindingState var editMode: EditMode = .inactive
+    @BindingState var filter: Filter = .all
     var todos: IdentifiedArrayOf<Todo.State> = []
 
     var filteredTodos: IdentifiedArrayOf<Todo.State> {
@@ -22,7 +22,7 @@ struct Todos: ReducerProtocol {
     }
   }
 
-  enum Action: BindableAction, Equatable {
+  enum Action: BindableAction, Equatable, Sendable {
     case addTodoButtonTapped
     case binding(BindingAction<State>)
     case clearCompletedButtonTapped
@@ -116,7 +116,13 @@ struct AppView: View {
     @BindableViewState var filter: Filter
     let isClearCompletedButtonDisabled: Bool
 
-    init(state: BindableStore<Todos.State>) {
+    init(state: BindingStore<Todos.State>) {
+      self._editMode = state.$editMode
+      self._filter = state.$filter
+      self.isClearCompletedButtonDisabled = !state.todos.contains(where: \.isComplete)
+    }
+
+    init(state: BindingStore<Todos.State>) {
       self._editMode = state.$editMode
       self._filter = state.$filter
       self.isClearCompletedButtonDisabled = !state.todos.contains(where: \.isComplete)

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
@@ -177,20 +177,20 @@ struct Settings: ReducerProtocol {
 ```
 
 This is a _lot_ of boilerplate for something that should be simple. Luckily, we can dramatically
-eliminate this boilerplate using ``BindableState``, ``BindableAction``, and ``BindingReducer``.
+eliminate this boilerplate using ``BindingState``, ``BindableAction``, and ``BindingReducer``.
 
-First, we can annotate each bindable value of state with the ``BindableState`` property wrapper:
+First, we can annotate each bindable value of state with the ``BindingState`` property wrapper:
 
 ```swift
 struct Settings: ReducerProtocol {
   struct State: Equatable {
-    @BindableState var digest = Digest.daily
-    @BindableState var displayName = ""
-    @BindableState var enableNotifications = false
+    @BindingState var digest = Digest.daily
+    @BindingState var displayName = ""
+    @BindingState var enableNotifications = false
     var isLoading = false
-    @BindableState var protectMyPosts = false
-    @BindableState var sendEmailNotifications = false
-    @BindableState var sendMobileNotifications = false
+    @BindingState var protectMyPosts = false
+    @BindingState var sendEmailNotifications = false
+    @BindingState var sendMobileNotifications = false
   }
 
   // ...

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
@@ -279,9 +279,9 @@ essentials of state that your view needs to do its job. This is especially true 
 closer to the root of the application, which tend to hold state for many child features, all of
 which is not needed in the view.
 
-However, if you are doing this _and_ using ``@BindingState``, then there is an extra step you must
+However, if you are doing this _and_ using `@BindingState`, then there is an extra step you must
 take. When defining the `ViewState` type in your view that holds onto all of the state your view
-cares about, you must mark each field that needs to derive a binding with ``@BindingViewState``:
+cares about, you must mark each field that needs to derive a binding with `@BindingViewState`:
 
 ```swift
 struct ViewState: Equatable {
@@ -291,8 +291,8 @@ struct ViewState: Equatable {
 }
 ```
 
-> Note: Just as is the case with ``@BindingState``, not all fields need to be annotated with 
-``@BindingViewState``. Just the ones that need to have bindings derived to hand to SwiftUI 
+> Note: Just as is the case with `@BindingState`, not all fields need to be annotated with 
+`@BindingViewState`. Just the ones that need to have bindings derived to hand to SwiftUI 
 components.
 
 And finally, you must provide a custom initializer that creates the ``BindingViewState`` for each
@@ -311,7 +311,7 @@ struct ViewState: Equatable {
 ```
 
 That code is only slightly different from the code that is written when not dealing with the 
-``@BindingState`` property wrapper.
+`@BindingState` property wrapper.
 
 And with those steps done you can now derive a binding from the view store very easily:
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
@@ -279,9 +279,9 @@ essentials of state that your view needs to do its job. This is especially true 
 closer to the root of the application, which tend to hold state for many child features, all of
 which is not needed in the view.
 
-However, if you are doing this _and_ using `@BindingState`, then there is an extra step you must
+However, if you are doing this _and_ using ``@BindingState``, then there is an extra step you must
 take. When defining the `ViewState` type in your view that holds onto all of the state your view
-cares about, you must mark each field that needs to derive a binding with `@BindingViewState`:
+cares about, you must mark each field that needs to derive a binding with ``@BindingViewState``:
 
 ```swift
 struct ViewState: Equatable {
@@ -291,12 +291,12 @@ struct ViewState: Equatable {
 }
 ```
 
-> Note: Just as is the case with `@BindingState`, not all fields need to be annotated with 
-`@BindingViewState`. Just the ones that need to have bindings derived to hand to SwiftUI 
+> Note: Just as is the case with ``@BindingState``, not all fields need to be annotated with 
+``@BindingViewState``. Just the ones that need to have bindings derived to hand to SwiftUI 
 components.
 
-And finally, you must provide a custom initializer that creates the `BindingViewState` for each
-field by going through the state's `bindings` property:
+And finally, you must provide a custom initializer that creates the ``BindingViewState`` for each
+field by going through the state's ``BindableStateProtocol/bindings`` property:
 
 ```swift
 struct ViewState: Equatable {
@@ -311,7 +311,7 @@ struct ViewState: Equatable {
 ```
 
 That code is only slightly different from the code that is written when not dealing with the 
-`@BindingState` property wrapper.
+``@BindingState`` property wrapper.
 
 And with those steps done you can now derive a binding from the view store very easily:
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
@@ -179,11 +179,12 @@ struct Settings: ReducerProtocol {
 This is a _lot_ of boilerplate for something that should be simple. Luckily, we can dramatically
 eliminate this boilerplate using ``BindingState``, ``BindableAction``, and ``BindingReducer``.
 
-First, we can annotate each bindable value of state with the ``BindingState`` property wrapper:
+First, we conform `State` to ``BindableStateProtocol``, and we annotate each bindable value of state 
+with the ``BindingState`` property wrapper:
 
 ```swift
 struct Settings: ReducerProtocol {
-  struct State: Equatable {
+  struct State: Equatable, BindableStateProtocol {
     @BindingState var digest = Digest.daily
     @BindingState var displayName = ""
     @BindingState var enableNotifications = false
@@ -235,7 +236,7 @@ Binding actions are constructed and sent to the store by calling
 ``ViewStore/binding(_:file:fileID:line:)`` with a key path to the bindable state:
 
 ```swift
-TextField("Display name", text: viewStore.binding(\.$displayName))
+TextField("Display name", text: viewStore.$displayName)
 ```
 
 Should you need to layer additional functionality over these bindings, your reducer can pattern

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/ViewStoreDeprecations.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/ViewStoreDeprecations.md
@@ -19,5 +19,5 @@ Avoid using deprecated APIs in your app. Select a method to see the replacement 
 
 ### SwiftUI integration
 
-- ``ViewStore/subscript(dynamicMember:)-7xjrv``
 - ``ViewStore/binding(keyPath:send:)``
+- ``ViewStore/binding(_:file:fileID:line:)``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwiftUI.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwiftUI.md
@@ -19,7 +19,7 @@ The Composable Architecture can be used to power applications built in many fram
 
 - <doc:Bindings>
 - ``ViewStore/binding(get:send:)-65xes``
-- ``BindableState``
+- ``BindingState``
 - ``BindableAction``
 - ``BindingAction``
 - ``BindingReducer``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwiftUI.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwiftUI.md
@@ -20,10 +20,10 @@ The Composable Architecture can be used to power applications built in many fram
 - <doc:Bindings>
 - ``ViewStore/binding(get:send:)-65xes``
 - ``BindingState``
-- ``BindableAction``
+- ``BindableStateProtocol``
 - ``BindingAction``
+- ``BindableAction``
 - ``BindingReducer``
-- ``ViewStore/binding(_:file:fileID:line:)``
 
 <!--DocC: Can't currently document `View` extensions-->
 <!--### View Modifiers-->

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -55,12 +55,18 @@ extension ViewStore where ViewAction: BindableAction, ViewAction.State == ViewSt
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) -> Binding<Value> {
-    self.binding(
+    let bindingViewState = self.state[keyPath: keyPath]
+    return self.binding(
       get: { $0[keyPath: keyPath].wrappedValue },
       send: { value in
         #if DEBUG
           let debugger = BindableActionViewStoreDebugger(
-            value: value, bindableActionType: ViewAction.self, file: file, fileID: fileID,
+            value: value, bindableActionType: ViewAction.self,
+            sourceFile: bindingViewState.file,
+            sourceFileID: bindingViewState.fileID,
+            sourceLine: bindingViewState.line,
+            file: file,
+            fileID: fileID,
             line: line
           )
           let set: (inout ViewState) -> Void = {

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -61,7 +61,9 @@ extension ViewStore where ViewAction: BindableAction, ViewAction.State == ViewSt
       send: { value in
         #if DEBUG
           let debugger = BindableActionViewStoreDebugger(
-            value: value, bindableActionType: ViewAction.self,
+            value: value,
+            bindableActionType: ViewAction.self,
+            bindableStateType: ViewAction.State.self,
             sourceFile: bindingViewState.file,
             sourceFileID: bindingViewState.fileID,
             sourceLine: bindingViewState.line,

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -8,6 +8,74 @@ import XCTestDynamicOverlay
 @available(*, deprecated, renamed: "BindingState")
 public typealias BindableState = BindingState
 
+extension ViewStore where ViewAction: BindableAction, ViewAction.State == ViewState {
+  /// Returns a binding to the resulting bindable state of a given key path.
+  ///
+  /// - Parameter keyPath: A key path to a specific bindable state.
+  /// - Returns: A new binding.
+  @available(
+    iOS,
+    deprecated: 9999.0,
+    message:
+      """
+      Extracting bindings as `viewStore.binding(\\.$foo)` is deprecated. \
+      Use dynamic lookup directly on the `viewStore` instead: `viewStore.$foo`.
+      """
+  )
+  @available(
+    tvOS,
+    deprecated: 9999.0,
+    message:
+      """
+      Extracting bindings as `viewStore.binding(\\.$foo)` is deprecated. \
+      Use dynamic lookup directly on the `viewStore` instead: `viewStore.$foo`.
+      """
+  )
+  @available(
+    macOS,
+    deprecated: 9999.0,
+    message:
+      """
+      Extracting bindings as `viewStore.binding(\\.$foo)` is deprecated. \
+      Use dynamic lookup directly on the `viewStore` instead: `viewStore.$foo`.
+      """
+  )
+  @available(
+    watchOS,
+    deprecated: 9999.0,
+    message:
+      """
+      Extracting bindings as `viewStore.binding(\\.$foo)` is deprecated. \
+      Use dynamic lookup directly on the `viewStore` instead: `viewStore.$foo`.
+      """
+  )
+  public func binding<Value: Equatable>(
+    _ keyPath: WritableKeyPath<ViewState, BindingState<Value>>,
+    file: StaticString = #file,
+    fileID: StaticString = #fileID,
+    line: UInt = #line
+  ) -> Binding<Value> {
+    self.binding(
+      get: { $0[keyPath: keyPath].wrappedValue },
+      send: { value in
+        #if DEBUG
+          let debugger = BindableActionViewStoreDebugger(
+            value: value, bindableActionType: ViewAction.self, file: file, fileID: fileID,
+            line: line
+          )
+          let set: (inout ViewState) -> Void = {
+            $0[keyPath: keyPath].wrappedValue = value
+            debugger.wasCalled = true
+          }
+        #else
+          let set: (inout ViewState) -> Void = { $0[keyPath: keyPath].wrappedValue = value }
+        #endif
+        return .binding(.init(keyPath: keyPath, set: set, value: value))
+      }
+    )
+  }
+}
+
 // MARK: - Deprecated after 0.45.0:
 
 @available(

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -18,8 +18,7 @@ extension ViewStore where ViewAction: BindableAction, ViewAction.State == ViewSt
     deprecated: 9999.0,
     message:
       """
-      Extracting bindings as `viewStore.binding(\\.$foo)` is deprecated. \
-      Use dynamic lookup directly on the `viewStore` instead: `viewStore.$foo`.
+      Deriving bindings from binding state via `viewStore.binding(\\.$value)` is deprecated. Use dynamic member lookup directly on the `viewStore` instead: `viewStore.$value`.
       """
   )
   @available(
@@ -27,8 +26,7 @@ extension ViewStore where ViewAction: BindableAction, ViewAction.State == ViewSt
     deprecated: 9999.0,
     message:
       """
-      Extracting bindings as `viewStore.binding(\\.$foo)` is deprecated. \
-      Use dynamic lookup directly on the `viewStore` instead: `viewStore.$foo`.
+      Deriving bindings from binding state via `viewStore.binding(\\.$value)` is deprecated. Use dynamic member lookup directly on the `viewStore` instead: `viewStore.$value`.
       """
   )
   @available(
@@ -36,8 +34,7 @@ extension ViewStore where ViewAction: BindableAction, ViewAction.State == ViewSt
     deprecated: 9999.0,
     message:
       """
-      Extracting bindings as `viewStore.binding(\\.$foo)` is deprecated. \
-      Use dynamic lookup directly on the `viewStore` instead: `viewStore.$foo`.
+      Deriving bindings from binding state via `viewStore.binding(\\.$value)` is deprecated. Use dynamic member lookup directly on the `viewStore` instead: `viewStore.$value`.
       """
   )
   @available(
@@ -45,8 +42,7 @@ extension ViewStore where ViewAction: BindableAction, ViewAction.State == ViewSt
     deprecated: 9999.0,
     message:
       """
-      Extracting bindings as `viewStore.binding(\\.$foo)` is deprecated. \
-      Use dynamic lookup directly on the `viewStore` instead: `viewStore.$foo`.
+      Deriving bindings from binding state via `viewStore.binding(\\.$value)` is deprecated. Use dynamic member lookup directly on the `viewStore` instead: `viewStore.$value`.
       """
   )
   public func binding<Value: Equatable>(

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -3,6 +3,11 @@ import Combine
 import SwiftUI
 import XCTestDynamicOverlay
 
+// MARK: - Deprecated after 0.47.2:
+
+@available(*, deprecated, renamed: "BindingState")
+public typealias BindableState = BindingState
+
 // MARK: - Deprecated after 0.45.0:
 
 @available(
@@ -949,8 +954,8 @@ extension BindingAction {
     *, deprecated,
     message:
       """
-      For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', \
-      and accessed via key paths to that 'BindableState', like '\\.$value'
+      For improved safety, bindable properties must now be wrapped explicitly in 'BindingState', \
+      and accessed via key paths to that 'BindingState', like '\\.$value'
       """
   )
   public static func set<Value: Equatable>(
@@ -969,8 +974,8 @@ extension BindingAction {
     *, deprecated,
     message:
       """
-      For improved safety, bindable properties must now be wrapped explicitly in 'BindableState', \
-      and accessed via key paths to that 'BindableState', like '\\.$value'
+      For improved safety, bindable properties must now be wrapped explicitly in 'BindingState', \
+      and accessed via key paths to that 'BindingState', like '\\.$value'
       """
   )
   public static func ~= <Value>(
@@ -1003,8 +1008,8 @@ extension ViewStore {
     *, deprecated,
     message:
       """
-      For improved safety, bindable properties must now be wrapped explicitly in 'BindableState'. \
-      Bindings are now derived via 'ViewStore.binding' with a key path to that 'BindableState' \
+      For improved safety, bindable properties must now be wrapped explicitly in 'BindingState'. \
+      Bindings are now derived via 'ViewStore.binding' with a key path to that 'BindingState' \
       (for example, 'viewStore.binding(\\.$value)'). For dynamic member lookup to be available, \
       the view store's 'Action' type must also conform to 'BindableAction'.
       """

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -942,28 +942,6 @@ extension Store {
   }
 }
 
-extension ViewStore where ViewAction: BindableAction, ViewAction.State == ViewState {
-  @available(
-    *, deprecated,
-    message:
-      """
-      Dynamic member lookup is no longer supported for bindable state. Instead of dot-chaining on \
-      the view store, e.g. 'viewStore.$value', invoke the 'binding' method on view store with a \
-      key path to the value, e.g. 'viewStore.binding(\\.$value)'. For more on this change, see: \
-      https://github.com/pointfreeco/swift-composable-architecture/pull/810
-      """
-  )
-  @MainActor
-  public subscript<Value: Equatable>(
-    dynamicMember keyPath: WritableKeyPath<ViewState, BindableState<Value>>
-  ) -> Binding<Value> {
-    self.binding(
-      get: { $0[keyPath: keyPath].wrappedValue },
-      send: { .binding(.set(keyPath, $0)) }
-    )
-  }
-}
-
 // MARK: - Deprecated after 0.25.0:
 
 extension BindingAction {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
@@ -1,6 +1,46 @@
 import SwiftUI
 
 /// A reducer that updates bindable state when it receives binding actions.
+///
+/// This reducer should typically be composed into the ``ReducerProtocol/body-swift.property-97ymy``
+/// of your feature's reducer:
+///
+/// ```swift
+/// struct Feature: ReducerProtocol {
+///   struct State: BindableStateProtocol {
+///     @BindingState var isOn = false
+///     // More properties...
+///   }
+///   enum Action: BindableAction {
+///     case binding(BindingAction<State>)
+///     // More actions
+///   }
+///
+///   var body: some ReducerProtocolOf<Self> {
+///     BindingReducer()
+///     Reduce { state, action in
+///       // Your feature's logic...
+///     }
+///   }
+/// }
+/// ```
+///
+/// This makes it so that the binding's logic is run before the feature's logic, i.e. you will only
+/// see the state after the binding was written. If you want to react to the state _before_ the
+/// binding was written, you can flip the order of the composition:
+///
+/// ```swift
+/// var body: some ReducerProtocolOf<Self> {
+///   BindingReducer()
+///   Reduce { state, action in
+///     // Your feature's logic...
+///   }
+/// }
+/// ```
+///
+/// If you forget to compose the ``BindingReducer`` into your feature's reducer, then when a binding
+/// is written to it will cause a runtime purple Xcode warning letting you know what needs to be
+/// fixed.
 public struct BindingReducer<State, Action>: ReducerProtocol
 where Action: BindableAction, State == Action.State {
   /// Initializes a reducer that updates bindable state when it receives binding actions.

--- a/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
@@ -31,10 +31,10 @@ import SwiftUI
 ///
 /// ```swift
 /// var body: some ReducerProtocolOf<Self> {
-///   BindingReducer()
 ///   Reduce { state, action in
 ///     // Your feature's logic...
 ///   }
+///   BindingReducer()
 /// }
 /// ```
 ///

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -150,6 +150,13 @@ extension BindableStateProtocol {
   public var bindings: BindingViewStates<Self> {
     .init(state: self)
   }
+  
+  public subscript<Value>(keyPath: WritableKeyPath<Self, BindingState<Value>>) -> BindingViewState<Value> {
+    .init(
+      wrappedValue: self[keyPath: keyPath].wrappedValue,
+      keyPath: keyPath
+    )
+  }
 }
 
 /// An action type that exposes a `binding` case that holds a ``BindingAction``.

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -26,7 +26,7 @@ public struct BindingState<Value> {
   /// `@BindingState`. To get the `projectedValue`, prefix the property with `$`:
   ///
   /// ```swift
-  /// TextField("Display name", text: viewStore.binding(\.$displayName))
+  /// TextField("Display name", text: viewStore.$displayName)
   /// ```
   ///
   /// See ``BindingState`` for more details.
@@ -171,6 +171,22 @@ extension BindableAction {
   }
 }
 
+/// A ``BindingState`` variant that is suitable for `ViewState`s.
+///
+/// You can only build these values using dynamic member lookup of ``BindingState`` properties on
+/// the ``BindingViewStates`` value from ``BindableStateProtocol/bindings``.
+///
+/// Because you're defining the ``BindingViewState`` value directly, you must assign the value
+/// of the property wrapper private storage using the underscored property name:
+///
+/// ```swift
+/// struct ViewState: Equatable {
+///   @BindingViewState var text: String
+///   init(state: State) {
+///     self._text = state.bindings.$text
+///   }
+/// }
+/// ```
 @propertyWrapper
 public struct BindingViewState<Value> {
   let keyPath: AnyKeyPath
@@ -188,7 +204,6 @@ extension BindingViewState: Equatable where Value: Equatable {}
 
 extension BindingViewState: Hashable where Value: Hashable {}
 
-// TODO: Improve this
 extension BindingViewState: CustomReflectable {
   public var customMirror: Mirror {
     Mirror(reflecting: self.wrappedValue)
@@ -491,7 +506,7 @@ extension BindingAction {
   /// WithViewStore(
   ///   self.store, observe: \.view, send: MyFeature.Action.view
   /// ) { viewStore in
-  ///   Stepper("\(viewStore.count)", viewStore.binding(\.$count))
+  ///   Stepper("\(viewStore.count)", viewStore.$count)
   ///   Button("Get number fact") { viewStore.send(.factButtonTapped) }
   ///   if let fact = viewStore.fact {
   ///     Text(fact)

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -129,7 +129,7 @@ extension BindableAction {
 }
 
 @propertyWrapper
-public struct BindableViewState<Value> {
+public struct BindingViewState<Value> {
   let binding: Binding<Value>
 
   public var wrappedValue: Value {
@@ -142,31 +142,31 @@ public struct BindableViewState<Value> {
   }
 }
 
-extension BindableViewState: Equatable where Value: Equatable {
+extension BindingViewState: Equatable where Value: Equatable {
   public static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.wrappedValue == rhs.wrappedValue
   }
 }
 
-extension BindableViewState: Hashable where Value: Hashable {
+extension BindingViewState: Hashable where Value: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(self.wrappedValue)
   }
 }
 
-extension BindableViewState: CustomReflectable {
+extension BindingViewState: CustomReflectable {
   public var customMirror: Mirror {
     Mirror(reflecting: self.wrappedValue)
   }
 }
 
-extension BindableViewState: CustomDumpRepresentable {
+extension BindingViewState: CustomDumpRepresentable {
   public var customDumpValue: Any {
     self.wrappedValue
   }
 }
 
-extension BindableViewState: CustomDebugStringConvertible
+extension BindingViewState: CustomDebugStringConvertible
 where Value: CustomDebugStringConvertible {
   public var debugDescription: String {
     self.wrappedValue.debugDescription
@@ -209,8 +209,8 @@ public struct BindingStore<State> {
 
   public subscript<Value: Equatable>(
     dynamicMember keyPath: WritableKeyPath<State, BindingState<Value>>
-  ) -> BindableViewState<Value> {
-    BindableViewState(
+  ) -> BindingViewState<Value> {
+    BindingViewState(
       binding: ViewStore(self.store, removeDuplicates: { _, _ in false }).binding(
         get: { $0[keyPath: keyPath].wrappedValue },
         send: { value in

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -39,6 +39,13 @@ public struct BindableState<Value> {
   ///
   /// - Parameter keyPath: A key path to a specific resulting value.
   /// - Returns: A new bindable state.
+  @available(
+    *,
+    deprecated,
+    message: """
+      Chaining onto properties of bindable state is deprecated. Push '@BindableState' use to the child state, instead.
+      """
+  )
   public subscript<Subject>(
     dynamicMember keyPath: WritableKeyPath<Value, Subject>
   ) -> BindableState<Subject> {
@@ -121,7 +128,215 @@ extension BindableAction {
   }
 }
 
-extension ViewStore where ViewAction: BindableAction, ViewAction.State == ViewState {
+@propertyWrapper
+public struct BindableViewState<Value> {
+  let binding: Binding<Value>
+
+  public var wrappedValue: Value {
+    get { self.binding.wrappedValue }
+    set { self.binding.wrappedValue = newValue }
+  }
+
+  public var projectedValue: Binding<Value> {
+    self.binding
+  }
+}
+
+extension BindableViewState: Equatable where Value: Equatable {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.wrappedValue == rhs.wrappedValue
+  }
+}
+
+extension BindableViewState: Hashable where Value: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(self.wrappedValue)
+  }
+}
+
+extension BindableViewState: CustomReflectable {
+  public var customMirror: Mirror {
+    Mirror(reflecting: self.wrappedValue)
+  }
+}
+
+extension BindableViewState: CustomDumpRepresentable {
+  public var customDumpValue: Any {
+    self.wrappedValue
+  }
+}
+
+extension BindableViewState: CustomDebugStringConvertible
+where Value: CustomDebugStringConvertible {
+  public var debugDescription: String {
+    self.wrappedValue.debugDescription
+  }
+}
+
+@dynamicMemberLookup
+@propertyWrapper
+public struct BindableStore<State> {
+  let store: Store<State, BindingAction<State>>
+  #if DEBUG
+    let bindableActionType: Any.Type
+  #endif
+
+  init<Action: BindableAction>(store: Store<State, Action>) where Action.State == State {
+    self.store = store.scope(state: { $0 }, action: Action.binding)
+    #if DEBUG
+      self.bindableActionType = type(of: Action.self)
+    #endif
+  }
+
+  public var wrappedValue: State {
+    self.store.state.value
+  }
+
+  public subscript<Value: Equatable>(
+    dynamicMember keyPath: WritableKeyPath<State, Value>
+  ) -> Value {
+    self.wrappedValue[keyPath: keyPath]
+  }
+
+  public subscript<Value: Equatable>(
+    dynamicMember keyPath: WritableKeyPath<State, BindableState<Value>>
+  ) -> BindableViewState<Value> {
+    BindableViewState(
+      binding: ViewStore(self.store, removeDuplicates: { _, _ in false }).binding(
+        get: { $0[keyPath: keyPath].wrappedValue },
+        send: { value in
+          #if DEBUG
+            let debugger = BindableActionViewStoreDebugger(
+              value: value,
+              bindableActionType: self.bindableActionType,
+              // TODO: Possible to provide better context here?
+              file: #file,
+              fileID: #fileID,
+              line: #line
+            )
+            let set: (inout State) -> Void = {
+              $0[keyPath: keyPath].wrappedValue = value
+              debugger.wasCalled = true
+            }
+          #else
+            let set: (inout State) -> Void = { $0[keyPath: keyPath].wrappedValue = value }
+          #endif
+          return .init(keyPath: keyPath, set: set, value: value)
+        }
+      )
+    )
+  }
+}
+
+extension WithViewStore where Content: View {
+  public init<State, Action: BindableAction>(
+    _ store: Store<State, Action>,
+    observe toViewState: @escaping (BindableStore<State>) -> ViewState,
+    send fromViewAction: @escaping (ViewAction) -> Action,
+    removeDuplicates isDuplicate: @escaping (ViewState, ViewState) -> Bool,
+    @ViewBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
+    file: StaticString = #fileID,
+    line: UInt = #line
+  ) where Action.State == State {
+    self.init(
+      store,
+      observe: { (_: State) in toViewState(BindableStore(store: store)) },
+      send: fromViewAction,
+      removeDuplicates: isDuplicate,
+      content: content,
+      file: file,
+      line: line
+    )
+  }
+
+  public init<State>(
+    _ store: Store<State, ViewAction>,
+    observe toViewState: @escaping (BindableStore<State>) -> ViewState,
+    removeDuplicates isDuplicate: @escaping (ViewState, ViewState) -> Bool,
+    @ViewBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
+    file: StaticString = #fileID,
+    line: UInt = #line
+  ) where ViewAction: BindableAction, ViewAction.State == State {
+    self.init(
+      store,
+      observe: toViewState,
+      send: { $0 },
+      removeDuplicates: isDuplicate,
+      content: content,
+      file: file,
+      line: line
+    )
+  }
+}
+
+extension WithViewStore where ViewState: Equatable, Content: View {
+  public init<State, Action: BindableAction>(
+    _ store: Store<State, Action>,
+    observe toViewState: @escaping (BindableStore<State>) -> ViewState,
+    send fromViewAction: @escaping (ViewAction) -> Action,
+    @ViewBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
+    file: StaticString = #fileID,
+    line: UInt = #line
+  ) where Action.State == State {
+    self.init(
+      store,
+      observe: toViewState,
+      send: fromViewAction,
+      removeDuplicates: ==,
+      content: content,
+      file: file,
+      line: line
+    )
+  }
+
+  public init<State>(
+    _ store: Store<State, ViewAction>,
+    observe toViewState: @escaping (BindableStore<State>) -> ViewState,
+    @ViewBuilder content: @escaping (ViewStore<ViewState, ViewAction>) -> Content,
+    file: StaticString = #fileID,
+    line: UInt = #line
+  ) where ViewAction: BindableAction, ViewAction.State == State {
+    self.init(
+      store,
+      observe: toViewState,
+      removeDuplicates: ==,
+      content: content,
+      file: file,
+      line: line
+    )
+  }
+}
+
+extension ViewStore where Action: BindableAction, Action.State == State {
+  @MainActor
+  public subscript<Value: Equatable>(
+    dynamicMember keyPath: WritableKeyPath<State, BindableState<Value>>
+  ) -> Binding<Value> {
+    self.binding(
+      get: { $0[keyPath: keyPath].wrappedValue },
+      send: { value in
+        #if DEBUG
+          let debugger = BindableActionViewStoreDebugger(
+            value: value,
+            bindableActionType: Action.self,
+            // TODO: Restore context
+            file: #file,
+            fileID: #fileID,
+            line: #line
+          )
+          let set: (inout State) -> Void = {
+            $0[keyPath: keyPath].wrappedValue = value
+            debugger.wasCalled = true
+          }
+        #else
+          let set: (inout State) -> Void = { $0[keyPath: keyPath].wrappedValue = value }
+        #endif
+        return .binding(.init(keyPath: keyPath, set: set, value: value))
+      }
+    )
+  }
+
+  // TODO: Deprecate:
   /// Returns a binding to the resulting bindable state of a given key path.
   ///
   /// - Parameter keyPath: A key path to a specific bindable state.

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -1,12 +1,29 @@
 import CustomDump
 import SwiftUI
 
-/// A property wrapper type that can designate properties of app state that can be directly bindable
-/// in SwiftUI views.
+/// A property wrapper type that can designate properties of a feature's state that can be directly
+/// bindable in SwiftUI views.
 ///
-/// Along with an action type that conforms to the ``BindableAction`` protocol, this type can be
-/// used to safely eliminate the boilerplate that is typically incurred when working with multiple
-/// mutable fields on state.
+/// This property is to be applied directly to fields in a reducer's `State` type, and it should
+/// be used in tandem with marking the `State` type with the ``BindableStateProtocol`` protocol:
+///
+/// ```swift
+/// struct Feature: ReducerProtocol {
+///   struct State: BindableStateProtocol {
+///     @BindingState var enableNotifications = false
+///     @BindingState var sendEmailNotifications = false
+///     @BindingState var sendMobileNotifications = false
+///     // More properties...
+///   }
+///   // ...
+/// }
+/// ```
+///
+/// > Note: It is not necessary to annotate _every_ field with `@BindingState`, and in fact it is
+/// not recommended. Marking a field with the property wrapper makes it instantly mutable from the
+/// outside, which may hurt the encapsulation of your feature. It is best to limit the usage of the
+/// property wrapper to only those fields that need to have bindings derived for handing to SwiftUI
+/// components.
 ///
 /// Read <doc:Bindings> for more information.
 @dynamicMemberLookup
@@ -147,13 +164,13 @@ public struct BindingViewStates<State> {
   }
 }
 
-/// A protocol that your feature's `State` should conform to in order to extract
-/// ``BindingViewState`` values from ``BindableStateProtocol/bindings``.
+/// A marker protocol that a feature's `State` should conform to in order to easily derive SwiftUI
+/// bindings from any fields marked with the ``BindingState`` property wrapper.
 ///
 /// There is no specific requirement to conform to this protocol.
 ///
 /// - Note: This protocol will be renamed `BindableState` in a future release, when the deprecated
-/// ``BindableState`` as a property wrapper will be obsoleted. At the same time, conforming to this
+/// ``BindableState`` property wrapper will be obsoleted. At the same time, conforming to this
 /// protocol will also be a requirement of ``BindingReducer``'s `State`, so you're encouraged to
 /// conform states hosting `@BindingState` properties to this protocol already.
 public protocol BindableStateProtocol {}
@@ -382,8 +399,16 @@ where
 
 /// An action that describes simple mutations to some root state at a writable key path.
 ///
-/// Used in conjunction with ``BindingState`` and ``BindableAction`` to safely eliminate the
-/// boilerplate typically associated with mutating multiple fields in state.
+/// When using the ``BindingState`` property wrapper in your feature's ``ReducerProtocol/State``
+/// for easily deriving SwiftUI bindings from fields, you must also add a `binding` case to your
+/// ``ReducerProtocol/Action`` enum that holds a ``BindingAction``:
+///
+/// ```swift
+/// enum Action: BindableAction {
+///   case binding(BindingAction<State>)
+///   // More actions...
+/// }
+/// ```
 ///
 /// Read <doc:Bindings> for more information.
 public struct BindingAction<Root>: Equatable {

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -148,26 +148,29 @@ public struct BindingViewStates<State> {
 }
 
 /// A protocol that your feature's `State` should conform to in order to extract
-/// ``BindingViewState`` values from ``BindableStateProtocol/binding``.
+/// ``BindingViewState`` values from ``BindableStateProtocol/bindings``.
 ///
 /// There is no specific requirement to conform to this protocol.
 ///
 /// - Note: This protocol will be renamed `BindableState` in a future release, when the deprecated
 /// ``BindableState`` as a property wrapper will be obsoleted. At the same time, conforming to this
-/// protocol will also be a requirement of ``BindingReducer``'s `State`, so you're invited to
+/// protocol will also be a requirement of ``BindingReducer``'s `State`, so you're encouraged to
 /// conform states hosting `@BindingState` properties to this protocol already.
 public protocol BindableStateProtocol {}
 
 extension BindableStateProtocol {
-  /// A ``BindingViewStates`` value from which you can extract ``BindingViewState``'s using
-  /// dynamic lookup.
-  ///
-  /// You use this type as a `BindingViewState`'s repository to assign `@BindingViewState`
-  /// properties in your `ViewState`s initializer:
+  /// A ``BindingViewStates`` value from which you can derive ``BindingViewState`` using
+  /// dynamic member lookup:
   ///
   /// ```swift
+  /// struct State: BindableStateProtocol {
+  ///   @BindingState var text = ""
+  ///   // More properties that do not need bindings.
+  /// }
+  ///
   /// struct ViewState: Equatable {
   ///   @BindingViewState var text: String
+  ///
   ///   init(state: State) {
   ///     self._text = state.bindings.$text
   ///   }
@@ -260,6 +263,7 @@ public struct BindingViewState<Value> {
     self.line = line
   }
 }
+
 extension BindingViewState: Equatable where Value: Equatable {
   public static func == (lhs: BindingViewState<Value>, rhs: BindingViewState<Value>) -> Bool {
     lhs.wrappedValue == rhs.wrappedValue && lhs.keyPath == rhs.keyPath
@@ -272,6 +276,10 @@ extension BindingViewState: Hashable where Value: Hashable {
     hasher.combine(keyPath)
   }
 }
+
+// NB: Safe to use @unchecked Sendable because AnyKeyPath and Value are both Sendable, and they
+//     are the only stored properties on the struct.
+extension BindingViewState: @unchecked Sendable where Value: Sendable {}
 
 extension BindingViewState: CustomReflectable {
   public var customMirror: Mirror {

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -100,6 +100,11 @@ extension BindingState: CustomDebugStringConvertible where Value: CustomDebugStr
   }
 }
 
+/// A type from which you can generate ``BindingViewState``'s pointing to its `State` using dynamic
+/// member lookup.
+///
+/// You don't create values of this type directly, but you can extract one using the
+/// ``BindableStateProtocol/bindings`` property that is available when your state
 @dynamicMemberLookup
 public struct BindingViewStates<State> {
   private let state: State
@@ -125,9 +130,13 @@ public struct BindingViewStates<State> {
 /// - Note: This protocol will be renamed `BindableState` in a future release, when the deprecated
 /// ``BindableState`` as a property wrapper will be obsoleted.
 public protocol BindableStateProtocol {}
+
 extension BindableStateProtocol {
-  /// A nanespace to extract ``BindingViewState``'s
-  public var binding: BindingViewStates<Self> {
+  /// A ``BindingViewStates`` value from which you can extract ``BindingViewState``'s using
+  /// dynamic lookup
+  ///
+  // TODO: Add an example
+  public var bindings: BindingViewStates<Self> {
     .init(state: self)
   }
 }

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -121,21 +121,32 @@ public struct BindingViewStates<State> {
   }
 }
 
-// Placeholder until `BindableState` is freed.
 /// A protocol that your feature's `State` should conform to in order to extract
 /// ``BindingViewState`` values from ``BindableStateProtocol/binding``.
 ///
 /// There is no specific requirement to conform to this protocol.
 ///
 /// - Note: This protocol will be renamed `BindableState` in a future release, when the deprecated
-/// ``BindableState`` as a property wrapper will be obsoleted.
+/// ``BindableState`` as a property wrapper will be obsoleted. At the same time, conforming to this
+/// protocol will also be a requirement of ``BindingReducer``'s `State`, so you're invited to
+/// conform states hosting `@BindingState` properties to this protocol already.
 public protocol BindableStateProtocol {}
 
 extension BindableStateProtocol {
   /// A ``BindingViewStates`` value from which you can extract ``BindingViewState``'s using
-  /// dynamic lookup
+  /// dynamic lookup.
   ///
-  // TODO: Add an example
+  /// You use this type as a `BindingViewState`'s repository to assign `@BindingViewState`
+  /// properties in your `ViewState`s initializer:
+  ///
+  /// ```swift
+  /// struct ViewState: Equatable {
+  ///   @BindingViewState var text: String
+  ///   init(state: State) {
+  ///     self._text = state.bindings.$text
+  ///   }
+  /// }
+  /// ```
   public var bindings: BindingViewStates<Self> {
     .init(state: self)
   }
@@ -187,6 +198,8 @@ extension BindableAction {
 ///   }
 /// }
 /// ```
+///
+/// Read <doc:Bindings> for more information.
 @propertyWrapper
 public struct BindingViewState<Value> {
   let keyPath: AnyKeyPath

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -100,6 +100,8 @@ extension BindingState: CustomDebugStringConvertible where Value: CustomDebugStr
   }
 }
 
+extension BindingState: Sendable where Value: Sendable {}
+
 /// A type from which you can generate ``BindingViewState``'s pointing to its `State` using dynamic
 /// member lookup.
 ///

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -73,8 +73,7 @@ public struct BindingState<Value> {
     deprecated,
     message:
       """
-      Chaining onto properties of bindable state is deprecated. Push '@BindingState' use to the \
-      child state, instead.
+      Chaining onto properties of bindable state is deprecated. Push '@BindingState' use to the child state, instead.
       """
   )
   public subscript<Subject>(
@@ -147,12 +146,14 @@ extension BindingState: Sendable where Value: Sendable {}
 @dynamicMemberLookup
 public struct BindingViewStates<State> {
   private let state: State
-  init(state: State) {
+
+  fileprivate init(state: State) {
     self.state = state
   }
-  public subscript<Value>(dynamicMember keyPath: WritableKeyPath<State, BindingState<Value>>)
-    -> BindingViewState<Value>
-  {
+
+  public subscript<Value>(
+    dynamicMember keyPath: WritableKeyPath<State, BindingState<Value>>
+  ) -> BindingViewState<Value> {
     let bindingState = self.state[keyPath: keyPath]
     return .init(
       wrappedValue: bindingState.wrappedValue,
@@ -176,8 +177,8 @@ public struct BindingViewStates<State> {
 public protocol BindableStateProtocol {}
 
 extension BindableStateProtocol {
-  /// A ``BindingViewStates`` value from which you can derive ``BindingViewState`` using
-  /// dynamic member lookup:
+  /// A ``BindingViewStates`` value from which you can derive ``BindingViewState`` using dynamic
+  /// member lookup:
   ///
   /// ```swift
   /// struct State: BindableStateProtocol {
@@ -308,9 +309,9 @@ where Value: CustomDebugStringConvertible {
 
 // `BindingViewState` dynamic member lookup.
 extension ViewStore where ViewAction: BindableAction {
-  public subscript<Value>(dynamicMember keyPath: KeyPath<ViewState, BindingViewState<Value>>)
-    -> Binding<Value> where Value: Equatable
-  {
+  public subscript<Value: Equatable>(
+    dynamicMember keyPath: KeyPath<ViewState, BindingViewState<Value>>
+  ) -> Binding<Value> {
     let bindingViewState = self.state[keyPath: keyPath]
     let stateKeyPath =
       bindingViewState.keyPath

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -150,13 +150,6 @@ extension BindableStateProtocol {
   public var bindings: BindingViewStates<Self> {
     .init(state: self)
   }
-  
-  public subscript<Value>(keyPath: WritableKeyPath<Self, BindingState<Value>>) -> BindingViewState<Value> {
-    .init(
-      wrappedValue: self[keyPath: keyPath].wrappedValue,
-      keyPath: keyPath
-    )
-  }
 }
 
 /// An action type that exposes a `binding` case that holds a ``BindingAction``.

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -468,8 +468,8 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
   ) -> Binding<Value> {
     @ObservedState var val = get(self.state)
     return .init(
-        get: { [$val] in $val.wrappedValue },
-        set: { [weak self] in self?.send(valueToAction($0)) }
+      get: { [$val] in $val.wrappedValue },
+      set: { [weak self] in self?.send(valueToAction($0)) }
     )
   }
 
@@ -757,12 +757,12 @@ final private class ValueWrapper<V>: ObservableObject {
 
 @propertyWrapper private struct ObservedState<Value>: DynamicProperty {
   @ObservedObject private var box: ValueWrapper<Value>
-  
+
   var wrappedValue: Value {
     get { box.value }
     nonmutating set { box.value = newValue }
   }
-  
+
   var projectedValue: Binding<Value> {
     .init(
       get: { wrappedValue },

--- a/Tests/ComposableArchitectureTests/BindingTests.swift
+++ b/Tests/ComposableArchitectureTests/BindingTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @MainActor
 final class BindingTests: XCTestCase {
   #if swift(>=5.7)
-    func testNestedBindingState() {
+    func testNestedBindingStateWithNestedMatching() {
       struct BindingTest: ReducerProtocol {
         struct State: Equatable, BindableStateProtocol {
           @BindingState var nested = Nested()
@@ -37,7 +37,47 @@ final class BindingTests: XCTestCase {
       let viewStore = ViewStore(store)
 
       viewStore.$nested.field.wrappedValue = "Hello"
+      // Pattern matching with nested `KeyPath`s is not supported anymore, so the following should
+      // now fail:
+      XCTExpectFailure {
+        XCTAssertEqual(viewStore.state, .init(nested: .init(field: "Hello!")))
+      }
+      XCTAssertEqual(viewStore.state, .init(nested: .init(field: "Hello")))
+    }
 
+    func testbindingState() {
+      struct BindingTest: ReducerProtocol {
+        struct State: Equatable, BindableStateProtocol {
+          @BindingState var nested = Nested()
+
+          struct Nested: Equatable {
+            var field = ""
+          }
+        }
+
+        enum Action: BindableAction, Equatable {
+          case binding(BindingAction<State>)
+        }
+
+        var body: some ReducerProtocol<State, Action> {
+          BindingReducer()
+          Reduce { state, action in
+            switch action {
+            case .binding(\.$nested):
+              state.nested.field += "!"
+              return .none
+            default:
+              return .none
+            }
+          }
+        }
+      }
+
+      let store = Store(initialState: BindingTest.State(), reducer: BindingTest())
+
+      let viewStore = ViewStore(store)
+
+      viewStore.$nested.field.wrappedValue = "Hello"
       XCTAssertEqual(viewStore.state, .init(nested: .init(field: "Hello!")))
     }
   #endif

--- a/Tests/ComposableArchitectureTests/BindingTests.swift
+++ b/Tests/ComposableArchitectureTests/BindingTests.swift
@@ -6,7 +6,7 @@ final class BindingTests: XCTestCase {
   #if swift(>=5.7)
     func testNestedBindingStateWithNestedMatching() {
       struct BindingTest: ReducerProtocol {
-        struct State: Equatable, BindableStateProtocol {
+        struct State: BindableStateProtocol, Equatable {
           @BindingState var nested = Nested()
 
           struct Nested: Equatable {
@@ -36,18 +36,19 @@ final class BindingTests: XCTestCase {
 
       let viewStore = ViewStore(store)
 
+      XCTAssertNoDifference(viewStore.state, .init(nested: .init(field: "")))
       viewStore.$nested.field.wrappedValue = "Hello"
       // Pattern matching with nested `KeyPath`s is not supported anymore, so the following should
       // now fail:
       XCTExpectFailure {
         XCTAssertEqual(viewStore.state, .init(nested: .init(field: "Hello!")))
       }
-      XCTAssertEqual(viewStore.state, .init(nested: .init(field: "Hello")))
+      XCTAssertNoDifference(viewStore.state, .init(nested: .init(field: "Hello")))
     }
 
-    func testbindingState() {
+    func testBindingState() {
       struct BindingTest: ReducerProtocol {
-        struct State: Equatable, BindableStateProtocol {
+        struct State: BindableStateProtocol, Equatable {
           @BindingState var nested = Nested()
 
           struct Nested: Equatable {

--- a/Tests/ComposableArchitectureTests/BindingTests.swift
+++ b/Tests/ComposableArchitectureTests/BindingTests.swift
@@ -4,10 +4,10 @@ import XCTest
 @MainActor
 final class BindingTests: XCTestCase {
   #if swift(>=5.7)
-    func testNestedBindableState() {
+    func testNestedBindingState() {
       struct BindingTest: ReducerProtocol {
         struct State: Equatable {
-          @BindableState var nested = Nested()
+          @BindingState var nested = Nested()
 
           struct Nested: Equatable {
             var field = ""

--- a/Tests/ComposableArchitectureTests/BindingTests.swift
+++ b/Tests/ComposableArchitectureTests/BindingTests.swift
@@ -6,7 +6,7 @@ final class BindingTests: XCTestCase {
   #if swift(>=5.7)
     func testNestedBindingState() {
       struct BindingTest: ReducerProtocol {
-        struct State: Equatable {
+        struct State: Equatable, BindableStateProtocol {
           @BindingState var nested = Nested()
 
           struct Nested: Equatable {
@@ -36,7 +36,7 @@ final class BindingTests: XCTestCase {
 
       let viewStore = ViewStore(store)
 
-      viewStore.binding(\.$nested.field).wrappedValue = "Hello"
+      viewStore.$nested.field.wrappedValue = "Hello"
 
       XCTAssertEqual(viewStore.state, .init(nested: .init(field: "Hello!")))
     }

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -45,7 +45,7 @@
 
     func testBindingAction() {
       struct State {
-        @BindableState var width = 0
+        @BindingState var width = 0
       }
       let action = BindingAction.set(\State.$width, 50)
       var dump = ""
@@ -54,7 +54,7 @@
         dump,
         #"""
         BindingAction.set(
-          WritableKeyPath<State, BindableState<Int>>,
+          WritableKeyPath<State, BindingState<Int>>,
           50
         )
         """#

--- a/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
+++ b/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
@@ -190,7 +190,7 @@
     @MainActor
     func testBindingUnhandledAction() {
       struct State: Equatable {
-        @BindableState var value = 0
+        @BindingState var value = 0
       }
       enum Action: BindableAction, Equatable {
         case binding(BindingAction<State>)


### PR DESCRIPTION
This PR proposes a solution to allow `BindingReducer` to work on `ViewState`. It consists in a simple protocol that you conform your `State` to, and a new property wrapper to expose `@Bindable` properties to `ViewState`. It also renames and deprecates a few types and methods in preparation for the version 1.0.

### What is changing
- `@BindableState` has been deprecated and renamed `@BindingState`, as "able" names are usually reserved for protocols.
- A `BindableStateProtocol` is introduced. You conform the `State` hosting `@BindingState` properties to it. The name of this protocol is transient and it will be renamed `BindableState` for the version 1.0.
- A `@BindingViewState` property wrapper is introduced. You use this property wrapper to annotate bindable values in your `ViewState`
- You directly create a `Binding<Value>` using `viewStore.$value`. The `viewStore.binding(\.$value)` style has been soft-deprecated (other `ViewStore.binding` methods are not concerned).
- Pattern matching in the reducer using nested KeyPath is deprecated. If you need to match a `binding` action, you should match the `KeyPath` from the `@BindingState` property directly, and not a nested property of it.

### How does it work

You conform your `State` to the `BindableStateProtocol`:
```swift
struct State: BindableStateProtocol {
  @BindingState var textFromState: String
}
```
(also note the renamed `@BindableState -> @BindingState`).

In your `ViewState`, you declare `@BindingViewState` properties in the following way:
```swift
struct ViewState: Equatable {
  @BindingViewState var text
  init(state: State) {
    self._text = state.bindings.$textFromState
  }
}
```
Note that you need to assign the private storage (with a _) of the `@BindingViewState` property wrapper. You extract one value using the `bindings` property of `BindableStateProtocol` that exposes `BindingViewState` values using dynamic member lookup from `State`.

You can then use this binding like a standard SwiftUI `Binding`:
```
TextField("Type here", text: viewStore.$text)
```
If you're not using a dedicated `ViewState` (`ViewStore(store, observe: { $0 })`), you can also use the same `$` syntax on `BindingState` properties: `viewStore.$textFromState`.

There are now two protocols (`BindableState[Protocol]` and `BindableAction`), and two wrappers types: `BindingState` and `BindingAction`, as well as a `ViewState` specific `BindingViewState`.

### Alternative implementations

I'm only exposing here alternative ways to implement this specific approach, not alternative solutions to the problem.

#### Using the projected value `$` to assign the `ViewState`'s property in the init:

The idea would be to allow to write the more familiar:
```swift
self.$text = state.bindings.$textFromState
```
This is technically possible, but it forces us to allow `BindingViewState` to be initialized without arguments. It then becomes possible to forget to link this property to a `BindingState` in the `init`. It furthermore would only work if these `BindingViewState` properties were assigned after the standard, non-wrapped, properties.
Using `_` instead of `$` doesn't seem to be a price too high to pay for the safety it brings.

#### Reusing `BindingState` instead of `BindingViewState` in `ViewState`:
This is likely technically possible, but it would allow us to perform the assignation wrongly in two different ways:
```swift
self.text = state.textFromState // This would be wrong
self.$text = state.$textFromState // This would be wrong
self._text = state.bindings.$textFromState // This would be the only correct way
```
The only recovery would be to display runtime warnings, which is very weak.

#### Using a subscript instead of `bindings` in `BindableState[Protocol]`:
This one is totally open to discussion. One would write:
```
self._text = state[\.$textFromState]
// instead of 
self._text = state.bindings.$textFromState
```
The latter approach (which is currently used in this PR) autocompletes and reads nicely, but it exposes a `bindings` property on `State` that may pop up in autocompletion through dynamic lookup, especially with `ViewStore` observing `{ $0 }`:
```swift
viewStore.b // Proposes `bindings, binding(…, etc.
```
Using a subscript would position this utility a little off-track, but the subscript is always more cryptic and less discoverable, especially for newcomers.

That's it!
Please let me know what you think!