### PR TITLE
Add support for SwiftUI withTransaction API

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Animation.swift
+++ b/Sources/ComposableArchitecture/Effects/Animation.swift
@@ -15,28 +15,7 @@ extension EffectPublisher {
   /// - Parameter animation: An animation.
   /// - Returns: A publisher.
   public func animation(_ animation: Animation? = .default) -> Self {
-    switch self.operation {
-    case .none:
-      return .none
-    case let .publisher(publisher):
-      return Self(
-        operation: .publisher(
-          TransactionPublisher(upstream: publisher, transaction: Transaction(animation: animation)).eraseToAnyPublisher()
-        )
-      )
-    case let .run(priority, operation):
-      return Self(
-        operation: .run(priority) { send in
-          await operation(
-            Send { value in
-              withTransaction(Transaction(animation: animation)) {
-                send(value)
-              }
-            }
-          )
-        }
-      )
-    }
+    self.transaction(Transaction(animation: animation))
   }
     
   /// Wraps the emission of each element with SwiftUI's `withTransaction`.


### PR DESCRIPTION
This adds EffectTask support to perform block with SwiftUI `Transaction`. As all animation stuff happens using `Transaction`, and Animation is a concrete example of Transaction  it seems reasonable to support that, even if it has few use cases.

Changes: Instead of creating another function, I generalized it for transactions and in `.animation(_ animation: Animation? = .default)` function calls it under the hood.

Example from SwiftUI Q&A Sessions

> Is there way to show `.fullScreenCover` without animation? I don't want to user see animated cover show from bottom to top. because it still see underline view in a short time. 

> You can create a `Transaction` value, set its `disablesAnimations` property to true, then set the binding that presents the fullScreenCover inside a `withTransaction` block. Something like:
```
var t = Transaction()
t.disablesAnimations = true
withTransaction(t) {
    isCoverPresented = true
}
``` 

