### PR TITLE
Add @warn_unqualified_access to reducer operators.

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -88,6 +88,7 @@ extension ViewStore {
 
 extension ReducerProtocol {
   @available(*, deprecated, renamed: "_printChanges")
+  @warn_unqualified_access
   public func debug() -> _PrintChangesReducer<Self> {
     self._printChanges()
   }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
@@ -7,6 +7,7 @@ extension ReducerProtocol {
   /// - Parameter printer: A printer for printing debug messages.
   /// - Returns: A reducer that prints debug messages for all received actions.
   @inlinable
+  @warn_unqualified_access
   public func _printChanges(
     _ printer: _ReducerPrinter<State, Action>? = .customDump
   ) -> _PrintChangesReducer<Self> {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
@@ -66,6 +66,7 @@ extension ReducerProtocol {
   ///   - value: The new value to set for the item specified by `keyPath`.
   /// - Returns: A reducer that has the given value set in its dependencies.
   @inlinable
+  @warn_unqualified_access
   public func dependency<Value>(
     _ keyPath: WritableKeyPath<DependencyValues, Value>,
     _ value: Value
@@ -117,6 +118,7 @@ extension ReducerProtocol {
   ///   - transform: A closure that is handed a mutable instance of the value specified by the key
   ///     path.
   @inlinable
+  @warn_unqualified_access
   public func transformDependency<V>(
     _ keyPath: WritableKeyPath<DependencyValues, V>,
     transform: @escaping (inout V) -> Void

--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -50,6 +50,7 @@ extension ReducerProtocol {
   ///     state.
   /// - Returns: A reducer that combines the child reducer with the parent reducer.
   @inlinable
+  @warn_unqualified_access
   public func forEach<ElementState, ElementAction, ID: Hashable, Element: ReducerProtocol>(
     _ toElementsState: WritableKeyPath<State, IdentifiedArray<ID, ElementState>>,
     action toElementAction: CasePath<Action, (ID, ElementAction)>,

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
@@ -46,6 +46,7 @@ extension ReducerProtocol {
   ///     present
   /// - Returns: A reducer that combines the child reducer with the parent reducer.
   @inlinable
+  @warn_unqualified_access
   public func ifCaseLet<CaseState, CaseAction, Case: ReducerProtocol>(
     _ toCaseState: CasePath<State, CaseState>,
     action toCaseAction: CasePath<Action, CaseAction>,

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
@@ -43,6 +43,7 @@ extension ReducerProtocol {
   ///     state.
   /// - Returns: A reducer that combines the child reducer with the parent reducer.
   @inlinable
+  @warn_unqualified_access
   public func ifLet<WrappedState, WrappedAction, Wrapped: ReducerProtocol>(
     _ toWrappedState: WritableKeyPath<State, WrappedState?>,
     action toWrappedAction: CasePath<Action, WrappedAction>,

--- a/Sources/ComposableArchitecture/Reducer/Reducers/SignpostReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/SignpostReducer.swift
@@ -21,6 +21,7 @@ extension ReducerProtocol {
   ///   - log: An `OSLog` to use for signposts.
   /// - Returns: A reducer that has been enhanced with instrumentation.
   @inlinable
+  @warn_unqualified_access
   public func signpost(
     _ prefix: String = "",
     log: OSLog = OSLog(


### PR DESCRIPTION
When using reducer operators (e.g. `.ifLet`, `.forEach`, etc.) it's possible to accidentally forget the `.`:

```swift
var body: some ReducerProtocolOf<Self> {
  Reduce { … }
    ifLet { … }
   ^ 
```

This will cause a mysterious infinite loop and crash. The same happens in SwiftUI, and luckily Swift has an attribute that will warn if you ever use the method without qualifying the receiver, so let's use it!