### PR TITLE
Revert #1802

### DIFF
--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -466,10 +466,8 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
     get: @escaping (ViewState) -> Value,
     send valueToAction: @escaping (Value) -> ViewAction
   ) -> Binding<Value> {
-    let base = ObservedObject(wrappedValue: self)
+    ObservedObject(wrappedValue: self)
       .projectedValue[get: .init(rawValue: get), send: .init(rawValue: valueToAction)]
-
-    return Binding(get: { base.wrappedValue }, set: { base.transaction($1).wrappedValue = $0 })
   }
 
   /// Derives a binding from the store that prevents direct writes to state and instead sends


### PR DESCRIPTION
Fixes #1812.

This regression was subtle, but it's better to retain the old crashing behavior than introduce this change since it's been with the library for a very long time, and we have workarounds like `ForEachStore`.

We'll try to re-explore these subtle binding behaviors in the future.