### PR TITLE
Fix alert not opening issue 

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -55,7 +55,6 @@ struct AlertAndConfirmationDialog: ReducerProtocol {
       return .none
 
     case .alertDismissed:
-      state.alert = nil
       return .none
 
     case .confirmationDialogButtonTapped:


### PR DESCRIPTION
A minor bug occurs in which a new alert does not appear when the Incremented button is pressed in the alert.
I think it's a timing issue.
After the first alert is closed and the alertDismissed action is called, the second alert should pop up, but the second alert doesn't appear because the alertDismissed action is called after the Incremented alert is called.

I solved the problem by deleting the statement **state.alert = nil**, but I'm not sure if this is correct.
And There are also problems with the test code not passing when the problem is solved in this way.


Can I get some advice on how to solve this problem? 
Thanks.