### PR TITLE
Relax constraints around bindable view state

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -16,7 +16,7 @@ private let readMe = """
 // MARK: - Feature domain
 
 struct BindingForm: ReducerProtocol {
-  struct State: BindableViewState, Equatable {
+  struct State: Equatable {
     @BindingState var sliderValue = 5.0
     @BindingState var stepCount = 10
     @BindingState var text = ""

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -16,7 +16,7 @@ private let readMe = """
 // MARK: - Feature domain
 
 struct BindingForm: ReducerProtocol {
-  struct State: BindableStateProtocol, Equatable {
+  struct State: BindableViewState, Equatable {
     @BindingState var sliderValue = 5.0
     @BindingState var stepCount = 10
     @BindingState var text = ""

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -9,7 +9,7 @@ private let readMe = """
 // MARK: - Feature domain
 
 struct FocusDemo: ReducerProtocol {
-  struct State: BindableStateProtocol, Equatable {
+  struct State: BindableViewState, Equatable {
     @BindingState var focusedField: Field?
     @BindingState var password: String = ""
     @BindingState var username: String = ""

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -9,7 +9,7 @@ private let readMe = """
 // MARK: - Feature domain
 
 struct FocusDemo: ReducerProtocol {
-  struct State: BindableViewState, Equatable {
+  struct State: Equatable {
     @BindingState var focusedField: Field?
     @BindingState var password: String = ""
     @BindingState var username: String = ""

--- a/Examples/Todos/Todos/Todo.swift
+++ b/Examples/Todos/Todos/Todo.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import SwiftUI
 
 struct Todo: ReducerProtocol {
-  struct State: BindableStateProtocol, Equatable, Identifiable {
+  struct State: Equatable, Identifiable {
     @BindingState var description = ""
     let id: UUID
     @BindingState var isComplete = false

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -8,7 +8,7 @@ enum Filter: LocalizedStringKey, CaseIterable, Hashable {
 }
 
 struct Todos: ReducerProtocol {
-  struct State: BindableStateProtocol, Equatable {
+  struct State: BindableViewState, Equatable {
     @BindingState var editMode: EditMode = .inactive
     @BindingState var filter: Filter = .all
     var todos: IdentifiedArrayOf<Todo.State> = []

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwiftUI.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwiftUI.md
@@ -20,7 +20,7 @@ The Composable Architecture can be used to power applications built in many fram
 - <doc:Bindings>
 - ``ViewStore/binding(get:send:)-65xes``
 - ``BindingState``
-- ``BindableStateProtocol``
+- ``BindableViewState``
 - ``BindingAction``
 - ``BindableAction``
 - ``BindingReducer``

--- a/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
@@ -7,7 +7,7 @@ import SwiftUI
 ///
 /// ```swift
 /// struct Feature: ReducerProtocol {
-///   struct State: BindableStateProtocol {
+///   struct State: BindableViewState {
 ///     @BindingState var isOn = false
 ///     // More properties...
 ///   }

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -5,11 +5,11 @@ import SwiftUI
 /// bindable in SwiftUI views.
 ///
 /// This property is to be applied directly to fields in a reducer's `State` type, and it should
-/// be used in tandem with marking the `State` type with the ``BindableStateProtocol`` protocol:
+/// be used in tandem with marking the `State` type with the ``BindableViewState`` protocol:
 ///
 /// ```swift
 /// struct Feature: ReducerProtocol {
-///   struct State: BindableStateProtocol {
+///   struct State: BindableViewState {
 ///     @BindingState var enableNotifications = false
 ///     @BindingState var sendEmailNotifications = false
 ///     @BindingState var sendMobileNotifications = false
@@ -85,7 +85,7 @@ public struct BindingState<Value> {
 }
 
 extension BindingState: Equatable where Value: Equatable {
-  public static func == (lhs: BindingState<Value>, rhs: BindingState<Value>) -> Bool {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.wrappedValue == rhs.wrappedValue
   }
 }
@@ -142,7 +142,7 @@ extension BindingState: Sendable where Value: Sendable {}
 /// member lookup.
 ///
 /// You don't create values of this type directly, but you can extract one using the
-/// ``BindableStateProtocol/bindings`` property that is available when your state
+/// ``BindableViewState/bindings`` property that is available when your state
 @dynamicMemberLookup
 public struct BindingViewStates<State> {
   private let state: State
@@ -169,19 +169,14 @@ public struct BindingViewStates<State> {
 /// bindings from any fields marked with the ``BindingState`` property wrapper.
 ///
 /// There is no specific requirement to conform to this protocol.
-///
-/// - Note: This protocol will be renamed `BindableState` in a future release, when the deprecated
-/// ``BindableState`` property wrapper will be obsoleted. At the same time, conforming to this
-/// protocol will also be a requirement of ``BindingReducer``'s `State`, so you're encouraged to
-/// conform states hosting `@BindingState` properties to this protocol already.
-public protocol BindableStateProtocol {}
+public protocol BindableViewState {}
 
-extension BindableStateProtocol {
+extension BindableViewState {
   /// A ``BindingViewStates`` value from which you can derive ``BindingViewState`` using dynamic
   /// member lookup:
   ///
   /// ```swift
-  /// struct State: BindableStateProtocol {
+  /// struct State: BindableViewState {
   ///   @BindingState var text = ""
   ///   // More properties that do not need bindings.
   /// }
@@ -232,7 +227,7 @@ extension BindableAction {
 /// A ``BindingState`` variant that is suitable for `ViewState`s.
 ///
 /// You can only build these values using dynamic member lookup of ``BindingState`` properties on
-/// the ``BindingViewStates`` value from ``BindableStateProtocol/bindings``.
+/// the ``BindingViewStates`` value from ``BindableViewState/bindings``.
 ///
 /// Because you're defining the ``BindingViewState`` value directly, you must assign the value
 /// of the property wrapper private storage using the underscored property name:
@@ -344,12 +339,10 @@ extension ViewStore where ViewAction: BindableAction {
   }
 }
 
-// `BindingState` from some `BindableStateProtocol` dynamic member lookup.
 extension ViewStore
 where
   ViewAction: BindableAction,
-  ViewAction.State == ViewState,
-  ViewAction.State: BindableStateProtocol
+  ViewAction.State == ViewState
 {
   public subscript<Value>(dynamicMember keyPath: WritableKeyPath<ViewState, BindingState<Value>>)
     -> Binding<Value> where Value: Equatable

--- a/Tests/ComposableArchitectureTests/BindingTests.swift
+++ b/Tests/ComposableArchitectureTests/BindingTests.swift
@@ -6,7 +6,7 @@ final class BindingTests: XCTestCase {
   #if swift(>=5.7)
     func testNestedBindingStateWithNestedMatching() {
       struct BindingTest: ReducerProtocol {
-        struct State: BindableViewState, Equatable {
+        struct State: Equatable {
           @BindingState var nested = Nested()
 
           struct Nested: Equatable {

--- a/Tests/ComposableArchitectureTests/BindingTests.swift
+++ b/Tests/ComposableArchitectureTests/BindingTests.swift
@@ -6,7 +6,7 @@ final class BindingTests: XCTestCase {
   #if swift(>=5.7)
     func testNestedBindingStateWithNestedMatching() {
       struct BindingTest: ReducerProtocol {
-        struct State: BindableStateProtocol, Equatable {
+        struct State: BindableViewState, Equatable {
           @BindingState var nested = Nested()
 
           struct Nested: Equatable {
@@ -48,7 +48,7 @@ final class BindingTests: XCTestCase {
 
     func testBindingState() {
       struct BindingTest: ReducerProtocol {
-        struct State: BindableStateProtocol, Equatable {
+        struct State: BindableViewState, Equatable {
           @BindingState var nested = Nested()
 
           struct Nested: Equatable {


### PR DESCRIPTION
With #1790 a `BindableStateProtocol` was introduced for deriving bindings to view state, and some new APIs required this constraint. On further use, this constraint seems overly strict, as leaf nodes that don't use view state don't really need this conformance.

While we're at it, let's rename `BindableStateProtocol` to `BindableViewState`, since it is currently only used to derive view bindings. If we decide the protocol can do more in the future, we could consider renaming it to `BindableState` (once the existing property wrapper type alias is fully removed).