### PR TITLE
Fix documentation

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -129,7 +129,7 @@ extension EffectPublisher where Failure == Never {
   ///   struct State { … }
   ///   enum FeatureAction {
   ///     case factButtonTapped
-  ///     case faceResponse(TaskResult<String>)
+  ///     case factResponse(TaskResult<String>)
   ///   }
   ///   @Dependency(\.numberFact) var numberFact
   ///


### PR DESCRIPTION
Fix a tiny typo found in the code snippet of `.task(...)`