### PR TITLE
Reducer builder improvements

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToTheReducerProtocol.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToTheReducerProtocol.md
@@ -417,7 +417,7 @@ Similar to `optional` reducers, another common pattern in applications is the us
 ``AnyReducer/forEach(state:action:environment:file:fileID:line:)-2ypoa`` to allow running a reducer
 on each element of a collection. Converting such child and parent reducers will look nearly
 identical to what we did above for optional reducers, but it will make use of the new
-``ReducerProtocol/forEach(_:action:_:file:fileID:line:)`` operator instead.
+``ReducerProtocol/forEach(_:action:element:file:fileID:line:)`` operator instead.
 
 In particular, the new `forEach` method operates on the parent reducer by specifying the collection
 sub-state you want to work on, and providing the element reducer you want to be able to run on

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerProtocol.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerProtocol.md
@@ -17,7 +17,7 @@
 - ``Scope``
 - ``ifLet(_:action:then:file:fileID:line:)``
 - ``ifCaseLet(_:action:then:file:fileID:line:)``
-- ``forEach(_:action:_:file:fileID:line:)``
+- ``forEach(_:action:element:file:fileID:line:)``
 
 ### Supporting reducers
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Store.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Store.md
@@ -4,7 +4,7 @@
 
 ### Creating a store
 
