### PR TITLE
Don't disable `_printChanges()` in tests

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
@@ -69,7 +69,7 @@ public struct _PrintChangesReducer<Base: ReducerProtocol>: ReducerProtocol {
     into state: inout Base.State, action: Base.Action
   ) -> EffectTask<Base.Action> {
     #if DEBUG
-      if self.context != .test, let printer = self.printer {
+      if let printer = self.printer {
         let oldState = state
         let effects = self.base.reduce(into: &state, action: action)
         return effects.merge(

--- a/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
@@ -61,9 +61,6 @@ public struct _PrintChangesReducer<Base: ReducerProtocol>: ReducerProtocol {
     self.printer = printer
   }
 
-  @usableFromInline
-  @Dependency(\.context) var context
-
   @inlinable
   public func reduce(
     into state: inout Base.State, action: Base.Action


### PR DESCRIPTION
It can be handy to have this logging during a test, so let's not go out of our way to suppress it.