### PR TITLE
Make the new XCTModify play nicely with non-exhaustive testing.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "c3a42e8d1a76ff557cf565ed6d8b0aee0e6e75af",
-        "version" : "0.11.0"
+        "revision" : "f623901b4bcc97f59c36704f81583f169b228e51",
+        "version" : "0.13.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "0.8.0"),
-    .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.10.0"),
+    .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.13.0"),
     .package(url: "https://github.com/apple/swift-collections", from: "1.0.2"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.7.0"),
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "0.1.2"),

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1,3 +1,4 @@
+@_spi(Internals) import CasePaths
 import Combine
 import CustomDump
 import Foundation
@@ -1168,6 +1169,13 @@ extension TestStore where ScopedState: Equatable {
   ) throws {
     let current = expected
     var expected = expected
+    let updateStateToExpectedResult = updateStateToExpectedResult.map { updateStateToExpectedResult in
+      { (state: inout ScopedState) in
+        try XCTModifyLocals.$isExhaustive.withValue(self.exhaustivity == .on) {
+          try updateStateToExpectedResult(&state)
+        }
+      }
+    }
 
     switch self.exhaustivity {
     case .on:
@@ -1745,6 +1753,14 @@ extension TestStore where ScopedState: Equatable {
     file: StaticString,
     line: UInt
   ) {
+    let updateStateToExpectedResult = updateStateToExpectedResult.map { updateStateToExpectedResult in
+      { (state: inout ScopedState) in
+        try XCTModifyLocals.$isExhaustive.withValue(self.exhaustivity == .on) {
+          try updateStateToExpectedResult(&state)
+        }
+      }
+    }
+
     guard !self.reducer.receivedActions.isEmpty else {
       XCTFail(
         failureMessage(),

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1169,10 +1169,10 @@ extension TestStore where ScopedState: Equatable {
   ) throws {
     let current = expected
     var expected = expected
-    let updateStateToExpectedResult = updateStateToExpectedResult.map { updateStateToExpectedResult in
+    let updateStateToExpectedResult = updateStateToExpectedResult.map { original in
       { (state: inout ScopedState) in
         try XCTModifyLocals.$isExhaustive.withValue(self.exhaustivity == .on) {
-          try updateStateToExpectedResult(&state)
+          try original(&state)
         }
       }
     }
@@ -1753,10 +1753,10 @@ extension TestStore where ScopedState: Equatable {
     file: StaticString,
     line: UInt
   ) {
-    let updateStateToExpectedResult = updateStateToExpectedResult.map { updateStateToExpectedResult in
+    let updateStateToExpectedResult = updateStateToExpectedResult.map { original in
       { (state: inout ScopedState) in
         try XCTModifyLocals.$isExhaustive.withValue(self.exhaustivity == .on) {
-          try updateStateToExpectedResult(&state)
+          try original(&state)
         }
       }
     }

--- a/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
@@ -707,7 +707,7 @@
       await store.send(.tap) { state in
         state.count = 1
         XCTExpectFailure {
-          XCTModify(&state.child, case: /Optional.some) { _ in }
+          XCTModify(&state.child, case: /.some) { _ in }
         } issueMatcher: {
           $0.compactDescription == """
             XCTModify failed: expected "Int" value to be modified but it was unchanged.


### PR DESCRIPTION
We recently added `XCTModify` to our case paths library that makes it easy to apply an in-place mutation to a case of an enum. We employ exhaustive checking in the function so that if you apply a mutation that doesn't actually change anything it will cause a test failure. However, we need to opt out of that behavior in non-exhaustive test stores, so that is what this PR does.