### PR TITLE
Mark popover as unavailable in watchOS (navigation)

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/Presentation.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Presentation.swift
@@ -340,6 +340,7 @@ extension View {
   }
 
   @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
   public func popover<State, Action, Content: View>(
     store: Store<PresentationState<State>, PresentationAction<State, Action>>,
     attachmentAnchor: PopoverAttachmentAnchor = .rect(.bounds),
@@ -357,6 +358,7 @@ extension View {
   }
 
   @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
   public func popover<State, Action, DestinationState, DestinationAction, Content: View>(
     store: Store<PresentationState<State>, PresentationAction<State, Action>>,
     state toDestinationState: @escaping (State) -> DestinationState?,


### PR DESCRIPTION
Really looking forward to the new navigation APIs in TCA and started experimenting with this branch.  I recognize this branch is a work in progress, but currently it doesn't compile under watchOS due to the lack of popover APIs in watchOS.  This PR correctly marks the popover APIs as unavailable in watchOS to address the issue.
