### PR TITLE
Add 'Effect.publisher' for bridging effects from Combine

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
@@ -28,6 +28,10 @@
 
 - ``EffectPublisher/unimplemented(_:)``
 
+### Combine integration
+
+- ``EffectPublisher/publisher(_:)``
+
 ### SwiftUI integration
 
 - ``EffectPublisher/animation(_:)``

--- a/Sources/ComposableArchitecture/Effects/Publisher.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher.swift
@@ -1,5 +1,18 @@
 import Combine
 
+extension EffectPublisher where Failure == Never {
+  /// Creates an effect from a Combine publisher.
+  /// 
+  /// - Parameter createPublisher: The closure to execute when the effect is performed.
+  /// - Returns: An effect wrapping a Combine publisher.
+  public static func publisher<P: Publisher>(_ createPublisher: @escaping () -> P) -> Self
+  where P.Output == Action, P.Failure == Never {
+    Self(
+      operation: .publisher(Deferred(createPublisher: createPublisher).eraseToAnyPublisher())
+    )
+  }
+}
+
 @available(iOS, deprecated: 9999.0)
 @available(macOS, deprecated: 9999.0)
 @available(tvOS, deprecated: 9999.0)
@@ -79,19 +92,19 @@ extension EffectPublisher {
   /// - Parameter publisher: A publisher.
   @available(
     iOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   @available(
     macOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   @available(
     tvOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   @available(
     watchOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   public init<P: Publisher>(_ publisher: P) where P.Output == Output, P.Failure == Failure {
     self.operation = .publisher(publisher.eraseToAnyPublisher())
@@ -367,19 +380,19 @@ extension Publisher {
   /// - Returns: An effect that wraps `self`.
   @available(
     iOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   @available(
     macOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   @available(
     tvOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   @available(
     watchOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   public func eraseToEffect() -> EffectPublisher<Output, Failure> {
     EffectPublisher(self)
@@ -402,19 +415,19 @@ extension Publisher {
   /// - Returns: An effect that wraps `self` after mapping `Output` values.
   @available(
     iOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   @available(
     macOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   @available(
     tvOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   @available(
     watchOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   public func eraseToEffect<T>(
     _ transform: @escaping (Output) -> T
@@ -447,19 +460,19 @@ extension Publisher {
   /// - Returns: An effect that wraps `self`.
   @available(
     iOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   @available(
     macOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   @available(
     tvOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   @available(
     watchOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   public func catchToEffect() -> EffectTask<Result<Output, Failure>> {
     self.catchToEffect { $0 }
@@ -482,19 +495,19 @@ extension Publisher {
   /// - Returns: An effect that wraps `self`.
   @available(
     iOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   @available(
     macOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   @available(
     tvOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   @available(
     watchOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead, or use 'EffectTask.publisher'."
   )
   public func catchToEffect<T>(
     _ transform: @escaping (Result<Output, Failure>) -> T


### PR DESCRIPTION
We are looking to deprecate TCA's dependence on Combine, _e.g._ the direct conformance of `Effect` to `Publisher`, as well as many Combine-centric APIs, but that doesn't mean we want to eliminate support for using Combine with TCA. Our current advice given by our soft deprecations is to iterate over `publisher.values`, but this is unavailable in iOS 13 and 14, so let's introduce a dedicated bridging mechanism, instead.