### PR TITLE
Qualify `Send` as `Effect(Task)<Send>`

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "4ad606ba5d7673ea60679a61ff867cc1ff8c8e86",
-        "version" : "1.2.1"
+        "revision" : "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
+        "version" : "1.2.2"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "87dd388a193569b288d03cb4060db54f90d1a66f",
-        "version" : "0.7.0"
+        "revision" : "dd86159e25c749873f144577e5d18309bf57534f",
+        "version" : "0.8.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",
       "state" : {
-        "revision" : "bf0fb9d53019cbde1a1e0cf290b560a0a0411282",
-        "version" : "0.6.0"
+        "revision" : "270a754308f5440be52fc295242eb7031638bd15",
+        "version" : "0.6.1"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "16b23a295fa322eb957af98037f86791449de60f",
-        "version" : "0.8.1"
+        "revision" : "ace21305e0dd3a9e749aef79fef14be79a3b4669",
+        "version" : "0.8.2"
       }
     }
   ],

--- a/Examples/Integration/Integration/BindingsAnimationsTestBench.swift
+++ b/Examples/Integration/Integration/BindingsAnimationsTestBench.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import SwiftUI
 
 struct BindingsAnimations: ReducerProtocol {
-  func reduce(into state: inout Bool, action: Void) -> EffectTask<Void> {
+  func reduce(into state: inout Bool, action: Void) -> Effect<Void> {
     state.toggle()
     return .none
   }

--- a/Examples/Integration/Integration/EscapedWithViewStoreTestCase.swift
+++ b/Examples/Integration/Integration/EscapedWithViewStoreTestCase.swift
@@ -7,7 +7,7 @@ struct EscapedWithViewStoreTestCase: ReducerProtocol {
     case decr
   }
 
-  func reduce(into state: inout Int, action: Action) -> EffectTask<Action> {
+  func reduce(into state: inout Int, action: Action) -> Effect<Action> {
     switch action {
     case .incr:
       state += 1

--- a/Examples/Integration/Integration/ForEachBindingTestCase.swift
+++ b/Examples/Integration/Integration/ForEachBindingTestCase.swift
@@ -10,7 +10,7 @@ struct ForEachBindingTestCase: ReducerProtocol {
     case removeLast
   }
 
-  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+  func reduce(into state: inout State, action: Action) -> Effect<Action> {
     switch action {
     case let .change(offset: offset, value: value):
       state.values[offset] = value

--- a/Examples/Integration/Integration/NavigationStackBindingTestCase.swift
+++ b/Examples/Integration/Integration/NavigationStackBindingTestCase.swift
@@ -13,7 +13,7 @@ struct NavigationStackBindingTestCase: ReducerProtocol {
     case navigationPathChanged([State.Destination])
   }
 
-  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+  func reduce(into state: inout State, action: Action) -> Effect<Action> {
     switch action {
     case .goToChild:
       state.path.append(.child)

--- a/Examples/Todos/Todos/Todo.swift
+++ b/Examples/Todos/Todos/Todo.swift
@@ -13,7 +13,7 @@ struct Todo: Reducer {
     case textFieldChanged(String)
   }
 
-  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+  func reduce(into state: inout State, action: Action) -> Effect<Action> {
     switch action {
     case .checkBoxToggled:
       state.isComplete.toggle()

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -57,7 +57,7 @@ public struct EffectPublisher<Action, Failure: Error> {
   enum Operation {
     case none
     case publisher(AnyPublisher<Action, Failure>)
-    case run(TaskPriority? = nil, @Sendable (EffectTask<Action>.Send) async -> Void)
+    case run(TaskPriority? = nil, @Sendable (Effect<Action>.Send) async -> Void)
   }
 
   @usableFromInline
@@ -352,7 +352,7 @@ extension EffectPublisher where Failure == Never {
   }
 }
 
-extension EffectTask {
+extension Effect {
   /// A type that can send actions back into the system when used from
   /// ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)``.
   ///
@@ -574,7 +574,7 @@ extension EffectPublisher {
           operation: .run(priority) { send in
             await escaped.yield {
               await operation(
-                EffectTask<Action>.Send { action in
+                Effect<Action>.Send { action in
                   send(transform(action))
                 }
               )

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -57,7 +57,7 @@ public struct EffectPublisher<Action, Failure: Error> {
   enum Operation {
     case none
     case publisher(AnyPublisher<Action, Failure>)
-    case run(TaskPriority? = nil, @Sendable (Send) async -> Void)
+    case run(TaskPriority? = nil, @Sendable (EffectTask<Action>.Send) async -> Void)
   }
 
   @usableFromInline
@@ -574,7 +574,7 @@ extension EffectPublisher {
           operation: .run(priority) { send in
             await escaped.yield {
               await operation(
-                Send { action in
+                EffectTask<Action>.Send { action in
                   send(transform(action))
                 }
               )

--- a/Sources/ComposableArchitecture/Effects/Animation.swift
+++ b/Sources/ComposableArchitecture/Effects/Animation.swift
@@ -46,7 +46,7 @@ extension EffectPublisher {
       return Self(
         operation: .run(priority) { send in
           await operation(
-            EffectTask<Action>.Send { value in
+            Effect<Action>.Send { value in
               withTransaction(transaction) {
                 send(value)
               }

--- a/Sources/ComposableArchitecture/Effects/Animation.swift
+++ b/Sources/ComposableArchitecture/Effects/Animation.swift
@@ -46,7 +46,7 @@ extension EffectPublisher {
       return Self(
         operation: .run(priority) { send in
           await operation(
-            Send { value in
+            EffectTask<Action>.Send { value in
               withTransaction(transaction) {
                 send(value)
               }

--- a/Sources/ComposableArchitecture/Effects/Publisher.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher.swift
@@ -24,7 +24,7 @@ extension EffectPublisher: Publisher {
             var isCompleted = false
             defer { isCompleted = true }
           #endif
-          let send = EffectTask<Action>.Send {
+          let send = Effect<Action>.Send {
             #if DEBUG
               if isCompleted {
                 runtimeWarn(
@@ -34,7 +34,7 @@ extension EffectPublisher: Publisher {
                     Action:
                       \(debugCaseOutput($0))
 
-                  Avoid sending actions using the 'send' argument from 'EffectTask.run' after \
+                  Avoid sending actions using the 'send' argument from 'Effect.run' after \
                   the effect has completed. This can happen if you escape the 'send' argument in \
                   an unstructured context.
 
@@ -462,7 +462,7 @@ internal struct EffectPublisherWrapper<Action, Failure: Error>: Publisher {
       return .create { subscriber in
         let task = Task(priority: priority) { @MainActor in
           defer { subscriber.send(completion: .finished) }
-          let send = EffectTask<Action>.Send { subscriber.send($0) }
+          let send = Effect<Action>.Send { subscriber.send($0) }
           await operation(send)
         }
         return AnyCancellable {

--- a/Sources/ComposableArchitecture/Effects/Publisher.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher.swift
@@ -24,7 +24,7 @@ extension EffectPublisher: Publisher {
             var isCompleted = false
             defer { isCompleted = true }
           #endif
-          let send = Send {
+          let send = EffectTask<Action>.Send {
             #if DEBUG
               if isCompleted {
                 runtimeWarn(
@@ -462,7 +462,7 @@ internal struct EffectPublisherWrapper<Action, Failure: Error>: Publisher {
       return .create { subscriber in
         let task = Task(priority: priority) { @MainActor in
           defer { subscriber.send(completion: .finished) }
-          let send = Send { subscriber.send($0) }
+          let send = EffectTask<Action>.Send { subscriber.send($0) }
           await operation(send)
         }
         return AnyCancellable {

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -28,9 +28,9 @@ public typealias ReducerProtocolOf<R: Reducer> = Reducer<R.State, R.Action>
 @available(
   *,
   deprecated,
-  message: "Use 'EffectTask<Action>.Send' instead."
+  message: "Use 'Effect<Action>.Send' instead."
 )
-public typealias Send<Action> = EffectTask<Action>.Send
+public typealias Send<Action> = Effect<Action>.Send
 
 // MARK: - Deprecated after 0.49.2
 

--- a/Sources/ComposableArchitecture/Reducer/Reducers/SignpostReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/SignpostReducer.swift
@@ -121,7 +121,7 @@ extension EffectPublisher where Failure == Never {
             actionOutput
           )
           await operation(
-            Send { action in
+            Effect<Action>.Send { action in
               os_signpost(
                 .event, log: log, name: "Effect Output", "%sOutput from %s", prefix, actionOutput
               )

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -423,7 +423,7 @@ public final class Store<State, Action> {
               defer { isCompleted = true }
             #endif
             await operation(
-              EffectTask<Action>.Send {
+              Effect<Action>.Send {
                 #if DEBUG
                   if isCompleted {
                     runtimeWarn(
@@ -436,7 +436,7 @@ public final class Store<State, Action> {
                         Effect returned from:
                           \(debugCaseOutput(action))
 
-                      Avoid sending actions using the 'send' argument from 'EffectTask.run' after \
+                      Avoid sending actions using the 'send' argument from 'Effect.run' after \
                       the effect has completed. This can happen if you escape the 'send' argument in \
                       an unstructured context.
 

--- a/Tests/ComposableArchitectureTests/BindingLocalTests.swift
+++ b/Tests/ComposableArchitectureTests/BindingLocalTests.swift
@@ -17,7 +17,7 @@
           case textChanged(String)
         }
 
-        func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+        func reduce(into state: inout State, action: Action) -> Effect<Action> {
           switch action {
           case let .textChanged(text):
             state.text = text

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -16,17 +16,17 @@ final class ComposableArchitectureTests: XCTestCase {
         case squareNow
       }
       @Dependency(\.mainQueue) var mainQueue
-      func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+      func reduce(into state: inout State, action: Action) -> Effect<Action> {
         switch action {
         case .incrAndSquareLater:
           return .merge(
-            EffectTask(value: .incrNow)
+            Effect(value: .incrNow)
               .delay(for: 2, scheduler: self.mainQueue)
               .eraseToEffect(),
-            EffectTask(value: .squareNow)
+            Effect(value: .squareNow)
               .delay(for: 1, scheduler: self.mainQueue)
               .eraseToEffect(),
-            EffectTask(value: .squareNow)
+            Effect(value: .squareNow)
               .delay(for: 2, scheduler: self.mainQueue)
               .eraseToEffect()
           )

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -66,7 +66,7 @@
       struct DebuggedReducer: Reducer {
         typealias State = Int
         typealias Action = Bool
-        func reduce(into state: inout Int, action: Bool) -> EffectTask<Bool> {
+        func reduce(into state: inout Int, action: Bool) -> Effect<Bool> {
           state += action ? 1 : -1
           return .none
         }

--- a/Tests/ComposableArchitectureTests/DependencyKeyWritingReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/DependencyKeyWritingReducerTests.swift
@@ -99,7 +99,7 @@ final class DependencyKeyWritingReducerTests: XCTestCase {
       }
       @Dependency(\.myValue) var myValue
 
-      func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+      func reduce(into state: inout State, action: Action) -> Effect<Action> {
         switch action {
         case .tap:
           state.count += 1
@@ -136,7 +136,7 @@ private struct Feature: Reducer {
   @Dependency(\.myValue) var myValue
   struct State: Equatable { var value = 0 }
   enum Action { case tap }
-  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+  func reduce(into state: inout State, action: Action) -> Effect<Action> {
     switch action {
     case .tap:
       state.value = self.myValue

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -28,7 +28,7 @@ final class EffectCancellationTests: XCTestCase {
     subject.send(2)
     XCTAssertEqual(values, [1, 2])
 
-    EffectTask<Never>.cancel(id: CancelID())
+    Effect<Never>.cancel(id: CancelID())
       .sink { _ in }
       .store(in: &self.cancellables)
 
@@ -75,7 +75,7 @@ final class EffectCancellationTests: XCTestCase {
     XCTAssertEqual(value, nil)
 
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-      EffectTask<Never>.cancel(id: CancelID())
+      Effect<Never>.cancel(id: CancelID())
         .sink { _ in }
         .store(in: &self.cancellables)
     }
@@ -98,7 +98,7 @@ final class EffectCancellationTests: XCTestCase {
     XCTAssertEqual(value, nil)
 
     mainQueue.advance(by: 1)
-    EffectTask<Never>.cancel(id: CancelID())
+    Effect<Never>.cancel(id: CancelID())
       .sink { _ in }
       .store(in: &self.cancellables)
 
@@ -153,7 +153,7 @@ final class EffectCancellationTests: XCTestCase {
     subject.send(1)
     XCTAssertEqual(values, [1])
 
-    EffectTask<Never>.cancel(id: CancelID())
+    Effect<Never>.cancel(id: CancelID())
       .sink { _ in }
       .store(in: &self.cancellables)
 
@@ -178,7 +178,7 @@ final class EffectCancellationTests: XCTestCase {
     subject.send(completion: .finished)
     XCTAssertEqual(values, [1])
 
-    EffectTask<Never>.cancel(id: CancelID())
+    Effect<Never>.cancel(id: CancelID())
       .sink { _ in }
       .store(in: &self.cancellables)
 
@@ -329,11 +329,11 @@ final class EffectCancellationTests: XCTestCase {
         .cancellable(id: id)
     }
 
-    EffectTask<AnyHashable>.merge(effects)
+    Effect<AnyHashable>.merge(effects)
       .sink { output.append($0) }
       .store(in: &self.cancellables)
 
-    EffectTask<AnyHashable>
+    Effect<AnyHashable>
       .cancel(ids: [A(), C()])
       .sink { _ in }
       .store(in: &self.cancellables)

--- a/Tests/ComposableArchitectureTests/EffectFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectFailureTests.swift
@@ -23,7 +23,7 @@
       }
 
       line = #line
-      let effect = EffectTask<Void>.task {
+      let effect = Effect<Void>.task {
         struct Unexpected: Error {}
         throw Unexpected()
       }
@@ -47,7 +47,7 @@
       }
 
       line = #line
-      let effect = EffectTask<Void>.run { _ in
+      let effect = Effect<Void>.run { _ in
         struct Unexpected: Error {}
         throw Unexpected()
       }

--- a/Tests/ComposableArchitectureTests/EffectFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectFailureTests.swift
@@ -37,12 +37,12 @@
       var line: UInt!
       XCTExpectFailure {
         $0.compactDescription == """
-          An "EffectTask.run" returned from "\(#fileID):\(line+1)" threw an unhandled error. …
+          An "Effect.run" returned from "\(#fileID):\(line+1)" threw an unhandled error. …
 
               EffectFailureTests.Unexpected()
 
           All non-cancellation errors must be explicitly handled via the "catch" parameter on \
-          "EffectTask.run", or via a "do" block.
+          "Effect.run", or via a "do" block.
           """
       }
 

--- a/Tests/ComposableArchitectureTests/EffectOperationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectOperationTests.swift
@@ -6,7 +6,7 @@
   @MainActor
   class EffectOperationTests: XCTestCase {
     func testMergeDiscardsNones() async {
-      var effect = EffectTask<Int>.none
+      var effect = Effect<Int>.none
         .merge(with: .none)
       switch effect.operation {
       case .none:
@@ -15,7 +15,7 @@
         XCTFail()
       }
 
-      effect = EffectTask<Int>.task { 42 }
+      effect = Effect<Int>.task { 42 }
         .merge(with: .none)
       switch effect.operation {
       case let .run(_, send):
@@ -24,7 +24,7 @@
         XCTFail()
       }
 
-      effect = EffectTask<Int>.none
+      effect = Effect<Int>.none
         .merge(with: .task { 42 })
       switch effect.operation {
       case let .run(_, send):
@@ -33,7 +33,7 @@
         XCTFail()
       }
 
-      effect = EffectTask<Int>.run { await $0(42) }
+      effect = Effect<Int>.run { await $0(42) }
         .merge(with: .none)
       switch effect.operation {
       case let .run(_, send):
@@ -42,7 +42,7 @@
         XCTFail()
       }
 
-      effect = EffectTask<Int>.none
+      effect = Effect<Int>.none
         .merge(with: .run { await $0(42) })
       switch effect.operation {
       case let .run(_, send):
@@ -53,7 +53,7 @@
     }
 
     func testConcatenateDiscardsNones() async {
-      var effect = EffectTask<Int>.none
+      var effect = Effect<Int>.none
         .concatenate(with: .none)
       switch effect.operation {
       case .none:
@@ -62,7 +62,7 @@
         XCTFail()
       }
 
-      effect = EffectTask<Int>.task { 42 }
+      effect = Effect<Int>.task { 42 }
         .concatenate(with: .none)
       switch effect.operation {
       case let .run(_, send):
@@ -71,7 +71,7 @@
         XCTFail()
       }
 
-      effect = EffectTask<Int>.none
+      effect = Effect<Int>.none
         .concatenate(with: .task { 42 })
       switch effect.operation {
       case let .run(_, send):
@@ -80,7 +80,7 @@
         XCTFail()
       }
 
-      effect = EffectTask<Int>.run { await $0(42) }
+      effect = Effect<Int>.run { await $0(42) }
         .concatenate(with: .none)
       switch effect.operation {
       case let .run(_, send):
@@ -89,7 +89,7 @@
         XCTFail()
       }
 
-      effect = EffectTask<Int>.none
+      effect = Effect<Int>.none
         .concatenate(with: .run { await $0(42) })
       switch effect.operation {
       case let .run(_, send):
@@ -102,7 +102,7 @@
     func testMergeFuses() async {
       var values = [Int]()
 
-      let effect = EffectTask<Int>.task {
+      let effect = Effect<Int>.task {
         try await Task.sleep(nanoseconds: NSEC_PER_SEC / 10)
         return 42
       }
@@ -125,7 +125,7 @@
     func testConcatenateFuses() async {
       var values = [Int]()
 
-      let effect = EffectTask<Int>.task { 42 }
+      let effect = Effect<Int>.task { 42 }
         .concatenate(with: .task { 1729 })
       switch effect.operation {
       case let .run(_, send):
@@ -138,7 +138,7 @@
     }
 
     func testMap() async {
-      let effect = EffectTask<Int>.task { 42 }
+      let effect = Effect<Int>.task { 42 }
         .map { "\($0)" }
 
       switch effect.operation {

--- a/Tests/ComposableArchitectureTests/EffectRunTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectRunTests.swift
@@ -46,12 +46,12 @@ final class EffectRunTests: XCTestCase {
       var line: UInt!
       XCTExpectFailure(nil, enabled: nil, strict: nil) {
         $0.compactDescription == """
-          An "EffectTask.run" returned from "\(#fileID):\(line+1)" threw an unhandled error. …
+          An "Effect.run" returned from "\(#fileID):\(line+1)" threw an unhandled error. …
 
               EffectRunTests.Failure()
 
           All non-cancellation errors must be explicitly handled via the "catch" parameter on \
-          "EffectTask.run", or via a "do" block.
+          "Effect.run", or via a "do" block.
           """
       }
       struct State: Equatable {}

--- a/Tests/ComposableArchitectureTests/EffectRunTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectRunTests.swift
@@ -130,7 +130,7 @@ final class EffectRunTests: XCTestCase {
             Effect returned from:
               EffectRunTests.Action.tap
 
-          Avoid sending actions using the 'send' argument from 'EffectTask.run' after the effect has \
+          Avoid sending actions using the 'send' argument from 'Effect.run' after the effect has \
           completed. This can happen if you escape the 'send' argument in an unstructured context.
 
           To fix this, make sure that your 'run' closure does not return until you're done calling \
@@ -172,7 +172,7 @@ final class EffectRunTests: XCTestCase {
             Action:
               EffectRunTests.Action.response
 
-          Avoid sending actions using the 'send' argument from 'EffectTask.run' after the effect has \
+          Avoid sending actions using the 'send' argument from 'Effect.run' after the effect has \
           completed. This can happen if you escape the 'send' argument in an unstructured context.
 
           To fix this, make sure that your 'run' closure does not return until you're done calling \

--- a/Tests/ComposableArchitectureTests/EffectTaskTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTaskTests.swift
@@ -46,12 +46,12 @@ final class EffectTaskTests: XCTestCase {
       var line: UInt!
       XCTExpectFailure(nil, enabled: nil, strict: nil) {
         $0.compactDescription == """
-          An "EffectTask.task" returned from "\(#fileID):\(line+1)" threw an unhandled error. …
+          An "Effect.task" returned from "\(#fileID):\(line+1)" threw an unhandled error. …
 
               EffectTaskTests.Failure()
 
           All non-cancellation errors must be explicitly handled via the "catch" parameter on \
-          "EffectTask.task", or via a "do" block.
+          "Effect.task", or via a "do" block.
           """
       }
       struct State: Equatable {}

--- a/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
@@ -7,13 +7,13 @@ private struct Test: Reducer {
   struct State {}
   enum Action { case tap }
 
-  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+  func reduce(into state: inout State, action: Action) -> Effect<Action> {
     .none
   }
 
   @available(iOS, introduced: 9999.0)
   struct Unavailable: Reducer {
-    func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+    func reduce(into state: inout State, action: Action) -> Effect<Action> {
       .none
     }
   }
@@ -173,7 +173,7 @@ private struct Root: Reducer {
       case action
     }
 
-    func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+    func reduce(into state: inout State, action: Action) -> Effect<Action> {
       .none
     }
   }

--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -35,7 +35,7 @@ final class ReducerTests: XCTestCase {
             let delay: Duration
             let setValue: @Sendable () async -> Void
 
-            func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+            func reduce(into state: inout State, action: Action) -> Effect<Action> {
               state += 1
               return .fireAndForget {
                 try await self.clock.sleep(for: self.delay)
@@ -86,7 +86,7 @@ final class ReducerTests: XCTestCase {
     struct One: Reducer {
       typealias State = Int
       let effect: @Sendable () async -> Void
-      func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+      func reduce(into state: inout State, action: Action) -> Effect<Action> {
         state += 1
         return .fireAndForget {
           await self.effect()

--- a/Tests/ComposableArchitectureTests/ScopeTests.swift
+++ b/Tests/ComposableArchitectureTests/ScopeTests.swift
@@ -118,7 +118,7 @@ private struct Child1: Reducer {
     case decrementButtonTapped
     case incrementButtonTapped
   }
-  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+  func reduce(into state: inout State, action: Action) -> Effect<Action> {
     switch action {
     case .decrementButtonTapped:
       state.count -= 1

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -18,7 +18,7 @@ final class StoreTests: XCTestCase {
 
   func testCancellableIsRemovedWhenEffectCompletes() {
     let mainQueue = DispatchQueue.test
-    let effect = EffectTask<Void>(value: ())
+    let effect = Effect<Void>(value: ())
       .delay(for: 1, scheduler: mainQueue)
       .eraseToEffect()
 
@@ -185,13 +185,13 @@ final class StoreTests: XCTestCase {
       switch action {
       case .tap:
         return .merge(
-          EffectTask(value: .next1),
-          EffectTask(value: .next2),
+          Effect(value: .next1),
+          Effect(value: .next2),
           .fireAndForget { values.append(1) }
         )
       case .next1:
         return .merge(
-          EffectTask(value: .end),
+          Effect(value: .end),
           .fireAndForget { values.append(2) }
         )
       case .next2:
@@ -214,7 +214,7 @@ final class StoreTests: XCTestCase {
       switch action {
       case .incr:
         state += 1
-        return state >= 100_000 ? EffectTask(value: .noop) : EffectTask(value: .incr)
+        return state >= 100_000 ? Effect(value: .noop) : Effect(value: .incr)
       case .noop:
         return .none
       }
@@ -355,9 +355,9 @@ final class StoreTests: XCTestCase {
         switch action {
         case 0:
           return .merge(
-            EffectTask(value: 1),
-            EffectTask(value: 2),
-            EffectTask(value: 3)
+            Effect(value: 1),
+            Effect(value: 2),
+            Effect(value: 3)
           )
         default:
           state = action
@@ -518,7 +518,7 @@ final class StoreTests: XCTestCase {
       @Dependency(\.timeZone) var timeZone
       @Dependency(\.urlSession) var urlSession
 
-      func reduce(into state: inout Int, action: Bool) -> EffectTask<Bool> {
+      func reduce(into state: inout Int, action: Bool) -> Effect<Bool> {
         _ = self.calendar
         _ = self.locale
         _ = self.timeZone
@@ -544,7 +544,7 @@ final class StoreTests: XCTestCase {
     struct MyReducer: ReducerProtocol {
       @Dependency(\.uuid) var uuid
 
-      func reduce(into state: inout UUID, action: Void) -> EffectTask<Void> {
+      func reduce(into state: inout UUID, action: Void) -> Effect<Void> {
         state = self.uuid()
         return .none
       }

--- a/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
@@ -270,7 +270,7 @@
     func testExpectedStateEqualityMustModify() async {
       let reducer = Reduce<Int, Bool> { state, action in
         switch action {
-        case true: return EffectTask(value: false)
+        case true: return Effect(value: false)
         case false: return .none
         }
       }

--- a/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
@@ -291,14 +291,14 @@
           case increment
           case loggedInResponse(Bool)
         }
-        func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+        func reduce(into state: inout State, action: Action) -> Effect<Action> {
           switch action {
           case .decrement:
             state.count -= 1
             return .none
           case .increment:
             state.count += 1
-            return EffectTask(value: .loggedInResponse(true))
+            return Effect(value: .loggedInResponse(true))
           case let .loggedInResponse(response):
             state.isLoggedIn = response
             return .none
@@ -333,11 +333,11 @@
           case increment
           case loggedInResponse(Bool)
         }
-        func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+        func reduce(into state: inout State, action: Action) -> Effect<Action> {
           switch action {
           case .increment:
             state.count += 1
-            return EffectTask(value: .loggedInResponse(true))
+            return Effect(value: .loggedInResponse(true))
           case let .loggedInResponse(response):
             state.isLoggedIn = response
             return .none
@@ -598,7 +598,7 @@
         reducer: Reduce<Int, Action> { state, action in
           switch action {
           case .tap:
-            return EffectTask(value: .response(NonEquatable()))
+            return Effect(value: .response(NonEquatable()))
           case .response:
             return .none
           }
@@ -621,7 +621,7 @@
         reducer: Reduce<Int, Action> { state, action in
           switch action {
           case .tap:
-            return EffectTask(value: .response(NonEquatable()))
+            return Effect(value: .response(NonEquatable()))
           case .response:
             return .none
           }
@@ -746,7 +746,7 @@
       case increment
       case decrement
     }
-    func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+    func reduce(into state: inout State, action: Action) -> Effect<Action> {
       switch action {
       case .increment:
         state.count += 1
@@ -771,7 +771,7 @@
       case response1(Int)
       case response2(String)
     }
-    func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+    func reduce(into state: inout State, action: Action) -> Effect<Action> {
       switch action {
       case .onAppear:
         state = State()
@@ -809,7 +809,7 @@
 
     @Dependency(\.mainQueue) var mainQueue
 
-    func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+    func reduce(into state: inout State, action: Action) -> Effect<Action> {
       switch action {
       case let .changeIdentity(name, surname):
         state.name = name

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -17,7 +17,7 @@ final class TestStoreTests: XCTestCase {
       switch action {
       case .a:
         return .merge(
-          EffectTask.concatenate(.init(value: .b1), .init(value: .c1))
+          Effect.concatenate(.init(value: .b1), .init(value: .c1))
             .delay(for: 1, scheduler: mainQueue)
             .eraseToEffect(),
           Empty(completeImmediately: false)
@@ -26,11 +26,11 @@ final class TestStoreTests: XCTestCase {
         )
       case .b1:
         return
-          EffectTask
+          Effect
           .concatenate(.init(value: .b2), .init(value: .b3))
       case .c1:
         return
-          EffectTask
+          Effect
           .concatenate(.init(value: .c2), .init(value: .c3))
       case .b2, .b3, .c2, .c3:
         return .none
@@ -100,7 +100,7 @@ final class TestStoreTests: XCTestCase {
         switch action {
         case .increment:
           state.isChanging = true
-          return EffectTask(value: .changed(from: state.count, to: state.count + 1))
+          return Effect(value: .changed(from: state.count, to: state.count + 1))
         case .changed(let from, let to):
           state.isChanging = false
           if state.count == from {
@@ -145,7 +145,7 @@ final class TestStoreTests: XCTestCase {
       let reducer = Reduce<State, Action> { state, action in
         switch action {
         case .noop:
-          return EffectTask(value: .finished)
+          return Effect(value: .finished)
         case .finished:
           return .none
         }
@@ -176,7 +176,7 @@ final class TestStoreTests: XCTestCase {
       let reducer = Reduce<Int, Action> { state, action in
         switch action {
         case .noop:
-          return EffectTask(value: .finished)
+          return Effect(value: .finished)
         case .finished:
           return .none
         }
@@ -250,7 +250,7 @@ final class TestStoreTests: XCTestCase {
       @Dependency(\.timeZone) var timeZone
       @Dependency(\.urlSession) var urlSession
 
-      func reduce(into state: inout Int, action: Bool) -> EffectTask<Bool> {
+      func reduce(into state: inout Int, action: Bool) -> Effect<Bool> {
         _ = self.calendar
         _ = self.locale
         _ = self.timeZone
@@ -279,7 +279,7 @@ final class TestStoreTests: XCTestCase {
       @Dependency(\.timeZone) var timeZone
       @Dependency(\.urlSession) var urlSession
 
-      func reduce(into state: inout Int, action: Bool) -> EffectTask<Bool> {
+      func reduce(into state: inout Int, action: Bool) -> Effect<Bool> {
         _ = self.calendar
         _ = self.locale
         _ = self.timeZone
@@ -305,7 +305,7 @@ final class TestStoreTests: XCTestCase {
     struct Counter: ReducerProtocol {
       @Dependency(\.date.now) var now
 
-      func reduce(into state: inout Int, action: ()) -> EffectTask<Void> {
+      func reduce(into state: inout Int, action: ()) -> Effect<Void> {
         state = Int(self.now.timeIntervalSince1970)
         return .none
       }
@@ -332,7 +332,7 @@ final class TestStoreTests: XCTestCase {
       @Dependency(\.timeZone) var timeZone
       @Dependency(\.urlSession) var urlSession
 
-      func reduce(into state: inout Int, action: Bool) -> EffectTask<Bool> {
+      func reduce(into state: inout Int, action: Bool) -> Effect<Bool> {
         _ = self.calendar
         _ = self.locale
         _ = self.timeZone
@@ -370,7 +370,7 @@ final class TestStoreTests: XCTestCase {
         case response(Int)
       }
       @Dependency(\.date.now) var now: Date
-      func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+      func reduce(into state: inout State, action: Action) -> Effect<Action> {
         switch action {
         case .tap:
           state.count += 1


### PR DESCRIPTION
I've qualified a few missed occurrences of unqualified `Send` that I missed in #1911. I can rebase these changes in `main` if you prefer.
I've used `EffectTask` as this alias is still used through the codebase.
This should fix #1924