### PR TITLE
Unavailable TestStore.send/receive when state/action is not Equatable

### DIFF
--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -2433,3 +2433,27 @@ private func _XCTExpectFailure(
     XCTExpectFailureWithOptionsInBlock(failureReason, options, failingBlock)
   #endif
 }
+
+extension TestStore {
+  @MainActor
+  @available(*, unavailable, message: "Action must conform to Equatable to receive.")
+  public func receive(
+    _ expectedAction: Action,
+    assert updateStateToExpectedResult: ((inout ScopedState) throws -> Void)? = nil,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) async {
+  }
+
+  @MainActor
+  @discardableResult
+  @available(*, unavailable, message: "Action must conform to Equatable to receive.")
+  public func send(
+    _ action: ScopedAction,
+    assert updateStateToExpectedResult: ((inout ScopedState) throws -> Void)? = nil,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) async -> TestStoreTask {
+    TestStoreTask(rawValue: nil, timeout: 0)
+  }
+}

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -2436,7 +2436,11 @@ private func _XCTExpectFailure(
 
 extension TestStore {
   @MainActor
-  @available(*, unavailable, message: "Action must conform to Equatable to receive actions.")
+  @available(
+    *,
+     unavailable,
+     message: "State and Action must conform to Equatable to receive actions."
+  )
   public func receive(
     _ expectedAction: Action,
     assert updateStateToExpectedResult: ((inout ScopedState) throws -> Void)? = nil,

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -2436,7 +2436,7 @@ private func _XCTExpectFailure(
 
 extension TestStore {
   @MainActor
-  @available(*, unavailable, message: "Action must conform to Equatable to receive.")
+  @available(*, unavailable, message: "Action must conform to Equatable to receive actions.")
   public func receive(
     _ expectedAction: Action,
     assert updateStateToExpectedResult: ((inout ScopedState) throws -> Void)? = nil,
@@ -2447,7 +2447,7 @@ extension TestStore {
 
   @MainActor
   @discardableResult
-  @available(*, unavailable, message: "Action must conform to Equatable to receive.")
+  @available(*, unavailable, message: "State must conform to Equatable to send actions.")
   public func send(
     _ action: ScopedAction,
     assert updateStateToExpectedResult: ((inout ScopedState) throws -> Void)? = nil,


### PR DESCRIPTION
Now that `TestStore` requires equatable state, we lose a bit of autocomplete and create a confusing situation while the user has to figure out how to fix.

We can help things along by defining a `unavailable` send/receive methods when state/action are not equatable, which helps with autocomplete, but also immediately tells the user what is wrong.