### PR TITLE
Soft-deprecate EffectPublisher

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/ComposableArchitecture.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/ComposableArchitecture.md
@@ -60,7 +60,7 @@ day-to-day when building applications, such as:
 ### State management
 
 - ``ReducerProtocol``
-- ``EffectPublisher``
+- ``EffectTask``
 - ``Store``
 - ``ViewStore``
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/SwiftUIDeprecations.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/SwiftUIDeprecations.md
@@ -33,9 +33,5 @@ Avoid using deprecated APIs in your app. Select a method to see the replacement 
 - ``WithViewStore/Action``
 - ``WithViewStore/State``
 
-### View state
-
-- ``ActionSheetState``
-
 <!--DocC: Can't currently document `View` extensions-->
 <!--### View Modifiers-->

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
@@ -1,27 +1,27 @@
-# ``ComposableArchitecture/EffectPublisher``
+# ``ComposableArchitecture/EffectTask``
 
 ## Topics
 
 ### Creating an effect
 
-- ``none``
-- ``task(priority:operation:catch:file:fileID:line:)``
-- ``run(priority:operation:catch:file:fileID:line:)``
-- ``fireAndForget(priority:_:)``
+- ``EffectPublisher/none``
+- ``EffectPublisher/task(priority:operation:catch:file:fileID:line:)``
+- ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)``
+- ``EffectPublisher/fireAndForget(priority:_:)``
 - ``TaskResult``
 
 ### Cancellation
 
-- ``cancellable(id:cancelInFlight:)-29q60``
-- ``cancel(id:)-6hzsl``
-- ``cancel(ids:)-1cqqx``
+- ``EffectPublisher/cancellable(id:cancelInFlight:)-29q60``
+- ``EffectPublisher/cancel(id:)-6hzsl``
+- ``EffectPublisher/cancel(ids:)-1cqqx``
 - ``withTaskCancellation(id:cancelInFlight:operation:)-4dtr6``
 
 ### Composition
 
-- ``map(_:)-yn70``
-- ``merge(_:)-45guh``
-- ``merge(_:)-3d54p``
+- ``EffectPublisher/map(_:)-yn70``
+- ``EffectPublisher/merge(_:)-45guh``
+- ``EffectPublisher/merge(_:)-3d54p``
 
 ### Concurrency
 
@@ -29,11 +29,11 @@
 
 ### Testing
 
-- ``unimplemented(_:)``
+- ``EffectPublisher/unimplemented(_:)``
 
 ### SwiftUI integration
 
-- ``animation(_:)``
+- ``EffectPublisher/animation(_:)``
 
 ### Deprecations
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStore.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStore.md
@@ -18,7 +18,7 @@
 - ``receive(_:timeout:assert:file:line:)-1rwdd``
 - ``receive(_:timeout:assert:file:line:)-4e4m0``
 - ``receive(_:timeout:assert:file:line:)-3myco``
-- ``finish(timeout:file:line:)``
+- ``finish(timeout:file:line:)-53gi5``
 - ``TestStoreTask``
 
 ### Methods for skipping actions and effects

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -8,10 +8,9 @@ import XCTestDynamicOverlay
   iOS,
   deprecated: 9999.0,
   message: """
-    'Effect' has been deprecated in favor of 'EffectTask'.
+    'EffectPublisher' has been deprecated in favor of 'EffectTask'.
 
-     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
-     concurrency to model failable streams of values.
+     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to use Swift concurrency to model asynchrony in dependencies.
 
      See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
     """
@@ -20,10 +19,9 @@ import XCTestDynamicOverlay
   macOS,
   deprecated: 9999.0,
   message: """
-    'Effect' has been deprecated in favor of 'EffectTask'.
+    'EffectPublisher' has been deprecated in favor of 'EffectTask'.
 
-     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
-     concurrency to model failable streams of values.
+     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to use Swift concurrency to model asynchrony in dependencies.
 
      See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
     """
@@ -32,10 +30,9 @@ import XCTestDynamicOverlay
   tvOS,
   deprecated: 9999.0,
   message: """
-    'Effect' has been deprecated in favor of 'EffectTask'.
+    'EffectPublisher' has been deprecated in favor of 'EffectTask'.
 
-     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
-     concurrency to model failable streams of values.
+     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to use Swift concurrency to model asynchrony in dependencies.
 
      See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
     """
