### PR TITLE
Add `Effect.send`

### DIFF
--- a/Examples/TicTacToe/tic-tac-toe/Tests/LoginSwiftUITests/LoginSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/LoginSwiftUITests/LoginSwiftUITests.swift
@@ -12,7 +12,7 @@ final class LoginSwiftUITests: XCTestCase {
       initialState: Login.State(),
       reducer: Login(),
       observe: LoginView.ViewState.init,
-      send: action: Login.Action.init
+      send: Login.Action.init
     ) {
       $0.authenticationClient.login = { _ in
         AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false)
@@ -45,7 +45,7 @@ final class LoginSwiftUITests: XCTestCase {
       initialState: Login.State(),
       reducer: Login(),
       observe: LoginView.ViewState.init,
-      send: action: Login.Action.init
+      send: Login.Action.init
     ) {
       $0.authenticationClient.login = { _ in
         AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: true)
@@ -82,7 +82,7 @@ final class LoginSwiftUITests: XCTestCase {
       initialState: Login.State(),
       reducer: Login(),
       observe: LoginView.ViewState.init,
-      send: action: Login.Action.init
+      send: Login.Action.init
     ) {
       $0.authenticationClient.login = { _ in
         throw AuthenticationError.invalidUserPassword

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test-examples:
 	for scheme in "CaseStudies (SwiftUI)" "CaseStudies (UIKit)" Integration Search SpeechRecognition TicTacToe Todos VoiceMemos; do \
 		xcodebuild test \
 			-scheme "$$scheme" \
-			-destination platform="$(PLATFORM_IOS)"; \
+			-destination platform="$(PLATFORM_IOS)" || exit 1; \
 	done
 
 benchmark:

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -236,15 +236,15 @@ struct Feature: ReducerProtocol {
     switch action {
     case .buttonTapped:
       state.count += 1
-      return EffectTask(value: .sharedComputation)
+      return .send(.sharedComputation)
 
     case .toggleChanged:
       state.isEnabled.toggle()
-      return EffectTask(value: .sharedComputation)
+      return .send(.sharedComputation)
 
     case let .textFieldChanged(text):
       state.description = text
-      return EffectTask(value: .sharedComputation)
+      return .send(.sharedComputation)
 
     case .sharedComputation:
       // Some shared work to compute something.

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
@@ -8,6 +8,7 @@
 - ``EffectPublisher/task(priority:operation:catch:file:fileID:line:)``
 - ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)``
 - ``EffectPublisher/fireAndForget(priority:_:)``
+- ``EffectPublisher/send(_:animation:)``
 - ``TaskResult``
 
 ### Cancellation

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
@@ -8,7 +8,7 @@
 - ``EffectPublisher/task(priority:operation:catch:file:fileID:line:)``
 - ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)``
 - ``EffectPublisher/fireAndForget(priority:_:)``
-- ``EffectPublisher/send(_:animation:)``
+- ``EffectPublisher/send(_:)``
 - ``TaskResult``
 
 ### Cancellation

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectSend.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectSend.md
@@ -1,0 +1,7 @@
+# ``ComposableArchitecture/EffectPublisher/send(_:)``
+
+## Topics
+
+### Animating actions
+
+- ``EffectPublisher/send(_:animation:)``

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -323,6 +323,19 @@ extension EffectPublisher where Failure == Never {
   ) -> Self {
     Self.run(priority: priority) { _ in try? await work() }
   }
+
+  /// Initializes an effect that immediately emits the action passed in.
+  ///
+  /// > Note: We do not recommend using `Effect.send` to share logic. Instead, limit usage to
+  /// > child-parent communication, where a child may want to emit a "delegate" action for a parent
+  /// > to listen to.
+  /// >
+  /// > For more information, see <doc:Performance#Sharing-logic-with-actions>.
+  ///
+  /// - Parameter action: The action that is immediately emitted by the effect.
+  public static func send(_ action: Action, animation: Animation? = nil) -> Self {
+    animation != nil ? Self(value: action).animation(animation) : Self(value: action)
+  }
 }
 
 /// A type that can send actions back into the system when used from

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -333,8 +333,23 @@ extension EffectPublisher where Failure == Never {
   /// > For more information, see <doc:Performance#Sharing-logic-with-actions>.
   ///
   /// - Parameter action: The action that is immediately emitted by the effect.
+  public static func send(_ action: Action) -> Self {
+    Self(value: action)
+  }
+
+  /// Initializes an effect that immediately emits the action passed in.
+  ///
+  /// > Note: We do not recommend using `Effect.send` to share logic. Instead, limit usage to
+  /// > child-parent communication, where a child may want to emit a "delegate" action for a parent
+  /// > to listen to.
+  /// >
+  /// > For more information, see <doc:Performance#Sharing-logic-with-actions>.
+  ///
+  /// - Parameters:
+  ///   - action: The action that is immediately emitted by the effect.
+  ///   - animation: An animation.
   public static func send(_ action: Action, animation: Animation? = nil) -> Self {
-    animation != nil ? Self(value: action).animation(animation) : Self(value: action)
+    Self(value: action).animation(animation)
   }
 }
 

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1885,7 +1885,8 @@ extension TestStore {
   @available(
     *,
     deprecated,
-    message: """
+    message:
+      """
       Use 'TestStore.init(initialState:reducer:observe:send:)' to scope a test store's state and actions.
       """
   )
@@ -1915,7 +1916,8 @@ extension TestStore {
   @available(
     *,
     deprecated,
-    message: """
+    message:
+      """
       Use 'TestStore.init(initialState:reducer:observe:)' to scope a test store's state.
       """
   )

--- a/Tests/ComposableArchitectureTests/CompatibilityTests.swift
+++ b/Tests/ComposableArchitectureTests/CompatibilityTests.swift
@@ -47,7 +47,7 @@ final class CompatibilityTests: XCTestCase {
           .cancellable(id: cancelID)
 
       case .kickOffAction:
-        return EffectTask(value: .actionSender(OnDeinit { passThroughSubject.send(.stop) }))
+        return .send(.actionSender(OnDeinit { passThroughSubject.send(.stop) }))
 
       case .actionSender:
         return .none

--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -22,56 +22,58 @@ final class ReducerTests: XCTestCase {
   #if swift(>=5.7) && (canImport(RegexBuilder) || !os(macOS) && !targetEnvironment(macCatalyst))
     func testCombine_EffectsAreMerged() async throws {
       if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
-        enum Action: Equatable {
-          case increment
-        }
+        try await _withMainSerialExecutor {
+          enum Action: Equatable {
+            case increment
+          }
 
-        struct Delayed: ReducerProtocol {
-          typealias State = Int
+          struct Delayed: ReducerProtocol {
+            typealias State = Int
 
-          @Dependency(\.continuousClock) var clock
+            @Dependency(\.continuousClock) var clock
 
-          let delay: Duration
-          let setValue: @Sendable () async -> Void
+            let delay: Duration
+            let setValue: @Sendable () async -> Void
 
-          func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
-            state += 1
-            return .fireAndForget {
-              try await self.clock.sleep(for: self.delay)
-              await self.setValue()
+            func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+              state += 1
+              return .fireAndForget {
+                try await self.clock.sleep(for: self.delay)
+                await self.setValue()
+              }
             }
           }
-        }
 
-        var fastValue: Int? = nil
-        var slowValue: Int? = nil
+          var fastValue: Int? = nil
+          var slowValue: Int? = nil
 
-        let clock = TestClock()
+          let clock = TestClock()
 
-        let store = TestStore(
-          initialState: 0,
-          reducer: CombineReducers {
-            Delayed(delay: .seconds(1), setValue: { @MainActor in fastValue = 42 })
-            Delayed(delay: .seconds(2), setValue: { @MainActor in slowValue = 1729 })
+          let store = TestStore(
+            initialState: 0,
+            reducer: CombineReducers {
+              Delayed(delay: .seconds(1), setValue: { @MainActor in fastValue = 42 })
+              Delayed(delay: .seconds(2), setValue: { @MainActor in slowValue = 1729 })
+            }
+          ) {
+            $0.continuousClock = clock
           }
-        ) {
-          $0.continuousClock = clock
-        }
 
-        await store.send(.increment) {
-          $0 = 2
+          await store.send(.increment) {
+            $0 = 2
+          }
+          // Waiting a second causes the fast effect to fire.
+          await clock.advance(by: .seconds(1))
+          try await Task.sleep(nanoseconds: NSEC_PER_SEC / 3)
+          XCTAssertEqual(fastValue, 42)
+          XCTAssertEqual(slowValue, nil)
+          // Waiting one more second causes the slow effect to fire. This proves that the effects
+          // are merged together, as opposed to concatenated.
+          await clock.advance(by: .seconds(1))
+          await store.finish()
+          XCTAssertEqual(fastValue, 42)
+          XCTAssertEqual(slowValue, 1729)
         }
-        // Waiting a second causes the fast effect to fire.
-        await clock.advance(by: .seconds(1))
-        try await Task.sleep(nanoseconds: NSEC_PER_SEC / 3)
-        XCTAssertEqual(fastValue, 42)
-        XCTAssertEqual(slowValue, nil)
-        // Waiting one more second causes the slow effect to fire. This proves that the effects
-        // are merged together, as opposed to concatenated.
-        await clock.advance(by: .seconds(1))
-        await store.finish()
-        XCTAssertEqual(fastValue, 42)
-        XCTAssertEqual(slowValue, 1729)
       }
     }
   #endif

--- a/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
@@ -584,7 +584,10 @@
 
     func testCasePathReceive_Exhaustive_NonEquatable() async {
       struct NonEquatable {}
-      enum Action { case tap, response(NonEquatable) }
+      enum Action {
+        case tap
+        case response(NonEquatable)
+      }
 
       let store = TestStore(
         initialState: 0,
@@ -604,7 +607,10 @@
 
     func testPredicateReceive_Exhaustive_NonEquatable() async {
       struct NonEquatable {}
-      enum Action { case tap, response(NonEquatable) }
+      enum Action {
+        case tap
+        case response(NonEquatable)
+      }
 
       let store = TestStore(
         initialState: 0,

--- a/Tests/ComposableArchitectureTests/ViewStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/ViewStoreTests.swift
@@ -167,33 +167,28 @@ final class ViewStoreTests: XCTestCase {
     XCTAssertEqual(results, Array(repeating: [0, 1, 2], count: 10).flatMap { $0 })
   }
 
-  func testSendWhile() {
-    let expectation = self.expectation(description: "await")
-    Task {
-      enum Action {
-        case response
-        case tapped
-      }
-      let reducer = Reduce<Bool, Action> { state, action in
-        switch action {
-        case .response:
-          state = false
-          return .none
-        case .tapped:
-          state = true
-          return .task { .response }
-        }
-      }
-
-      let store = Store(initialState: false, reducer: reducer)
-      let viewStore = ViewStore(store, observe: { $0 })
-
-      XCTAssertEqual(viewStore.state, false)
-      await viewStore.send(.tapped, while: { $0 })
-      XCTAssertEqual(viewStore.state, false)
-      expectation.fulfill()
+  func testSendWhile() async {
+    enum Action {
+      case response
+      case tapped
     }
-    self.wait(for: [expectation], timeout: 1)
+    let reducer = Reduce<Bool, Action> { state, action in
+      switch action {
+      case .response:
+        state = false
+        return .none
+      case .tapped:
+        state = true
+        return .task { .response }
+      }
+    }
+
+    let store = Store(initialState: false, reducer: reducer)
+    let viewStore = ViewStore(store, observe: { $0 })
+
+    XCTAssertEqual(viewStore.state, false)
+    await viewStore.send(.tapped, while: { $0 })
+    XCTAssertEqual(viewStore.state, false)
   }
 
   func testSuspend() {


### PR DESCRIPTION
With the `Effect<Action, Failure>` -> `Effect<Action>` migration, `Effect.init(value:)` and `Effect.init(error:)` no longer make sense. We will be retiring the latter some time in the future, so let's also get a head start and rename the former to `Effect.send`.

For now it will call `Effect.init(value:)` under the hood, but in the future we will want a non-Combine-driven way of running synchronous effects.
