### PR TITLE
Update SwiftUI Navigation to support new alert mappings

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "9f39744e025c7d377987f30b03770805dcb0bcd1",
-        "version" : "1.1.4"
+        "revision" : "4ad606ba5d7673ea60679a61ff867cc1ff8c8e86",
+        "version" : "1.2.1"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "f504716c27d2e5d4144fa4794b12129301d17729",
-        "version" : "1.0.3"
+        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
+        "version" : "1.0.4"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "819d9d370cd721c9d87671e29d947279292e4541",
-        "version" : "0.6.0"
+        "revision" : "ead7d30cc224c3642c150b546f4f1080d1c411a8",
+        "version" : "0.6.1"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "e9e82b5302025092ab8358e794f89a0f0397dd9d",
-        "version" : "0.1.2"
+        "revision" : "8282b0c59662eb38946afe30eb403663fc2ecf76",
+        "version" : "0.1.4"
       }
     },
     {
@@ -77,7 +77,16 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+        "revision" : "10bc670db657d11bdd561e07de30a9041311b2b1",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
       }
     },
@@ -86,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",
       "state" : {
-        "revision" : "bfb0d43e75a15b6dfac770bf33479e8393884a36",
-        "version" : "0.4.1"
+        "revision" : "fd34c544ad27f3ba6b19142b348005bfa85b6005",
+        "version" : "0.6.0"
       }
     },
     {
@@ -95,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",
       "state" : {
-        "branch" : "alert-mappings",
-        "revision" : "8b4ee1e2ca3b375403f894202f52391fa4a53478"
+        "revision" : "bf0fb9d53019cbde1a1e0cf290b560a0a0411282",
+        "version" : "0.6.0"
       }
     },
     {
@@ -104,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "a9daebf0bf65981fd159c885d504481a65a75f02",
-        "version" : "0.8.0"
+        "revision" : "16b23a295fa322eb957af98037f86791449de60f",
+        "version" : "0.8.1"
       }
     }
   ],

--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "bb436421f57269fbcfe7360735985321585a86e5",
-        "version" : "0.10.1"
+        "revision" : "c3a42e8d1a76ff557cf565ed6d8b0aee0e6e75af",
+        "version" : "0.11.0"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",
       "state" : {
-        "revision" : "46acf5ecc1cabdb28d7fe03289f6c8b13a023f52",
-        "version" : "0.4.5"
+        "branch" : "alert-mappings",
+        "revision" : "8b4ee1e2ca3b375403f894202f52391fa4a53478"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "fddd1c00396eed152c45a46bea9f47b98e59301d",
-        "version" : "1.2.0"
+        "revision" : "4ad606ba5d7673ea60679a61ff867cc1ff8c8e86",
+        "version" : "1.2.1"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "e9e82b5302025092ab8358e794f89a0f0397dd9d",
-        "version" : "0.1.2"
+        "revision" : "8282b0c59662eb38946afe30eb403663fc2ecf76",
+        "version" : "0.1.4"
       }
     },
     {
@@ -77,7 +77,16 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+        "revision" : "10bc670db657d11bdd561e07de30a9041311b2b1",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
       }
     },
