### PR TITLE
Conform ExpressibleByNilLiteral by EffectPublisher

### DIFF
--- a/Examples/TicTacToe/tic-tac-toe/Sources/AppCore/AppCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/AppCore/AppCore.swift
@@ -24,21 +24,21 @@ public struct TicTacToe: ReducerProtocol {
       switch action {
       case .login(.twoFactor(.twoFactorResponse(.success))):
         state = .newGame(NewGame.State())
-        return .none
+        return nil
 
       case let .login(.loginResponse(.success(response))) where !response.twoFactorRequired:
         state = .newGame(NewGame.State())
-        return .none
+        return nil
 
       case .login:
-        return .none
+        return nil
 
       case .newGame(.logoutButtonTapped):
         state = .login(Login.State())
-        return .none
+        return nil
 
       case .newGame:
-        return .none
+        return nil
       }
     }
     .ifCaseLet(/State.login, action: /Action.login) {

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -80,6 +80,13 @@ extension EffectPublisher {
   }
 }
 
+extension EffectPublisher: ExpressibleByNilLiteral {
+  @inlinable
+  public init(nilLiteral: ()) {
+    self.init(operation: .none)
+  }
+}
+
 /// A type that encapsulates a unit of work that can be run in the outside world, and can feed
 /// actions back to the ``Store``.
 ///


### PR DESCRIPTION
This PR adds `ExpressibleByNilLiteral` conformance for `EffectPublisher`.

Looks that this change natively fits Swift syntax sugar.

PS. I'll update other examples if this change fits for you.