### PR TITLE
Fix TestStore.init with prepareDependencies.

### DIFF
--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -666,8 +666,8 @@ public final class TestStore<State, Action, ScopedState, ScopedAction, Environme
     Environment == Void
   {
     var dependencies = DependencyValues._current
-    prepareDependencies(&dependencies)
     let initialState = withDependencies {
+      prepareDependencies(&dependencies)
       $0 = dependencies
     } operation: {
       initialState()

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -335,7 +335,7 @@ final class TestStoreTests: XCTestCase {
 
       func reduce(into state: inout Int, action: Bool) -> EffectTask<Bool> {
         _ = self.calendar
-        _ = self.client.fetch()
+        _ = self.fetch()
         _ = self.locale
         _ = self.timeZone
         _ = self.urlSession

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -328,12 +328,14 @@ final class TestStoreTests: XCTestCase {
   func testOverrideDependenciesOnTestStore_Init() {
     struct Counter: ReducerProtocol {
       @Dependency(\.calendar) var calendar
+      @Dependency(\.client) var client
       @Dependency(\.locale) var locale
       @Dependency(\.timeZone) var timeZone
       @Dependency(\.urlSession) var urlSession
 
       func reduce(into state: inout Int, action: Bool) -> EffectTask<Bool> {
         _ = self.calendar
+        _ = self.client.fetch()
         _ = self.locale
         _ = self.timeZone
         _ = self.urlSession
@@ -347,6 +349,7 @@ final class TestStoreTests: XCTestCase {
       reducer: Counter()
     ) {
       $0.calendar = Calendar(identifier: .gregorian)
+      $0.client.fetch = { 1 }
       $0.locale = Locale(identifier: "en_US")
       $0.timeZone = TimeZone(secondsFromGMT: 0)!
       $0.urlSession = URLSession(configuration: .ephemeral)
@@ -400,5 +403,16 @@ final class TestStoreTests: XCTestCase {
       $0.count = 42
       $0.date = now
     }
+  }
+}
+
+private struct Client: DependencyKey {
+  var fetch: () -> Int
+  static let liveValue = Client(fetch: { 42 })
+}
+extension DependencyValues {
+  fileprivate var client: Client {
+    get { self[Client.self] }
+    set { self[Client.self] = newValue }
   }
 }

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -328,7 +328,7 @@ final class TestStoreTests: XCTestCase {
   func testOverrideDependenciesOnTestStore_Init() {
     struct Counter: ReducerProtocol {
       @Dependency(\.calendar) var calendar
-      @Dependency(\.client) var client
+      @Dependency(\.client.fetch) var fetch
       @Dependency(\.locale) var locale
       @Dependency(\.timeZone) var timeZone
       @Dependency(\.urlSession) var urlSession


### PR DESCRIPTION
This was reported by @oronbz in Slack. We call `prepareDependencies` immediately in the `TestStore` initializer which means accessing a dependency in the trailing closure can trigger a test failure. We need to move it into `withDependencies` so that such failures are suppressed.