### PR TITLE
RFC: Unsafe access to store state and actions.

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/ViewStoreDeprecations.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/ViewStoreDeprecations.md
@@ -16,6 +16,7 @@ Avoid using deprecated APIs in your app. Select a method to see the replacement 
 ### Interacting with Concurrency
 
 - ``ViewStore/suspend(while:)``
+- ``ViewStoreTask``
 
 ### SwiftUI integration
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/ViewStore.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/ViewStore.md
@@ -19,7 +19,7 @@
 - ``send(_:)``
 - ``send(_:while:)``
 - ``yield(while:)``
-- ``ViewStoreTask``
+- ``StoreTask``
 
 ### SwiftUI integration
 

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -565,7 +565,7 @@ extension Store {
           reducer: .init { childState, childAction, _ in
             let task = self.send(fromChildAction(childAction))
             childState = extractChildState(self.state.value) ?? childState
-            if let task = task {
+            if let task = task.rawValue {
               return .fireAndForget { await task.cancellableValue }
             } else {
               return .none

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -805,8 +805,8 @@ extension Store {
   }
 }
 
-/// The type returned from ``ViewStore/send(_:)`` that represents the lifecycle of the effect
-/// started from sending an action.
+/// The type returned from ``ViewStore/send(_:)`` and ``UnsafeStore/send(_:)-5i6za`` that represents
+/// the lifecycle of the effect started from sending an action.
 ///
 /// You can use this value to tie the effect's lifecycle _and_ cancellation to an asynchronous
 /// context, such as the `task` view modifier.

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -777,7 +777,7 @@ public typealias StoreOf<R: ReducerProtocol> = Store<R.State, R.Action>
   }
 #endif
 
-/// An "unsafe" view into a store for accessing state and sending an action.
+/// An "unsafe" view into a store for accessing state and sending actions.
 ///
 /// See ``Store/withUnsafeStore(_:)`` for more information.
 public struct UnsafeStore<State, Action> {

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -688,22 +688,22 @@ extension WithViewStore where ViewState == Void, Content: View {
   @available(
     iOS,
     deprecated: 9999.0,
-    message: "Use 'ViewStore(store).send(action)' instead of observing stateless stores."
+    message: "Use 'store.withUnsafeStore' instead of observing stateless stores."
   )
   @available(
     macOS,
     deprecated: 9999.0,
-    message: "Use 'ViewStore(store).send(action)' instead of observing stateless stores."
+    message: "Use 'store.withUnsafeStore' instead of observing stateless stores."
   )
   @available(
     tvOS,
     deprecated: 9999.0,
-    message: "Use 'ViewStore(store).send(action)' instead of observing stateless stores."
+    message: "Use 'store.withUnsafeStore' instead of observing stateless stores."
   )
   @available(
     watchOS,
     deprecated: 9999.0,
-    message: "Use 'ViewStore(store).send(action)' instead of observing stateless stores."
+    message: "Use 'store.withUnsafeStore' instead of observing stateless stores."
   )
   public init(
     _ store: Store<ViewState, ViewAction>,

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1067,7 +1067,7 @@ extension TestStore where ScopedState: Equatable {
     // NB: Give concurrency runtime more time to kick off effects so users don't need to manually
     //     instrument their effects.
     await Task.megaYield(count: 20)
-    return .init(rawValue: task, timeout: self.timeout)
+    return .init(rawValue: task.rawValue, timeout: self.timeout)
   }
 
   /// Sends an action to the store and asserts when state changes.
@@ -1159,7 +1159,7 @@ extension TestStore where ScopedState: Equatable {
       self.line = line
     }
 
-    return .init(rawValue: task, timeout: self.timeout)
+    return .init(rawValue: task.rawValue, timeout: self.timeout)
   }
 
   private func expectedStateShouldMatch(
@@ -2177,7 +2177,7 @@ extension TestStore {
 /// See ``TestStore/finish(timeout:file:line:)`` for the ability to await all in-flight
 /// effects in the test store.
 ///
-/// See ``ViewStoreTask`` for the analog provided to ``ViewStore``.
+/// See ``StoreTask`` for the analog provided to ``Store`` and ``ViewStore``.
 public struct TestStoreTask: Hashable, Sendable {
   fileprivate let rawValue: Task<Void, Never>?
   fileprivate let timeout: UInt64

--- a/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
+++ b/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
@@ -1,6 +1,6 @@
 #if DEBUG
   import Combine
-  import ComposableArchitecture
+  @_spi(Internals) import ComposableArchitecture
   import XCTest
 
   final class RuntimeWarningTests: XCTestCase {
@@ -50,7 +50,7 @@
           }
         }
       )
-      ViewStore(store, observe: { $0 }).send(.tap)
+      _ = store.send(.tap)
       _ = XCTWaiter.wait(for: [.init()], timeout: 0.5)
     }
 
@@ -107,7 +107,7 @@
 
       let store = Store<Int, Void>(initialState: 0, reducer: EmptyReducer())
       Task {
-        ViewStore(store, observe: { $0 }).send(())
+        store.send(())
       }
       _ = XCTWaiter.wait(for: [.init()], timeout: 0.5)
     }

--- a/Tests/ComposableArchitectureTests/ViewStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/ViewStoreTests.swift
@@ -1,5 +1,5 @@
 import Combine
-import ComposableArchitecture
+@_spi(Internals) import ComposableArchitecture
 import XCTest
 
 @MainActor
@@ -132,7 +132,7 @@ final class ViewStoreTests: XCTestCase {
       .sink { results.append($0) }
       .store(in: &self.cancellables)
 
-    ViewStore(store, observe: { $0 }).send(())
+    _ = store.send(())
     XCTAssertEqual(results, [0, 1])
   }
 


### PR DESCRIPTION
A few months ago we moved to start making view store observations a lot more explicit. We now encourage people to do `WithViewStore(store: observe: { … })` and `ViewStore(store, observe: { … })` in order to chisel away at the state to the bare essentials the store needs.

There's one big ergonomic problem with this that we never dealt with, and that's a quick way to send actions when you only have a `Store`. Technically you would have to do something like this:

```swift
ViewStore(store, observe: { $0 }).send(…)
```

That's awkward, and gets even more awkward if the state is not equatable.

Really, view stores are just kind of awkward in general. We introduced them out of necessity but it's been a constant struggle to have good ergonomics. Luckily we think view stores aren't long for this world thanks to some of the new [`Observation`](https://forums.swift.org/t/pitch-observation/62051) stuff coming soon.

So, we're looking to add some new API surface area to improve the view store ergonomics today, knowing that hopefully someday in the future we can completely remove the concept, or at least make it necessary only in a small number of situations.

We are suggesting adding a `withUnsafeStore` API that will give you instant access to the store's state and sending actions for a well defined scope:

```swift
store.withUnsafeStore { $0.users }
store.withUnsafeStore { $0.send(.addButtonTapped) }
```

It's named "unsafe" because it does not perform any observation at all. You are only getting a snapshot of state at a specific time. And it's a little verbose, but a lot nicer than the alternative today.

What are people's thoughts on this?