### PR TITLE
Make reducer builder closure parameters explicit

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -53,7 +53,7 @@ extension ReducerProtocol {
   public func forEach<ElementState, ElementAction, ID: Hashable, Element: ReducerProtocol>(
     _ toElementsState: WritableKeyPath<State, IdentifiedArray<ID, ElementState>>,
     action toElementAction: CasePath<Action, (ID, ElementAction)>,
-    @ReducerBuilder<ElementState, ElementAction> _ element: () -> Element,
+    @ReducerBuilder<ElementState, ElementAction> element: () -> Element,
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
@@ -146,7 +146,7 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
   public init<ChildState, ChildAction>(
     state toChildState: WritableKeyPath<ParentState, ChildState>,
     action toChildAction: CasePath<ParentAction, ChildAction>,
-    @ReducerBuilder<ChildState, ChildAction> _ child: () -> Child
+    @ReducerBuilder<ChildState, ChildAction> child: () -> Child
   ) where ChildState == Child.State, ChildAction == Child.Action {
     self.init(
       toChildState: .keyPath(toChildState),
@@ -218,7 +218,7 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
   public init<ChildState, ChildAction>(
     state toChildState: CasePath<ParentState, ChildState>,
     action toChildAction: CasePath<ParentAction, ChildAction>,
-    @ReducerBuilder<ChildState, ChildAction> _ child: () -> Child,
+    @ReducerBuilder<ChildState, ChildAction> child: () -> Child,
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line


### PR DESCRIPTION
While this is a breaking change, its impact is likely pretty low, as trailing closure syntax should be overwhelmingly preferred in usage, and Xcode should provide automatic migration to the new parameter names:

  - `Scope(...:child:)`
  - `forEach(...:element:)`

The one exception that still is nameless is `CombineReducers` because it already includes the `Reducers` in its name, and a parameter name comes across redundant/verbose.