### PR TITLE
Workaround for BindingAction existential layout crash

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -170,7 +170,7 @@ public struct BindingAction<Root>: Equatable {
   //     payloads. We can box the existential to work around the bug.
   #if swift(<5.8)
     private let _value: [Any]
-    var value: Any { self._value }
+    var value: Any { self._value[0] }
   #else
     let value: Any
   #endif

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -166,8 +166,31 @@ public struct BindingAction<Root>: Equatable {
 
   @usableFromInline
   let set: (inout Root) -> Void
-  let value: Any
+  // NB: swift(<5.8) has an enum existential layout bug that can cause crashes when extracting
+  //     payloads. We can box the existential to work around the bug.
+  #if swift(<5.8)
+    private let _value: [Any]
+    var value: Any { self._value }
+  #else
+    let value: Any
+  #endif
   let valueIsEqualTo: (Any) -> Bool
+
+  init(
+    keyPath: PartialKeyPath<Root>,
+    set: @escaping (inout Root) -> Void,
+    value: Any,
+    valueIsEqualTo: @escaping (Any) -> Bool
+  ) {
+    self.keyPath = keyPath
+    self.set = set
+    #if swift(<5.8)
+      self._value = [value]
+    #else
+      self.value = value
+    #endif
+    self.valueIsEqualTo = valueIsEqualTo
+  }
 
   public static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.keyPath == rhs.keyPath && lhs.valueIsEqualTo(rhs.value)

--- a/Tests/ComposableArchitectureTests/BindingTests.swift
+++ b/Tests/ComposableArchitectureTests/BindingTests.swift
@@ -41,4 +41,17 @@ final class BindingTests: XCTestCase {
       XCTAssertEqual(viewStore.state, .init(nested: .init(field: "Hello!")))
     }
   #endif
+
+  // NB: This crashes in Swift(<5.8) RELEASE when `BindingAction` holds directly onto an unboxed
+  //     `value: Any` existential
+  func testLayoutBug() {
+    enum Foo {
+      case bar(Baz)
+    }
+    enum Baz {
+      case fizz(BindingAction<Void>)
+      case buzz(Bool)
+    }
+    _ = (/Foo.bar).extract(from: .bar(.buzz(true)))
+  }
 }


### PR DESCRIPTION
This PR will address the crash found in #1877. The fact that `BindingAction` holds onto an `Any` existential directly means that attempting to extract another action from an enum that holds a `BindingAction` can lead to crashes in release mode depending on the layout.

This Swift bug is fixed in Swift 5.8, but we will need to provide a workaround.

Will start by pushing a test case to verify the crash on CI, then will push a workaround that boxes the existential in < 5.8.