### PR TITLE
Use @StateObject for iOS 15+ alert modifier.

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -34,7 +34,7 @@ extension View {
 // NB: Workaround for iOS 14 runtime crashes during iOS 15 availability checks.
 @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
 private struct NewAlertModifier<Action>: ViewModifier {
-  @ObservedObject var viewStore: ViewStore<AlertState<Action>?, Action>
+  @StateObject var viewStore: ViewStore<AlertState<Action>?, Action>
   let dismiss: Action
 
   func body(content: Content) -> some View {

--- a/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
@@ -40,7 +40,7 @@ extension View {
 // NB: Workaround for iOS 14 runtime crashes during iOS 15 availability checks.
 @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
 private struct NewConfirmationDialogModifier<Action>: ViewModifier {
-  @ObservedObject var viewStore: ViewStore<ConfirmationDialogState<Action>?, Action>
+  @StateObject var viewStore: ViewStore<ConfirmationDialogState<Action>?, Action>
   let dismiss: Action
 
   func body(content: Content) -> some View {


### PR DESCRIPTION
Just a small win I found. Eventually we want to move a lot of `@ObservedObject`s to `@StateObject`s in the library, but can't until we drop iOS 13. However, these two instances can be done now.