### PR TITLE
Make `Store.filter` internal

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -326,7 +326,7 @@ public final class Store<State, Action> {
     self.scope(state: toChildState, action: { $0 })
   }
 
-  @_spi(Internals) public func filter(
+  func filter(
     _ isSent: @escaping (State, Action) -> Bool
   ) -> Store<State, Action> {
     self.threadCheck(status: .scope)

--- a/Tests/ComposableArchitectureTests/StoreFilterTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreFilterTests.swift
@@ -1,0 +1,26 @@
+import Combine
+import XCTest
+
+@testable import ComposableArchitecture
+
+@MainActor
+final class StoreFilterTests: XCTestCase {
+  var cancellables: Set<AnyCancellable> = []
+
+  func testFilter() {
+    let store = Store<Int?, Void>(initialState: nil, reducer: EmptyReducer())
+      .filter { state, _ in state != nil }
+
+    let viewStore = ViewStore(store)
+    var count = 0
+    viewStore.publisher
+      .sink { _ in count += 1 }
+      .store(in: &self.cancellables)
+
+    XCTAssertEqual(count, 1)
+    viewStore.send(())
+    XCTAssertEqual(count, 1)
+    viewStore.send(())
+    XCTAssertEqual(count, 1)
+  }
+}

--- a/Tests/ComposableArchitectureTests/StoreFilterTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreFilterTests.swift
@@ -1,26 +1,28 @@
-import Combine
-import XCTest
+#if DEBUG
+  import Combine
+  import XCTest
 
-@testable import ComposableArchitecture
+  @testable import ComposableArchitecture
 
-@MainActor
-final class StoreFilterTests: XCTestCase {
-  var cancellables: Set<AnyCancellable> = []
+  @MainActor
+  final class StoreFilterTests: XCTestCase {
+    var cancellables: Set<AnyCancellable> = []
 
-  func testFilter() {
-    let store = Store<Int?, Void>(initialState: nil, reducer: EmptyReducer())
-      .filter { state, _ in state != nil }
+    func testFilter() {
+      let store = Store<Int?, Void>(initialState: nil, reducer: EmptyReducer())
+        .filter { state, _ in state != nil }
 
-    let viewStore = ViewStore(store)
-    var count = 0
-    viewStore.publisher
-      .sink { _ in count += 1 }
-      .store(in: &self.cancellables)
+      let viewStore = ViewStore(store)
+      var count = 0
+      viewStore.publisher
+        .sink { _ in count += 1 }
+        .store(in: &self.cancellables)
 
-    XCTAssertEqual(count, 1)
-    viewStore.send(())
-    XCTAssertEqual(count, 1)
-    viewStore.send(())
-    XCTAssertEqual(count, 1)
+      XCTAssertEqual(count, 1)
+      viewStore.send(())
+      XCTAssertEqual(count, 1)
+      viewStore.send(())
+      XCTAssertEqual(count, 1)
+    }
   }
-}
+#endif

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -559,21 +559,4 @@ final class StoreTests: XCTestCase {
 
     XCTAssertEqual(viewStore.state, UUID(uuidString: "deadbeef-dead-beef-dead-beefdeadbeef")!)
   }
-
-  func testFilter() {
-    let store = Store<Int?, Void>(initialState: nil, reducer: EmptyReducer())
-      .filter { state, _ in state != nil }
-
-    let viewStore = ViewStore(store)
-    var count = 0
-    viewStore.publisher
-      .sink { _ in count += 1 }
-      .store(in: &self.cancellables)
-
-    XCTAssertEqual(count, 1)
-    viewStore.send(())
-    XCTAssertEqual(count, 1)
-    viewStore.send(())
-    XCTAssertEqual(count, 1)
-  }
 }


### PR DESCRIPTION
We're not ready to make it `public`, and `@_spi` APIs can still come up in autocomplete somehow. Xcode surfaces internal stuff in autocomplete too, occasionally, but maybe this will suppress it a bit.