### PR TITLE
Unconstrain TestStore action for predicate/case path `receive`

### DIFF
--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1633,8 +1633,7 @@ extension TestStore where ScopedState: Equatable {
         !predicate(receivedAction.action)
       {
         self.reducer.receivedActions.removeFirst()
-        let expectedAction = receivedAction.action
-        actions.append(expectedAction)
+        actions.append(receivedAction.action)
         self.reducer.state = receivedAction.state
       }
 

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -377,7 +377,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
   /// - Parameters:
   ///   - action: An action.
   ///   - predicate: A predicate on `ViewState` that determines for how long this method should
-  ///                suspend.
+  ///     suspend.
   @MainActor
   public func send(_ action: ViewAction, while predicate: @escaping (ViewState) -> Bool) async {
     let task = self.send(action)
@@ -396,7 +396,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
   ///   - action: An action.
   ///   - animation: The animation to perform when the action is sent.
   ///   - predicate: A predicate on `ViewState` that determines for how long this method should
-  ///                suspend.
+  ///     suspend.
   @MainActor
   public func send(
     _ action: ViewAction,
@@ -417,7 +417,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
   /// ``send(_:while:)``.
   ///
   /// - Parameter predicate: A predicate on `ViewState` that determines for how long this method
-  ///                        should suspend.
+  ///   should suspend.
   @MainActor
   public func yield(while predicate: @escaping (ViewState) -> Bool) async {
     if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -307,33 +307,35 @@ final class EffectTests: XCTestCase {
   }
 
   func testDependenciesTransferredToEffects_Run() async {
-    struct Feature: ReducerProtocol {
-      enum Action: Equatable {
-        case tap
-        case response(Int)
-      }
-      @Dependency(\.date) var date
-      func reduce(into state: inout Int, action: Action) -> EffectTask<Action> {
-        switch action {
-        case .tap:
-          return .run { send in
-            await send(.response(Int(self.date.now.timeIntervalSinceReferenceDate)))
+    await _withMainSerialExecutor {
+      struct Feature: ReducerProtocol {
+        enum Action: Equatable {
+          case tap
+          case response(Int)
+        }
+        @Dependency(\.date) var date
+        func reduce(into state: inout Int, action: Action) -> EffectTask<Action> {
+          switch action {
+          case .tap:
+            return .run { send in
+              await send(.response(Int(self.date.now.timeIntervalSinceReferenceDate)))
+            }
+          case let .response(value):
+            state = value
+            return .none
           }
-        case let .response(value):
-          state = value
-          return .none
         }
       }
-    }
-    let store = TestStore(
-      initialState: 0,
-      reducer: Feature()
-        .dependency(\.date, .constant(.init(timeIntervalSinceReferenceDate: 1_234_567_890)))
-    )
+      let store = TestStore(
+        initialState: 0,
+        reducer: Feature()
+          .dependency(\.date, .constant(.init(timeIntervalSinceReferenceDate: 1_234_567_890)))
+      )
 
-    await store.send(.tap).finish(timeout: NSEC_PER_SEC)
-    await store.receive(.response(1_234_567_890)) {
-      $0 = 1_234_567_890
+      await store.send(.tap).finish(timeout: NSEC_PER_SEC)
+      await store.receive(.response(1_234_567_890)) {
+        $0 = 1_234_567_890
+      }
     }
   }
 

--- a/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
@@ -582,6 +582,46 @@
       }
     }
 
+    func testCasePathReceive_Exhaustive_NonEquatable() async {
+      struct NonEquatable {}
+      enum Action { case tap, response(NonEquatable) }
+
+      let store = TestStore(
+        initialState: 0,
+        reducer: Reduce<Int, Action> { state, action in
+          switch action {
+          case .tap:
+            return EffectTask(value: .response(NonEquatable()))
+          case .response:
+            return .none
+          }
+        }
+      )
+
+      await store.send(.tap)
+      await store.receive(/Action.response)
+    }
+
+    func testPredicateReceive_Exhaustive_NonEquatable() async {
+      struct NonEquatable {}
+      enum Action { case tap, response(NonEquatable) }
+
+      let store = TestStore(
+        initialState: 0,
+        reducer: Reduce<Int, Action> { state, action in
+          switch action {
+          case .tap:
+            return EffectTask(value: .response(NonEquatable()))
+          case .response:
+            return .none
+          }
+        }
+      )
+
+      await store.send(.tap)
+      await store.receive({ (/Action.response) ~= $0 })
+    }
+
     func testCasePathReceive_SkipReceivedAction() async {
       let store = TestStore(
         initialState: NonExhaustiveReceive.State(),


### PR DESCRIPTION
These methods are currently defined in a constrained extension, but it's not necessary, so let's loosen the constraint.