### PR TITLE
Do not propagate dependencies to effect actions.

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "62041e6016a30f56952f5d7d3f12a3fd7029e1cd",
-        "version" : "0.8.3"
+        "revision" : "ace21305e0dd3a9e749aef79fef14be79a3b4669",
+        "version" : "0.8.2"
       }
     }
   ],

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -402,7 +402,9 @@ public final class Store<State, Action> {
               },
               receiveValue: { [weak self] effectAction in
                 guard let self = self else { return }
-                if let task = continuation.yield({ self.send(effectAction, originatingFrom: action) }) {
+                if let task = continuation.yield({
+                  self.send(effectAction, originatingFrom: action)
+                }) {
                   tasks.wrappedValue.append(task)
                 }
               }

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -385,28 +385,29 @@ public final class Store<State, Action> {
         var didComplete = false
         let boxedTask = Box<Task<Void, Never>?>(wrappedValue: nil)
         let uuid = UUID()
-        let effectCancellable =
+        let effectCancellable = withEscapedDependencies { continuation in
           publisher
-          .handleEvents(
-            receiveCancel: { [weak self] in
-              self?.threadCheck(status: .effectCompletion(action))
-              self?.effectCancellables[uuid] = nil
-            }
-          )
-          .sink(
-            receiveCompletion: { [weak self] _ in
-              self?.threadCheck(status: .effectCompletion(action))
-              boxedTask.wrappedValue?.cancel()
-              didComplete = true
-              self?.effectCancellables[uuid] = nil
-            },
-            receiveValue: { [weak self] effectAction in
-              guard let self = self else { return }
-              if let task = self.send(effectAction, originatingFrom: action) {
-                tasks.wrappedValue.append(task)
+            .handleEvents(
+              receiveCancel: { [weak self] in
+                self?.threadCheck(status: .effectCompletion(action))
+                self?.effectCancellables[uuid] = nil
               }
-            }
-          )
+            )
+            .sink(
+              receiveCompletion: { [weak self] _ in
+                self?.threadCheck(status: .effectCompletion(action))
+                boxedTask.wrappedValue?.cancel()
+                didComplete = true
+                self?.effectCancellables[uuid] = nil
+              },
+              receiveValue: { [weak self] effectAction in
+                guard let self = self else { return }
+                if let task = continuation.yield({ self.send(effectAction, originatingFrom: action) }) {
+                  tasks.wrappedValue.append(task)
+                }
+              }
+            )
+        }
 
         if !didComplete {
           let task = Task<Void, Never> { @MainActor in
@@ -418,43 +419,47 @@ public final class Store<State, Action> {
           self.effectCancellables[uuid] = effectCancellable
         }
       case let .run(priority, operation):
-        tasks.wrappedValue.append(
-          Task(priority: priority) { @MainActor in
-            #if DEBUG
-              var isCompleted = false
-              defer { isCompleted = true }
-            #endif
-            await operation(
-              EffectTask<Action>.Send {
-                #if DEBUG
-                  if isCompleted {
-                    runtimeWarn(
-                      """
-                      An action was sent from a completed effect:
+        withEscapedDependencies { continuation in
+          tasks.wrappedValue.append(
+            Task(priority: priority) { @MainActor in
+              #if DEBUG
+                var isCompleted = false
+                defer { isCompleted = true }
+              #endif
+              await operation(
+                EffectTask<Action>.Send { effectAction in
+                  #if DEBUG
+                    if isCompleted {
+                      runtimeWarn(
+                        """
+                        An action was sent from a completed effect:
 
-                        Action:
-                          \(debugCaseOutput($0))
+                          Action:
+                            \(debugCaseOutput(effectAction))
 
-                        Effect returned from:
-                          \(debugCaseOutput(action))
+                          Effect returned from:
+                            \(debugCaseOutput(action))
 
-                      Avoid sending actions using the 'send' argument from 'EffectTask.run' after \
-                      the effect has completed. This can happen if you escape the 'send' argument in \
-                      an unstructured context.
+                        Avoid sending actions using the 'send' argument from 'EffectTask.run' after \
+                        the effect has completed. This can happen if you escape the 'send' argument in \
+                        an unstructured context.
 
-                      To fix this, make sure that your 'run' closure does not return until you're \
-                      done calling 'send'.
-                      """
-                    )
+                        To fix this, make sure that your 'run' closure does not return until you're \
+                        done calling 'send'.
+                        """
+                      )
+                    }
+                  #endif
+                  if let task = continuation.yield({
+                    self.send(effectAction, originatingFrom: action)
+                  }) {
+                    tasks.wrappedValue.append(task)
                   }
-                #endif
-                if let task = self.send($0, originatingFrom: action) {
-                  tasks.wrappedValue.append(task)
                 }
-              }
-            )
-          }
-        )
+              )
+            }
+          )
+        }
       }
     }
 

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -131,7 +131,7 @@ public final class Store<State, Action> {
     private let reducer: (inout State, Action) -> EffectTask<Action>
     fileprivate var scope: AnyStoreScope?
   #endif
-  var state: CurrentValueSubject<State, Never>
+  @_spi(Internals) public var state: CurrentValueSubject<State, Never>
   #if DEBUG
     private let mainThreadChecksEnabled: Bool
   #endif

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -573,31 +573,31 @@ final class StoreTests: XCTestCase {
       }
       @Dependency(\.count) var count
       func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
-switch action {
-case .tap:
-  return withDependencies {
-    $0.count.value += 1
-  } operation: {
-    .task { .response1(self.count.value) }
-  }
-case let .response1(count):
-  state.count = count
-  return withDependencies {
-    $0.count.value += 1
-  } operation: {
-    .task { .response2(self.count.value) }
-  }
-case let .response2(count):
-  state.count = count
-  return withDependencies {
-    $0.count.value += 1
-  } operation: {
-    .task { .response3(self.count.value) }
-  }
-case let .response3(count):
-  state.count = count
-  return .none
-}
+        switch action {
+        case .tap:
+          return withDependencies {
+            $0.count.value += 1
+          } operation: {
+            .task { .response1(self.count.value) }
+          }
+        case let .response1(count):
+          state.count = count
+          return withDependencies {
+            $0.count.value += 1
+          } operation: {
+            .task { .response2(self.count.value) }
+          }
+        case let .response2(count):
+          state.count = count
+          return withDependencies {
+            $0.count.value += 1
+          } operation: {
+            .task { .response3(self.count.value) }
+          }
+        case let .response3(count):
+          state.count = count
+          return .none
+        }
       }
     }
 
