### PR TITLE
Allow scoping store's action while keeping state intact

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -326,6 +326,18 @@ public final class Store<State, Action> {
     self.scope(state: toChildState, action: { $0 })
   }
 
+  /// Scopes the store to one that exposes child action.
+  ///
+  /// A version of ``scope(state:action:)`` that leaves the state type unchanged.
+  ///
+  /// - Parameter fromChildAction: A function that transforms `ChildAction` into `Action`.
+  /// - Returns: A new store with its domain (state and action) transformed.
+  public func scope<ChildAction>(
+    action fromChildAction: @escaping (ChildAction) -> Action
+  ) -> Store<State, ChildAction> {
+    self.scope(state: { $0 }, action: fromChildAction)
+  }
+
   func filter(
     _ isSent: @escaping (State, Action) -> Bool
   ) -> Store<State, Action> {

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -609,6 +609,13 @@ extension ViewStore where ViewState: Equatable {
     self.init(store, observe: toViewState, removeDuplicates: ==)
   }
 
+  public convenience init<Action>(
+    _ store: Store<ViewState, Action>,
+    send fromViewAction: @escaping (ViewAction) -> Action
+  ) {
+    self.init(store, observe: { $0 }, send: fromViewAction, removeDuplicates: ==)
+  }
+
   public convenience init<State, Action>(
     _ store: Store<State, Action>,
     observe toViewState: @escaping (State) -> ViewState,
@@ -684,6 +691,13 @@ extension ViewStore where ViewState: Equatable {
 extension ViewStore where ViewState == Void {
   public convenience init(_ store: Store<Void, ViewAction>) {
     self.init(store, removeDuplicates: ==)
+  }
+
+  public convenience init<Action>(
+    _ store: Store<ViewState, Action>,
+    send fromViewAction: @escaping (ViewAction) -> Action
+  ) {
+    self.init(store.scope(state: { _ in }, action: fromViewAction))
   }
 }
 


### PR DESCRIPTION
I noticed that there are convenience initializers and functions that allow for scoping without having to explicitly pass an action, but the same can't be said for state.

l don't know if this is intentional or not, but here's a PR for the functionality just in case.

If you're also wondering when this would ever be useful, here's a snippet of code from my FontManagerCell's `update` function where Reducer.Action utilizes [action boundaries](https://github.com/pointfreeco/swift-composable-architecture/discussions/1440):
```swift
public func update(
  id: Tagged<RadioRowItem, UUID>,
  with store: Store<RadioSection, FontManager.Action>
) {
  let viewStore = ViewStore(store, send: Reducer.Action.view)
  self.store = store
  self.viewStore = viewStore
  self.id = id

  setupBindings(on: viewStore)
}
```