### PR TITLE
Update swift-custom-dump to 0.10.0.

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "de8ba65649e7ee317b9daf27dd5eebf34bd4be57",
-        "version" : "0.9.1"
+        "revision" : "805c57f32a5934ee420f30ba129f00aa8c7575a1",
+        "version" : "0.10.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "de8ba65649e7ee317b9daf27dd5eebf34bd4be57",
-        "version" : "0.9.1"
+        "revision" : "805c57f32a5934ee420f30ba129f00aa8c7575a1",
+        "version" : "0.10.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "0.8.0"),
     .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.14.0"),
     .package(url: "https://github.com/apple/swift-collections", from: "1.0.2"),
-    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.9.1"),
+    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.10.0"),
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "0.2.0"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "0.7.0"),
     .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "0.7.1"),

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -51,39 +51,15 @@
       var dump = ""
       customDump(action, to: &dump)
 
-      #if swift(>=5.8)
-        if #available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, *) {
-          XCTAssertEqual(
-            dump,
-            #"""
-            BindingAction.set(
-              \State.$width,
-              50
-            )
-            """#
-          )
-        } else {
-          XCTAssertEqual(
-            dump,
-            #"""
-            BindingAction.set(
-              WritableKeyPath<State, BindingState<Int>>,
-              50
-            )
-            """#
-          )
-        }
-      #else
-        XCTAssertEqual(
-          dump,
-          #"""
-          BindingAction.set(
-            WritableKeyPath<State, BindingState<Int>>,
-            50
-          )
-          """#
+      XCTAssertEqual(
+        dump,
+        #"""
+        BindingAction.set(
+          WritableKeyPath<DebugTests.State, BindingState<Int>>,
+          50
         )
-      #endif
+        """#
+      )
     }
 
     @MainActor


### PR DESCRIPTION
We recently worked around a Swift 5.8 crash in swift-custom-dump, and so it would be nice to get some visibility into this and encourage everyone to update their dependencies.