### PR TITLE
Improve `TestStore.init` ergonomics

### DIFF
--- a/Examples/TicTacToe/tic-tac-toe/Tests/GameSwiftUITests/GameSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/GameSwiftUITests/GameSwiftUITests.swift
@@ -11,9 +11,10 @@ final class GameSwiftUITests: XCTestCase {
       oPlayerName: "Blob Jr.",
       xPlayerName: "Blob Sr."
     ),
-    reducer: Game()
+    reducer: Game(),
+    observe: GameView.ViewState.init,
+    send: { $0 }
   )
-  .scope(state: GameView.ViewState.init)
 
   func testFlow_Winner_Quit() async {
     await self.store.send(.cellTapped(row: 0, column: 0)) {

--- a/Examples/TicTacToe/tic-tac-toe/Tests/LoginSwiftUITests/LoginSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/LoginSwiftUITests/LoginSwiftUITests.swift
@@ -10,13 +10,14 @@ final class LoginSwiftUITests: XCTestCase {
   func testFlow_Success() async {
     let store = TestStore(
       initialState: Login.State(),
-      reducer: Login()
+      reducer: Login(),
+      observe: LoginView.ViewState.init,
+      send: action: Login.Action.init
     ) {
       $0.authenticationClient.login = { _ in
         AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false)
       }
     }
-    .scope(state: LoginView.ViewState.init, action: Login.Action.init)
 
     await store.send(.emailChanged("blob@pointfree.co")) {
       $0.email = "blob@pointfree.co"
@@ -42,13 +43,14 @@ final class LoginSwiftUITests: XCTestCase {
   func testFlow_Success_TwoFactor() async {
     let store = TestStore(
       initialState: Login.State(),
-      reducer: Login()
+      reducer: Login(),
+      observe: LoginView.ViewState.init,
+      send: action: Login.Action.init
     ) {
       $0.authenticationClient.login = { _ in
         AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: true)
       }
     }
-    .scope(state: LoginView.ViewState.init, action: Login.Action.init)
 
     await store.send(.emailChanged("2fa@pointfree.co")) {
       $0.email = "2fa@pointfree.co"
@@ -78,13 +80,14 @@ final class LoginSwiftUITests: XCTestCase {
   func testFlow_Failure() async {
     let store = TestStore(
       initialState: Login.State(),
-      reducer: Login()
+      reducer: Login(),
+      observe: LoginView.ViewState.init,
+      send: action: Login.Action.init
     ) {
       $0.authenticationClient.login = { _ in
         throw AuthenticationError.invalidUserPassword
       }
     }
-    .scope(state: LoginView.ViewState.init, action: Login.Action.init)
 
     await store.send(.emailChanged("blob")) {
       $0.email = "blob"

--- a/Examples/TicTacToe/tic-tac-toe/Tests/NewGameSwiftUITests/NewGameSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/NewGameSwiftUITests/NewGameSwiftUITests.swift
@@ -8,9 +8,10 @@ import XCTest
 final class NewGameSwiftUITests: XCTestCase {
   let store = TestStore(
     initialState: NewGame.State(),
-    reducer: NewGame()
+    reducer: NewGame(),
+    observe: NewGameView.ViewState.init,
+    send: NewGame.Action.init
   )
-  .scope(state: NewGameView.ViewState.init, action: NewGame.Action.init)
 
   func testNewGame() async {
     await self.store.send(.xPlayerNameChanged("Blob Sr.")) {

--- a/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorSwiftUITests/TwoFactorSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorSwiftUITests/TwoFactorSwiftUITests.swift
@@ -10,13 +10,14 @@ final class TwoFactorSwiftUITests: XCTestCase {
   func testFlow_Success() async {
     let store = TestStore(
       initialState: TwoFactor.State(token: "deadbeefdeadbeef"),
-      reducer: TwoFactor()
+      reducer: TwoFactor(),
+      observe: TwoFactorView.ViewState.init,
+      send: TwoFactor.Action.init
     ) {
       $0.authenticationClient.twoFactor = { _ in
         AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false)
       }
     }
-    .scope(state: TwoFactorView.ViewState.init, action: TwoFactor.Action.init)
 
     await store.send(.codeChanged("1")) {
       $0.code = "1"
@@ -50,13 +51,14 @@ final class TwoFactorSwiftUITests: XCTestCase {
   func testFlow_Failure() async {
     let store = TestStore(
       initialState: TwoFactor.State(token: "deadbeefdeadbeef"),
-      reducer: TwoFactor()
+      reducer: TwoFactor(),
+      observe: TwoFactorView.ViewState.init,
+      send: TwoFactor.Action.init
     ) {
       $0.authenticationClient.twoFactor = { _ in
         throw AuthenticationError.invalidTwoFactor
       }
     }
-    .scope(state: TwoFactorView.ViewState.init, action: TwoFactor.Action.init)
 
     await store.send(.codeChanged("1234")) {
       $0.code = "1234"


### PR DESCRIPTION
It's a bit easy to dive into testing and be met with bad ergonomics if you forgot to conform `State` to be `Equatable`. Right now it doesn't require `Equatable` because it's possible to scope test stores and assert against view state/actions. This feature is pretty niche, though, and shouldn't make the more general case painful, so let's take a few steps to improve things:

1. We can deprecate the `TestStore.init` that takes non-equatable state
2. We can introduce a `TestStore.init(…:observe:send:…)` for testing view state/actions.
3. We can deprecate `TestStore.scope` (scoping a test store multiple times doesn't seem useful enough to support).