### PR TITLE
Fix UI test for ForEach bindings.

### DIFF
--- a/Examples/Integration/Integration/ForEachBindingTestCase.swift
+++ b/Examples/Integration/Integration/ForEachBindingTestCase.swift
@@ -26,17 +26,30 @@ struct ForEachBindingTestCase: ReducerProtocol {
 }
 
 struct ForEachBindingTestCaseView: View {
+  @State var assertion: String?
   let store: StoreOf<ForEachBindingTestCase>
 
   var body: some View {
     WithViewStore(self.store, observe: { $0 }) { viewStore in
       VStack {  // ⚠️ Must use VStack, not List.
+        if let assertion = self.assertion {
+          Text(assertion)
+        }
         ForEach(Array(viewStore.values.enumerated()), id: \.offset) { offset, value in
           HStack {  // ⚠️ Must wrap in an HStack.
             TextField(  // ⚠️ Must use a TextField.
               "\(value)",
               text: viewStore.binding(
-                get: { $0.values[offset] },
+                get: {
+                  if offset < $0.values.count {
+                    return $0.values[offset]
+                  } else {
+                    DispatchQueue.main.async {
+                      self.assertion = "🛑"
+                    }
+                    return ""
+                  }
+                },
                 send: { .change(offset: offset, value: $0) }
               )
             )

--- a/Examples/Integration/IntegrationUITests/EscapedWithViewStoreTests.swift
+++ b/Examples/Integration/IntegrationUITests/EscapedWithViewStoreTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class EscapedWithViewStoreTests: XCTestCase {
 
   override func setUpWithError() throws {
-    continueAfterFailure = false
+    self.continueAfterFailure = false
   }
 
   func testExample() async throws {

--- a/Examples/Integration/IntegrationUITests/ForEachBindingTests.swift
+++ b/Examples/Integration/IntegrationUITests/ForEachBindingTests.swift
@@ -2,9 +2,8 @@ import XCTest
 
 @MainActor
 final class ForEachBindingTests: XCTestCase {
-
   override func setUpWithError() throws {
-    continueAfterFailure = false
+    self.continueAfterFailure = false
   }
 
   func testExample() async throws {
@@ -13,7 +12,18 @@ final class ForEachBindingTests: XCTestCase {
 
     app.collectionViews.buttons["ForEachBindingTestCase"].tap()
     app.buttons["Remove last"].tap()
+    app.buttons["Remove last"].tap()
+    app.buttons["Remove last"].tap()
 
+    XCTAssertFalse(app.textFields["A"].exists)
+    XCTAssertFalse(app.textFields["B"].exists)
     XCTAssertFalse(app.textFields["C"].exists)
+    XCTExpectFailure("""
+      This ideally would not fail, but currently does. See this PR for more details:
+
+      https://github.com/pointfreeco/swift-composable-architecture/pull/1845
+    """) {
+      XCTAssertFalse(app.staticTexts["🛑"].exists)
+    }
   }
 }

--- a/Examples/Integration/IntegrationUITests/ForEachBindingTests.swift
+++ b/Examples/Integration/IntegrationUITests/ForEachBindingTests.swift
@@ -12,12 +12,12 @@ final class ForEachBindingTests: XCTestCase {
 
     app.collectionViews.buttons["ForEachBindingTestCase"].tap()
     app.buttons["Remove last"].tap()
-    app.buttons["Remove last"].tap()
-    app.buttons["Remove last"].tap()
-
-    XCTAssertFalse(app.textFields["A"].exists)
-    XCTAssertFalse(app.textFields["B"].exists)
     XCTAssertFalse(app.textFields["C"].exists)
+    app.buttons["Remove last"].tap()
+    XCTAssertFalse(app.textFields["B"].exists)
+    app.buttons["Remove last"].tap()
+    XCTAssertFalse(app.textFields["A"].exists)
+
     XCTExpectFailure("""
       This ideally would not fail, but currently does. See this PR for more details:
 

--- a/Examples/Integration/IntegrationUITests/NavigationStackBindingTests.swift
+++ b/Examples/Integration/IntegrationUITests/NavigationStackBindingTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @MainActor
 final class NavigationStackBindingTests: XCTestCase {
   override func setUpWithError() throws {
-    continueAfterFailure = false
+    self.continueAfterFailure = false
   }
 
   func testExample() async throws {

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test-docs:
 		&& exit 1)
 
 test-examples:
-	for scheme in "CaseStudies (SwiftUI)" "CaseStudies (UIKit)" Integration Search SpeechRecognition TicTacToe Todos VoiceMemos; do \
+	for scheme in Integration; do \
 		xcodebuild test \
 			-scheme "$$scheme" \
 			-destination platform="$(PLATFORM_IOS)" || exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test-docs:
 		&& exit 1)
 
 test-examples:
-	for scheme in Integration; do \
+	for scheme in "CaseStudies (SwiftUI)" "CaseStudies (UIKit)" Integration Search SpeechRecognition TicTacToe Todos VoiceMemos; do \
 		xcodebuild test \
 			-scheme "$$scheme" \
 			-destination platform="$(PLATFORM_IOS)" || exit 1; \

--- a/Tests/ComposableArchitectureTests/ViewStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/ViewStoreTests.swift
@@ -168,27 +168,29 @@ final class ViewStoreTests: XCTestCase {
   }
 
   func testSendWhile() async {
-    enum Action {
-      case response
-      case tapped
-    }
-    let reducer = Reduce<Bool, Action> { state, action in
-      switch action {
-      case .response:
-        state = false
-        return .none
-      case .tapped:
-        state = true
-        return .task { .response }
+    await _withMainSerialExecutor {
+      enum Action {
+        case response
+        case tapped
       }
+      let reducer = Reduce<Bool, Action> { state, action in
+        switch action {
+        case .response:
+          state = false
+          return .none
+        case .tapped:
+          state = true
+          return .task { .response }
+        }
+      }
+      
+      let store = Store(initialState: false, reducer: reducer)
+      let viewStore = ViewStore(store, observe: { $0 })
+      
+      XCTAssertEqual(viewStore.state, false)
+      await viewStore.send(.tapped, while: { $0 })
+      XCTAssertEqual(viewStore.state, false)
     }
-
-    let store = Store(initialState: false, reducer: reducer)
-    let viewStore = ViewStore(store, observe: { $0 })
-
-    XCTAssertEqual(viewStore.state, false)
-    await viewStore.send(.tapped, while: { $0 })
-    XCTAssertEqual(viewStore.state, false)
   }
 
   func testSuspend() {


### PR DESCRIPTION
In #1845 we reverted #1802 and as such our UI test for the strange binding behavior inside `ForEach`'s started to crash. However, apparently app crashes do not cause test failures (would love to know if anyone knows how to do that though).

So, I've updated the test to be more resilient and not crash, and as such added a `XCTExpectFailure` in the UI test. This way if we ever do finally fix this behavior we will have a test that will fail and then can be corrected.