### PR TITLE
Escape dependencies to `EffectTask.publisher`

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Publisher.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher.swift
@@ -8,7 +8,16 @@ extension EffectPublisher where Failure == Never {
   public static func publisher<P: Publisher>(_ createPublisher: @escaping () -> P) -> Self
   where P.Output == Action, P.Failure == Never {
     Self(
-      operation: .publisher(Deferred(createPublisher: createPublisher).eraseToAnyPublisher())
+      operation: .publisher(
+        withEscapedDependencies { continuation in
+          Deferred {
+            continuation.yield {
+              createPublisher()
+            }
+          }
+        }
+        .eraseToAnyPublisher()
+      )
     )
   }
 }

--- a/Tests/ComposableArchitectureTests/EffectPublisherTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectPublisherTests.swift
@@ -1,0 +1,24 @@
+import Combine
+import ComposableArchitecture
+import XCTest
+
+@MainActor
+final class EffectPublisherTests: BaseTCATestCase {
+  var cancellables: Set<AnyCancellable> = []
+
+  func testEscapedDependencies() {
+    @Dependency(\.date.now) var now
+
+    let effect = withDependencies {
+      $0.date.now = Date(timeIntervalSince1970: 1234567890)
+    } operation: {
+      EffectTask.publisher {
+        Just(now)
+      }
+    }
+
+    var value: Date?
+    effect.sink { value = $0 }.store(in: &self.cancellables)
+    XCTAssertEqual(value, Date(timeIntervalSince1970: 1234567890))
+  }
+}


### PR DESCRIPTION
Currently the escaping closure drops them.