### PR TITLE
Nest `Send<Action>` as `Effect<Action>.Send`

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -57,7 +57,7 @@ public struct EffectPublisher<Action, Failure: Error> {
   enum Operation {
     case none
     case publisher(AnyPublisher<Action, Failure>)
-    case run(TaskPriority? = nil, @Sendable (Send<Action>) async -> Void)
+    case run(TaskPriority? = nil, @Sendable (Send) async -> Void)
   }
 
   @usableFromInline
@@ -253,8 +253,8 @@ extension EffectPublisher where Failure == Never {
   /// - Returns: An effect wrapping the given asynchronous work.
   public static func run(
     priority: TaskPriority? = nil,
-    operation: @escaping @Sendable (Send<Action>) async throws -> Void,
-    catch handler: (@Sendable (Error, Send<Action>) async -> Void)? = nil,
+    operation: @escaping @Sendable (Send) async throws -> Void,
+    catch handler: (@Sendable (Error, Send) async -> Void)? = nil,
     file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
@@ -353,68 +353,70 @@ extension EffectPublisher where Failure == Never {
   }
 }
 
-/// A type that can send actions back into the system when used from
-/// ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)``.
-///
-/// This type implements [`callAsFunction`][callAsFunction] so that you invoke it as a function
-/// rather than calling methods on it:
-///
-/// ```swift
-/// return .run { send in
-///   send(.started)
-///   defer { send(.finished) }
-///   for await event in self.events {
-///     send(.event(event))
-///   }
-/// }
-/// ```
-///
-/// You can also send actions with animation:
-///
-/// ```swift
-/// send(.started, animation: .spring())
-/// defer { send(.finished, animation: .default) }
-/// ```
-///
-/// See ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)`` for more information on how to
-/// use this value to construct effects that can emit any number of times in an asynchronous
-/// context.
-///
-/// [callAsFunction]: https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#ID622
-@MainActor
-public struct Send<Action> {
-  public let send: @MainActor (Action) -> Void
-
-  public init(send: @escaping @MainActor (Action) -> Void) {
-    self.send = send
-  }
-
-  /// Sends an action back into the system from an effect.
+extension EffectTask {
+  /// A type that can send actions back into the system when used from
+  /// ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)``.
   ///
-  /// - Parameter action: An action.
-  public func callAsFunction(_ action: Action) {
-    guard !Task.isCancelled else { return }
-    self.send(action)
-  }
-
-  /// Sends an action back into the system from an effect with animation.
+  /// This type implements [`callAsFunction`][callAsFunction] so that you invoke it as a function
+  /// rather than calling methods on it:
   ///
-  /// - Parameters:
-  ///   - action: An action.
-  ///   - animation: An animation.
-  public func callAsFunction(_ action: Action, animation: Animation?) {
-    callAsFunction(action, transaction: Transaction(animation: animation))
-  }
-
-  /// Sends an action back into the system from an effect with transaction.
+  /// ```swift
+  /// return .run { send in
+  ///   send(.started)
+  ///   defer { send(.finished) }
+  ///   for await event in self.events {
+  ///     send(.event(event))
+  ///   }
+  /// }
+  /// ```
   ///
-  /// - Parameters:
-  ///   - action: An action.
-  ///   - transaction: A transaction.
-  public func callAsFunction(_ action: Action, transaction: Transaction) {
-    guard !Task.isCancelled else { return }
-    withTransaction(transaction) {
-      self(action)
+  /// You can also send actions with animation:
+  ///
+  /// ```swift
+  /// send(.started, animation: .spring())
+  /// defer { send(.finished, animation: .default) }
+  /// ```
+  ///
+  /// See ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)`` for more information on how to
+  /// use this value to construct effects that can emit any number of times in an asynchronous
+  /// context.
+  ///
+  /// [callAsFunction]: https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#ID622
+  @MainActor
+  public struct Send {
+    public let send: @MainActor (Action) -> Void
+
+    public init(send: @escaping @MainActor (Action) -> Void) {
+      self.send = send
+    }
+
+    /// Sends an action back into the system from an effect.
+    ///
+    /// - Parameter action: An action.
+    public func callAsFunction(_ action: Action) {
+      guard !Task.isCancelled else { return }
+      self.send(action)
+    }
+
+    /// Sends an action back into the system from an effect with animation.
+    ///
+    /// - Parameters:
+    ///   - action: An action.
+    ///   - animation: An animation.
+    public func callAsFunction(_ action: Action, animation: Animation?) {
+      callAsFunction(action, transaction: Transaction(animation: animation))
+    }
+
+    /// Sends an action back into the system from an effect with transaction.
+    ///
+    /// - Parameters:
+    ///   - action: An action.
+    ///   - transaction: A transaction.
+    public func callAsFunction(_ action: Action, transaction: Transaction) {
+      guard !Task.isCancelled else { return }
+      withTransaction(transaction) {
+        self(action)
+      }
     }
   }
 }

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -3,6 +3,15 @@ import Combine
 import SwiftUI
 import XCTestDynamicOverlay
 
+// MARK: - Deprecated after 0.50.4
+
+@available(
+  *,
+  deprecated,
+  message: "Use 'EffectTask<Action>.Send' instead."
+)
+public typealias Send<Action> = EffectTask<Action>.Send
+
 // MARK: - Deprecated after 0.49.2
 
 @available(

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -419,7 +419,7 @@ public final class Store<State, Action> {
         tasks.wrappedValue.append(
           Task(priority: priority) {
             await operation(
-              Send {
+              EffectTask<Action>.Send {
                 if let task = self.send($0, originatingFrom: action) {
                   tasks.wrappedValue.append(task)
                 }


### PR DESCRIPTION
Right now, `Send<Action>` being a top-level type makes it the preferred autocompletion choice when you type "Send…" to make some type `Sendable` (a very frequent operation). This is suboptimal.

Fortunately, this value is always provided by the library in standard operations, and the user usually doesn't have to handle its type directly. This PR relocates `Send<Action>` in `EffectTask<Action>.Send` (that is `EffectPublisher<Action, Never>.Send`, but it should transparently migrate to `Effect<Action>.Send` for the `v1.0`.). The current top-level `Send` is deprecated (which lowers its autocompletion rank and gives way to `Sendable`), but this shouldn't impact existing user code which should seamlessly resolve to `Effect<Action>.Send` instead of `Send<Action>` in the vast majority of cases.

It doesn't seem possible to provide a `rename:` argument to the deprecation annotation.