### PR TITLE
Wrap view store binding to avoid reading stale state

### DIFF
--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -466,8 +466,10 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
     get: @escaping (ViewState) -> Value,
     send valueToAction: @escaping (Value) -> ViewAction
   ) -> Binding<Value> {
-    ObservedObject(wrappedValue: self)
+    let base = ObservedObject(wrappedValue: self)
       .projectedValue[get: .init(rawValue: get), send: .init(rawValue: valueToAction)]
+    
+    return Binding(get: { base.wrappedValue }, set: { base.transaction($1).wrappedValue = $0 })
   }
 
   /// Derives a binding from the store that prevents direct writes to state and instead sends


### PR DESCRIPTION
Attempt to fix #1800

The current method creates a binding with a location type of `ObservableObjectLocation`. By wrapping the binding the location type becomes `FunctionalLocation`. Bindings that use `ObservableObjectLocation` seem to have their getter called while evaluating if a views inputs have changed. This doesn't seem to be the case with `FunctionalLocation`. Which kind of makes sense.

I've confirmed this works for #1783 and #1798 as well as checked animations work as expected.

@stephencelis @mbrandonw @tgrapperon maybe you can stress test this a bit to see if there are any unwanted effects. I imagine there is going to be some sort of optimisation that can be applied to bindings that use `ObservableObjectLocation`, but don't really think that's relevant here.