### PR TITLE
Add `ReducerReader` for building reducers out of state and action

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/Reducers/ReducerReader.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ReducerReader.swift
@@ -1,0 +1,24 @@
+/// A reducer that builds a reducer from the current state and action.
+public struct ReducerReader<State, Action, Reader: ReducerProtocol>: ReducerProtocol
+where Reader.State == State, Reader.Action == Action {
+  @usableFromInline
+  let reader: (State, Action) -> Reader
+
+  /// Initializes a reducer that builds a reducer from the current state and action.
+  ///
+  /// - Parameter reader: A reducer builder that has access to the current state and action.
+  @inlinable
+  public init(@ReducerBuilder<State, Action> _ reader: @escaping (State, Action) -> Reader) {
+    self.init(internal: reader)
+  }
+
+  @usableFromInline
+  init(internal reader: @escaping (State, Action) -> Reader) {
+    self.reader = reader
+  }
+
+  @inlinable
+  public func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+    self.reader(state, action).reduce(into: &state, action: action)
+  }
+}

--- a/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
@@ -191,20 +191,32 @@ private struct Root: ReducerProtocol {
 
     #if swift(>=5.7)
       var body: some ReducerProtocol<State, Action> {
-        Scope(state: /State.featureA, action: /Action.featureA) {
-          Feature()
-        }
-        Scope(state: /State.featureB, action: /Action.featureB) {
-          Feature()
+        ReducerReader { state, _ in
+          switch state {
+          case .featureA:
+            Scope(state: /State.featureA, action: /Action.featureA) {
+              Feature()
+            }
+          case .featureB:
+            Scope(state: /State.featureB, action: /Action.featureB) {
+              Feature()
+            }
+          }
         }
       }
     #else
       var body: Reduce<State, Action> {
-        Scope(state: /State.featureA, action: /Action.featureA) {
-          Feature()
-        }
-        Scope(state: /State.featureB, action: /Action.featureB) {
-          Feature()
+        ReducerReader { state, _ in
+          switch state {
+          case .featureA:
+            Scope(state: /State.featureA, action: /Action.featureA) {
+              Feature()
+            }
+          case .featureB:
+            Scope(state: /State.featureB, action: /Action.featureB) {
+              Feature()
+            }
+          }
         }
       }
     #endif

--- a/Tests/ComposableArchitectureTests/ReducerReaderTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerReaderTests.swift
@@ -1,0 +1,28 @@
+import ComposableArchitecture
+import XCTest
+
+@MainActor
+final class StateReaderTests: XCTestCase {
+  func testDependenciesPropagate() async {
+    struct Feature: ReducerProtocol {
+      struct State: Equatable {}
+
+      enum Action: Equatable {
+        case tap
+      }
+
+      @Dependency(\.date.now) var now
+
+      var body: some ReducerProtocolOf<Self> {
+        ReducerReader { _, _ in
+          let _ = self.now
+        }
+      }
+    }
+
+    let store = TestStore(initialState: Feature.State(), reducer: Feature()) {
+      $0.date.now = Date(timeIntervalSince1970: 1234567890)
+    }
+    await store.send(.tap)
+  }
+}


### PR DESCRIPTION
Let's consider adding a reducer that builds itself from the current state and action. We've experimented with the concept before and called it `_Observe`, but decided to wait a bit before shipping such a thing. More and more community members have built their own versions of `_Observe`, though, calling them `StateReader` and `ActionReader`, _etc._, which nicely evokes `ScrollViewReader` and `GeometryReader`, and we've also found more and more uses, so let's consider shipping this tool as a first-class citizen, and let's consider calling it `ReducerReader`.

We think a single `ReducerReader` entity is the way to go vs. three reducers, one for reading state _and_ action (`ReducerReader`), and then one for just reading state (`StateReader`) and one for just reading actions (`ActionReader`), since you can simply ignore the value you don't need to read:

```swift
// Instead of:
StateReader { state in /* ... */ }
// Do:
ReducerReader { state, _ in /* ... */ }

// Instead of:
ActionReader { action in /* ... */ }
// Do:
ReducerReader { _, action in /* ... */ }
```

A couple example uses:

### Exhaustively handling enum state:

```swift
var body: some ReducerProtocol<State, Action> {
  ReducerReader { state, _ in
    switch state {  // Compile-time failure if new cases are added
    case .loggedIn:
      Scope(state: /AppFeature.loggedIn, action: /AppFeature.loggedIn) {
        LoggedInFeature()
      }
    case .loggedOut:
      Scope(state: /AppFeature.loggedOut, action: /AppFeature.loggedOut) {
        LoggedOutFeature()
      }
    }
  }
}
```

### Filtering:

```swift
var body: some ReducerProtocol<State, Action> {
  ReducerReader { state, action in
    if state.isAdmin && action.isAdmin {
      AdminFeature()
    }
  }
}
```

## Feedback, please!

We'd love any feedback the community may have, especially from those that have used this kind of reducer in their applications.