### PR TITLE
Get some test coverage on child/parent effect cancellation behavior.

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "ace21305e0dd3a9e749aef79fef14be79a3b4669",
-        "version" : "0.8.2"
+        "revision" : "62041e6016a30f56952f5d7d3f12a3fd7029e1cd",
+        "version" : "0.8.3"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "ace21305e0dd3a9e749aef79fef14be79a3b4669",
-        "version" : "0.8.2"
+        "revision" : "ab8c9f45843694dd16be4297e6d44c0634fd9913",
+        "version" : "0.8.4"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "0.2.0"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "0.7.0"),
     .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "0.7.0"),
-    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.5.0"),
+    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.8.3"),
   ],
   targets: [
     .target(

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -683,77 +683,79 @@ final class StoreTests: XCTestCase {
     XCTAssertEqual(store.state.value.count, testStore.state.count)
   }
 
-  func testChidlParentEffectCancellation() async throws {
-    struct Child: ReducerProtocol {
-      struct State: Equatable {}
-      enum Action: Equatable {
-        case task
-        case didFinish
-      }
-
-      func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
-        switch action {
-        case .task:
-          return .run { send in await send(.didFinish) }
-        case .didFinish:
-          return .none
+  #if swift(>=5.7)
+    func testChidlParentEffectCancellation() async throws {
+      struct Child: ReducerProtocol {
+        struct State: Equatable {}
+        enum Action: Equatable {
+          case task
+          case didFinish
         }
-      }
-    }
-    struct Parent: ReducerProtocol {
-      struct State: Equatable {
-        var count = 0
-        var child: Child.State?
-      }
-      enum Action: Equatable {
-        case child(Child.Action)
-        case delay
-      }
-      @Dependency(\.mainQueue) var mainQueue
-      var body: Reduce<State, Action> {
-        Reduce { state, action in
+
+        func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
           switch action {
-          case .child(.didFinish):
-            state.child = nil
-            return .task {
-              try await self.mainQueue.sleep(for: .seconds(1))
-              return .delay
-            }
-          case .child:
-            return .none
-          case .delay:
-            state.count += 1
+          case .task:
+            return .run { send in await send(.didFinish) }
+          case .didFinish:
             return .none
           }
         }
-        .ifLet(\.child, action: /Action.child) {
-          Child()
+      }
+      struct Parent: ReducerProtocol {
+        struct State: Equatable {
+          var count = 0
+          var child: Child.State?
+        }
+        enum Action: Equatable {
+          case child(Child.Action)
+          case delay
+        }
+        @Dependency(\.mainQueue) var mainQueue
+        var body: Reduce<State, Action> {
+          Reduce { state, action in
+            switch action {
+            case .child(.didFinish):
+              state.child = nil
+              return .task {
+                try await self.mainQueue.sleep(for: .seconds(1))
+                return .delay
+              }
+            case .child:
+              return .none
+            case .delay:
+              state.count += 1
+              return .none
+            }
+          }
+          .ifLet(\.child, action: /Action.child) {
+            Child()
+          }
         }
       }
+
+      let mainQueue = DispatchQueue.test
+      let store = Store(
+        initialState: Parent.State(child: Child.State()),
+        reducer: Parent()
+      ) {
+        $0.mainQueue = mainQueue.eraseToAnyScheduler()
+      }
+      let viewStore = ViewStore(store)
+
+      let childTask = viewStore.send(.child(.task))
+      try await Task.sleep(nanoseconds: 100_000_000)
+      XCTAssertEqual(viewStore.child, nil)
+
+      await childTask.cancel()
+      await mainQueue.advance(by: 1)
+      try await Task.sleep(nanoseconds: 100_000_000)
+      XCTodo(
+        """
+        This fails because cancelling a child task will cancel all parent effects too.
+        """)
+      XCTAssertEqual(viewStore.count, 1)
     }
-
-    let mainQueue = DispatchQueue.test
-    let store = Store(
-      initialState: Parent.State(child: Child.State()),
-      reducer: Parent()
-    ) {
-      $0.mainQueue = mainQueue.eraseToAnyScheduler()
-    }
-    let viewStore = ViewStore(store)
-
-    let childTask = viewStore.send(.child(.task))
-    try await Task.sleep(nanoseconds: 100_000_000)
-    XCTAssertEqual(viewStore.child, nil)
-
-    await childTask.cancel()
-    await mainQueue.advance(by: 1)
-    try await Task.sleep(nanoseconds: 100_000_000)
-    XCTExpectFailure("""
-      This fails because cancelling a child task will cancel all parent effects too. If we fix
-      this we can remove the XCTExpectFailure.
-      """)
-    XCTAssertEqual(viewStore.count, 1)
-  }
+  #endif
 }
 
 private struct Count: TestDependencyKey {

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -710,7 +710,7 @@ final class StoreTests: XCTestCase {
         case delay
       }
       @Dependency(\.mainQueue) var mainQueue
-      var body: some ReducerProtocol<State, Action> {
+      var body: Reduce<State, Action> {
         Reduce { state, action in
           switch action {
           case .child(.didFinish):

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -749,7 +749,7 @@ final class StoreTests: XCTestCase {
       await childTask.cancel()
       await mainQueue.advance(by: 1)
       try await Task.sleep(nanoseconds: 100_000_000)
-      XCTodo(
+      XCTTODO(
         """
         This fails because cancelling a child task will cancel all parent effects too.
         """)

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -682,6 +682,78 @@ final class StoreTests: XCTestCase {
     await store.send(.tap)?.value
     XCTAssertEqual(store.state.value.count, testStore.state.count)
   }
+
+  func testChidlParentEffectCancellation() async throws {
+    struct Child: ReducerProtocol {
+      struct State: Equatable {}
+      enum Action: Equatable {
+        case task
+        case didFinish
+      }
+
+      func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+        switch action {
+        case .task:
+          return .run { send in await send(.didFinish) }
+        case .didFinish:
+          return .none
+        }
+      }
+    }
+    struct Parent: ReducerProtocol {
+      struct State: Equatable {
+        var count = 0
+        var child: Child.State?
+      }
+      enum Action: Equatable {
+        case child(Child.Action)
+        case delay
+      }
+      @Dependency(\.mainQueue) var mainQueue
+      var body: some ReducerProtocol<State, Action> {
+        Reduce { state, action in
+          switch action {
+          case .child(.didFinish):
+            state.child = nil
+            return .task {
+              try await self.mainQueue.sleep(for: .seconds(1))
+              return .delay
+            }
+          case .child:
+            return .none
+          case .delay:
+            state.count += 1
+            return .none
+          }
+        }
+        .ifLet(\.child, action: /Action.child) {
+          Child()
+        }
+      }
+    }
+
+    let mainQueue = DispatchQueue.test
+    let store = Store(
+      initialState: Parent.State(child: Child.State()),
+      reducer: Parent()
+    ) {
+      $0.mainQueue = mainQueue.eraseToAnyScheduler()
+    }
+    let viewStore = ViewStore(store)
+
+    let childTask = viewStore.send(.child(.task))
+    try await Task.sleep(nanoseconds: 100_000_000)
+    XCTAssertEqual(viewStore.child, nil)
+
+    await childTask.cancel()
+    await mainQueue.advance(by: 1)
+    try await Task.sleep(nanoseconds: 100_000_000)
+    XCTExpectFailure("""
+      This fails because cancelling a child task will cancel all parent effects too. If we fix
+      this we can remove the XCTExpectFailure.
+      """)
+    XCTAssertEqual(viewStore.count, 1)
+  }
 }
 
 private struct Count: TestDependencyKey {

--- a/Tests/ComposableArchitectureTests/TestHelpers.swift
+++ b/Tests/ComposableArchitectureTests/TestHelpers.swift
@@ -5,6 +5,6 @@ import XCTest
   deprecated,
   message: "This is a test that currently fails but should not in the future."
 )
-func XCTodo(_ message: String) {
+func XCTTODO(_ message: String) {
   XCTExpectFailure(message)
 }

--- a/Tests/ComposableArchitectureTests/TestHelpers.swift
+++ b/Tests/ComposableArchitectureTests/TestHelpers.swift
@@ -1,0 +1,10 @@
+import XCTest
+
+@available(
+  *,
+  deprecated,
+  message: "This is a test that currently fails but should not in the future."
+)
+func XCTodo(_ message: String) {
+  XCTExpectFailure(message)
+}


### PR DESCRIPTION
This discussion #1717 brings up some interesting behavior with child task cancellation that I think we want to address eventually. For now I'm getting a test in place that documents the behavior so that we can decide how to handle later.