@@ -44,10 +41,9 @@ import XCTestDynamicOverlay
   watchOS,
   deprecated: 9999.0,
   message: """
-    'Effect' has been deprecated in favor of 'EffectTask'.
+    'EffectPublisher' has been deprecated in favor of 'EffectTask'.
 
-     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
-     concurrency to model failable streams of values.
+     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to use Swift concurrency to model asynchrony in dependencies.
 
      See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
     """

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -3,35 +3,55 @@ import Foundation
 import SwiftUI
 import XCTestDynamicOverlay
 
-/// A type that encapsulates a unit of work that can be run in the outside world, and can feed
-/// actions back to the ``Store``.
-///
-/// Effects are the perfect place to do side effects, such as network requests, saving/loading
-/// from disk, creating timers, interacting with dependencies, and more. They are returned from
-/// reducers so that the ``Store`` can perform the effects after the reducer is done running.
-///
-/// There are 2 distinct ways to create an `Effect`: one using Swift's native concurrency tools, and
-/// the other using Apple's Combine framework:
-///
-/// * If using Swift's native structured concurrency tools then there are 3 main ways to create an
-/// effect, depending on if you want to emit one single action back into the system, or any number
-/// of actions, or just execute some work without emitting any actions:
-///   * ``EffectPublisher/task(priority:operation:catch:file:fileID:line:)``
-///   * ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)``
-///   * ``EffectPublisher/fireAndForget(priority:_:)``
-/// * If using Combine in your application, in particular for the dependencies of your feature
-/// then you can create effects by making use of any of Combine's operators, and then erasing the
-/// publisher type to ``EffectPublisher`` with either `eraseToEffect` or `catchToEffect`. Note that
-/// the Combine interface to ``EffectPublisher`` is considered soft deprecated, and you should
-/// eventually port to Swift's native concurrency tools.
-///
-/// > Important: ``Store`` is not thread safe, and so all effects must receive values on the same
-/// thread. This is typically the main thread,  **and** if the store is being used to drive UI then
-/// it must receive values on the main thread.
-/// >
-/// > This is only an issue if using the Combine interface of ``EffectPublisher`` as mentioned
-/// above. If  you are using Swift's concurrency tools and the `.task`, `.run` and `.fireAndForget`
-/// functions on ``EffectTask``, then threading is automatically handled for you.
+/// This type is deprecated in favor of ``EffectTask``. See its documentation for more information.
+@available(
+  iOS,
+  deprecated: 9999.0,
+  message: """
+    'Effect' has been deprecated in favor of 'EffectTask'.
+
+     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
+     concurrency to model failable streams of values.
+
+     See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
+    """
+)
+@available(
+  macOS,
+  deprecated: 9999.0,
+  message: """
+    'Effect' has been deprecated in favor of 'EffectTask'.
+
+     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
+     concurrency to model failable streams of values.
+
+     See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
+    """
+)
+@available(
+  tvOS,
+  deprecated: 9999.0,
+  message: """
+    'Effect' has been deprecated in favor of 'EffectTask'.
+
+     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
+     concurrency to model failable streams of values.
+
+     See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
+    """
+)
+@available(
+  watchOS,
+  deprecated: 9999.0,
+  message: """
+    'Effect' has been deprecated in favor of 'EffectTask'.
+
+     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
+     concurrency to model failable streams of values.
+
+     See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
+    """
+)
 public struct EffectPublisher<Action, Failure: Error> {
   @usableFromInline
   enum Operation {
@@ -60,20 +80,38 @@ extension EffectPublisher {
   }
 }
 
-/// A convenience type alias for referring to an effect that can never fail, like the kind of
-/// ``EffectPublisher`` returned by a reducer after processing an action.
+/// A type that encapsulates a unit of work that can be run in the outside world, and can feed
+/// actions back to the ``Store``.
 ///
-/// Instead of specifying `Never` as `Failure`:
+/// Effects are the perfect place to do side effects, such as network requests, saving/loading
+/// from disk, creating timers, interacting with dependencies, and more. They are returned from
+/// reducers so that the ``Store`` can perform the effects after the reducer is done running.
 ///
-/// ```swift
-/// func reduce(into state: inout State, action: Action) -> EffectPublisher<Action, Never> { … }
-/// ```
+/// There are 2 distinct ways to create an `Effect`: one using Swift's native concurrency tools, and
+/// the other using Apple's Combine framework:
 ///
-/// You can specify a single generic:
+/// * If using Swift's native structured concurrency tools then there are 3 main ways to create an
+/// effect, depending on if you want to emit one single action back into the system, or any number
+/// of actions, or just execute some work without emitting any actions:
+///   * ``EffectPublisher/task(priority:operation:catch:file:fileID:line:)``
+///   * ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)``
+///   * ``EffectPublisher/fireAndForget(priority:_:)``
+/// * If using Combine in your application, in particular for the dependencies of your feature
+/// then you can create effects by making use of any of Combine's operators, and then erasing the
+/// publisher type to ``EffectPublisher`` with either `eraseToEffect` or `catchToEffect`. Note that
+/// the Combine interface to ``EffectPublisher`` is considered soft deprecated, and you should
+/// eventually port to Swift's native concurrency tools.
 ///
-/// ```swift
-/// func reduce(into state: inout State, action: Action) -> EffectTask<Action>  { … }
-/// ```
+/// > Important: The publisher interface to ``EffectTask`` is considered deperecated, and you should
+/// try converting any uses of that interface to Swift's native concurrency tools.
+/// >
+/// > Also, ``Store`` is not thread safe, and so all effects must receive values on the same
+/// thread. This is typically the main thread,  **and** if the store is being used to drive UI then
+/// it must receive values on the main thread.
+/// >
+/// > This is only an issue if using the Combine interface of ``EffectPublisher`` as mentioned
+/// above. If  you are using Swift's concurrency tools and the `.task`, `.run` and `.fireAndForget`
+/// functions on ``EffectTask``, then threading is automatically handled for you.
 public typealias EffectTask<Action> = Effect<Action, Never>
 
 extension EffectPublisher where Failure == Never {

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -542,7 +542,7 @@ public final class TestStore<State, Action, ScopedState, ScopedAction, Environme
   /// The default timeout used in all methods that take an optional timeout.
   ///
   /// This is the default timeout used in all methods that take an optional timeout, such as
-  /// ``receive(_:timeout:assert:file:line:)-1rwdd`` and ``finish(timeout:file:line:)``.
+  /// ``receive(_:timeout:assert:file:line:)-1rwdd`` and ``finish(timeout:file:line:)-53gi5``.
   public var timeout: UInt64
 
   private var _environment: Box<Environment>
@@ -1317,7 +1317,7 @@ extension TestStore where ScopedState: Equatable, Action: Equatable {
     /// Asserts an action was received from an effect that matches a predicate, and asserts how the
     /// state changes.
     ///
-    /// This method is similar to ``receive(_:timeout:assert:file:line:)-5n755``, except it allows
+    /// This method is similar to ``receive(_:timeout:assert:file:line:)-4he05``, except it allows
     /// you to assert that an action was received that matches a predicate without asserting on all
     /// the data in the action:
     ///
@@ -1336,7 +1336,7 @@ extension TestStore where ScopedState: Equatable, Action: Equatable {
     /// data was in the effect that you chose not to assert on.
     ///
     /// If you only want to check that a particular action case was received, then you might find
-    /// the ``receive(_:timeout:assert:file:line:)-5n755`` overload of this method more useful.
+    /// the ``receive(_:timeout:assert:file:line:)-4he05`` overload of this method more useful.
     ///
     /// - Parameters:
     ///   - isMatching: A closure that attempts to match an action. If it returns `false`, a test
@@ -1530,7 +1530,7 @@ extension TestStore where ScopedState: Equatable, Action: Equatable {
   #if swift(>=5.7) && !os(macOS) && !targetEnvironment(macCatalyst)
     /// Asserts an action was received matching a case path and asserts how the state changes.
     ///
-    /// This method is similar to ``receive(_:timeout:assert:file:line:)-5n755``, except it allows
+    /// This method is similar to ``receive(_:timeout:assert:file:line:)-4he05``, except it allows
     /// you to assert that an action was received that matches a particular case of the action enum
     /// without asserting on all the data in the action.
     ///
@@ -1988,8 +1988,8 @@ extension TestStore {
 /// await store.send(.stopTimerButtonTapped).finish()
 /// ```
 ///
-/// See ``TestStore/finish(timeout:file:line:)`` for the ability to await all in-flight effects in
-/// the test store.
+/// See ``TestStore/finish(timeout:file:line:)-53gi5`` for the ability to await all in-flight
+/// effects in the test store.
 ///
 /// See ``ViewStoreTask`` for the analog provided to ``ViewStore``.
 public struct TestStoreTask: Hashable, Sendable {


### PR DESCRIPTION
Another step towards getting to `Effect<Action>` for reducers is to eventually remove the publisher interface to `Effect`. For now we are going to soft-deprecate `EffectPublisher` and eventually hard deprecate it and then remove it in 1.0.

Most likely no one is even using this type. The most likely place to use it would be in the return type of dependencies, and now people should migrate towards using Swift's concurrency tools for that.