@@ -630,7 +630,7 @@ case let .response3(count):
         case response1(Int)
         case response2(Int)
         case response3(Int)
-      } 
+      }
       @Dependency(\.count) var count
       func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
         switch action {

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -565,32 +565,34 @@ final class StoreTests: XCTestCase {
       struct State: Equatable {
         var count = 0
       }
-      enum Action: Equatable { case tap, response1(Int), response2(Int), response3(Int) }
+      enum Action: Equatable {
+        case tap
+        case response1(Int)
+        case response2(Int)
+        case response3(Int)
+      }
       @Dependency(\.count) var count
       func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
         switch action {
         case .tap:
           return withDependencies { deps in
-            let currentCount = deps.count.value()
-            deps.count.value = { currentCount + 1 }
+            deps.count.value += 1
           } operation: {
-            .task { .response1(self.count.value())}
+            .task { .response1(self.count.value) }
           }
         case let .response1(count):
           state.count = count
           return withDependencies { deps in
-            let currentCount = deps.count.value()
-            deps.count.value = { currentCount + 1 }
+            deps.count.value += 1
           } operation: {
-            .task { .response2(self.count.value())}
+            .task { .response2(self.count.value) }
           }
         case let .response2(count):
           state.count = count
           return withDependencies { deps in
-            let currentCount = deps.count.value()
-            deps.count.value = { currentCount + 1 }
+            deps.count.value += 1
           } operation: {
-            .task { .response3(self.count.value())}
+            .task { .response3(self.count.value) }
           }
         case let .response3(count):
           state.count = count
@@ -608,7 +610,7 @@ final class StoreTests: XCTestCase {
       $0.count = 1
     }
     await testStore.receive(.response2(1))
-    await testStore.receive(.response3(1)) 
+    await testStore.receive(.response3(1))
 
     let store = Store(
       initialState: Feature.State(),
@@ -621,9 +623,9 @@ final class StoreTests: XCTestCase {
 }
 
 private struct Count: TestDependencyKey {
-  var value: () -> Int
-  static let liveValue = Count(value: { 0 })
-  static let testValue = Count(value: { 0 })
+  var value: Int
+  static let liveValue = Count(value: 0)
+  static let testValue = Count(value: 0)
 }
 extension DependencyValues {
   fileprivate var count: Count {

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -695,33 +695,3 @@ extension DependencyValues {
     set { self[Count.self] = newValue }
   }
 }
-
-
-public struct _Observe<Reducers: ReducerProtocol>: ReducerProtocol {
-  @usableFromInline
-  let reducers: (State, Action) -> Reducers
-
-  /// Initializes a reducer that builds a reducer from the current state and action.
-  ///
-  /// - Parameter build: A reducer builder that has access to the current state and action.
-  @inlinable
-  public init(
-    @ReducerBuilder<Reducers.State, Reducers.Action> _ build: @escaping (Reducers.State, Reducers.Action) -> Reducers
-  ) where Reducers.State == State, Reducers.Action == Action {
-    self.init(internal: build)
-  }
-
-  @usableFromInline
-  init(
-    internal reducers: @escaping (Reducers.State, Reducers.Action) -> Reducers
-  ) {
-    self.reducers = reducers
-  }
-
-  @inlinable
-  public func reduce(
-    into state: inout Reducers.State, action: Reducers.Action
-  ) -> EffectTask<Reducers.Action> {
-    self.reducers(state, action).reduce(into: &state, action: action)
-  }
-}

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -618,7 +618,71 @@ final class StoreTests: XCTestCase {
     )
     let viewStore = ViewStore(store)
     await store.send(.tap)?.value
-    XCTAssertEqual(viewStore.count, 3)
+    XCTAssertEqual(viewStore.count, testStore.state.count)
+  }
+
+  func testStoreVsTestStore_Publisher() async {
+    struct Feature: ReducerProtocol {
+      struct State: Equatable {
+        var count = 0
+      }
+      enum Action: Equatable {
+        case tap
+        case response1(Int)
+        case response2(Int)
+        case response3(Int)
+      }
+      @Dependency(\.count) var count
+      func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+        switch action {
+        case .tap:
+          return withDependencies { deps in
+            deps.count.value += 1
+          } operation: {
+            EffectTask.task { .response1(self.count.value) }
+          }
+          .eraseToEffect()
+        case let .response1(count):
+          state.count = count
+          return withDependencies { deps in
+            deps.count.value += 1
+          } operation: {
+            EffectTask.task { .response2(self.count.value) }
+          }
+          .eraseToEffect()
+        case let .response2(count):
+          state.count = count
+          return withDependencies { deps in
+            deps.count.value += 1
+          } operation: {
+            EffectTask.task { .response3(self.count.value) }
+          }
+          .eraseToEffect()
+        case let .response3(count):
+          state.count = count
+          return .none
+        }
+      }
+    }
+
+    let testStore = TestStore(
+      initialState: Feature.State(),
+      reducer: Feature()
+    )
+    await testStore.send(.tap)
+    await testStore.receive(.response1(1)) {
+      $0.count = 1
+    }
+    await testStore.receive(.response2(1))
+    await testStore.receive(.response3(1))
+
+    let store = Store(
+      initialState: Feature.State(),
+      reducer: Feature()
+    )
+    let viewStore = ViewStore(store)
+    await store.send(.tap)?.value
+    XCTAssertEqual(viewStore.count, testStore.state.count)
   }
 }
 

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -631,7 +631,7 @@ final class StoreTests: XCTestCase {
         case response1(Int)
         case response2(Int)
         case response3(Int)
-      }
+      } 
       @Dependency(\.count) var count
       func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
         switch action {


### PR DESCRIPTION
The issue #1947 for something related to the navigation beta (#1944) has surfaced a small problem in the library that exists on `main` today.

Right now effect actions (i.e. actions sent into the system from effects) are executed with the dependencies that were active at the moment the effect was constructed. This allows some surprising behavior in which dependency changes "accumulate" when you have an effect that emits an action, and that action returns an effect that emits an action, and on and on.

Take this for example:

```swift
switch action {
case .tap:
  return withDependencies {
    $0.count.value += 1
  } operation: {
    .task { .response1(self.count.value) }
  }
case let .response1(count):
  state.count = count
  return withDependencies {
    $0.count.value += 1
  } operation: {
    .task { .response2(self.count.value) }
  }
case let .response2(count):
  state.count = count
  return withDependencies {
    $0.count.value += 1
  } operation: {
    .task { .response3(self.count.value) }
  }
case let .response3(count):
  state.count = count
  return .none
}
```

By the last `.response3` the count has become 3 because each step of the way the dependencies were carried over from the previous step.

An added benefit to this change is that it fixes a discrepancy between `Store` and `TestStore`. We were able to write a test that passed for `TestStore` but that did not actually capture what happens in reality for `Store`, which of course completely destroys the confidence one should have when writing tests against the `TestStore`. That was a huge bummer, and is now fixed.

Now, there may be some power in allowing this, but we don't think it should be the default. If it turns out there is use for this, we could (possibly) support a parameter on `Effect.run` that propagates dependencies more deeply, and then have to figure out how to integrate it with the `TestStore`.

This will fix #1947 and make #1948 unnecessary.