### PR TITLE
Conditionally Conform BindableState to Sendable.

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -91,6 +91,8 @@ extension BindableState: CustomDebugStringConvertible where Value: CustomDebugSt
   }
 }
 
+extension BindableState: Sendable where Value: Sendable {}
+
 /// An action type that exposes a `binding` case that holds a ``BindingAction``.
 ///
 /// Used in conjunction with ``BindableState`` to safely eliminate the boilerplate typically


### PR DESCRIPTION
This PR makes `BindableState` conditionally conform to `Sendable`, as was done in #1790 but was subsequently lost when that PR was reverted. I can add any other desired conformances as well.