@@ -95,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",
       "state" : {
-        "revision" : "ddc01cdcddfd30ef7a966049b2e1d251e224ad93",
-        "version" : "0.5.0"
+        "revision" : "bf0fb9d53019cbde1a1e0cf290b560a0a0411282",
+        "version" : "0.6.0"
       }
     },
     {
@@ -104,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "a9daebf0bf65981fd159c885d504481a65a75f02",
-        "version" : "0.8.0"
+        "revision" : "16b23a295fa322eb957af98037f86791449de60f",
+        "version" : "0.8.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.6.0"),
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "0.1.2"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "0.4.1"),
-    .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "0.4.5"),
+    .package(url: "https://github.com/pointfreeco/swiftui-navigation", branch: "alert-mappings"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.5.0"),
   ],
   targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.6.0"),
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "0.1.2"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "0.4.1"),
-    .package(url: "https://github.com/pointfreeco/swiftui-navigation", branch: "alert-mappings"),
+    .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "0.6.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.5.0"),
   ],
   targets: [

--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -44,7 +44,11 @@ private struct NewAlertModifier<Action>: ViewModifier {
       presenting: viewStore.state,
       actions: {
         ForEach($0.buttons) {
-          Button($0) { viewStore.send($0) }
+          Button($0) { action in
+            if let action = action {
+              viewStore.send(action)
+            }
+          }
         }
       },
       message: { $0.message.map { Text($0) } }
@@ -58,7 +62,11 @@ private struct OldAlertModifier<Action>: ViewModifier {
 
   func body(content: Content) -> some View {
     content.alert(item: viewStore.binding(send: dismiss)) { state in
-      Alert(state) { viewStore.send($0) }
+      Alert(state) { action in
+        if let action = action {
+          viewStore.send(action)
+        }
+      }
     }
   }
 }

--- a/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
@@ -51,7 +51,11 @@ private struct NewConfirmationDialogModifier<Action>: ViewModifier {
       presenting: viewStore.state,
       actions: {
         ForEach($0.buttons) {
-          Button($0, action: { viewStore.send($0) })
+          Button($0) { action in
+            if let action = action {
+              viewStore.send(action)
+            }
+          }
         }
       },
       message: { $0.message.map { Text($0) } }
@@ -70,7 +74,11 @@ private struct OldConfirmationDialogModifier<Action>: ViewModifier {
   func body(content: Content) -> some View {
     #if !os(macOS)
       return content.actionSheet(item: viewStore.binding(send: dismiss)) {
-        ActionSheet($0) { viewStore.send($0) }
+        ActionSheet($0) { action in
+          if let action = action {
+            viewStore.send(action)
+          }
+        }
       }
     #else
       return EmptyView()

--- a/Sources/ComposableArchitecture/UIKit/AlertStateUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/AlertStateUIKit.swift
@@ -1,4 +1,6 @@
 #if canImport(UIKit) && !os(watchOS)
+  // TODO: Add deprecated overloads with handlers that take a non-optional actions
+
   import UIKit
 
   @available(iOS 13, *)
@@ -43,7 +45,7 @@
     ///   - send: A function that wraps an alert action in the view store's action type.
     public convenience init<Action>(
       state: AlertState<Action>,
-      send: @escaping (Action) -> Void
+      send: @escaping (Action?) -> Void
     ) {
       self.init(
         title: String(state: state.title),
@@ -61,7 +63,7 @@
     ///   - state: The state of dialog that can be shown to the user.
     ///   - send: A function that wraps a dialog action in the view store's action type.
     public convenience init<Action>(
-      state: ConfirmationDialogState<Action>, send: @escaping (Action) -> Void
+      state: ConfirmationDialogState<Action>, send: @escaping (Action?) -> Void
     ) {
       self.init(
         title: String(state: state.title),
@@ -80,7 +82,7 @@
   @available(tvOS 13, *)
   @available(watchOS, unavailable)
   extension UIAlertAction.Style {
-    init<Action>(_ role: ButtonState<Action>.Role) {
+    init(_ role: ButtonStateRole) {
       switch role {
       case .cancel:
         self = .cancel
@@ -98,13 +100,14 @@
   extension UIAlertAction {
     convenience init<Action>(
       _ button: ButtonState<Action>,
-      action: @escaping (Action) -> Void
+      action handler: @escaping (Action?) -> Void
     ) {
       self.init(
         title: String(state: button.label),
-        style: button.role.map(UIAlertAction.Style.init) ?? .default,
-        handler: button.action.map { _ in { _ in button.withAction(action) } }
-      )
+        style: button.role.map(UIAlertAction.Style.init) ?? .default
+      ) { _ in
+        button.withAction(handler)
+      }
     }
   }
 #endif

--- a/Sources/ComposableArchitecture/UIKit/AlertStateUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/AlertStateUIKit.swift
@@ -1,6 +1,4 @@
 #if canImport(UIKit) && !os(watchOS)
-  // TODO: Add deprecated overloads with handlers that take a non-optional actions
-
   import UIKit
 
   @available(iOS 13, *)


### PR DESCRIPTION
Alerts in SwiftUI Navigation are having a small breaking change in 0.6.0, so we need to release TCA shortly after to prevent folks from being in a broken state.