### PR TITLE
Add ability to specify a keypath for the enum to ifCaseLet

### DIFF
--- a/Tests/ComposableArchitectureTests/IfCaseLetReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/IfCaseLetReducerTests.swift
@@ -70,4 +70,80 @@ final class IfCaseLetReducerTests: XCTestCase {
       await store.send(.success(1))
     }
   #endif
+
+  func testChildActionWithKeyPath() async {
+    struct SomeError: Error, Equatable {}
+
+    struct State: Equatable {
+      var someEnum: Result<Int, SomeError>
+    }
+
+    let store = TestStore(
+      initialState: .init(someEnum: Result.success(0)),
+      reducer: Reduce<State, Result<Int, SomeError>> { state, action in
+          .none
+      }
+      .ifCaseLet(\.someEnum, case: /Result.success, action: /Result.success) {
+        Reduce { state, action in
+          state = action
+          return state < 0 ? .run { await $0(0) } : .none
+        }
+      }
+    )
+
+    await store.send(.success(1)) {
+      $0.someEnum = .success(1)
+    }
+    await store.send(.failure(SomeError()))
+    await store.send(.success(-1)) {
+      $0.someEnum = .success(-1)
+    }
+    await store.receive(.success(0)) {
+      $0.someEnum = .success(0)
+    }
+  }
+
+  #if DEBUG
+    func testNilChildWithKeyPath() async {
+      struct SomeError: Error, Equatable {}
+
+      struct State: Equatable {
+        var someEnum: Result<Int, SomeError>
+      }
+
+      let store = TestStore(
+        initialState: .init(someEnum: Result.failure(SomeError())),
+        reducer: EmptyReducer<State, Result<Int, SomeError>>()
+          .ifCaseLet(\.someEnum, case: /Result.success, action: /Result.success) {}
+      )
+
+      XCTExpectFailure {
+        $0.compactDescription == """
+          An "ifCaseLet" at "\(#fileID):\(#line - 5)" received a child action when child state was \
+          set to a different case. …
+
+            Action:
+              Result.success
+            State:
+              IfCaseLetReducerTests.State
+
+          This is generally considered an application logic error, and can happen for a few reasons:
+
+          • A parent reducer set "IfCaseLetReducerTests.State" to a different case before this reducer ran. This reducer \
+          must run before any other reducer sets child state to a different case. This ensures that \
+          child reducers can handle their actions while their state is still available.
+
+          • An in-flight effect emitted this action when child state was unavailable. While it may \
+          be perfectly reasonable to ignore this action, consider canceling the associated effect \
+          before child state changes to another case, especially if it is a long-living effect.
+
+          • This action was sent to the store while state was another case. Make sure that actions \
+          for this reducer can only be sent from a view store when state is set to the appropriate \
+          case. In SwiftUI applications, use "SwitchStore".
+          """
+      }
+
+      await store.send(.success(1))
+    }
+  #endif
 }


### PR DESCRIPTION
This extends the `_IfCaseLetReducer` and the `.ifCaseLetFunction` on the `ReducerProtocol` with the option to specify a KeyPath to a property containing the enum to be checked instead of requiring the whole State to be an enum.

### Reasoning:

I recently started working with TCA on a new project and I encountered it multiple times that we might want to use a SwitchStore to handle multiple mutually exclusive children, but also might have additional state properties we might want to handle.

```
struct SomeFeature: ReducerProtocol {
  struct State: Equatable {
    enum SomeEnum: Equatable {
      case someChild(SomeChild.State)
      case someOtherChild(SomeOtherChild.State)
    }

    var someLocalState: String
    var someChildStateEnum: SomeEnum
  }

  enum Action {
    case someChild(SomeChild.Action)
    case someOtherChild(SomeOtherChild.Action)
  }

  var body: some ReducerProtocol<State, Action> {
    ???
  }
}
```

The way I understand this there are currently two ways to handle this. You could do something like this:

```
var body: some ReducerProtocol<State, Action> {
    Scope(state: \.someChildStateEnum, action: /.self) {
      EmptyReducer()
        .ifCaseLet(/State.SomeEnum.someChild, action: /Action.someChild) {
          SomeChild()
        }
        .ifCaseLet(/State.SomeEnum.someOtherChild, action: /Action.someOtherChild) {
          SomeOtherChild()
        }
    }
    Reduce({ state, action in
      return .none
    })
}
```

Having the extra `Scope` and `EmptyReducer` here (It would also be possible to nest multiple `Scope`) does not feel very clean, might be hard to understand and reintroduces the ordering issue that the function is supposed to avoid.

It is also possible to extract the `SwitchStore` part of the view into an extra Feature with its own reducer and model that reducers state to be an enum. But sometimes that might feel like unnecessary extra work to just work around the `ifCaseLet` limitation, if the parent now only hold very little state and logic.

With this change it would be possible to simply use the `ifCaseLet` like in a pure `SwitchStore` view.

```
var body: some ReducerProtocol<State, Action> {
  Reduce({ state, action in
    return .none
  })
  .ifCaseLet(\.someChildStateEnum, case: /State.SomeEnum.someChild, action: /Action.someChild) {
    SomeChild()
  }
  .ifCaseLet(\.someChildStateEnum, case: /State.SomeEnum.someOtherChild, action: /Action.someOtherChild) {
    SomeOtherChild()
  }
}
```

I also saw questions regarding similar examples in the discussions, but those were often related to navigation or mentioned the first solution as a workaround. 

I think this change would make using `SwitchStore` and `ifCaseLet` more ergonomic and should hopefully have no downsides. The only issue might be that it modifies the theoretically public `_IfCaseLetReducer` so it is a breaking change. Alternatively it would be possible to introduce something like a `_IfCaseLetPullbackReducer` to avoid modifying the existing Type, but since they model pretty much functionality I thought it would be better to integrate them.