-- ``init(initialState:reducer:)``
+- ``init(initialState:reducer:prepareDependencies:)``
 - ``StoreOf``
 
 ### Scoping stores

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
@@ -451,7 +451,7 @@ public struct AnyReducer<State, Action, Environment> {
 
   /// This API has been soft-deprecated in favor of
   /// ``ReducerProtocol/ifCaseLet(_:action:then:file:fileID:line:)`` and
-  /// ``Scope/init(state:action:_:file:fileID:line:)``. Read <doc:MigratingToTheReducerProtocol>
+  /// ``Scope/init(state:action:child:file:fileID:line:)``. Read <doc:MigratingToTheReducerProtocol>
   /// for more information.
   ///
   /// Transforms a reducer that works on child state, action, and environment into one that works on
@@ -942,7 +942,7 @@ public struct AnyReducer<State, Action, Environment> {
   }
 
   /// This API has been soft-deprecated in favor of
-  /// ``ReducerProtocol/forEach(_:action:_:file:fileID:line:)``. Read
+  /// ``ReducerProtocol/forEach(_:action:element:file:fileID:line:)``. Read
   /// <doc:MigratingToTheReducerProtocol> for more information.
   ///
   /// A version of ``pullback(state:action:environment:)`` that transforms a reducer that works on

--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -53,7 +53,7 @@ extension ReducerProtocol {
   public func forEach<ElementState, ElementAction, ID: Hashable, Element: ReducerProtocol>(
     _ toElementsState: WritableKeyPath<State, IdentifiedArray<ID, ElementState>>,
     action toElementAction: CasePath<Action, (ID, ElementAction)>,
-    @ReducerBuilder<ElementState, ElementAction> _ element: () -> Element,
+    @ReducerBuilder<ElementState, ElementAction> element: () -> Element,
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Reduce.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Reduce.swift
@@ -15,6 +15,18 @@ public struct Reduce<State, Action>: ReducerProtocol {
 
   /// Initializes a reducer with a `reduce` function.
   ///
+  /// - Parameter reduce: A function that is called when ``reduce(into:action:)`` is invoked.
+  @inlinable
+  public init(_ reduce: @escaping (inout State, Action) -> EffectTask<Action>) {
+    self.init(internal: reduce)
+  }
+
+  /// Initializes a reducer with a `reduce` function and explicit `State` and `Action` types to
+  /// assist the compiler in type checking.
+  ///
+  /// > Specifying `State.self` and `Action.self` as parameter is equivalent to specifying the
+  /// > generics in `Reduce<State, Action>`.
+  ///
   /// - Parameters:
   ///   - stateType: The type of state. Assists the compiler in type checking the reduce closure.
   ///     Specify when autocompletion fails to suggest properties on state.
@@ -23,8 +35,8 @@ public struct Reduce<State, Action>: ReducerProtocol {
   ///   - reduce: A function that is called when ``reduce(into:action:)`` is invoked.
   @inlinable
   public init(
-    into stateType: State.Type = State.self,
-    action actionType: Action.Type = Action.self,
+    into stateType: State.Type,
+    action actionType: Action.Type,
     _ reduce: @escaping (inout State, Action
   ) -> EffectTask<Action>) {
     self.init(internal: reduce)

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Reduce.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Reduce.swift
@@ -15,9 +15,18 @@ public struct Reduce<State, Action>: ReducerProtocol {
 
   /// Initializes a reducer with a `reduce` function.
   ///
-  /// - Parameter reduce: A function that is called when ``reduce(into:action:)`` is invoked.
+  /// - Parameters:
+  ///   - stateType: The type of state. Assists the compiler in type checking the reduce closure.
+  ///     Specify when autocompletion fails to suggest properties on state.
+  ///   - actionType: The type of action. Assists the compiler in type checking the reduce closure.
+  ///     Specify when autocompletion fails to suggest action cases.
+  ///   - reduce: A function that is called when ``reduce(into:action:)`` is invoked.
   @inlinable
-  public init(_ reduce: @escaping (inout State, Action) -> EffectTask<Action>) {
+  public init(
+    into stateType: State.Type = State.self,
+    action actionType: Action.Type = Action.self,
+    _ reduce: @escaping (inout State, Action
+  ) -> EffectTask<Action>) {
     self.init(internal: reduce)
   }
 

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
@@ -146,7 +146,7 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
   public init<ChildState, ChildAction>(
     state toChildState: WritableKeyPath<ParentState, ChildState>,
     action toChildAction: CasePath<ParentAction, ChildAction>,
-    @ReducerBuilder<ChildState, ChildAction> _ child: () -> Child
+    @ReducerBuilder<ChildState, ChildAction> child: () -> Child
   ) where ChildState == Child.State, ChildAction == Child.Action {
     self.init(
       toChildState: .keyPath(toChildState),
@@ -218,7 +218,7 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
   public init<ChildState, ChildAction>(
     state toChildState: CasePath<ParentState, ChildState>,
     action toChildAction: CasePath<ParentAction, ChildAction>,
-    @ReducerBuilder<ChildState, ChildAction> _ child: () -> Child,
+    @ReducerBuilder<ChildState, ChildAction> child: () -> Child,
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
@@ -29,7 +29,7 @@
 /// ```
 ///
 /// A parent reducer with a domain that holds onto the child domain can use
-/// ``init(state:action:_:)`` to embed the child reducer in its
+/// ``init(state:action:child:)`` to embed the child reducer in its
 /// ``ReducerProtocol/body-swift.property-7foai``:
 ///
 /// ```swift
@@ -58,7 +58,7 @@
 /// ## Enum state
 ///
 /// The ``Scope`` reducer also works when state is modeled as an enum, not just a struct. In that
-/// case you can use ``init(state:action:_:file:fileID:line:)`` to specify a case path that
+/// case you can use ``init(state:action:child:file:fileID:line:)`` to specify a case path that
 /// identifies the case of state you want to scope to.
 ///
 /// For example, if your state was modeled as an enum for unloaded/loading/loaded, you could

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -116,10 +116,10 @@ import Foundation
 /// #### Thread safety checks
 ///
 /// The store performs some basic thread safety checks in order to help catch mistakes. Stores
-/// constructed via the initializer ``init(initialState:reducer:)`` are assumed to run
-/// only on the main thread, and so a check is executed immediately to make sure that is the case.
-/// Further, all actions sent to the store and all scopes (see ``scope(state:action:)``) of the
-/// store are also checked to make sure that work is performed on the main thread.
+/// constructed via the initializer ``init(initialState:reducer:prepareDependencies:)`` are assumed
+/// to run only on the main thread, and so a check is executed immediately to make sure that is the
+/// case. Further, all actions sent to the store and all scopes (see ``scope(state:action:)``) of
+/// the store are also checked to make sure that work is performed on the main thread.
 public final class Store<State, Action> {
   private var bufferedActions: [Action] = []
   @_spi(Internals) public var effectCancellables: [UUID: AnyCancellable] = [:]

--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -54,7 +54,7 @@ import SwiftUI
 /// }
 /// ```
 ///
-/// Enhance its core reducer using ``ReducerProtocol/forEach(_:action:_:file:fileID:line:)``:
+/// Enhance its core reducer using ``ReducerProtocol/forEach(_:action:element:file:fileID:line:)``:
 ///
 /// ```swift
 /// var body: some ReducerProtocol<State, Action> {

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -51,7 +51,7 @@ import SwiftUI
 /// ```
 ///
 /// See ``ReducerProtocol/ifCaseLet(_:action:then:file:fileID:line:)`` and
-/// ``Scope/init(state:action:_:file:fileID:line:)`` for embedding reducers that operate on each
+/// ``Scope/init(state:action:child:file:fileID:line:)`` for embedding reducers that operate on each
 /// case of an enum in reducers that operate on the entire enum.
 public struct SwitchStore<State, Action, Content: View>: View {
   public let store: Store<State, Action>


### PR DESCRIPTION
A couple improvements to reducer builders:

  * Let's add explicit parameter names to builders where appropriate. It reads a bit nicer when you rarely need to call them and aren't using trailing closure syntax.

  * Let's add optional `stateType` and `actionType` to the `Reduce` initializer. It provides better discovery for improving type checking when building reducers than manually specifying the generics.