### PR TITLE
Improve reducer builder inference and prepare for Swift 5.8

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -5,6 +5,13 @@ import XCTestDynamicOverlay
 
 // MARK: - Deprecated after 0.49.2
 
+@available(
+  *,
+  deprecated,
+  message: "Use 'ReducerBuilder<_, _>' with explicit 'State' and 'Action' generics, instead."
+)
+public typealias ReducerBuilderOf<R: ReducerProtocol> = ReducerBuilder<R.State, R.Action>
+
 // NB: As of Swift 5.7, property wrapper deprecations are not diagnosed, so we may want to keep this
 //     deprecation around for now:
 //     https://github.com/apple/swift/issues/63139

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerCompatibility.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerCompatibility.swift
@@ -90,8 +90,9 @@ extension Reduce {
     """
 )
 extension AnyReducer {
-  public init<R: ReducerProtocol>(@ReducerBuilderOf<R> _ build: @escaping (Environment) -> R)
-  where R.State == State, R.Action == Action {
+  public init<R: ReducerProtocol>(
+    @ReducerBuilder<State, Action> _ build: @escaping (Environment) -> R
+  ) where R.State == State, R.Action == Action {
     self.init { state, action, environment in
       build(environment).reduce(into: &state, action: action)
     }

--- a/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
+++ b/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
@@ -7,101 +7,82 @@
 /// See ``CombineReducers`` for an entry point into a reducer builder context.
 @resultBuilder
 public enum ReducerBuilder<State, Action> {
-  #if swift(>=5.7)
-    @inlinable
-    public static func buildArray(
-      _ reducers: [some ReducerProtocol<State, Action>]
-    ) -> some ReducerProtocol<State, Action> {
-      _SequenceMany(reducers: reducers)
-    }
+  @inlinable
+  public static func buildArray<R: ReducerProtocol>(_ reducers: [R]) -> _SequenceMany<R>
+  where R.State == State, R.Action == Action {
+    _SequenceMany(reducers: reducers)
+  }
 
-    @inlinable
-    public static func buildBlock() -> some ReducerProtocol<State, Action> {
-      EmptyReducer()
-    }
+  @inlinable
+  public static func buildBlock() -> EmptyReducer<State, Action> {
+    EmptyReducer()
+  }
 
-    @inlinable
-    public static func buildBlock(
-      _ reducer: some ReducerProtocol<State, Action>
-    ) -> some ReducerProtocol<State, Action> {
-      reducer
-    }
+  @inlinable
+  public static func buildBlock<R: ReducerProtocol>(_ reducer: R) -> R
+  where R.State == State, R.Action == Action {
+    reducer
+  }
 
-    @inlinable
-    public static func buildEither<R0: ReducerProtocol, R1: ReducerProtocol>(
-      first reducer: R0
-    ) -> _Conditional<R0, R1>
-    where R0.State == State, R0.Action == Action, R1.State == State, R1.Action == Action {
-      .first(reducer)
-    }
+  @inlinable
+  public static func buildEither<R0: ReducerProtocol, R1: ReducerProtocol>(
+    first reducer: R0
+  ) -> _Conditional<R0, R1>
+  where R0.State == State, R0.Action == Action, R1.State == State, R1.Action == Action {
+    .first(reducer)
+  }
 
-    @inlinable
-    public static func buildEither<R0: ReducerProtocol, R1: ReducerProtocol>(
-      second reducer: R1
-    ) -> _Conditional<R0, R1>
-    where R0.State == State, R0.Action == Action, R1.State == State, R1.Action == Action {
-      .second(reducer)
-    }
+  @inlinable
+  public static func buildEither<R0: ReducerProtocol, R1: ReducerProtocol>(
+    second reducer: R1
+  ) -> _Conditional<R0, R1>
+  where R0.State == State, R0.Action == Action, R1.State == State, R1.Action == Action {
+    .second(reducer)
+  }
 
-    @inlinable
-    public static func buildExpression(
-      _ expression: some ReducerProtocol<State, Action>
-    ) -> some ReducerProtocol<State, Action> {
-      expression
-    }
+  @inlinable
+  public static func buildExpression<R: ReducerProtocol>(_ expression: R) -> R
+  where R.State == State, R.Action == Action {
+    expression
+  }
 
-    @inlinable
-    public static func buildFinalResult(
-      _ reducer: some ReducerProtocol<State, Action>
-    ) -> some ReducerProtocol<State, Action> {
-      reducer
-    }
+  @inlinable
+  public static func buildFinalResult<R: ReducerProtocol>(_ reducer: R) -> R
+  where R.State == State, R.Action == Action {
+    reducer
+  }
 
-    @inlinable
-    public static func buildLimitedAvailability(
-      _ wrapped: some ReducerProtocol<State, Action>
-    ) -> Reduce<State, Action> {
-      Reduce(wrapped)
-    }
+  @inlinable
+  public static func buildLimitedAvailability<R: ReducerProtocol>(
+    _ wrapped: R
+  ) -> Reduce<State, Action>
+  where R.State == State, R.Action == Action {
+    Reduce(wrapped)
+  }
 
-    @inlinable
-    public static func buildOptional(
-      _ wrapped: (some ReducerProtocol<State, Action>)?
-    ) -> some ReducerProtocol<State, Action> {
-      wrapped
-    }
+  @inlinable
+  public static func buildOptional<R: ReducerProtocol>(_ wrapped: R?) -> R?
+  where R.State == State, R.Action == Action {
+    wrapped
+  }
 
-    @inlinable
-    public static func buildPartialBlock(
-      first: some ReducerProtocol<State, Action>
-    ) -> some ReducerProtocol<State, Action> {
-      first
-    }
+  @inlinable
+  public static func buildPartialBlock<R: ReducerProtocol>(
+    first: R
+  ) -> R
+  where R.State == State, R.Action == Action {
+    first
+  }
 
-    @inlinable
-    public static func buildPartialBlock(
-      accumulated: some ReducerProtocol<State, Action>, next: some ReducerProtocol<State, Action>
-    ) -> some ReducerProtocol<State, Action> {
-      _Sequence(accumulated, next)
-    }
-  #else
-    @inlinable
-    public static func buildArray<R: ReducerProtocol>(_ reducers: [R]) -> _SequenceMany<R>
-    where R.State == State, R.Action == Action {
-      _SequenceMany(reducers: reducers)
-    }
+  @inlinable
+  public static func buildPartialBlock<R0: ReducerProtocol, R1: ReducerProtocol>(
+    accumulated: R0, next: R1
+  ) -> _Sequence<R0, R1>
+  where R0.State == State, R0.Action == Action, R1.State == State, R1.Action == Action {
+    _Sequence(accumulated, next)
+  }
 
-    @inlinable
-    public static func buildBlock() -> EmptyReducer<State, Action> {
-      EmptyReducer()
-    }
-
-    @inlinable
-    public static func buildBlock<R: ReducerProtocol>(_ reducer: R) -> R
-    where R.State == State, R.Action == Action {
-      reducer
-    }
-
+  #if swift(<5.7)
     @inlinable
     public static func buildBlock<
       R0: ReducerProtocol,
@@ -330,53 +311,11 @@ public enum ReducerBuilder<State, Action> {
       )
     }
 
-    @inlinable
-    public static func buildEither<R0: ReducerProtocol, R1: ReducerProtocol>(
-      first reducer: R0
-    ) -> _Conditional<R0, R1>
-    where R0.State == State, R0.Action == Action {
-      .first(reducer)
-    }
-
-    @inlinable
-    public static func buildEither<R0: ReducerProtocol, R1: ReducerProtocol>(
-      second reducer: R1
-    ) -> _Conditional<R0, R1>
-    where R1.State == State, R1.Action == Action {
-      .second(reducer)
-    }
-
-    @inlinable
-    public static func buildExpression<R: ReducerProtocol>(_ expression: R) -> R
-    where R.State == State, R.Action == Action {
-      expression
-    }
-
-    @inlinable
-    public static func buildFinalResult<R: ReducerProtocol>(_ reducer: R) -> R
-    where R.State == State, R.Action == Action {
-      reducer
-    }
-
     @_disfavoredOverload
     @inlinable
     public static func buildFinalResult<R: ReducerProtocol>(_ reducer: R) -> Reduce<State, Action>
     where R.State == State, R.Action == Action {
       Reduce(reducer)
-    }
-
-    @inlinable
-    public static func buildLimitedAvailability<R: ReducerProtocol>(
-      _ wrapped: R
-    ) -> Reduce<R.State, R.Action>
-    where R.State == State, R.Action == Action {
-      Reduce(wrapped)
-    }
-
-    @inlinable
-    public static func buildOptional<R: ReducerProtocol>(_ wrapped: R?) -> R?
-    where R.State == State, R.Action == Action {
-      wrapped
     }
   #endif
 

--- a/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
+++ b/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
@@ -440,5 +440,3 @@ public enum ReducerBuilder<State, Action> {
     }
   }
 }
-
-public typealias ReducerBuilderOf<R: ReducerProtocol> = ReducerBuilder<R.State, R.Action>

--- a/Sources/ComposableArchitecture/Reducer/Reducers/CombineReducers.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/CombineReducers.swift
@@ -23,9 +23,9 @@ public struct CombineReducers<Reducers: ReducerProtocol>: ReducerProtocol {
   ///
   /// - Parameter build: A reducer builder.
   @inlinable
-  public init(
-    @ReducerBuilderOf<Reducers> _ build: () -> Reducers
-  ) {
+  public init<State, Action>(
+    @ReducerBuilder<State, Action> _ build: () -> Reducers
+  ) where State == Reducers.State, Action == Reducers.Action {
     self.init(internal: build())
   }
 

--- a/Sources/ComposableArchitecture/Reducer/Reducers/CombineReducers.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/CombineReducers.swift
@@ -15,7 +15,8 @@
 ///   .ifLet(\.child, action: /Action.child)
 /// }
 /// ```
-public struct CombineReducers<Reducers: ReducerProtocol>: ReducerProtocol {
+public struct CombineReducers<State, Action, Reducers: ReducerProtocol>: ReducerProtocol
+where State == Reducers.State, Action == Reducers.Action {
   @usableFromInline
   let reducers: Reducers
 
@@ -23,9 +24,9 @@ public struct CombineReducers<Reducers: ReducerProtocol>: ReducerProtocol {
   ///
   /// - Parameter build: A reducer builder.
   @inlinable
-  public init<State, Action>(
+  public init(
     @ReducerBuilder<State, Action> _ build: () -> Reducers
-  ) where State == Reducers.State, Action == Reducers.Action {
+  ) {
     self.init(internal: build())
   }
 

--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -50,14 +50,15 @@ extension ReducerProtocol {
   ///     state.
   /// - Returns: A reducer that combines the child reducer with the parent reducer.
   @inlinable
-  public func forEach<ID: Hashable, Element: ReducerProtocol>(
-    _ toElementsState: WritableKeyPath<State, IdentifiedArray<ID, Element.State>>,
-    action toElementAction: CasePath<Action, (ID, Element.Action)>,
-    @ReducerBuilderOf<Element> _ element: () -> Element,
+  public func forEach<ElementState, ElementAction, ID: Hashable, Element: ReducerProtocol>(
+    _ toElementsState: WritableKeyPath<State, IdentifiedArray<ID, ElementState>>,
+    action toElementAction: CasePath<Action, (ID, ElementAction)>,
+    @ReducerBuilder<ElementState, ElementAction> _ element: () -> Element,
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
-  ) -> _ForEachReducer<Self, ID, Element> {
+  ) -> _ForEachReducer<Self, ID, Element>
+  where ElementState == Element.State, ElementAction == Element.Action {
     _ForEachReducer(
       parent: self,
       toElementsState: toElementsState,

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
@@ -46,14 +46,15 @@ extension ReducerProtocol {
   ///     present
   /// - Returns: A reducer that combines the child reducer with the parent reducer.
   @inlinable
-  public func ifCaseLet<Case: ReducerProtocol>(
-    _ toCaseState: CasePath<State, Case.State>,
-    action toCaseAction: CasePath<Action, Case.Action>,
-    @ReducerBuilderOf<Case> then case: () -> Case,
+  public func ifCaseLet<CaseState, CaseAction, Case: ReducerProtocol>(
+    _ toCaseState: CasePath<State, CaseState>,
+    action toCaseAction: CasePath<Action, CaseAction>,
+    @ReducerBuilder<CaseState, CaseAction> then case: () -> Case,
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
-  ) -> _IfCaseLetReducer<Self, Case> {
+  ) -> _IfCaseLetReducer<Self, Case>
+  where CaseState == Case.State, CaseAction == Case.Action {
     .init(
       parent: self,
       child: `case`(),

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
@@ -43,14 +43,15 @@ extension ReducerProtocol {
   ///     state.
   /// - Returns: A reducer that combines the child reducer with the parent reducer.
   @inlinable
-  public func ifLet<Wrapped: ReducerProtocol>(
-    _ toWrappedState: WritableKeyPath<State, Wrapped.State?>,
-    action toWrappedAction: CasePath<Action, Wrapped.Action>,
-    @ReducerBuilderOf<Wrapped> then wrapped: () -> Wrapped,
+  public func ifLet<WrappedState, WrappedAction, Wrapped: ReducerProtocol>(
+    _ toWrappedState: WritableKeyPath<State, WrappedState?>,
+    action toWrappedAction: CasePath<Action, WrappedAction>,
+    @ReducerBuilder<WrappedState, WrappedAction> then wrapped: () -> Wrapped,
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
-  ) -> _IfLetReducer<Self, Wrapped> {
+  ) -> _IfLetReducer<Self, Wrapped>
+  where WrappedState == Wrapped.State, WrappedAction == Wrapped.Action {
     .init(
       parent: self,
       child: wrapped(),

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
@@ -143,11 +143,11 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
   ///   - toChildAction: A case path from parent action to a case containing child actions.
   ///   - child: A reducer that will be invoked with child actions against child state.
   @inlinable
-  public init(
-    state toChildState: WritableKeyPath<ParentState, Child.State>,
-    action toChildAction: CasePath<ParentAction, Child.Action>,
-    @ReducerBuilderOf<Child> _ child: () -> Child
-  ) {
+  public init<ChildState, ChildAction>(
+    state toChildState: WritableKeyPath<ParentState, ChildState>,
+    action toChildAction: CasePath<ParentAction, ChildAction>,
+    @ReducerBuilder<ChildState, ChildAction> _ child: () -> Child
+  ) where ChildState == Child.State, ChildAction == Child.Action {
     self.init(
       toChildState: .keyPath(toChildState),
       toChildAction: toChildAction,
@@ -215,14 +215,14 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
   ///   - toChildAction: A case path from parent action to a case containing child actions.
   ///   - child: A reducer that will be invoked with child actions against child state.
   @inlinable
-  public init(
-    state toChildState: CasePath<ParentState, Child.State>,
-    action toChildAction: CasePath<ParentAction, Child.Action>,
-    @ReducerBuilderOf<Child> _ child: () -> Child,
+  public init<ChildState, ChildAction>(
+    state toChildState: CasePath<ParentState, ChildState>,
+    action toChildAction: CasePath<ParentAction, ChildAction>,
+    @ReducerBuilder<ChildState, ChildAction> _ child: () -> Child,
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
-  ) {
+  ) where ChildState == Child.State, ChildAction == Child.Action {
     self.init(
       toChildState: .casePath(toChildState, file: file, fileID: fileID, line: line),
       toChildAction: toChildAction,

--- a/Tests/ComposableArchitectureTests/ForEachReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ForEachReducerTests.swift
@@ -85,7 +85,7 @@ struct Elements: ReducerProtocol {
   }
   #if swift(>=5.7)
     var body: some ReducerProtocol<State, Action> {
-      Reduce<State, Action> { state, action in
+      Reduce { state, action in
         .none
       }
       .forEach(\.rows, action: /Action.row) {
@@ -99,7 +99,7 @@ struct Elements: ReducerProtocol {
     }
   #else
     var body: Reduce<State, Action> {
-      Reduce<State, Action> { state, action in
+      Reduce { state, action in
         .none
       }
       .forEach(\.rows, action: /Action.row) {

--- a/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
@@ -53,20 +53,20 @@ private struct Root: ReducerProtocol {
   #if swift(>=5.7)
     var body: some ReducerProtocol<State, Action> {
       CombineReducers {
-        Scope(state: \State.feature, action: /Action.feature) {
+        Scope(state: \.feature, action: /Action.feature) {
           Feature()
           Feature()
         }
-        Scope(state: \State.feature, action: /Action.feature) {
+        Scope(state: \.feature, action: /Action.feature) {
           Feature()
           Feature()
         }
       }
-      .ifLet(\State.optionalFeature, action: /Action.optionalFeature) {
+      .ifLet(\.optionalFeature, action: /Action.optionalFeature) {
         Feature()
         Feature()
       }
-      .ifLet(\State.enumFeature, action: /Action.enumFeature) {
+      .ifLet(\.enumFeature, action: /Action.enumFeature) {
         EmptyReducer()
           .ifCaseLet(/Features.State.featureA, action: /Features.Action.featureA) {
             Feature()
@@ -79,7 +79,7 @@ private struct Root: ReducerProtocol {
 
         Features()
       }
-      .forEach(\State.features, action: /Action.features) {
+      .forEach(\.features, action: /Action.features) {
         Feature()
         Feature()
       }

--- a/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
@@ -53,20 +53,20 @@ private struct Root: ReducerProtocol {
   #if swift(>=5.7)
     var body: some ReducerProtocol<State, Action> {
       CombineReducers {
-        Scope(state: \.feature, action: /Action.feature) {
+        Scope(state: \State.feature, action: /Action.feature) {
           Feature()
           Feature()
         }
-        Scope(state: \.feature, action: /Action.feature) {
+        Scope(state: \State.feature, action: /Action.feature) {
           Feature()
           Feature()
         }
       }
-      .ifLet(\.optionalFeature, action: /Action.optionalFeature) {
+      .ifLet(\State.optionalFeature, action: /Action.optionalFeature) {
         Feature()
         Feature()
       }
-      .ifLet(\.enumFeature, action: /Action.enumFeature) {
+      .ifLet(\State.enumFeature, action: /Action.enumFeature) {
         EmptyReducer()
           .ifCaseLet(/Features.State.featureA, action: /Features.Action.featureA) {
             Feature()
@@ -79,7 +79,7 @@ private struct Root: ReducerProtocol {
 
         Features()
       }
-      .forEach(\.features, action: /Action.features) {
+      .forEach(\State.features, action: /Action.features) {
         Feature()
         Feature()
       }


### PR DESCRIPTION
Swift 5.8 has some changes coming to how result builders are type checked and requires us to make some changes for things to continue to compile. See the discussion [here](https://github.com/apple/swift/issues/62978) for more info.