### PR TITLE
Improve expected action test store failure message

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "ead7d30cc224c3642c150b546f4f1080d1c411a8",
-        "version" : "0.6.1"
+        "revision" : "87dd388a193569b288d03cb4060db54f90d1a66f",
+        "version" : "0.7.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "ead7d30cc224c3642c150b546f4f1080d1c411a8",
-        "version" : "0.6.1"
+        "revision" : "87dd388a193569b288d03cb4060db54f90d1a66f",
+        "version" : "0.7.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",
       "state" : {
-        "revision" : "bf0fb9d53019cbde1a1e0cf290b560a0a0411282",
-        "version" : "0.6.0"
+        "revision" : "270a754308f5440be52fc295242eb7031638bd15",
+        "version" : "0.6.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "0.8.0"),
     .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.10.0"),
     .package(url: "https://github.com/apple/swift-collections", from: "1.0.2"),
-    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.6.0"),
+    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.7.0"),
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "0.1.2"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "0.4.1"),
     .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "0.6.0"),

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1311,9 +1311,15 @@ extension TestStore where ScopedState: Equatable, Action: Equatable {
     file: StaticString = #file,
     line: UInt = #line
   ) {
+    var expectedActionDump = ""
+    customDump(expectedAction, to: &expectedActionDump, indent: 2)
     self.receiveAction(
       matching: { expectedAction == $0 },
-      failureMessage: #"Expected to receive an action "\#(expectedAction)", but didn't get one."#,
+      failureMessage: """
+        Expected to receive the following action, but didn't: …
+
+        \(expectedActionDump)
+        """,
       unexpectedActionDescription: { receivedAction in
         TaskResultDebugging.$emitRuntimeWarnings.withValue(false) {
           diff(expectedAction, receivedAction, format: .proportional)
@@ -1768,14 +1774,14 @@ extension TestStore where ScopedState: Equatable {
       }
 
       if !actions.isEmpty {
-        var action = ""
-        customDump(actions, to: &action)
+        var actionsDump = ""
+        customDump(actions, to: &actionsDump)
         XCTFailHelper(
           """
           \(actions.count) received action\
           \(actions.count == 1 ? " was" : "s were") skipped:
 
-          \(action)
+          \(actionsDump)
           """,
           file: file,
           line: line

--- a/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
@@ -136,7 +136,7 @@
           The store received 1 unexpected action after this one: …
 
           Unhandled actions: [
-            [0]: TestStoreFailureTests.Action.second
+            [0]: .second
           ]
           """
       }
@@ -200,7 +200,7 @@
           Must handle 1 received action before sending an action: …
 
           Unhandled actions: [
-            [0]: TestStoreFailureTests.Action.second
+            [0]: .second
           ]
           """
       }
@@ -216,7 +216,11 @@
       XCTExpectFailure {
         store.receive(.action)
       } issueMatcher: { issue in
-        issue.compactDescription == #"Expected to receive an action "action", but didn't get one."#
+        issue.compactDescription == """
+          Expected to receive the following action, but didn't: …
+
+            TestStoreFailureTests.Action.action
+          """
       }
     }
 


### PR DESCRIPTION
We currently interpolate the action directly, which prints in a pretty crude format that becomes almost incomprehensible for deeply nested actions (common in "integration" tests). So let's leverage Custom Dump instead!
