### PR TITLE
Add `prepareDependencies` to `Store.init`

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
@@ -7,13 +7,14 @@ import XCTest
 @MainActor
 final class AnimationTests: XCTestCase {
   func testRainbow() async {
+    let clock = TestClock()
+
     let store = TestStore(
       initialState: Animations.State(),
       reducer: Animations()
-    )
-
-    let clock = TestClock()
-    store.dependencies.continuousClock = clock
+    ) {
+      $0.continuousClock = clock
+    }
 
     await store.send(.rainbowButtonTapped)
     await store.receive(.setColor(.red)) {
@@ -59,13 +60,14 @@ final class AnimationTests: XCTestCase {
   }
 
   func testReset() async {
+    let clock = TestClock()
+
     let store = TestStore(
       initialState: Animations.State(),
       reducer: Animations()
-    )
-
-    let clock = TestClock()
-    store.dependencies.continuousClock = clock
+    ) {
+      $0.continuousClock = clock
+    }
 
     await store.send(.rainbowButtonTapped)
     await store.receive(.setColor(.red)) {

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-BasicsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-BasicsTests.swift
@@ -9,9 +9,9 @@ final class EffectsBasicsTests: XCTestCase {
     let store = TestStore(
       initialState: EffectsBasics.State(),
       reducer: EffectsBasics()
-    )
-
-    store.dependencies.continuousClock = ImmediateClock()
+    ) {
+      $0.continuousClock = ImmediateClock()
+    }
 
     await store.send(.incrementButtonTapped) {
       $0.count = 1
@@ -25,10 +25,10 @@ final class EffectsBasicsTests: XCTestCase {
     let store = TestStore(
       initialState: EffectsBasics.State(),
       reducer: EffectsBasics()
-    )
-
-    store.dependencies.factClient.fetch = { "\($0) is a good number Brent" }
-    store.dependencies.continuousClock = ImmediateClock()
+    ) {
+      $0.factClient.fetch = { "\($0) is a good number Brent" }
+      $0.continuousClock = ImmediateClock()
+    }
 
     await store.send(.incrementButtonTapped) {
       $0.count = 1
@@ -46,9 +46,9 @@ final class EffectsBasicsTests: XCTestCase {
     let store = TestStore(
       initialState: EffectsBasics.State(),
       reducer: EffectsBasics()
-    )
-
-    store.dependencies.continuousClock = ImmediateClock()
+    ) {
+      $0.continuousClock = ImmediateClock()
+    }
 
     await store.send(.decrementButtonTapped) {
       $0.count = -1
@@ -62,9 +62,9 @@ final class EffectsBasicsTests: XCTestCase {
     let store = TestStore(
       initialState: EffectsBasics.State(),
       reducer: EffectsBasics()
-    )
-
-    store.dependencies.continuousClock = TestClock()
+    ) {
+      $0.continuousClock = TestClock()
+    }
 
     await store.send(.decrementButtonTapped) {
       $0.count = -1

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-CancellationTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-CancellationTests.swift
@@ -9,9 +9,9 @@ final class EffectsCancellationTests: XCTestCase {
     let store = TestStore(
       initialState: EffectsCancellation.State(),
       reducer: EffectsCancellation()
-    )
-
-    store.dependencies.factClient.fetch = { "\($0) is a good number Brent" }
+    ) {
+      $0.factClient.fetch = { "\($0) is a good number Brent" }
+    }
 
     await store.send(.stepperChanged(1)) {
       $0.count = 1
@@ -33,9 +33,9 @@ final class EffectsCancellationTests: XCTestCase {
     let store = TestStore(
       initialState: EffectsCancellation.State(),
       reducer: EffectsCancellation()
-    )
-
-    store.dependencies.factClient.fetch = { _ in throw FactError() }
+    ) {
+      $0.factClient.fetch = { _ in throw FactError() }
+    }
 
     await store.send(.factButtonTapped) {
       $0.isFactRequestInFlight = true
@@ -55,11 +55,11 @@ final class EffectsCancellationTests: XCTestCase {
     let store = TestStore(
       initialState: EffectsCancellation.State(),
       reducer: EffectsCancellation()
-    )
-
-    store.dependencies.factClient.fetch = {
-      try await Task.sleep(nanoseconds: NSEC_PER_SEC)
-      return "\($0) is a good number Brent"
+    ) {
+      $0.factClient.fetch = {
+        try await Task.sleep(nanoseconds: NSEC_PER_SEC)
+        return "\($0) is a good number Brent"
+      }
     }
 
     await store.send(.factButtonTapped) {
@@ -74,11 +74,11 @@ final class EffectsCancellationTests: XCTestCase {
     let store = TestStore(
       initialState: EffectsCancellation.State(),
       reducer: EffectsCancellation()
-    )
-
-    store.dependencies.factClient.fetch = {
-      try await Task.sleep(nanoseconds: NSEC_PER_SEC)
-      return "\($0) is a good number Brent"
+    ) {
+      $0.factClient.fetch = {
+        try await Task.sleep(nanoseconds: NSEC_PER_SEC)
+        return "\($0) is a good number Brent"
+      }
     }
 
     await store.send(.factButtonTapped) {

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
@@ -11,9 +11,9 @@ final class LongLivingEffectsTests: XCTestCase {
     let store = TestStore(
       initialState: LongLivingEffects.State(),
       reducer: LongLivingEffects()
-    )
-
-    store.dependencies.screenshots = { screenshots }
+    ) {
+      $0.screenshots = { screenshots }
+    }
 
     let task = await store.send(.task)
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-RefreshableTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-RefreshableTests.swift
@@ -9,10 +9,10 @@ final class RefreshableTests: XCTestCase {
     let store = TestStore(
       initialState: Refreshable.State(),
       reducer: Refreshable()
-    )
-
-    store.dependencies.factClient.fetch = { "\($0) is a good number." }
-    store.dependencies.continuousClock = ImmediateClock()
+    ) {
+      $0.factClient.fetch = { "\($0) is a good number." }
+      $0.continuousClock = ImmediateClock()
+    }
 
     await store.send(.incrementButtonTapped) {
       $0.count = 1
@@ -24,14 +24,15 @@ final class RefreshableTests: XCTestCase {
   }
 
   func testUnhappyPath() async {
+    struct FactError: Equatable, Error {}
+
     let store = TestStore(
       initialState: Refreshable.State(),
       reducer: Refreshable()
-    )
-
-    struct FactError: Equatable, Error {}
-    store.dependencies.factClient.fetch = { _ in throw FactError() }
-    store.dependencies.continuousClock = ImmediateClock()
+    ) {
+      $0.factClient.fetch = { _ in throw FactError() }
+      $0.continuousClock = ImmediateClock()
+    }
 
     await store.send(.incrementButtonTapped) {
       $0.count = 1
@@ -44,13 +45,13 @@ final class RefreshableTests: XCTestCase {
     let store = TestStore(
       initialState: Refreshable.State(),
       reducer: Refreshable()
-    )
-
-    store.dependencies.factClient.fetch = {
-      try await Task.sleep(nanoseconds: NSEC_PER_SEC)
-      return "\($0) is a good number."
+    ) {
+      $0.factClient.fetch = {
+        try await Task.sleep(nanoseconds: NSEC_PER_SEC)
+        return "\($0) is a good number."
+      }
+      $0.continuousClock = ImmediateClock()
     }
-    store.dependencies.continuousClock = ImmediateClock()
 
     await store.send(.incrementButtonTapped) {
       $0.count = 1

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-TimersTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-TimersTests.swift
@@ -6,13 +6,14 @@ import XCTest
 @MainActor
 final class TimersTests: XCTestCase {
   func testStart() async {
+    let clock = TestClock()
+
     let store = TestStore(
       initialState: Timers.State(),
       reducer: Timers()
-    )
-
-    let clock = TestClock()
-    store.dependencies.continuousClock = clock
+    ) {
+      $0.continuousClock = clock
+    }
 
     await store.send(.toggleTimerButtonTapped) {
       $0.isTimerActive = true

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-LifecycleTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-LifecycleTests.swift
@@ -6,13 +6,14 @@ import XCTest
 @MainActor
 final class LifecycleTests: XCTestCase {
   func testLifecycle() async {
+    let clock = TestClock()
+
     let store = TestStore(
       initialState: LifecycleDemo.State(),
       reducer: LifecycleDemo()
-    )
-
-    let clock = TestClock()
-    store.dependencies.continuousClock = clock
+    ) {
+      $0.continuousClock = clock
+    }
 
     await store.send(.toggleTimerButtonTapped) {
       $0.count = 0

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-RecursionTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-RecursionTests.swift
@@ -9,9 +9,9 @@ final class RecursionTests: XCTestCase {
     let store = TestStore(
       initialState: Nested.State(id: UUID()),
       reducer: Nested()
-    )
-
-    store.dependencies.uuid = .incrementing
+    ) {
+      $0.uuid = .incrementing
+    }
 
     let id0 = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
     let id1 = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
@@ -15,9 +15,9 @@ final class ReusableComponentsDownloadComponentTests: XCTestCase {
         url: URL(string: "https://www.pointfree.co")!
       ),
       reducer: DownloadComponent()
-    )
-
-    store.dependencies.downloadClient.download = { _ in self.download.stream }
+    ) {
+      $0.downloadClient.download = { _ in self.download.stream }
+    }
 
     await store.send(.buttonTapped) {
       $0.mode = .startingToDownload
@@ -43,9 +43,9 @@ final class ReusableComponentsDownloadComponentTests: XCTestCase {
         url: URL(string: "https://www.pointfree.co")!
       ),
       reducer: DownloadComponent()
-    )
-
-    store.dependencies.downloadClient.download = { _ in self.download.stream }
+    ) {
+      $0.downloadClient.download = { _ in self.download.stream }
+    }
 
     await store.send(.buttonTapped) {
       $0.mode = .startingToDownload
@@ -83,9 +83,9 @@ final class ReusableComponentsDownloadComponentTests: XCTestCase {
         url: URL(string: "https://www.pointfree.co")!
       ),
       reducer: DownloadComponent()
-    )
-
-    store.dependencies.downloadClient.download = { _ in self.download.stream }
+    ) {
+      $0.downloadClient.download = { _ in self.download.stream }
+    }
 
     let task = await store.send(.buttonTapped) {
       $0.mode = .startingToDownload
@@ -122,9 +122,9 @@ final class ReusableComponentsDownloadComponentTests: XCTestCase {
         url: URL(string: "https://www.pointfree.co")!
       ),
       reducer: DownloadComponent()
-    )
-
-    store.dependencies.downloadClient.download = { _ in self.download.stream }
+    ) {
+      $0.downloadClient.download = { _ in self.download.stream }
+    }
 
     await store.send(.buttonTapped) {
       $0.alert = AlertState {

--- a/Examples/CaseStudies/tvOSCaseStudiesTests/FocusTests.swift
+++ b/Examples/CaseStudies/tvOSCaseStudiesTests/FocusTests.swift
@@ -9,9 +9,9 @@ final class tvOSCaseStudiesTests: XCTestCase {
     let store = TestStore(
       initialState: Focus.State(currentFocus: 1),
       reducer: Focus()
-    )
-
-    store.dependencies.withRandomNumberGenerator = .init(LCRNG())
+    ) {
+      $0.withRandomNumberGenerator = .init(LCRNG())
+    }
 
     await store.send(.randomButtonClicked)
     await store.send(.randomButtonClicked) {

--- a/Examples/Search/SearchTests/SearchTests.swift
+++ b/Examples/Search/SearchTests/SearchTests.swift
@@ -9,9 +9,9 @@ final class SearchTests: XCTestCase {
     let store = TestStore(
       initialState: Search.State(),
       reducer: Search()
-    )
-
-    store.dependencies.weatherClient.search = { _ in .mock }
+    ) {
+      $0.weatherClient.search = { _ in .mock }
+    }
 
     await store.send(.searchQueryChanged("S")) {
       $0.searchQuery = "S"
@@ -30,9 +30,9 @@ final class SearchTests: XCTestCase {
     let store = TestStore(
       initialState: Search.State(),
       reducer: Search()
-    )
-
-    store.dependencies.weatherClient.search = { _ in throw SomethingWentWrong() }
+    ) {
+      $0.weatherClient.search = { _ in throw SomethingWentWrong() }
+    }
 
     await store.send(.searchQueryChanged("S")) {
       $0.searchQuery = "S"
@@ -45,9 +45,9 @@ final class SearchTests: XCTestCase {
     let store = TestStore(
       initialState: Search.State(),
       reducer: Search()
-    )
-
-    store.dependencies.weatherClient.search = { _ in .mock }
+    ) {
+      $0.weatherClient.search = { _ in .mock }
+    }
 
     let searchQueryChanged = await store.send(.searchQueryChanged("S")) {
       $0.searchQuery = "S"
@@ -73,9 +73,9 @@ final class SearchTests: XCTestCase {
     let store = TestStore(
       initialState: Search.State(results: results),
       reducer: Search()
-    )
-
-    store.dependencies.weatherClient.forecast = { _ in .mock }
+    ) {
+      $0.weatherClient.forecast = { _ in .mock }
+    }
 
     await store.send(.searchResultTapped(specialResult)) {
       $0.resultForecastRequestInFlight = specialResult
@@ -123,15 +123,16 @@ final class SearchTests: XCTestCase {
     var results = GeocodingSearch.mock.results
     results.append(specialResult)
 
+    let clock = TestClock()
+
     let store = TestStore(
       initialState: Search.State(results: results),
       reducer: Search()
-    )
-
-    let clock = TestClock()
-    store.dependencies.weatherClient.forecast = { _ in
-      try await clock.sleep(for: .seconds(0))
-      return .mock
+    ) {
+      $0.weatherClient.forecast = { _ in
+        try await clock.sleep(for: .seconds(0))
+        return .mock
+      }
     }
 
     await store.send(.searchResultTapped(results.first!)) {
@@ -178,9 +179,9 @@ final class SearchTests: XCTestCase {
     let store = TestStore(
       initialState: Search.State(results: results),
       reducer: Search()
-    )
-
-    store.dependencies.weatherClient.forecast = { _ in throw SomethingWentWrong() }
+    ) {
+      $0.weatherClient.forecast = { _ in throw SomethingWentWrong() }
+    }
 
     await store.send(.searchResultTapped(results.first!)) {
       $0.resultForecastRequestInFlight = results.first!

--- a/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
+++ b/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
@@ -11,9 +11,9 @@ final class SpeechRecognitionTests: XCTestCase {
     let store = TestStore(
       initialState: SpeechRecognition.State(),
       reducer: SpeechRecognition()
-    )
-
-    store.dependencies.speechClient.requestAuthorization = { .denied }
+    ) {
+      $0.speechClient.requestAuthorization = { .denied }
+    }
 
     await store.send(.recordButtonTapped) {
       $0.isRecording = true
@@ -34,9 +34,9 @@ final class SpeechRecognitionTests: XCTestCase {
     let store = TestStore(
       initialState: SpeechRecognition.State(),
       reducer: SpeechRecognition()
-    )
-
-    store.dependencies.speechClient.requestAuthorization = { .restricted }
+    ) {
+      $0.speechClient.requestAuthorization = { .restricted }
+    }
 
     await store.send(.recordButtonTapped) {
       $0.isRecording = true
@@ -51,11 +51,11 @@ final class SpeechRecognitionTests: XCTestCase {
     let store = TestStore(
       initialState: SpeechRecognition.State(),
       reducer: SpeechRecognition()
-    )
-
-    store.dependencies.speechClient.finishTask = { self.recognitionTask.continuation.finish() }
-    store.dependencies.speechClient.startTask = { _ in self.recognitionTask.stream }
-    store.dependencies.speechClient.requestAuthorization = { .authorized }
+    ) {
+      $0.speechClient.finishTask = { self.recognitionTask.continuation.finish() }
+      $0.speechClient.startTask = { _ in self.recognitionTask.stream }
+      $0.speechClient.requestAuthorization = { .authorized }
+    }
 
     let firstResult = SpeechRecognitionResult(
       bestTranscription: Transcription(
@@ -95,10 +95,10 @@ final class SpeechRecognitionTests: XCTestCase {
     let store = TestStore(
       initialState: SpeechRecognition.State(),
       reducer: SpeechRecognition()
-    )
-
-    store.dependencies.speechClient.startTask = { _ in self.recognitionTask.stream }
-    store.dependencies.speechClient.requestAuthorization = { .authorized }
+    ) {
+      $0.speechClient.startTask = { _ in self.recognitionTask.stream }
+      $0.speechClient.requestAuthorization = { .authorized }
+    }
 
     await store.send(.recordButtonTapped) {
       $0.isRecording = true
@@ -116,10 +116,10 @@ final class SpeechRecognitionTests: XCTestCase {
     let store = TestStore(
       initialState: SpeechRecognition.State(),
       reducer: SpeechRecognition()
-    )
-
-    store.dependencies.speechClient.startTask = { _ in self.recognitionTask.stream }
-    store.dependencies.speechClient.requestAuthorization = { .authorized }
+    ) {
+      $0.speechClient.startTask = { _ in self.recognitionTask.stream }
+      $0.speechClient.requestAuthorization = { .authorized }
+    }
 
     await store.send(.recordButtonTapped) {
       $0.isRecording = true

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -125,13 +125,14 @@ struct LoginView_Previews: PreviewProvider {
         store: Store(
           initialState: Login.State(),
           reducer: Login()
-            .dependency(\.authenticationClient.login) { _ in
-              AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
-            }
-            .dependency(\.authenticationClient.twoFactor) { _ in
-              AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
-            }
-        )
+        ) {
+          $0.authenticationClient.login = { _ in
+            AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
+          }
+          $0.authenticationClient.twoFactor = { _ in
+            AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
+          }
+        }
       )
     }
   }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
@@ -93,13 +93,14 @@ struct TwoFactorView_Previews: PreviewProvider {
         store: Store(
           initialState: TwoFactor.State(token: "deadbeef"),
           reducer: TwoFactor()
-            .dependency(\.authenticationClient.login) { _ in
-              AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
-            }
-            .dependency(\.authenticationClient.twoFactor) { _ in
-              AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
-            }
-        )
+        ) {
+          $0.authenticationClient.login = { _ in
+            AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
+          }
+          $0.authenticationClient.twoFactor = { _ in
+            AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
+          }
+        }
       )
     }
   }

--- a/Examples/TicTacToe/tic-tac-toe/Tests/AppCoreTests/AppCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/AppCoreTests/AppCoreTests.swift
@@ -12,10 +12,10 @@ final class AppCoreTests: XCTestCase {
     let store = TestStore(
       initialState: TicTacToe.State(),
       reducer: TicTacToe()
-    )
-
-    store.dependencies.authenticationClient.login = { _ in
-      AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
+    ) {
+      $0.authenticationClient.login = { _ in
+        AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
+      }
     }
 
     await store.send(.login(.emailChanged("blob@pointfree.co"))) {
@@ -57,13 +57,13 @@ final class AppCoreTests: XCTestCase {
     let store = TestStore(
       initialState: TicTacToe.State(),
       reducer: TicTacToe()
-    )
-
-    store.dependencies.authenticationClient.login = { _ in
-      AuthenticationResponse(token: "deadbeef", twoFactorRequired: true)
-    }
-    store.dependencies.authenticationClient.twoFactor = { _ in
-      AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
+    ) {
+      $0.authenticationClient.login = { _ in
+        AuthenticationResponse(token: "deadbeef", twoFactorRequired: true)
+      }
+      $0.authenticationClient.twoFactor = { _ in
+        AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
+      }
     }
 
     await store.send(.login(.emailChanged("blob@pointfree.co"))) {

--- a/Examples/TicTacToe/tic-tac-toe/Tests/LoginCoreTests/LoginCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/LoginCoreTests/LoginCoreTests.swift
@@ -10,13 +10,13 @@ final class LoginCoreTests: XCTestCase {
     let store = TestStore(
       initialState: Login.State(),
       reducer: Login()
-    )
-
-    store.dependencies.authenticationClient.login = { _ in
-      AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: true)
-    }
-    store.dependencies.authenticationClient.twoFactor = { _ in
-      AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false)
+    ) {
+      $0.authenticationClient.login = { _ in
+        AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: true)
+      }
+      $0.authenticationClient.twoFactor = { _ in
+        AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false)
+      }
     }
 
     await store.send(.emailChanged("2fa@pointfree.co")) {
@@ -59,14 +59,14 @@ final class LoginCoreTests: XCTestCase {
     let store = TestStore(
       initialState: Login.State(),
       reducer: Login()
-    )
-
-    store.dependencies.authenticationClient.login = { _ in
-      AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: true)
-    }
-    store.dependencies.authenticationClient.twoFactor = { _ in
-      try await Task.sleep(nanoseconds: NSEC_PER_SEC)
-      return AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false)
+    ) {
+      $0.authenticationClient.login = { _ in
+        AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: true)
+      }
+      $0.authenticationClient.twoFactor = { _ in
+        try await Task.sleep(nanoseconds: NSEC_PER_SEC)
+        return AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false)
+      }
     }
 
     await store.send(.emailChanged("2fa@pointfree.co")) {

--- a/Examples/TicTacToe/tic-tac-toe/Tests/LoginSwiftUITests/LoginSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/LoginSwiftUITests/LoginSwiftUITests.swift
@@ -11,12 +11,12 @@ final class LoginSwiftUITests: XCTestCase {
     let store = TestStore(
       initialState: Login.State(),
       reducer: Login()
-    )
-    .scope(state: LoginView.ViewState.init, action: Login.Action.init)
-
-    store.dependencies.authenticationClient.login = { _ in
-      AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false)
+    ) {
+      $0.authenticationClient.login = { _ in
+        AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false)
+      }
     }
+    .scope(state: LoginView.ViewState.init, action: Login.Action.init)
 
     await store.send(.emailChanged("blob@pointfree.co")) {
       $0.email = "blob@pointfree.co"
@@ -43,12 +43,12 @@ final class LoginSwiftUITests: XCTestCase {
     let store = TestStore(
       initialState: Login.State(),
       reducer: Login()
-    )
-    .scope(state: LoginView.ViewState.init, action: Login.Action.init)
-
-    store.dependencies.authenticationClient.login = { _ in
-      AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: true)
+    ) {
+      $0.authenticationClient.login = { _ in
+        AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: true)
+      }
     }
+    .scope(state: LoginView.ViewState.init, action: Login.Action.init)
 
     await store.send(.emailChanged("2fa@pointfree.co")) {
       $0.email = "2fa@pointfree.co"
@@ -79,12 +79,12 @@ final class LoginSwiftUITests: XCTestCase {
     let store = TestStore(
       initialState: Login.State(),
       reducer: Login()
-    )
-    .scope(state: LoginView.ViewState.init, action: Login.Action.init)
-
-    store.dependencies.authenticationClient.login = { _ in
-      throw AuthenticationError.invalidUserPassword
+    ) {
+      $0.authenticationClient.login = { _ in
+        throw AuthenticationError.invalidUserPassword
+      }
     }
+    .scope(state: LoginView.ViewState.init, action: Login.Action.init)
 
     await store.send(.emailChanged("blob")) {
       $0.email = "blob"

--- a/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorCoreTests/TwoFactorCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorCoreTests/TwoFactorCoreTests.swift
@@ -9,10 +9,10 @@ final class TwoFactorCoreTests: XCTestCase {
     let store = TestStore(
       initialState: TwoFactor.State(token: "deadbeefdeadbeef"),
       reducer: TwoFactor()
-    )
-
-    store.dependencies.authenticationClient.twoFactor = { _ in
-      AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false)
+    ) {
+      $0.authenticationClient.twoFactor = { _ in
+        AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false)
+      }
     }
 
     await store.send(.codeChanged("1")) {
@@ -44,10 +44,10 @@ final class TwoFactorCoreTests: XCTestCase {
     let store = TestStore(
       initialState: TwoFactor.State(token: "deadbeefdeadbeef"),
       reducer: TwoFactor()
-    )
-
-    store.dependencies.authenticationClient.twoFactor = { _ in
-      throw AuthenticationError.invalidTwoFactor
+    ) {
+      $0.authenticationClient.twoFactor = { _ in
+        throw AuthenticationError.invalidTwoFactor
+      }
     }
 
     await store.send(.codeChanged("1234")) {

--- a/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorSwiftUITests/TwoFactorSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorSwiftUITests/TwoFactorSwiftUITests.swift
@@ -11,12 +11,12 @@ final class TwoFactorSwiftUITests: XCTestCase {
     let store = TestStore(
       initialState: TwoFactor.State(token: "deadbeefdeadbeef"),
       reducer: TwoFactor()
-    )
-    .scope(state: TwoFactorView.ViewState.init, action: TwoFactor.Action.init)
-
-    store.dependencies.authenticationClient.twoFactor = { _ in
-      AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false)
+    ) {
+      $0.authenticationClient.twoFactor = { _ in
+        AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false)
+      }
     }
+    .scope(state: TwoFactorView.ViewState.init, action: TwoFactor.Action.init)
 
     await store.send(.codeChanged("1")) {
       $0.code = "1"
@@ -51,12 +51,12 @@ final class TwoFactorSwiftUITests: XCTestCase {
     let store = TestStore(
       initialState: TwoFactor.State(token: "deadbeefdeadbeef"),
       reducer: TwoFactor()
-    )
-    .scope(state: TwoFactorView.ViewState.init, action: TwoFactor.Action.init)
-
-    store.dependencies.authenticationClient.twoFactor = { _ in
-      throw AuthenticationError.invalidTwoFactor
+    ) {
+      $0.authenticationClient.twoFactor = { _ in
+        throw AuthenticationError.invalidTwoFactor
+      }
     }
+    .scope(state: TwoFactorView.ViewState.init, action: TwoFactor.Action.init)
 
     await store.send(.codeChanged("1234")) {
       $0.code = "1234"

--- a/Examples/Todos/TodosTests/TodosTests.swift
+++ b/Examples/Todos/TodosTests/TodosTests.swift
@@ -11,9 +11,9 @@ final class TodosTests: XCTestCase {
     let store = TestStore(
       initialState: Todos.State(),
       reducer: Todos()
-    )
-
-    store.dependencies.uuid = .incrementing
+    ) {
+      $0.uuid = .incrementing
+    }
 
     await store.send(.addTodoButtonTapped) {
       $0.todos.insert(
@@ -84,9 +84,9 @@ final class TodosTests: XCTestCase {
     let store = TestStore(
       initialState: state,
       reducer: Todos()
-    )
-
-    store.dependencies.continuousClock = self.clock
+    ) {
+      $0.continuousClock = self.clock
+    }
 
     await store.send(.todo(id: state.todos[0].id, action: .checkBoxToggled)) {
       $0.todos[id: state.todos[0].id]?.isComplete = true
@@ -119,9 +119,9 @@ final class TodosTests: XCTestCase {
     let store = TestStore(
       initialState: state,
       reducer: Todos()
-    )
-
-    store.dependencies.continuousClock = self.clock
+    ) {
+      $0.continuousClock = self.clock
+    }
 
     await store.send(.todo(id: state.todos[0].id, action: .checkBoxToggled)) {
       $0.todos[id: state.todos[0].id]?.isComplete = true
@@ -255,9 +255,9 @@ final class TodosTests: XCTestCase {
     let store = TestStore(
       initialState: state,
       reducer: Todos()
-    )
-
-    store.dependencies.continuousClock = self.clock
+    ) {
+      $0.continuousClock = self.clock
+    }
 
     await store.send(.editModeChanged(.active)) {
       $0.editMode = .active
@@ -302,10 +302,10 @@ final class TodosTests: XCTestCase {
     let store = TestStore(
       initialState: state,
       reducer: Todos()
-    )
-
-    store.dependencies.continuousClock = self.clock
-    store.dependencies.uuid = .incrementing
+    ) {
+      $0.continuousClock = self.clock
+      $0.uuid = .incrementing
+    }
 
     await store.send(.editModeChanged(.active)) {
       $0.editMode = .active

--- a/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
+++ b/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
@@ -11,25 +11,26 @@ final class VoiceMemosTests: XCTestCase {
     // NB: Combine's concatenation behavior is different in 13.3
     guard #available(iOS 13.4, *) else { return }
 
+    let didFinish = AsyncThrowingStream<Bool, Error>.streamWithContinuation()
+
     let store = TestStore(
       initialState: VoiceMemos.State(),
       reducer: VoiceMemos()
-    )
-
-    let didFinish = AsyncThrowingStream<Bool, Error>.streamWithContinuation()
-    store.dependencies.audioRecorder.currentTime = { 2.5 }
-    store.dependencies.audioRecorder.requestRecordPermission = { true }
-    store.dependencies.audioRecorder.startRecording = { _ in
-      try await didFinish.stream.first { _ in true }!
+    ) {
+      $0.audioRecorder.currentTime = { 2.5 }
+      $0.audioRecorder.requestRecordPermission = { true }
+      $0.audioRecorder.startRecording = { _ in
+        try await didFinish.stream.first { _ in true }!
+      }
+      $0.audioRecorder.stopRecording = {
+        didFinish.continuation.yield(true)
+        didFinish.continuation.finish()
+      }
+      $0.date = .constant(Date(timeIntervalSinceReferenceDate: 0))
+      $0.continuousClock = self.clock
+      $0.temporaryDirectory = { URL(fileURLWithPath: "/tmp") }
+      $0.uuid = .constant(UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF")!)
     }
-    store.dependencies.audioRecorder.stopRecording = {
-      didFinish.continuation.yield(true)
-      didFinish.continuation.finish()
-    }
-    store.dependencies.date = .constant(Date(timeIntervalSinceReferenceDate: 0))
-    store.dependencies.continuousClock = self.clock
-    store.dependencies.temporaryDirectory = { URL(fileURLWithPath: "/tmp") }
-    store.dependencies.uuid = .constant(UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF")!)
 
     await store.send(.recordButtonTapped)
     await self.clock.advance()
@@ -76,15 +77,14 @@ final class VoiceMemosTests: XCTestCase {
   }
 
   func testPermissionDenied() async {
+    var didOpenSettings = false
     let store = TestStore(
       initialState: VoiceMemos.State(),
       reducer: VoiceMemos()
-    )
-
-    var didOpenSettings = false
-
-    store.dependencies.audioRecorder.requestRecordPermission = { false }
-    store.dependencies.openSettings = { @MainActor in didOpenSettings = true }
+    ) {
+      $0.audioRecorder.requestRecordPermission = { false }
+      $0.openSettings = { @MainActor in didOpenSettings = true }
+    }
 
     await store.send(.recordButtonTapped)
     await store.receive(.recordPermissionResponse(false)) {
@@ -99,23 +99,23 @@ final class VoiceMemosTests: XCTestCase {
   }
 
   func testRecordMemoFailure() async {
-    let store = TestStore(
-      initialState: VoiceMemos.State(),
-      reducer: VoiceMemos()
-    )
-
     struct SomeError: Error, Equatable {}
     let didFinish = AsyncThrowingStream<Bool, Error>.streamWithContinuation()
 
-    store.dependencies.audioRecorder.currentTime = { 2.5 }
-    store.dependencies.audioRecorder.requestRecordPermission = { true }
-    store.dependencies.audioRecorder.startRecording = { _ in
-      try await didFinish.stream.first { _ in true }!
+    let store = TestStore(
+      initialState: VoiceMemos.State(),
+      reducer: VoiceMemos()
+    ) {
+      $0.audioRecorder.currentTime = { 2.5 }
+      $0.audioRecorder.requestRecordPermission = { true }
+      $0.audioRecorder.startRecording = { _ in
+        try await didFinish.stream.first { _ in true }!
+      }
+      $0.continuousClock = self.clock
+      $0.date = .constant(Date(timeIntervalSinceReferenceDate: 0))
+      $0.temporaryDirectory = { URL(fileURLWithPath: "/tmp") }
+      $0.uuid = .constant(UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF")!)
     }
-    store.dependencies.continuousClock = self.clock
-    store.dependencies.date = .constant(Date(timeIntervalSinceReferenceDate: 0))
-    store.dependencies.temporaryDirectory = { URL(fileURLWithPath: "/tmp") }
-    store.dependencies.uuid = .constant(UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF")!)
 
     await store.send(.recordButtonTapped)
     await store.receive(.recordPermissionResponse(true)) {
@@ -141,24 +141,24 @@ final class VoiceMemosTests: XCTestCase {
   // Demonstration of how to write a non-exhaustive test for recording a memo and it failing to
   // record.
   func testRecordMemoFailure_NonExhaustive() async {
-    let store = TestStore(
-      initialState: VoiceMemos.State(),
-      reducer: VoiceMemos()
-    )
-    store.exhaustivity = .off(showSkippedAssertions: true)
-
     struct SomeError: Error, Equatable {}
     let didFinish = AsyncThrowingStream<Bool, Error>.streamWithContinuation()
 
-    store.dependencies.audioRecorder.currentTime = { 2.5 }
-    store.dependencies.audioRecorder.requestRecordPermission = { true }
-    store.dependencies.audioRecorder.startRecording = { _ in
-      try await didFinish.stream.first { _ in true }!
+    let store = TestStore(
+      initialState: VoiceMemos.State(),
+      reducer: VoiceMemos()
+    ) {
+      $0.audioRecorder.currentTime = { 2.5 }
+      $0.audioRecorder.requestRecordPermission = { true }
+      $0.audioRecorder.startRecording = { _ in
+        try await didFinish.stream.first { _ in true }!
+      }
+      $0.continuousClock = self.clock
+      $0.date = .constant(Date(timeIntervalSinceReferenceDate: 0))
+      $0.temporaryDirectory = { URL(fileURLWithPath: "/tmp") }
+      $0.uuid = .constant(UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF")!)
     }
-    store.dependencies.continuousClock = self.clock
-    store.dependencies.date = .constant(Date(timeIntervalSinceReferenceDate: 0))
-    store.dependencies.temporaryDirectory = { URL(fileURLWithPath: "/tmp") }
-    store.dependencies.uuid = .constant(UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF")!)
+    store.exhaustivity = .off(showSkippedAssertions: true)
 
     await store.send(.recordButtonTapped)
     await store.send(.recordingMemo(.task))
@@ -184,13 +184,13 @@ final class VoiceMemosTests: XCTestCase {
         ]
       ),
       reducer: VoiceMemos()
-    )
-
-    store.dependencies.audioPlayer.play = { _ in
-      try await self.clock.sleep(for: .milliseconds(1_250))
-      return true
+    ) {
+      $0.audioPlayer.play = { _ in
+        try await self.clock.sleep(for: .milliseconds(1_250))
+        return true
+      }
+      $0.continuousClock = self.clock
     }
-    store.dependencies.continuousClock = self.clock
 
     let task = await store.send(.voiceMemo(id: url, action: .playButtonTapped)) {
       $0.voiceMemos[id: url]?.mode = .playing(progress: 0)
@@ -211,6 +211,8 @@ final class VoiceMemosTests: XCTestCase {
   }
 
   func testPlayMemoFailure() async {
+    struct SomeError: Error, Equatable {}
+
     let url = URL(fileURLWithPath: "pointfreeco/functions.m4a")
     let store = TestStore(
       initialState: VoiceMemos.State(
@@ -225,12 +227,10 @@ final class VoiceMemosTests: XCTestCase {
         ]
       ),
       reducer: VoiceMemos()
-    )
-
-    struct SomeError: Error, Equatable {}
-
-    store.dependencies.audioPlayer.play = { _ in throw SomeError() }
-    store.dependencies.continuousClock = self.clock
+    ) {
+      $0.audioPlayer.play = { _ in throw SomeError() }
+      $0.continuousClock = self.clock
+    }
 
     let task = await store.send(.voiceMemo(id: url, action: .playButtonTapped)) {
       $0.voiceMemos[id: url]?.mode = .playing(progress: 0)
@@ -302,10 +302,10 @@ final class VoiceMemosTests: XCTestCase {
         ]
       ),
       reducer: VoiceMemos()
-    )
-
-    store.dependencies.audioPlayer.play = { _ in try await Task.never() }
-    store.dependencies.continuousClock = self.clock
+    ) {
+      $0.audioPlayer.play = { _ in try await Task.never() }
+      $0.continuousClock = self.clock
+    }
 
     await store.send(.voiceMemo(id: url, action: .playButtonTapped)) {
       $0.voiceMemos[id: url]?.mode = .playing(progress: 0)

--- a/README.md
+++ b/README.md
@@ -530,9 +530,9 @@ override any dependency you need to for the purpose of the test:
 let store = TestStore(
   initialState: Feature.State(),
   reducer: Feature()
-)
-
-store.dependencies.numberFact.fetch = { "\($0) is a good number Brent" }
+) {
+  $0.numberFact.fetch = { "\($0) is a good number Brent" }
+}
 
 …
 ```

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
@@ -465,9 +465,9 @@ override any dependency you need to for the purpose of the test:
 let store = TestStore(
   initialState: Feature.State(),
   reducer: Feature()
-)
-
-store.dependencies.numberFact.fetch = { "\($0) is a good number Brent" }
+) {
+  $0.numberFact.fetch = { "\($0) is a good number Brent" }
+}
 
 await store.send(.numberFactButtonTapped)
 await store.receive(.numberFactResponse(.success("0 is a good number Brent"))) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToTheReducerProtocol.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToTheReducerProtocol.md
@@ -577,10 +577,24 @@ By default test stores will employ "test" dependencies wherever a dependency is 
 reducer via the `@Dependency` property wrapper.
 
 Instead of passing an environment of test dependencies to the store, or mutating the store's
-``TestStore/environment``, you will instead mutate the test store's ``TestStore/dependencies`` to
+``TestStore/environment``, you can either provide a trailing closure when initializing ``TestStore``
+or you can directly mutate the test store's ``TestStore/dependencies`` to
 override dependencies driving a feature.
 
 For example, to install a test clock as the continuous clock dependency you can do the following:
+
+```swift
+let clock = TestClock()
+
+let store = TestStore(
+  initialState: Feature.State(),
+  reducer: Feature()
+) {
+  $0.continuousClock = .clock 
+}
+```
+
+…or you can do:
 
 ```swift
 let clock = TestClock()

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
@@ -365,9 +365,9 @@ as an immediate clock that does not suspend at all when you ask it to sleep:
 let store = TestStore(
   initialState: Feature.State(count: 0),
   reducer: Feature()
-)
-
-store.dependencies.continuousClock = ImmediateClock()
+) {
+  $0.continuousClock = ImmediateClock()
+}
 ```
 
 With that small change we can drop the `timeout` arguments from the

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -11,7 +11,7 @@ import XCTestDynamicOverlay
     """
     'EffectPublisher' has been deprecated in favor of 'EffectTask'.
 
-     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to use Swift concurrency to model asynchrony in dependencies.
+     You are encouraged to use `EffectTask<Action>` to model the output of your reducers, and to use Swift concurrency to model asynchrony in dependencies.
 
      See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
     """
@@ -23,7 +23,7 @@ import XCTestDynamicOverlay
     """
     'EffectPublisher' has been deprecated in favor of 'EffectTask'.
 
-     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to use Swift concurrency to model asynchrony in dependencies.
+     You are encouraged to use `EffectTask<Action>` to model the output of your reducers, and to use Swift concurrency to model asynchrony in dependencies.
 
      See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
     """
@@ -35,7 +35,7 @@ import XCTestDynamicOverlay
     """
     'EffectPublisher' has been deprecated in favor of 'EffectTask'.
 
-     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to use Swift concurrency to model asynchrony in dependencies.
+     You are encouraged to use `EffectTask<Action>` to model the output of your reducers, and to use Swift concurrency to model asynchrony in dependencies.
 
      See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
     """
@@ -47,7 +47,7 @@ import XCTestDynamicOverlay
     """
     'EffectPublisher' has been deprecated in favor of 'EffectTask'.
 
-     You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to use Swift concurrency to model asynchrony in dependencies.
+     You are encouraged to use `EffectTask<Action>` to model the output of your reducers, and to use Swift concurrency to model asynchrony in dependencies.
 
      See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
     """

--- a/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
@@ -55,9 +55,9 @@ extension EffectPublisher where Failure == Never {
   ///   let store = TestStore(
   ///     initialState: Feature.State(),
   ///     reducer: Feature()
-  ///   )
-  ///
-  ///   store.dependencies.mainQueue = mainQueue.eraseToAnyScheduler()
+  ///   ) {
+  ///     $0.mainQueue = mainQueue.eraseToAnyScheduler()
+  ///   }
   ///
   ///   await store.send(.startButtonTapped)
   ///

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -142,14 +142,23 @@ public final class Store<State, Action> {
   ///   - initialState: The state to start the application in.
   ///   - reducer: The reducer that powers the business logic of the application.
   public convenience init<R: ReducerProtocol>(
-    initialState: R.State,
-    reducer: R
+    initialState: @autoclosure () -> R.State,
+    reducer: R,
+    prepareDependencies: ((inout DependencyValues) -> Void)? = nil
   ) where R.State == State, R.Action == Action {
-    self.init(
-      initialState: initialState,
-      reducer: reducer,
-      mainThreadChecksEnabled: true
-    )
+    if let prepareDependencies = prepareDependencies {
+      self.init(
+        initialState: withDependencies(prepareDependencies) { initialState() },
+        reducer: reducer.transformDependency(\.self, transform: prepareDependencies),
+        mainThreadChecksEnabled: true
+      )
+    } else {
+      self.init(
+        initialState: initialState(),
+        reducer: reducer,
+        mainThreadChecksEnabled: true
+      )
+    }
   }
 
   /// Scopes the store to one that exposes child state and actions.

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -490,7 +490,7 @@ public final class TestStore<State, Action, ScopedState, ScopedAction, Environme
     deprecated: 9999,
     message:
       """
-      'Reducer' and `Environment` have been deprecated in favor of 'ReducerProtocol' and 'DependencyValues'.
+      'Reducer' and 'Environment' have been deprecated in favor of 'ReducerProtocol' and 'DependencyValues'.
 
       See the migration guide for more information: https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/reducerprotocol
       """
@@ -500,7 +500,7 @@ public final class TestStore<State, Action, ScopedState, ScopedAction, Environme
     deprecated: 9999,
     message:
       """
-      'Reducer' and `Environment` have been deprecated in favor of 'ReducerProtocol' and 'DependencyValues'.
+      'Reducer' and 'Environment' have been deprecated in favor of 'ReducerProtocol' and 'DependencyValues'.
 
       See the migration guide for more information: https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/reducerprotocol
       """
@@ -510,7 +510,7 @@ public final class TestStore<State, Action, ScopedState, ScopedAction, Environme
     deprecated: 9999,
     message:
       """
-      'Reducer' and `Environment` have been deprecated in favor of 'ReducerProtocol' and 'DependencyValues'.
+      'Reducer' and 'Environment' have been deprecated in favor of 'ReducerProtocol' and 'DependencyValues'.
 
       See the migration guide for more information: https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/reducerprotocol
       """
@@ -520,7 +520,7 @@ public final class TestStore<State, Action, ScopedState, ScopedAction, Environme
     deprecated: 9999,
     message:
       """
-      'Reducer' and `Environment` have been deprecated in favor of 'ReducerProtocol' and 'DependencyValues'.
+      'Reducer' and 'Environment' have been deprecated in favor of 'ReducerProtocol' and 'DependencyValues'.
 
       See the migration guide for more information: https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/reducerprotocol
       """

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -165,19 +165,21 @@ import XCTestDynamicOverlay
 /// values that are fully controlled and deterministic:
 ///
 /// ```swift
+/// // Create a test clock to control the timing of effects
+/// let clock = TestClock()
+///
 /// let store = TestStore(
 ///   initialState: Search.State(),
 ///   reducer: Search()
+/// ) {
+///   // Override the clock dependency with the test clock
+///   $0.continuousClock = clock
+///
+///   // Simulate a search response with one item
+///   $0.apiClient.search = { _ in
+///     ["Composable Architecture"]
+///   }
 /// )
-///
-/// // Simulate a search response with one item
-/// store.dependencies.apiClient.search = { _ in
-///   ["Composable Architecture"]
-/// }
-///
-/// // Create a test clock to control the timing of effects
-/// let clock = TestClock()
-/// store.dependencies.continuousClock = clock
 ///
 /// // Change the query
 /// await store.send(.searchFieldChanged("c") {
@@ -433,10 +435,10 @@ public final class TestStore<State, Action, ScopedState, ScopedAction, Environme
   /// its job, you can override those dependencies like so:
   ///
   /// ```swift
-  /// let store = TestStore(/* ... */)
-  ///
-  /// store.dependencies.apiClient = .mock
-  /// store.dependencies.date = .constant(Date(timeIntervalSinceReferenceDate: 1234567890))
+  /// let store = TestStore(/* ... */) {
+  ///   $0.apiClient = .mock
+  ///   $0.date = .constant(Date(timeIntervalSinceReferenceDate: 1234567890))
+  /// }
   ///
   /// // Store assertions here
   /// ```

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -40,13 +40,14 @@ final class ComposableArchitectureTests: XCTestCase {
       }
     }
 
+    let mainQueue = DispatchQueue.test
+
     let store = TestStore(
       initialState: 2,
       reducer: Counter()
-    )
-
-    let mainQueue = DispatchQueue.test
-    store.dependencies.mainQueue = mainQueue.eraseToAnyScheduler()
+    ) {
+      $0.mainQueue = mainQueue.eraseToAnyScheduler()
+    }
 
     await store.send(.incrAndSquareLater)
     await mainQueue.advance(by: 1)

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -86,8 +86,9 @@
           return .none
         }
       }
-      let store = TestStore(initialState: 0, reducer: DebuggedReducer()._printChanges())
-      store.dependencies.context = .preview
+      let store = TestStore(initialState: 0, reducer: DebuggedReducer()._printChanges()) {
+        $0.context = .preview
+      }
       await store.send(true) { $0 = 1 }
     }
   }

--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -46,16 +46,17 @@ final class ReducerTests: XCTestCase {
         var fastValue: Int? = nil
         var slowValue: Int? = nil
 
+        let clock = TestClock()
+
         let store = TestStore(
           initialState: 0,
           reducer: CombineReducers {
             Delayed(delay: .seconds(1), setValue: { @MainActor in fastValue = 42 })
             Delayed(delay: .seconds(2), setValue: { @MainActor in slowValue = 1729 })
           }
-        )
-
-        let clock = TestClock()
-        store.dependencies.continuousClock = clock
+        ) {
+          $0.continuousClock = clock
+        }
 
         await store.send(.increment) {
           $0 = 2

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -539,4 +539,24 @@ final class StoreTests: XCTestCase {
 
     ViewStore(store, observe: { $0 }).send(true)
   }
+
+  func testOverrideDependenciesDirectlyOnStore() {
+    struct MyReducer: ReducerProtocol {
+      @Dependency(\.uuid) var uuid
+
+      func reduce(into state: inout UUID, action: Void) -> EffectTask<Void> {
+        state = self.uuid()
+        return .none
+      }
+    }
+
+    @Dependency(\.uuid) var uuid
+
+    let store = Store(initialState: uuid(), reducer: MyReducer()) {
+      $0.uuid = .constant(UUID(uuidString: "deadbeef-dead-beef-dead-beefdeadbeef")!)
+    }
+    let viewStore = ViewStore(store, observe: { $0 })
+
+    XCTAssertEqual(viewStore.state, UUID(uuidString: "deadbeef-dead-beef-dead-beefdeadbeef")!)
+  }
 }

--- a/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
@@ -673,9 +673,10 @@
       let store = TestStore(
         initialState: KrzysztofExample.State(),
         reducer: KrzysztofExample()
-      )
+      ) {
+        $0.mainQueue = mainQueue.eraseToAnyScheduler()
+      }
       store.exhaustivity = .off
-      store.dependencies.mainQueue = mainQueue.eraseToAnyScheduler()
 
       store.send(.advanceAgeAndMoodAfterDelay)
       mainQueue.advance(by: 1)

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -301,7 +301,7 @@ final class TestStoreTests: XCTestCase {
     store.send(true) { $0 = 1 }
   }
 
-  func testOverrideDependenciesOnTestStore_Midway() {
+  func testOverrideDependenciesOnTestStore_MidwayChange() {
     struct Counter: ReducerProtocol {
       @Dependency(\.date.now) var now
 

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -301,6 +301,37 @@ final class TestStoreTests: XCTestCase {
     store.send(true) { $0 = 1 }
   }
 
+  func testOverrideDependenciesOnTestStore_Init() {
+    struct Counter: ReducerProtocol {
+      @Dependency(\.calendar) var calendar
+      @Dependency(\.locale) var locale
+      @Dependency(\.timeZone) var timeZone
+      @Dependency(\.urlSession) var urlSession
+
+      func reduce(into state: inout Int, action: Bool) -> EffectTask<Bool> {
+        _ = self.calendar
+        _ = self.locale
+        _ = self.timeZone
+        _ = self.urlSession
+        state += action ? 1 : -1
+        return .none
+      }
+    }
+
+    let store = TestStore(
+      initialState: 0,
+      reducer: Counter()
+    ) {
+      $0.calendar = Calendar(identifier: .gregorian)
+      $0.locale = Locale(identifier: "en_US")
+      $0.timeZone = TimeZone(secondsFromGMT: 0)!
+      $0.urlSession = URLSession(configuration: .ephemeral)
+    }
+
+    store.send(true) { $0 = 1 }
+  }
+
+
   func testDependenciesEarlyBinding() async {
     struct Feature: ReducerProtocol {
       struct State: Equatable {


### PR DESCRIPTION
Seems useful to have `Store` mirror `TestStore` here.

I've also updated all our tests to prefer this initializer, as it's a bit less noisy for declaring upfront dependencies.