### PR TITLE
Add missing deprecated

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -663,6 +663,7 @@ extension EffectPublisher {
 
 @available(
   *,
+  deprecated,
   message:
     """
     'Effect' has been deprecated in favor of 'EffectTask' when 'Failure == Never', or 'EffectPublisher<Output, Failure>' in general.


### PR DESCRIPTION
According to "[Road to 1.0](https://github.com/pointfreeco/swift-composable-architecture/discussions/1477)", missing `deprecated` on https://github.com/pointfreeco/swift-composable-architecture/pull/1788 ?