### PR TITLE
Deprecate async version of withValue and introduce sync version.

### DIFF
--- a/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift
+++ b/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift
@@ -325,11 +325,11 @@ public final actor ActorIsolated<Value: Sendable> {
   /// - Parameters: operation: An operation to be performed on the actor with the underlying value.
   /// - Returns: The result of the operation.
   public func withValue<T: Sendable>(
-    _ operation: @Sendable (inout Value) async throws -> T
-  ) async rethrows -> T {
+    _ operation: @Sendable (inout Value) throws -> T
+  ) rethrows -> T {
     var value = self.value
     defer { self.value = value }
-    return try await operation(&value)
+    return try operation(&value)
   }
 
   /// Overwrite the isolated value with a new value.

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -3,6 +3,23 @@ import Combine
 import SwiftUI
 import XCTestDynamicOverlay
 
+// MARK: - Deprecated after 0.47.2
+
+extension ActorIsolated {
+  @available(
+    *,
+     deprecated,
+     message: "Use the non-async version of 'withValue'."
+  )
+  public func withValue<T: Sendable>(
+    _ operation: @Sendable (inout Value) async throws -> T
+  ) async rethrows -> T {
+    var value = self.value
+    defer { self.value = value }
+    return try await operation(&value)
+  }
+}
+
 // MARK: - Deprecated after 0.45.0:
 
 @available(


### PR DESCRIPTION
With made `withValue` async on `ActorIsolated`, but I don't think we really meant to. That makes the method re-entrant, which means inflight operations can overwrite each other.

For example, this test fails when it shouldn't:

```swift
func testAsyncWithValue() async {
  let xs = ActorIsolated<[Int]>([])

  let task1 = Task {
    await xs.withValue {
      try? await Task.sleep(nanoseconds: NSEC_PER_MSEC * 100)
      $0.append(1)
    }
  }
  let task2 = Task {
    await xs.withValue {
      try? await Task.sleep(nanoseconds: NSEC_PER_MSEC * 200)
      $0.append(2)
    }
  }
  let task3 = Task {
    await xs.withValue {
      try? await Task.sleep(nanoseconds: NSEC_PER_MSEC * 300)
      $0.append(3)
    }
  }

  await task1.value
  await task2.value
  await task3.value
  let value = await xs.value
  XCTAssertEqual(value, [1, 2, 3])
}
```