### PR TITLE
Add a UI test for escaped `ViewStore` from `WithViewStore`, and a `Binding` animations test bench

### DIFF
--- a/Examples/Integration/Integration.xcodeproj/project.pbxproj
+++ b/Examples/Integration/Integration.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		CAA1CB1F296DEEAC000665B1 /* ForEachBindingTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA1CB1E296DEEAC000665B1 /* ForEachBindingTestCase.swift */; };
 		E9919D3E296E28C800C8716B /* EscapedWithViewStoreTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9919D3D296E28C800C8716B /* EscapedWithViewStoreTestCase.swift */; };
 		E9919D40296E3EF400C8716B /* EscapedWithViewStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9919D3F296E3EF400C8716B /* EscapedWithViewStoreTests.swift */; };
+		E9919D42296E47A400C8716B /* BindingsAnimationsTestBench.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9919D41296E47A400C8716B /* BindingsAnimationsTestBench.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -42,6 +43,7 @@
 		CAA1CB1E296DEEAC000665B1 /* ForEachBindingTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForEachBindingTestCase.swift; sourceTree = "<group>"; };
 		E9919D3D296E28C800C8716B /* EscapedWithViewStoreTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapedWithViewStoreTestCase.swift; sourceTree = "<group>"; };
 		E9919D3F296E3EF400C8716B /* EscapedWithViewStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapedWithViewStoreTests.swift; sourceTree = "<group>"; };
+		E9919D41296E47A400C8716B /* BindingsAnimationsTestBench.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindingsAnimationsTestBench.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -86,6 +88,7 @@
 		CAA1CAF3296DEE78000665B1 /* Integration */ = {
 			isa = PBXGroup;
 			children = (
+				E9919D41296E47A400C8716B /* BindingsAnimationsTestBench.swift */,
 				E9919D3D296E28C800C8716B /* EscapedWithViewStoreTestCase.swift */,
 				CAA1CB1E296DEEAC000665B1 /* ForEachBindingTestCase.swift */,
 				CA595272296DF46D00B5B695 /* NavigationStackBindingTestCase.swift */,
@@ -226,6 +229,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CAA1CB1F296DEEAC000665B1 /* ForEachBindingTestCase.swift in Sources */,
+				E9919D42296E47A400C8716B /* BindingsAnimationsTestBench.swift in Sources */,
 				CA595273296DF46D00B5B695 /* NavigationStackBindingTestCase.swift in Sources */,
 				E9919D3E296E28C800C8716B /* EscapedWithViewStoreTestCase.swift in Sources */,
 				CAA1CAF5296DEE78000665B1 /* IntegrationApp.swift in Sources */,

--- a/Examples/Integration/Integration.xcodeproj/project.pbxproj
+++ b/Examples/Integration/Integration.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		CAA1CAFC296DEE79000665B1 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CAA1CAFB296DEE79000665B1 /* Preview Assets.xcassets */; };
 		CAA1CB10296DEE79000665B1 /* ForEachBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA1CB0F296DEE79000665B1 /* ForEachBindingTests.swift */; };
 		CAA1CB1F296DEEAC000665B1 /* ForEachBindingTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA1CB1E296DEEAC000665B1 /* ForEachBindingTestCase.swift */; };
