### PR TITLE
Revert #1784: Resolve binding key path crash

### DIFF
--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -466,11 +466,8 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
     get: @escaping (ViewState) -> Value,
     send valueToAction: @escaping (Value) -> ViewAction
   ) -> Binding<Value> {
-    @ObservedState var val = get(self.state)
-    return .init(
-      get: { [$val] in $val.wrappedValue },
-      set: { [weak self] in self?.send(valueToAction($0)) }
-    )
+    ObservedObject(wrappedValue: self)
+      .projectedValue[get: .init(rawValue: get), send: .init(rawValue: valueToAction)]
   }
 
   /// Derives a binding from the store that prevents direct writes to state and instead sends
@@ -561,6 +558,14 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
   /// - Returns: A binding.
   public func binding(send action: ViewAction) -> Binding<ViewState> {
     self.binding(send: { _ in action })
+  }
+
+  private subscript<Value>(
+    get state: HashableWrapper<(ViewState) -> Value>,
+    send action: HashableWrapper<(Value) -> ViewAction>
+  ) -> Value {
+    get { state.rawValue(self.state) }
+    set { self.send(action.rawValue(newValue)) }
   }
 }
 
@@ -745,31 +750,8 @@ public struct StorePublisher<State>: Publisher {
   }
 }
 
-final private class ValueWrapper<V>: ObservableObject {
-  var value: V {
-    willSet { objectWillChange.send() }
-  }
-
-  init(_ value: V) {
-    self.value = value
-  }
-}
-
-@propertyWrapper private struct ObservedState<Value>: DynamicProperty {
-  @ObservedObject private var box: ValueWrapper<Value>
-
-  var wrappedValue: Value {
-    get { box.value }
-    nonmutating set { box.value = newValue }
-  }
-
-  var projectedValue: Binding<Value> {
-    .init(
-      get: { wrappedValue },
-      set: { wrappedValue = $0 }
-    )
-  }
-  init(wrappedValue value: Value) {
-    self._box = ObservedObject(wrappedValue: .init(value))
-  }
+private struct HashableWrapper<Value>: Hashable {
+  let rawValue: Value
+  static func == (lhs: Self, rhs: Self) -> Bool { false }
+  func hash(into hasher: inout Hasher) {}
 }

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -466,14 +466,11 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
     get: @escaping (ViewState) -> Value,
     send valueToAction: @escaping (Value) -> ViewAction
   ) -> Binding<Value> {
-    ObservedObject(
-      wrappedValue: ObservedState(
-        initialValue: get(self.state),
-        send: { self.send(valueToAction($0)) }
-      )
+    @ObservedState var val = get(self.state)
+    return .init(
+      get: { [$val] in $val.wrappedValue },
+      set: { [weak self] in self?.send(valueToAction($0)) }
     )
-    .projectedValue
-    .wrappedValue
   }
 
   /// Derives a binding from the store that prevents direct writes to state and instead sends
@@ -748,12 +745,31 @@ public struct StorePublisher<State>: Publisher {
   }
 }
 
-private final class ObservedState<Value>: ObservableObject {
-  @Published var wrappedValue: Value
-  var cancellable: AnyCancellable?
+final private class ValueWrapper<V>: ObservableObject {
+  var value: V {
+    willSet { objectWillChange.send() }
+  }
 
-  init(initialValue: Value, send: @escaping (Value) -> Void) {
-    self.wrappedValue = initialValue
-    self.cancellable = self.$wrappedValue.dropFirst().sink(receiveValue: send)
+  init(_ value: V) {
+    self.value = value
+  }
+}
+
+@propertyWrapper private struct ObservedState<Value>: DynamicProperty {
+  @ObservedObject private var box: ValueWrapper<Value>
+
+  var wrappedValue: Value {
+    get { box.value }
+    nonmutating set { box.value = newValue }
+  }
+
+  var projectedValue: Binding<Value> {
+    .init(
+      get: { wrappedValue },
+      set: { wrappedValue = $0 }
+    )
+  }
+  init(wrappedValue value: Value) {
+    self._box = ObservedObject(wrappedValue: .init(value))
   }
 }


### PR DESCRIPTION
While #1784 manages to work around a longstanding bug in SwiftUI, it unfortunately seems to introduce another one, as found in #1798. In the interest of addressing this regression with a patch release, let's revert things and re-evaluate if the problem is fixable.

@barabashd If you'd like to explore a fix that manages to avoid the crash in #1798, please let us know what you find! As for the original crash you encountered, it was mainly due to what we believe is a bug in Apple's SwiftUI framework. We actually provide a tool to work around this bug, called [`ForEachStore`](https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/foreachstore), which allows you to compose into an array of features in a fashion similar to the ad hoc approach you took in your demo app.

Fixes #1798.