### PR TITLE
Introduce secondary `scope(state:action:)` with state/action for action scoping

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -345,6 +345,38 @@ public final class Store<State, Action> {
     )
   }
 
+  /// Scopes the store to one that exposes child state and actions.
+  ///
+  /// A version of ``scope(state:action:)-9iai9`` that exposes the child state along
+  /// with the child action for scoping actions.
+  ///
+  /// - Parameters:
+  ///   - toChildState: A function that transforms `State` into `ChildState`.
+  ///   - fromChildStateAndAction: A function that transforms `ChildState` and `ChildAction` into `Action`.
+  /// - Returns: A new store with its domain (state and action) transformed.
+  @_spi(Internals) public func scope<ChildState, ChildAction>(
+    state toChildState: @escaping (State) -> ChildState,
+    action fromChildStateAndAction: @escaping (ChildState, ChildAction) -> Action
+  ) -> Store<ChildState, ChildAction> {
+    self.threadCheck(status: .scope)
+
+    #if swift(>=5.7)
+      return self.reducer.rescope(
+        self,
+        state: toChildState,
+        action: fromChildStateAndAction,
+        removeDuplicates: nil
+      )
+    #else
+      return (self.scope ?? StoreScope(root: self)).rescope(
+        self,
+        state: toChildState,
+        action: fromChildStateAndAction,
+        removeDuplicates: nil
+      )
+    #endif
+  }
+
   func scope<ChildState, ChildAction>(
     state toChildState: @escaping (State) -> ChildState,
     action fromChildAction: @escaping (ChildAction) -> Action,


### PR DESCRIPTION
This is motivated by a handy `Relay` reducer I needed to introduce into my codebase which depended on this scoping variant being available:

```swift
@_spi(Internals) import ComposableArchitecture

public struct RelayState<RelayedState, MainState> {
	public let relayedState: RelayedState
	public var mainState: MainState

	public static func relayed(
		_ relayedState: RelayedState,
		with mainState: MainState
	) -> Self {
		Self(relayedState: relayedState, mainState: mainState)
	}
}

extension RelayState: Equatable where RelayedState: Equatable, MainState: Equatable {}
extension RelayState: Hashable where RelayedState: Hashable, MainState: Hashable {}

public enum RelayAction<RelayedState, MainAction> {
	case relay(RelayedState, MainAction)
}

extension RelayAction: Equatable where RelayedState: Equatable, MainAction: Equatable {}
extension RelayAction: Hashable where RelayedState: Hashable, MainAction: Hashable {}

public struct Relay<
	RelayedState,
	MainState,
	MainAction,
	MainReducer
>: ReducerProtocol where MainReducer: ReducerProtocol<MainState, MainAction> {
	public typealias State = RelayState<RelayedState, MainState>
	public typealias Action = RelayAction<RelayedState, MainAction>

	public let mainReducer: MainReducer

	public init(
		@ReducerBuilder<MainState, MainAction> _ mainReducer: () -> MainReducer
	) {
		self.mainReducer = mainReducer()
	}

	public func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
		switch action {
		case let .relay(relayedState, mainAction):
			return mainReducer.reduce(into: &state.mainState, action: mainAction).map {
				Action.relay(relayedState, $0)
			}
		}
	}
}

public extension Store {
	func relay<RelayedState, MainState, MainAction>() -> Store<MainState, MainAction> where
		State == RelayState<RelayedState, MainState>,
		Action == RelayAction<RelayedState, MainAction>
	{
		self
			.scope(state: { $0 }, action: { .relay($0.relayedState, $1) }) // here!
			.scope(state: { $0.mainState }, action: { $0 })
	}
}
```

As a separate question, was this scope function originally in TCA but was later removed by any chance? I very vaguely remember it being there but I might be wrong.