### PR TITLE
Re-enable `_printChanges()` for previews

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
@@ -31,8 +31,6 @@ public struct _ReducerPrinter<State, Action> {
 extension _ReducerPrinter {
   public static var customDump: Self {
     Self { receivedAction, oldState, newState in
-      @Dependency(\.context) var context
-      guard context != .preview else { return }
       var target = ""
       target.write("received action:\n")
       CustomDump.customDump(receivedAction, to: &target, indent: 2)
@@ -44,8 +42,6 @@ extension _ReducerPrinter {
 
   public static var actionLabels: Self {
     Self { receivedAction, _, _ in
-      @Dependency(\.context) var context
-      guard context != .preview else { return }
       print("received action: \(debugCaseOutput(receivedAction))")
     }
   }

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -75,21 +75,5 @@
       let store = TestStore(initialState: 0, reducer: DebuggedReducer()._printChanges())
       await store.send(true) { $0 = 1 }
     }
-
-    @MainActor
-    func testDebugReducerInPreview() async {
-      struct DebuggedReducer: ReducerProtocol {
-        typealias State = Int
-        typealias Action = Bool
-        func reduce(into state: inout Int, action: Bool) -> EffectTask<Bool> {
-          state += action ? 1 : -1
-          return .none
-        }
-      }
-      let store = TestStore(initialState: 0, reducer: DebuggedReducer()._printChanges()) {
-        $0.context = .preview
-      }
-      await store.send(true) { $0 = 1 }
-    }
   }
 #endif


### PR DESCRIPTION
For optimization reasons, `Reducer._printChanges()`'s isn't generating output for Xcode previews (#1625).
The new beta version of Xcode 14.3 now displays `Swift.print(…)` messages in the console under the "previews" tab, so we should probably revert the changes from #1625 and re-enable `_printChanges()`'s output in `preview` context.

I don't think there is a way to detect when previews are reloaded, so the output of successive reloads concatenates. It's better than nothing I guess, but this can maybe be improved in a subsequent PR.