### PR TITLE
Deprecations only for versions supporting clock.timer

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
@@ -89,7 +89,10 @@ extension EffectPublisher where Failure == Never {
   ///   - tolerance: The allowed timing variance when emitting events. Defaults to `nil`, which
   ///     allows any variance.
   ///   - options: Scheduler options passed to the timer. Defaults to `nil`.
-  @available(*, deprecated, message: "Use 'clock.timer' in an 'Effect.run', instead.")
+  @available(iOS, deprecated: 16.0, message: "Use 'clock.timer' in an 'Effect.run', instead.")
+  @available(macOS, deprecated: 13.0, message: "Use 'clock.timer' in an 'Effect.run', instead.")
+  @available(tvOS, deprecated: 16.0, message: "Use 'clock.timer' in an 'Effect.run', instead.")
+  @available(watchOS, deprecated: 9.0, message: "Use 'clock.timer' in an 'Effect.run', instead.")
   public static func timer<S: Scheduler>(
     id: AnyHashable,
     every interval: S.SchedulerTimeType.Stride,
@@ -118,7 +121,10 @@ extension EffectPublisher where Failure == Never {
   ///   - tolerance: The allowed timing variance when emitting events. Defaults to `nil`, which
   ///     allows any variance.
   ///   - options: Scheduler options passed to the timer. Defaults to `nil`.
-  @available(*, deprecated, message: "Use 'clock.timer' in an 'Effect.run', instead.")
+  @available(iOS, deprecated: 16.0, message: "Use 'clock.timer' in an 'Effect.run', instead.")
+  @available(macOS, deprecated: 13.0, message: "Use 'clock.timer' in an 'Effect.run', instead.")
+  @available(tvOS, deprecated: 16.0, message: "Use 'clock.timer' in an 'Effect.run', instead.")
+  @available(watchOS, deprecated: 9.0, message: "Use 'clock.timer' in an 'Effect.run', instead.")
   public static func timer<S: Scheduler>(
     id: Any.Type,
     every interval: S.SchedulerTimeType.Stride,


### PR DESCRIPTION
Show deprecation warnings only for versions [that support](https://github.com/pointfreeco/swift-dependencies/blob/d3406a54315daccc2c86a21da04584b1fefa7136/Sources/Dependencies/DependencyValues/Clocks.swift#L2) `@Dependency(\.continuousClock) var clock`.