### PR TITLE
Rethrow `CancellationError` in `TaskResult.init(catching:)`

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "c3a42e8d1a76ff557cf565ed6d8b0aee0e6e75af",
-        "version" : "0.11.0"
+        "revision" : "3c4eea896f8ee9cbe1c11d1d3d46b0f2809da958",
+        "version" : "0.12.0"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "ace21305e0dd3a9e749aef79fef14be79a3b4669",
-        "version" : "0.8.2"
+        "revision" : "62041e6016a30f56952f5d7d3f12a3fd7029e1cd",
+        "version" : "0.8.3"
       }
     }
   ],

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -72,7 +72,7 @@ struct EffectsBasics: Reducer {
       // Return an effect that fetches a number fact from the API and returns the
       // value back to the reducer's `numberFactResponse` action.
       return .task { [count = state.count] in
-        await .numberFactResponse(TaskResult { try await self.factClient.fetch(count) })
+        try await .numberFactResponse(TaskResult { try await self.factClient.fetch(count) })
       }
 
     case let .numberFactResponse(.success(response)):

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -48,7 +48,7 @@ struct EffectsCancellation: Reducer {
       state.isFactRequestInFlight = true
 
       return .task { [count = state.count] in
-        await .factResponse(TaskResult { try await self.factClient.fetch(count) })
+        try await .factResponse(TaskResult { try await self.factClient.fetch(count) })
       }
       .cancellable(id: NumberFactRequestID.self)
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -54,7 +54,7 @@ struct Refreshable: Reducer {
     case .refresh:
       state.fact = nil
       return .task { [count = state.count] in
-        await .factResponse(TaskResult { try await self.factClient.fetch(count) })
+        try await .factResponse(TaskResult { try await self.factClient.fetch(count) })
       }
       .animation()
       .cancellable(id: FactRequestID.self)

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -285,8 +285,10 @@ extension WebSocketClient: DependencyKey {
         let socket = try self.socket(id: ObjectIdentifier(id))
         return AsyncStream { continuation in
           let task = Task {
-            while !Task.isCancelled {
-              continuation.yield(await TaskResult { try await Message(socket.receive()) })
+            while
+              let result = try? await TaskResult(catching: { try await Message(socket.receive()) })
+            {
+              continuation.yield(result)
             }
             continuation.finish()
           }

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -51,7 +51,7 @@ struct Favoriting<ID: Hashable & Sendable>: Reducer {
       state.isFavorite.toggle()
 
       return .task { [id = state.id, isFavorite = state.isFavorite, favorite] in
-        await .response(TaskResult { try await favorite(id, isFavorite) })
+        try await .response(TaskResult { try await favorite(id, isFavorite) })
       }
       .cancellable(id: CancelID(id: state.id), cancelInFlight: true)
 

--- a/Examples/Search/Search/SearchView.swift
+++ b/Examples/Search/Search/SearchView.swift
@@ -82,7 +82,7 @@ struct Search: Reducer {
         return .none
       }
       return .task { [query = state.searchQuery] in
-        await .searchResponse(TaskResult { try await self.weatherClient.search(query) })
+        try await .searchResponse(TaskResult { try await self.weatherClient.search(query) })
       }
       .cancellable(id: SearchLocationID.self)
 
@@ -98,7 +98,7 @@ struct Search: Reducer {
       state.resultForecastRequestInFlight = location
 
       return .task {
-        await .forecastResponse(
+        try await .forecastResponse(
           location.id,
           TaskResult { try await self.weatherClient.forecast(location) }
         )

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginCore/LoginCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginCore/LoginCore.swift
@@ -62,7 +62,7 @@ public struct Login: Reducer, Sendable {
         state.isLoginRequestInFlight = true
         return .task { [email = state.email, password = state.password] in
           .loginResponse(
-            await TaskResult {
+            try await TaskResult {
               try await self.authenticationClient.login(
                 .init(email: email, password: password)
               )

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
@@ -44,7 +44,7 @@ public struct TwoFactor: Reducer, Sendable {
       state.isTwoFactorRequestInFlight = true
       return .task { [code = state.code, token = state.token] in
         .twoFactorResponse(
-          await TaskResult {
+          try await TaskResult {
             try await self.authenticationClient.twoFactor(.init(code: code, token: token))
           }
         )

--- a/Examples/VoiceMemos/VoiceMemos/RecordingMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/RecordingMemo.swift
@@ -69,7 +69,7 @@ struct RecordingMemo: Reducer {
         for await _ in self.clock.timer(interval: .seconds(1)) {
           await send(.timerUpdated)
         }
-        await startRecording
+        try await startRecording
       }
 
     case .timerUpdated:

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
@@ -64,7 +64,7 @@ struct VoiceMemo: Reducer {
             await send(.timerUpdated(start))
           }
 
-          await playAudio
+          try await playAudio
         }
         .cancellable(id: PlayID.self, cancelInFlight: true)
 

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Then we can use it in the `reduce` implementation:
 ```swift
 case .numberFactButtonTapped:
   return .task { [count = state.count] in 
-    await .numberFactResponse(TaskResult { try await self.numberFact(count) })
+    try await .numberFactResponse(TaskResult { try await self.numberFact(count) })
   }
 ```
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
@@ -120,7 +120,7 @@ struct Feature: Reducer {
 
       case .numberFactButtonTapped:
         return .task { [count = state.count] in 
-          await .numberFactResponse(
+          try await .numberFactResponse(
             TaskResult { 
               String(
                 decoding: try await URLSession.shared
@@ -331,7 +331,7 @@ Then we can use it in the `reduce` implementation:
 ```swift
 case .numberFactButtonTapped:
   return .task { [count = state.count] in 
-    await .numberFactResponse(TaskResult { try await self.numberFact(count) })
+    try await .numberFactResponse(TaskResult { try await self.numberFact(count) })
   }
 ```
 

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -137,7 +137,7 @@ extension EffectPublisher where Failure == Never {
   ///     switch action {
   ///       case .factButtonTapped:
   ///         return .task { [number = state.number] in
-  ///           await .factResponse(TaskResult { try await self.numberFact.fetch(number) })
+  ///           try await .factResponse(TaskResult { try await self.numberFact.fetch(number) })
   ///         }
   ///
   ///       case .factResponse(.success(fact)):

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -188,7 +188,7 @@ extension EffectPublisher {
   /// return .task {
   ///   await withTaskCancellation(id: CancelID.self, cancelInFlight: true) {
   ///     try await self.clock.sleep(for: .seconds(0.3))
-  ///     return await .debouncedResponse(
+  ///     return try await .debouncedResponse(
   ///       TaskResult { try await environment.request() }
   ///     )
   ///   }

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -296,7 +296,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
   ///     case .pulledToRefresh:
   ///       state.isLoading = true
   ///       return .task {
-  ///         await .receivedResponse(TaskResult { try await self.fetch() })
+  ///         try await .receivedResponse(TaskResult { try await self.fetch() })
   ///       }
   ///
   ///     case let .receivedResponse(result):


### PR DESCRIPTION
This came up on the Slack: it seems surprising that `TaskResult` can swallow cancellation errors. Instead it'd make sense for `TaskResult` to propagate them into the `Effect`.

This is technically a breaking change, where all `TaskResult.init`s must now be qualified with a `try`, and this can even look a lil confusing. At the very least the compiler can usually fix things automatically by inserting `try`.

Thoughts? Is there a better approach? Is there more surface area to think about? `TaskResult.init(result:)`, for example?