+		E9919D3E296E28C800C8716B /* EscapedWithViewStoreTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9919D3D296E28C800C8716B /* EscapedWithViewStoreTestCase.swift */; };
+		E9919D40296E3EF400C8716B /* EscapedWithViewStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9919D3F296E3EF400C8716B /* EscapedWithViewStoreTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,6 +40,8 @@
 		CAA1CB0B296DEE79000665B1 /* IntegrationUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IntegrationUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CAA1CB0F296DEE79000665B1 /* ForEachBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForEachBindingTests.swift; sourceTree = "<group>"; };
 		CAA1CB1E296DEEAC000665B1 /* ForEachBindingTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForEachBindingTestCase.swift; sourceTree = "<group>"; };
+		E9919D3D296E28C800C8716B /* EscapedWithViewStoreTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapedWithViewStoreTestCase.swift; sourceTree = "<group>"; };
+		E9919D3F296E3EF400C8716B /* EscapedWithViewStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapedWithViewStoreTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,9 +86,10 @@
 		CAA1CAF3296DEE78000665B1 /* Integration */ = {
 			isa = PBXGroup;
 			children = (
+				E9919D3D296E28C800C8716B /* EscapedWithViewStoreTestCase.swift */,
 				CAA1CB1E296DEEAC000665B1 /* ForEachBindingTestCase.swift */,
-				CAA1CAF4296DEE78000665B1 /* IntegrationApp.swift */,
 				CA595272296DF46D00B5B695 /* NavigationStackBindingTestCase.swift */,
+				CAA1CAF4296DEE78000665B1 /* IntegrationApp.swift */,
 				CAA1CAF8296DEE79000665B1 /* Assets.xcassets */,
 				CAA1CAFA296DEE79000665B1 /* Preview Content */,
 			);
@@ -102,6 +107,7 @@
 		CAA1CB0E296DEE79000665B1 /* IntegrationUITests */ = {
 			isa = PBXGroup;
 			children = (
+				E9919D3F296E3EF400C8716B /* EscapedWithViewStoreTests.swift */,
 				CAA1CB0F296DEE79000665B1 /* ForEachBindingTests.swift */,
 				CA595274296DF55A00B5B695 /* NavigationStackBindingTests.swift */,
 			);
@@ -221,6 +227,7 @@
 			files = (
 				CAA1CB1F296DEEAC000665B1 /* ForEachBindingTestCase.swift in Sources */,
 				CA595273296DF46D00B5B695 /* NavigationStackBindingTestCase.swift in Sources */,
+				E9919D3E296E28C800C8716B /* EscapedWithViewStoreTestCase.swift in Sources */,
 				CAA1CAF5296DEE78000665B1 /* IntegrationApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -229,6 +236,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E9919D40296E3EF400C8716B /* EscapedWithViewStoreTests.swift in Sources */,
 				CA595275296DF55A00B5B695 /* NavigationStackBindingTests.swift in Sources */,
 				CAA1CB10296DEE79000665B1 /* ForEachBindingTests.swift in Sources */,
 			);

--- a/Examples/Integration/Integration/BindingsAnimationsTestBench.swift
+++ b/Examples/Integration/Integration/BindingsAnimationsTestBench.swift
@@ -113,21 +113,8 @@ struct ContentView: View {
 }
 
 struct AnimatedWithObservation {
-  struct StateBinding: View {
-    @State var flag = false
-
-    var body: some View {
-      ZStack {
-        ContentView(flag: $flag)
-          .animation(mediumAnimation, value: flag)
-        Toggle("", isOn: $flag)
-      }
-    }
-  }
-
   struct ObservedObjectBinding: View {
     @EnvironmentObject var vanillaModel: VanillaModel
-
     var body: some View {
       ZStack {
         ContentView(flag: $vanillaModel.flag)
@@ -139,7 +126,6 @@ struct AnimatedWithObservation {
 
   struct ViewStoreBinding: View {
     @EnvironmentObject var viewStore: ViewStoreOf<BindingsAnimations>
-
     var body: some View {
       ZStack {
         ContentView(flag: viewStore.binding(send: ()))
@@ -151,20 +137,8 @@ struct AnimatedWithObservation {
 }
 
 struct AnimatedFromBinding {
-  struct StateBinding: View {
-    @State var flag = false
-
-    var body: some View {
-      ZStack {
-        ContentView(flag: $flag)
-        Toggle("", isOn: $flag.animation(fastAnimation))
-      }
-    }
-  }
-
   struct ObservedObjectBinding: View {
     @EnvironmentObject var vanillaModel: VanillaModel
-
     var body: some View {
       ZStack {
         ContentView(flag: $vanillaModel.flag)
@@ -175,7 +149,6 @@ struct AnimatedFromBinding {
 
   struct ViewStoreBinding: View {
     @EnvironmentObject var viewStore: ViewStoreOf<BindingsAnimations>
-
     var body: some View {
       ZStack {
         ContentView(flag: viewStore.binding(send: ()))
@@ -186,21 +159,8 @@ struct AnimatedFromBinding {
 }
 
 struct AnimatedFromBindingWithObservation {
-  struct StateBinding: View {
-    @State var flag = false
-
-    var body: some View {
-      ZStack {
-        ContentView(flag: $flag)
-          .animation(mediumAnimation, value: flag)
-        Toggle("", isOn: $flag.animation(fastAnimation))
-      }
-    }
-  }
-
   struct ObservedObjectBinding: View {
     @EnvironmentObject var vanillaModel: VanillaModel
-
     var body: some View {
       ZStack {
         ContentView(flag: $vanillaModel.flag)
@@ -212,7 +172,6 @@ struct AnimatedFromBindingWithObservation {
 
   struct ViewStoreBinding: View {
     @EnvironmentObject var viewStore: ViewStoreOf<BindingsAnimations>
-
     var body: some View {
       ZStack {
         ContentView(flag: viewStore.binding(send: ()))

--- a/Examples/Integration/Integration/BindingsAnimationsTestBench.swift
+++ b/Examples/Integration/Integration/BindingsAnimationsTestBench.swift
@@ -1,0 +1,235 @@
+import ComposableArchitecture
+import SwiftUI
+
+struct BindingsAnimations: ReducerProtocol {
+  func reduce(into state: inout Bool, action: Void) -> EffectTask<Void> {
+    state.toggle()
+    return .none
+  }
+}
+
+final class VanillaModel: ObservableObject {
+  @Published var flag = false
+}
+
+let mediumAnimation = Animation.linear(duration: 0.7)
+let fastAnimation = Animation.linear(duration: 0.2)
+
+struct BindingsAnimationsTestBench: View {
+  let viewStore: ViewStoreOf<BindingsAnimations>
+  let vanillaModel = VanillaModel()
+
+  init(store: StoreOf<BindingsAnimations>) {
+    self.viewStore = ViewStore(store, observe: { $0 })
+  }
+
+  var body: some View {
+    List {
+      Section {
+        SideBySide {
+          AnimatedWithObservation.ObservedObjectBinding()
+        } viewStoreView: {
+          AnimatedWithObservation.ViewStoreBinding()
+        }
+      } header: {
+        Text("Animated with observation.")
+      } footer: {
+        Text("Should animate with the \"medium\" animation.")
+      }
+
+      Section {
+        SideBySide {
+          AnimatedFromBinding.ObservedObjectBinding()
+        } viewStoreView: {
+          AnimatedFromBinding.ViewStoreBinding()
+        }
+      } header: {
+        Text("Animated from binding.")
+      } footer: {
+        Text("Should animate with the \"fast\" animation.")
+      }
+
+      Section {
+        SideBySide {
+          AnimatedFromBindingWithObservation.ObservedObjectBinding()
+        } viewStoreView: {
+          AnimatedFromBindingWithObservation.ViewStoreBinding()
+        }
+      } header: {
+        Text("Animated from binding with observation.")
+      } footer: {
+        Text("Should animate with the \"medium\" animation.")
+      }
+    }
+    .headerProminence(.increased)
+    .environmentObject(viewStore)
+    .environmentObject(vanillaModel)
+  }
+}
+
+struct SideBySide<ObservedObjectView: View, ViewStoreView: View>: View {
+  let observedObjectView: ObservedObjectView
+  let viewStoreView: ViewStoreView
+  init(
+    @ViewBuilder observedObjectView: () -> ObservedObjectView,
+    @ViewBuilder viewStoreView: () -> ViewStoreView
+  ) {
+    self.observedObjectView = observedObjectView()
+    self.viewStoreView = viewStoreView()
+  }
+  var body: some View {
+    Grid {
+      GridRow {
+        observedObjectView
+          .frame(width: 100, height: 100)
+        viewStoreView
+          .frame(width: 100, height: 100)
+      }
+      .labelsHidden()
+      GridRow {
+        Text("@ObservedObject")
+          .fixedSize()
+        Text("ViewStore")
+      }
+      .font(.footnote.bold())
+      .monospaced()
+    }
+    .frame(maxWidth: .infinity)
+  }
+}
+
+struct ContentView: View {
+  @Binding var flag: Bool
+
+  var body: some View {
+    ZStack {
+      Circle()
+        .fill(.red.opacity(0.25))
+      Circle()
+        .strokeBorder(.red.opacity(0.5), lineWidth: 2)
+    }
+    .frame(width: flag ? 100 : 75)
+  }
+}
+
+struct AnimatedWithObservation {
+  struct StateBinding: View {
+    @State var flag = false
+
+    var body: some View {
+      ZStack {
+        ContentView(flag: $flag)
+          .animation(mediumAnimation, value: flag)
+        Toggle("", isOn: $flag)
+      }
+    }
+  }
+
+  struct ObservedObjectBinding: View {
+    @EnvironmentObject var vanillaModel: VanillaModel
+
+    var body: some View {
+      ZStack {
+        ContentView(flag: $vanillaModel.flag)
+          .animation(mediumAnimation, value: vanillaModel.flag)
+        Toggle("", isOn: $vanillaModel.flag)
+      }
+    }
+  }
+
+  struct ViewStoreBinding: View {
+    @EnvironmentObject var viewStore: ViewStoreOf<BindingsAnimations>
+
+    var body: some View {
+      ZStack {
+        ContentView(flag: viewStore.binding(send: ()))
+          .animation(mediumAnimation, value: viewStore.state)
+        Toggle("", isOn: viewStore.binding(send: ()))
+      }
+    }
+  }
+}
+
+struct AnimatedFromBinding {
+  struct StateBinding: View {
+    @State var flag = false
+
+    var body: some View {
+      ZStack {
+        ContentView(flag: $flag)
+        Toggle("", isOn: $flag.animation(fastAnimation))
+      }
+    }
+  }
+
+  struct ObservedObjectBinding: View {
+    @EnvironmentObject var vanillaModel: VanillaModel
+
+    var body: some View {
+      ZStack {
+        ContentView(flag: $vanillaModel.flag)
+        Toggle("", isOn: $vanillaModel.flag.animation(fastAnimation))
+      }
+    }
+  }
+
+  struct ViewStoreBinding: View {
+    @EnvironmentObject var viewStore: ViewStoreOf<BindingsAnimations>
+
+    var body: some View {
+      ZStack {
+        ContentView(flag: viewStore.binding(send: ()))
+        Toggle("", isOn: viewStore.binding(send: ()).animation(fastAnimation))
+      }
+    }
+  }
+}
+
+struct AnimatedFromBindingWithObservation {
+  struct StateBinding: View {
+    @State var flag = false
+
+    var body: some View {
+      ZStack {
+        ContentView(flag: $flag)
+          .animation(mediumAnimation, value: flag)
+        Toggle("", isOn: $flag.animation(fastAnimation))
+      }
+    }
+  }
+
+  struct ObservedObjectBinding: View {
+    @EnvironmentObject var vanillaModel: VanillaModel
+
+    var body: some View {
+      ZStack {
+        ContentView(flag: $vanillaModel.flag)
+          .animation(mediumAnimation, value: vanillaModel.flag)
+        Toggle("", isOn: $vanillaModel.flag.animation(fastAnimation))
+      }
+    }
+  }
+
+  struct ViewStoreBinding: View {
+    @EnvironmentObject var viewStore: ViewStoreOf<BindingsAnimations>
+
+    var body: some View {
+      ZStack {
+        ContentView(flag: viewStore.binding(send: ()))
+          .animation(mediumAnimation, value: viewStore.state)
+        Toggle("", isOn: viewStore.binding(send: ()).animation(fastAnimation))
+      }
+    }
+  }
+}
+
+struct BindingsAnimationsTestBench_Previews: PreviewProvider {
+  static var previews: some View {
+    BindingsAnimationsTestBench(
+      store: .init(
+        initialState: false,
+        reducer: BindingsAnimations()
+      )
+    )
+  }
+}

--- a/Examples/Integration/Integration/EscapedWithViewStoreTestCase.swift
+++ b/Examples/Integration/Integration/EscapedWithViewStoreTestCase.swift
@@ -1,0 +1,47 @@
+import ComposableArchitecture
+import SwiftUI
+
+struct EscapedWithViewStoreTestCase: ReducerProtocol {
+  enum Action: Equatable, Sendable {
+    case incr
+    case decr
+  }
+
+  func reduce(into state: inout Int, action: Action) -> EffectTask<Action> {
+    switch action {
+    case .incr:
+      state += 1
+      return .none
+    case .decr:
+      state -= 1
+      return .none
+    }
+  }
+}
+
+struct EscapedWithViewStoreTestCaseView: View {
+  let store: StoreOf<EscapedWithViewStoreTestCase>
+
+  var body: some View {
+    VStack {
+      WithViewStore(store, observe: { $0 }) { viewStore in
+        GeometryReader { proxy in
+          Text("\(viewStore.state)")
+            .accessibilityValue("\(viewStore.state)")
+            .accessibilityLabel("EscapedLabel")
+        }
+        Button("Button", action: { viewStore.send(.incr) })
+        Text("\(viewStore.state)")
+          .accessibilityValue("\(viewStore.state)")
+          .accessibilityLabel("Label")
+        Stepper {
+          Text("Stepper")
+        } onIncrement: {
+          viewStore.send(.incr)
+        } onDecrement: {
+          viewStore.send(.decr)
+        }
+      }
+    }
+  }
+}

--- a/Examples/Integration/Integration/IntegrationApp.swift
+++ b/Examples/Integration/Integration/IntegrationApp.swift
@@ -37,6 +37,15 @@ struct IntegrationApp: App {
               )
             )
           }
+          
+          NavigationLink("Binding Animations Test Bench") {
+            BindingsAnimationsTestBench(
+              store: Store(
+                initialState: false,
+                reducer: BindingsAnimations()
+              )
+            )
+          }
         }
       }
     }

--- a/Examples/Integration/Integration/IntegrationApp.swift
+++ b/Examples/Integration/Integration/IntegrationApp.swift
@@ -9,6 +9,14 @@ struct IntegrationApp: App {
     WindowGroup {
       NavigationStack {
         List {
+          NavigationLink("EscapedWithViewStoreTestCase") {
+            EscapedWithViewStoreTestCaseView(
+              store: Store(
+                initialState: 10,
+                reducer: EscapedWithViewStoreTestCase()
+              )
+            )
+          }
           NavigationLink("ForEachBindingTestCase") {
             ForEachBindingTestCaseView(
               store: Store(

--- a/Examples/Integration/IntegrationUITests/EscapedWithViewStoreTests.swift
+++ b/Examples/Integration/IntegrationUITests/EscapedWithViewStoreTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+
+@MainActor
+final class EscapedWithViewStoreTests: XCTestCase {
+
+  override func setUpWithError() throws {
+    continueAfterFailure = false
+  }
+
+  func testExample() async throws {
+    let app = XCUIApplication()
+    app.launch()
+
+    app.collectionViews.buttons["EscapedWithViewStoreTestCase"].tap()
+
+    XCTAssertEqual(app.staticTexts["Label"].value as? String, "10")
+    XCTAssertEqual(app.staticTexts["EscapedLabel"].value as? String, "10")
+
+    app.buttons["Button"].tap()
+    
+    XCTAssertEqual(app.staticTexts["Label"].value as? String, "11")
+    XCTAssertEqual(app.staticTexts["EscapedLabel"].value as? String, "11")
+    
+    let stepper = app.steppers["Stepper"]
+    
+    stepper.buttons["Increment"].tap()
+    stepper.buttons["Increment"].tap()
+    stepper.buttons["Increment"].tap()
+    stepper.buttons["Increment"].tap()
+
+    XCTAssertEqual(app.staticTexts["Label"].value as? String, "15")
+    XCTAssertEqual(app.staticTexts["EscapedLabel"].value as? String, "15")
+    
+    stepper.buttons["Decrement"].tap()
+    stepper.buttons["Decrement"].tap()
+    stepper.buttons["Decrement"].tap()
+    
+    XCTAssertEqual(app.staticTexts["Label"].value as? String, "12")
+    XCTAssertEqual(app.staticTexts["EscapedLabel"].value as? String, "12")
+  }
+}


### PR DESCRIPTION
This adds a test case for `ViewStore` from `WithViewStore` being escaped. We're taking measures to propagate the invalidation, but this should assert that they're still effective if `WithViewStore` implementation changes.

The test checks simultaneously a capture by a `GeometryReader`, and by some `Stepper`'s `onIncrement`. Both issues were solved by the same solution, but it is not exactly clear why the `Stepper`'s escape was causing an issue, so I feel it is better to check both. Because they share the same fix, they're tested in the same UITest though. I've also checked that each would spot a regression by reverting the `ViewStore` copy in `WithViewStore`.

I've also added a `Binding` animations test bench. This is not checked automatically, but this puts side to side binding animations from a Vanilla `ObservedObject` and from a `ViewStore`. Various configurations are presented, so one can quickly check if the binding is animating with the same animations as the vanilla model.

https://user-images.githubusercontent.com/35562418/211711186-89788f1b-1fc2-4899-891d-0562fd9f8403.mp4

It is maybe possible to programmatically check that things are indeed animating, but I didn't investigate farther yet. This `Bindings` test bench can be removed from the PR if you prefer this keep this target for automated tests only. Let me know what you think!