### PR TITLE
Pass state to `SwitchStore.init` view builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        xcode: ['13.4.1', '14.0.1']
+        xcode: ['13.4.1', '14.2']
         config: ['debug', 'release']
     steps:
       - uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        xcode: ['13.4.1', '14.1']
+        xcode: ['13.4.1', '14.2']
     steps:
       - uses: actions/checkout@v3
       - name: Select Xcode ${{ matrix.xcode }}
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Select Xcode 14.1
-        run: sudo xcode-select -s /Applications/Xcode_14.1.app
+        run: sudo xcode-select -s /Applications/Xcode_14.2.app
       - name: Run benchmark
         run: make benchmark
 
@@ -53,6 +53,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Select Xcode ${{ matrix.xcode }}
-        run: sudo xcode-select -s /Applications/Xcode_14.0.1.app
+        run: sudo xcode-select -s /Applications/Xcode_14.2.app
       - name: Run tests
         run: make test-examples

--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "de8ba65649e7ee317b9daf27dd5eebf34bd4be57",
-        "version" : "0.9.1"
+        "revision" : "805c57f32a5934ee420f30ba129f00aa8c7575a1",
+        "version" : "0.10.0"
       }
     },
     {

--- a/Examples/Integration/Integration.xcodeproj/project.pbxproj
+++ b/Examples/Integration/Integration.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		CAA1CAFC296DEE79000665B1 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CAA1CAFB296DEE79000665B1 /* Preview Assets.xcassets */; };
 		CAA1CB10296DEE79000665B1 /* ForEachBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA1CB0F296DEE79000665B1 /* ForEachBindingTests.swift */; };
 		CAA1CB1F296DEEAC000665B1 /* ForEachBindingTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA1CB1E296DEEAC000665B1 /* ForEachBindingTestCase.swift */; };
+		DC140CC529E0BB2C006DF553 /* SwitchStoreTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC140CC429E0BB2C006DF553 /* SwitchStoreTestCase.swift */; };
+		DC140CC729E0E8F3006DF553 /* SwitchStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC140CC629E0E8F3006DF553 /* SwitchStoreTests.swift */; };
 		E9919D3E296E28C800C8716B /* EscapedWithViewStoreTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9919D3D296E28C800C8716B /* EscapedWithViewStoreTestCase.swift */; };
 		E9919D40296E3EF400C8716B /* EscapedWithViewStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9919D3F296E3EF400C8716B /* EscapedWithViewStoreTests.swift */; };
 		E9919D42296E47A400C8716B /* BindingsAnimationsTestBench.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9919D41296E47A400C8716B /* BindingsAnimationsTestBench.swift */; };
@@ -41,6 +43,8 @@
 		CAA1CB0B296DEE79000665B1 /* IntegrationUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IntegrationUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CAA1CB0F296DEE79000665B1 /* ForEachBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForEachBindingTests.swift; sourceTree = "<group>"; };
 		CAA1CB1E296DEEAC000665B1 /* ForEachBindingTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForEachBindingTestCase.swift; sourceTree = "<group>"; };
+		DC140CC429E0BB2C006DF553 /* SwitchStoreTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchStoreTestCase.swift; sourceTree = "<group>"; };
+		DC140CC629E0E8F3006DF553 /* SwitchStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchStoreTests.swift; sourceTree = "<group>"; };
 		E9919D3D296E28C800C8716B /* EscapedWithViewStoreTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapedWithViewStoreTestCase.swift; sourceTree = "<group>"; };
 		E9919D3F296E3EF400C8716B /* EscapedWithViewStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapedWithViewStoreTests.swift; sourceTree = "<group>"; };
 		E9919D41296E47A400C8716B /* BindingsAnimationsTestBench.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindingsAnimationsTestBench.swift; sourceTree = "<group>"; };
@@ -92,6 +96,7 @@
 				E9919D3D296E28C800C8716B /* EscapedWithViewStoreTestCase.swift */,
 				CAA1CB1E296DEEAC000665B1 /* ForEachBindingTestCase.swift */,
 				CA595272296DF46D00B5B695 /* NavigationStackBindingTestCase.swift */,
+				DC140CC429E0BB2C006DF553 /* SwitchStoreTestCase.swift */,
 				CAA1CAF4296DEE78000665B1 /* IntegrationApp.swift */,
 				CAA1CAF8296DEE79000665B1 /* Assets.xcassets */,
 				CAA1CAFA296DEE79000665B1 /* Preview Content */,
@@ -112,6 +117,7 @@
 			children = (
 				E9919D3F296E3EF400C8716B /* EscapedWithViewStoreTests.swift */,
 				CAA1CB0F296DEE79000665B1 /* ForEachBindingTests.swift */,
+				DC140CC629E0E8F3006DF553 /* SwitchStoreTests.swift */,
 				CA595274296DF55A00B5B695 /* NavigationStackBindingTests.swift */,
 			);
 			path = IntegrationUITests;
@@ -229,6 +235,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CAA1CB1F296DEEAC000665B1 /* ForEachBindingTestCase.swift in Sources */,
+				DC140CC529E0BB2C006DF553 /* SwitchStoreTestCase.swift in Sources */,
 				E9919D42296E47A400C8716B /* BindingsAnimationsTestBench.swift in Sources */,
 				CA595273296DF46D00B5B695 /* NavigationStackBindingTestCase.swift in Sources */,
 				E9919D3E296E28C800C8716B /* EscapedWithViewStoreTestCase.swift in Sources */,
@@ -243,6 +250,7 @@
 				E9919D40296E3EF400C8716B /* EscapedWithViewStoreTests.swift in Sources */,
 				CA595275296DF55A00B5B695 /* NavigationStackBindingTests.swift in Sources */,
 				CAA1CB10296DEE79000665B1 /* ForEachBindingTests.swift in Sources */,
+				DC140CC729E0E8F3006DF553 /* SwitchStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Examples/Integration/Integration/IntegrationApp.swift
+++ b/Examples/Integration/Integration/IntegrationApp.swift
@@ -38,6 +38,15 @@ struct IntegrationApp: App {
             )
           }
 
+          NavigationLink("SwitchStoreTestCase") {
+            SwitchStoreTestCaseView(
+              store: Store(
+                initialState: SwitchStoreTestCase.State.screenA(SwitchStoreTestCase.Screen.State()),
+                reducer: SwitchStoreTestCase()
+              )
+            )
+          }
+
           NavigationLink("Binding Animations Test Bench") {
             BindingsAnimationsTestBench(
               store: Store(

--- a/Examples/Integration/Integration/SwitchStoreTestCase.swift
+++ b/Examples/Integration/Integration/SwitchStoreTestCase.swift
@@ -1,0 +1,96 @@
+import ComposableArchitecture
+import SwiftUI
+
+struct SwitchStoreTestCase: ReducerProtocol {
+  struct Screen: ReducerProtocol {
+    struct State: Equatable {
+      var count = 0
+    }
+    enum Action {
+      case decrementButtonTapped
+      case incrementButtonTapped
+    }
+    func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+      switch action {
+      case .decrementButtonTapped:
+        state.count -= 1
+        return .none
+      case .incrementButtonTapped:
+        state.count += 1
+        return .none
+      }
+    }
+  }
+
+  enum State: Equatable {
+    case screenA(Screen.State)
+    case screenB(Screen.State)
+  }
+  enum Action {
+    case screenA(Screen.Action)
+    case screenB(Screen.Action)
+    case swap
+  }
+
+  var body: some ReducerProtocolOf<Self> {
+    Reduce { state, action in
+      switch (state, action) {
+      case (_, .screenA), (_, .screenB):
+        return .none
+      case (.screenA, .swap):
+        state = .screenB(Screen.State())
+        return .none
+      case (.screenB, .swap):
+        state = .screenA(Screen.State())
+        return .none
+      }
+    }
+    .ifCaseLet(/State.screenA, action: /Action.screenA) {
+      Screen()
+    }
+    .ifCaseLet(/State.screenB, action: /Action.screenB) {
+      Screen()
+    }
+  }
+}
+
+struct SwitchStoreTestCaseView: View {
+  let store: StoreOf<SwitchStoreTestCase>
+
+  var body: some View {
+    WithViewStore(store.stateless) { viewStore in
+      Button("Swap") { viewStore.send(.swap) }
+    }
+    SwitchStore(self.store) {
+      switch $0 {
+      case .screenA:
+        CaseLet(
+          /SwitchStoreTestCase.State.screenA, action: SwitchStoreTestCase.Action.screenA
+        ) { store in
+          ScreenView(store: store)
+        }
+      case .screenB:
+        // Simulate copy-paste error:
+        CaseLet(
+          /SwitchStoreTestCase.State.screenA, action: SwitchStoreTestCase.Action.screenA
+        ) { store in
+          ScreenView(store: store)
+        }
+      }
+    }
+  }
+
+  struct ScreenView: View {
+    let store: StoreOf<SwitchStoreTestCase.Screen>
+
+    var body: some View {
+      WithViewStore(self.store, observe: { $0 }) { viewStore in
+        HStack {
+          Button("-") { viewStore.send(.decrementButtonTapped) }
+          Text("\(viewStore.count)")
+          Button("+") { viewStore.send(.decrementButtonTapped) }
+        }
+      }
+    }
+  }
+}

--- a/Examples/Integration/IntegrationUITests/SwitchStoreTests.swift
+++ b/Examples/Integration/IntegrationUITests/SwitchStoreTests.swift
@@ -18,7 +18,7 @@ final class SwitchStoreTests: XCTestCase {
 
     XCTAssertTrue(
       app.staticTexts
-        .containing(NSPredicate(format: "label CONTAINS[c] %@", "Warning"))
+        .containing(NSPredicate(format: "label CONTAINS[c] Warning"))
         .element
         .exists
     )

--- a/Examples/Integration/IntegrationUITests/SwitchStoreTests.swift
+++ b/Examples/Integration/IntegrationUITests/SwitchStoreTests.swift
@@ -16,7 +16,11 @@ final class SwitchStoreTests: XCTestCase {
 
     app.buttons["Swap"].tap()
 
-    // TODO: Figure out how to assert this
-    //XCTAssertTrue(app.staticTexts["Warning"].exists)
+    XCTAssertTrue(
+      app.staticTexts
+        .containing(NSPredicate(format: "label CONTAINS[c] %@", "Warning"))
+        .element
+        .exists
+    )
   }
 }

--- a/Examples/Integration/IntegrationUITests/SwitchStoreTests.swift
+++ b/Examples/Integration/IntegrationUITests/SwitchStoreTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+
+@MainActor
+final class SwitchStoreTests: XCTestCase {
+  override func setUpWithError() throws {
+    self.continueAfterFailure = false
+  }
+
+  func testExample() async throws {
+    let app = XCUIApplication()
+    app.launch()
+
+    app.collectionViews.buttons["SwitchStoreTestCase"].tap()
+
+    XCTAssertFalse(app.staticTexts["Warning"].exists)
+
+    app.buttons["Swap"].tap()
+
+    // TODO: Figure out how to assert this
+    //XCTAssertTrue(app.staticTexts["Warning"].exists)
+  }
+}

--- a/Examples/Integration/IntegrationUITests/SwitchStoreTests.swift
+++ b/Examples/Integration/IntegrationUITests/SwitchStoreTests.swift
@@ -18,7 +18,7 @@ final class SwitchStoreTests: XCTestCase {
 
     XCTAssertTrue(
       app.staticTexts
-        .containing(NSPredicate(format: "label CONTAINS[c] Warning"))
+        .containing(NSPredicate(format: #"label CONTAINS[c] "Warning""#))
         .element
         .exists
     )

--- a/Examples/Integration/IntegrationUITests/SwitchStoreTests.swift
+++ b/Examples/Integration/IntegrationUITests/SwitchStoreTests.swift
@@ -18,7 +18,7 @@ final class SwitchStoreTests: XCTestCase {
 
     XCTAssertTrue(
       app.staticTexts
-        .containing(NSPredicate(format: #"label CONTAINS[c] "Warning""#))
+        .containing(NSPredicate(format: #"label CONTAINS[c] "Warning: ""#))
         .element
         .exists
     )

--- a/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
@@ -12,31 +12,22 @@ public struct AppView: View {
   }
 
   public var body: some View {
-    SwitchStore(self.store) { // state in
-//      Group {
-//        switch state {
-//        case .login:
-          CaseLet(/TicTacToe.State.login, action: TicTacToe.Action.login) { store in
-            NavigationView {
-              LoginView(store: store)
-            }
-            .navigationViewStyle(.stack)
-          }
-//        case .newGame:
-//          CaseLet(/TicTacToe.State.newGame, action: TicTacToe.Action.newGame) { store in
-//            NavigationView {
-//              NewGameView(store: store)
-//            }
-//          }
-          CaseLet(/TicTacToe.State.login, action: TicTacToe.Action.login) { store in
-            NavigationView {
-              LoginView(store: store)
-            }
-            .navigationViewStyle(.stack)
+    SwitchStore(self.store) { state in
+      switch state {
+      case .login:
+        CaseLet(/TicTacToe.State.login, action: TicTacToe.Action.login) { store in
+          NavigationView {
+            LoginView(store: store)
           }
         }
-//      }
-//      .navigationViewStyle(.stack)
-//    }
+      case .newGame:
+        CaseLet(/TicTacToe.State.newGame, action: TicTacToe.Action.newGame) { store in
+          NavigationView {
+            NewGameView(store: store)
+          }
+        }
+      }
+    }
+    .navigationViewStyle(.stack)
   }
 }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
@@ -12,18 +12,22 @@ public struct AppView: View {
   }
 
   public var body: some View {
-    SwitchStore(self.store) {
-      CaseLet(state: /TicTacToe.State.login, action: TicTacToe.Action.login) { store in
-        NavigationView {
-          LoginView(store: store)
+    SwitchStore(self.store) { state in
+      switch state {
+      case .login:
+        CaseLet(state: /TicTacToe.State.login, action: TicTacToe.Action.login) { store in
+          NavigationView {
+            LoginView(store: store)
+          }
+          .navigationViewStyle(.stack)
         }
-        .navigationViewStyle(.stack)
-      }
-      CaseLet(state: /TicTacToe.State.newGame, action: TicTacToe.Action.newGame) { store in
-        NavigationView {
-          NewGameView(store: store)
+      case .newGame:
+        CaseLet(state: /TicTacToe.State.newGame, action: TicTacToe.Action.newGame) { store in
+          NavigationView {
+            NewGameView(store: store)
+          }
+          .navigationViewStyle(.stack)
         }
-        .navigationViewStyle(.stack)
       }
     }
   }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
@@ -12,23 +12,31 @@ public struct AppView: View {
   }
 
   public var body: some View {
-    SwitchStore(self.store) { state in
-      switch state {
-      case .login:
-        CaseLet(state: /TicTacToe.State.login, action: TicTacToe.Action.login) { store in
-          NavigationView {
-            LoginView(store: store)
+    SwitchStore(self.store) { // state in
+//      Group {
+//        switch state {
+//        case .login:
+          CaseLet(/TicTacToe.State.login, action: TicTacToe.Action.login) { store in
+            NavigationView {
+              LoginView(store: store)
+            }
+            .navigationViewStyle(.stack)
           }
-          .navigationViewStyle(.stack)
-        }
-      case .newGame:
-        CaseLet(state: /TicTacToe.State.newGame, action: TicTacToe.Action.newGame) { store in
-          NavigationView {
-            NewGameView(store: store)
+//        case .newGame:
+//          CaseLet(/TicTacToe.State.newGame, action: TicTacToe.Action.newGame) { store in
+//            NavigationView {
+//              NewGameView(store: store)
+//            }
+//          }
+          CaseLet(/TicTacToe.State.login, action: TicTacToe.Action.login) { store in
+            NavigationView {
+              LoginView(store: store)
+            }
+            .navigationViewStyle(.stack)
           }
-          .navigationViewStyle(.stack)
         }
-      }
-    }
+//      }
+//      .navigationViewStyle(.stack)
+//    }
   }
 }

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -20,53 +20,43 @@ import SwiftUI
 ///   let store: StoreOf<App>
 ///
 ///   var body: some View {
-///     SwitchStore(self.store) {
-///       CaseLet(state: /App.State.loggedIn, action: App.Action.loggedIn) { loggedInStore in
-///         LoggedInView(store: loggedInStore)
-///       }
-///       CaseLet(state: /App.State.loggedOut, action: App.Action.loggedOut) { loggedOutStore in
-///         LoggedOutView(store: loggedOutStore)
+///     SwitchStore(self.store) { state in
+///       switch state {
+///       case .loggedIn:
+///         CaseLet(state: /App.State.loggedIn, action: App.Action.loggedIn) { loggedInStore in
+///           LoggedInView(store: loggedInStore)
+///         }
+///       case .loggedOut:
+///         CaseLet(state: /App.State.loggedOut, action: App.Action.loggedOut) { loggedOutStore in
+///           LoggedOutView(store: loggedOutStore)
+///         }
 ///       }
 ///     }
 ///   }
 /// }
 /// ```
 ///
-/// If a ``SwitchStore`` does not exhaustively handle every case with a corresponding ``CaseLet``
-/// view, a runtime warning will be logged when an unhandled case is encountered. To fall back on a
-/// default view instead, introduce a ``Default`` view at the end of the ``SwitchStore``:
-///
-/// ```swift
-/// SwitchStore(self.store) {
-///   CaseLet(state: /MyState.first, action: MyAction.first) {
-///     FirstView(store: $0)
-///   }
-///   CaseLet(state: /MyState.second, action: MyAction.second) {
-///     SecondView(store: $0)
-///   }
-///   Default {
-///     Text("State is neither first nor second.")
-///   }
-/// }
-/// ```
+/// > Note: The `SwitchStore` view builder is only evaluated when the case of state passed to it
+/// > changes. As such, you should not rely on this value for anything other than checking the
+/// > current case, _e.g._ by switching on it and calling the appropriate `CaseLet`
 ///
 /// See ``ReducerProtocol/ifCaseLet(_:action:then:file:fileID:line:)`` and
 /// ``Scope/init(state:action:child:file:fileID:line:)`` for embedding reducers that operate on each
 /// case of an enum in reducers that operate on the entire enum.
 public struct SwitchStore<State, Action, Content: View>: View {
   public let store: Store<State, Action>
-  public let content: Content
+  public let content: (State) -> Content
 
-  init(
-    store: Store<State, Action>,
-    @ViewBuilder content: () -> Content
+  public init(
+    _ store: Store<State, Action>,
+    @ViewBuilder content: @escaping (State) -> Content
   ) {
     self.store = store
-    self.content = content()
+    self.content = content
   }
 
   public var body: some View {
-    self.content
+    self.content(self.store.state.value)
       .environmentObject(StoreObservableObject(store: self.store))
   }
 }
@@ -134,6 +124,30 @@ extension CaseLet where EnumAction == CaseAction {
 /// If you wish to use ``SwitchStore`` in a non-exhaustive manner (i.e. you do not want to provide
 /// a ``CaseLet`` for each case of the enum), then you must insert a ``Default`` view at the end of
 /// the ``SwitchStore``'s body.
+@available(
+  iOS,
+  deprecated: 9999,
+  message:
+    "Use the 'SwitchStore.init' that can 'switch' over a given 'state' and use 'default' instead."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message:
+    "Use the 'SwitchStore.init' that can 'switch' over a given 'state' and use 'default' instead."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message:
+    "Use the 'SwitchStore.init' that can 'switch' over a given 'state' and use 'default' instead."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message:
+    "Use the 'SwitchStore.init' that can 'switch' over a given 'state' and use 'default' instead."
+)
 public struct Default<Content: View>: View {
   private let content: Content
 
@@ -152,6 +166,26 @@ public struct Default<Content: View>: View {
 }
 
 extension SwitchStore {
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
   public init<State1, Action1, Content1, DefaultContent>(
     _ store: Store<State, Action>,
     @ViewBuilder content: () -> TupleView<
@@ -172,7 +206,7 @@ extension SwitchStore {
     >
   {
     let content = content().value
-    self.init(store: store) {
+    self.init(store) { _ in
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
@@ -183,6 +217,26 @@ extension SwitchStore {
     }
   }
 
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
   public init<State1, Action1, Content1>(
     _ store: Store<State, Action>,
     file: StaticString = #file,
@@ -206,6 +260,26 @@ extension SwitchStore {
     }
   }
 
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
   public init<State1, Action1, Content1, State2, Action2, Content2, DefaultContent>(
     _ store: Store<State, Action>,
     @ViewBuilder content: () -> TupleView<
@@ -230,7 +304,7 @@ extension SwitchStore {
     >
   {
     let content = content().value
-    self.init(store: store) {
+    self.init(store) { _ in
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
@@ -243,6 +317,26 @@ extension SwitchStore {
     }
   }
 
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
   public init<State1, Action1, Content1, State2, Action2, Content2>(
     _ store: Store<State, Action>,
     file: StaticString = #file,
@@ -276,6 +370,26 @@ extension SwitchStore {
     }
   }
 
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
   public init<
     State1, Action1, Content1,
     State2, Action2, Content2,
@@ -309,7 +423,7 @@ extension SwitchStore {
     >
   {
     let content = content().value
-    self.init(store: store) {
+    self.init(store) { _ in
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
@@ -324,6 +438,26 @@ extension SwitchStore {
     }
   }
 
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
   public init<State1, Action1, Content1, State2, Action2, Content2, State3, Action3, Content3>(
     _ store: Store<State, Action>,
     file: StaticString = #file,
@@ -362,6 +496,26 @@ extension SwitchStore {
     }
   }
 
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
   public init<
     State1, Action1, Content1,
     State2, Action2, Content2,
@@ -400,7 +554,7 @@ extension SwitchStore {
     >
   {
     let content = content().value
-    self.init(store: store) {
+    self.init(store) { _ in
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
@@ -417,6 +571,26 @@ extension SwitchStore {
     }
   }
 
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
   public init<
     State1, Action1, Content1,
     State2, Action2, Content2,
@@ -465,6 +639,26 @@ extension SwitchStore {
     }
   }
 
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
   public init<
     State1, Action1, Content1,
     State2, Action2, Content2,
@@ -508,7 +702,7 @@ extension SwitchStore {
     >
   {
     let content = content().value
-    self.init(store: store) {
+    self.init(store) { _ in
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
@@ -527,6 +721,26 @@ extension SwitchStore {
     }
   }
 
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
   public init<
     State1, Action1, Content1,
     State2, Action2, Content2,
@@ -581,6 +795,26 @@ extension SwitchStore {
     }
   }
 
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
   public init<
     State1, Action1, Content1,
     State2, Action2, Content2,
@@ -629,7 +863,7 @@ extension SwitchStore {
     >
   {
     let content = content().value
-    self.init(store: store) {
+    self.init(store) { _ in
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
@@ -650,6 +884,26 @@ extension SwitchStore {
     }
   }
 
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
   public init<
     State1, Action1, Content1,
     State2, Action2, Content2,
@@ -710,6 +964,26 @@ extension SwitchStore {
     }
   }
 
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
   public init<
     State1, Action1, Content1,
     State2, Action2, Content2,
@@ -763,7 +1037,7 @@ extension SwitchStore {
     >
   {
     let content = content().value
-    self.init(store: store) {
+    self.init(store) { _ in
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
@@ -786,6 +1060,26 @@ extension SwitchStore {
     }
   }
 
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
   public init<
     State1, Action1, Content1,
     State2, Action2, Content2,
@@ -852,6 +1146,26 @@ extension SwitchStore {
     }
   }
 
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
   public init<
     State1, Action1, Content1,
     State2, Action2, Content2,
@@ -910,7 +1224,7 @@ extension SwitchStore {
     >
   {
     let content = content().value
-    self.init(store: store) {
+    self.init(store) { _ in
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
@@ -935,6 +1249,26 @@ extension SwitchStore {
     }
   }
 
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
   public init<
     State1, Action1, Content1,
     State2, Action2, Content2,
@@ -1007,6 +1341,26 @@ extension SwitchStore {
     }
   }
 
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
   public init<
     State1, Action1, Content1,
     State2, Action2, Content2,
@@ -1070,7 +1424,7 @@ extension SwitchStore {
     >
   {
     let content = content().value
-    self.init(store: store) {
+    self.init(store) { _ in
       return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
         if content.0.toCaseState(viewStore.state) != nil {
           content.0
@@ -1097,6 +1451,26 @@ extension SwitchStore {
     }
   }
 
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+  )
   public init<
     State1, Action1, Content1,
     State2, Action2, Content2,
@@ -1176,6 +1550,26 @@ extension SwitchStore {
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
+)
 public struct _ExhaustivityCheckView<State, Action>: View {
   @EnvironmentObject private var store: StoreObservableObject<State, Action>
   let file: StaticString

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -56,8 +56,12 @@ public struct SwitchStore<State, Action, Content: View>: View {
   }
 
   public var body: some View {
-    self.content(self.store.state.value)
-      .environmentObject(StoreObservableObject(store: self.store))
+    WithViewStore(
+      self.store, observe: { $0 }, removeDuplicates: { enumTag($0) == enumTag($1) }
+    ) { viewStore in
+      self.content(viewStore.state)
+        .environmentObject(StoreObservableObject(store: self.store))
+    }
   }
 }
 

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -200,23 +200,17 @@ extension SwitchStore {
     >
   )
   where
-    Content == WithViewStore<
-      State,
-      Action,
-      _ConditionalContent<
-        CaseLet<State, Action, State1, Action1, Content1>,
-        Default<DefaultContent>
-      >
+    Content == _ConditionalContent<
+      CaseLet<State, Action, State1, Action1, Content1>,
+      Default<DefaultContent>
     >
   {
     let content = content().value
-    self.init(store) { _ in
-      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
-        if content.0.toCaseState(viewStore.state) != nil {
-          content.0
-        } else {
-          content.1
-        }
+    self.init(store) { state in
+      if content.0.toCaseState(state) != nil {
+        content.0
+      } else {
+        content.1
       }
     }
   }
@@ -249,13 +243,9 @@ extension SwitchStore {
     @ViewBuilder content: () -> CaseLet<State, Action, State1, Action1, Content1>
   )
   where
-    Content == WithViewStore<
-      State,
-      Action,
-      _ConditionalContent<
-        CaseLet<State, Action, State1, Action1, Content1>,
-        Default<_ExhaustivityCheckView<State, Action>>
-      >
+    Content == _ConditionalContent<
+      CaseLet<State, Action, State1, Action1, Content1>,
+      Default<_ExhaustivityCheckView<State, Action>>
     >
   {
     self.init(store) {
@@ -295,28 +285,22 @@ extension SwitchStore {
     >
   )
   where
-    Content == WithViewStore<
-      State,
-      Action,
+    Content == _ConditionalContent<
       _ConditionalContent<
-        _ConditionalContent<
-          CaseLet<State, Action, State1, Action1, Content1>,
-          CaseLet<State, Action, State2, Action2, Content2>
-        >,
-        Default<DefaultContent>
-      >
+        CaseLet<State, Action, State1, Action1, Content1>,
+        CaseLet<State, Action, State2, Action2, Content2>
+      >,
+      Default<DefaultContent>
     >
   {
     let content = content().value
-    self.init(store) { _ in
-      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
-        if content.0.toCaseState(viewStore.state) != nil {
-          content.0
-        } else if content.1.toCaseState(viewStore.state) != nil {
-          content.1
-        } else {
-          content.2
-        }
+    self.init(store) { state in
+      if content.0.toCaseState(state) != nil {
+        content.0
+      } else if content.1.toCaseState(state) != nil {
+        content.1
+      } else {
+        content.2
       }
     }
   }
@@ -354,16 +338,12 @@ extension SwitchStore {
     >
   )
   where
-    Content == WithViewStore<
-      State,
-      Action,
+    Content == _ConditionalContent<
       _ConditionalContent<
-        _ConditionalContent<
-          CaseLet<State, Action, State1, Action1, Content1>,
-          CaseLet<State, Action, State2, Action2, Content2>
-        >,
-        Default<_ExhaustivityCheckView<State, Action>>
-      >
+        CaseLet<State, Action, State1, Action1, Content1>,
+        CaseLet<State, Action, State2, Action2, Content2>
+      >,
+      Default<_ExhaustivityCheckView<State, Action>>
     >
   {
     let content = content()
@@ -411,33 +391,27 @@ extension SwitchStore {
     >
   )
   where
-    Content == WithViewStore<
-      State,
-      Action,
+    Content == _ConditionalContent<
       _ConditionalContent<
-        _ConditionalContent<
-          CaseLet<State, Action, State1, Action1, Content1>,
-          CaseLet<State, Action, State2, Action2, Content2>
-        >,
-        _ConditionalContent<
-          CaseLet<State, Action, State3, Action3, Content3>,
-          Default<DefaultContent>
-        >
+        CaseLet<State, Action, State1, Action1, Content1>,
+        CaseLet<State, Action, State2, Action2, Content2>
+      >,
+      _ConditionalContent<
+        CaseLet<State, Action, State3, Action3, Content3>,
+        Default<DefaultContent>
       >
     >
   {
     let content = content().value
-    self.init(store) { _ in
-      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
-        if content.0.toCaseState(viewStore.state) != nil {
-          content.0
-        } else if content.1.toCaseState(viewStore.state) != nil {
-          content.1
-        } else if content.2.toCaseState(viewStore.state) != nil {
-          content.2
-        } else {
-          content.3
-        }
+    self.init(store) { state in
+      if content.0.toCaseState(state) != nil {
+        content.0
+      } else if content.1.toCaseState(state) != nil {
+        content.1
+      } else if content.2.toCaseState(state) != nil {
+        content.2
+      } else {
+        content.3
       }
     }
   }
@@ -476,18 +450,14 @@ extension SwitchStore {
     >
   )
   where
-    Content == WithViewStore<
-      State,
-      Action,
+    Content == _ConditionalContent<
       _ConditionalContent<
-        _ConditionalContent<
-          CaseLet<State, Action, State1, Action1, Content1>,
-          CaseLet<State, Action, State2, Action2, Content2>
-        >,
-        _ConditionalContent<
-          CaseLet<State, Action, State3, Action3, Content3>,
-          Default<_ExhaustivityCheckView<State, Action>>
-        >
+        CaseLet<State, Action, State1, Action1, Content1>,
+        CaseLet<State, Action, State2, Action2, Content2>
+      >,
+      _ConditionalContent<
+        CaseLet<State, Action, State3, Action3, Content3>,
+        Default<_ExhaustivityCheckView<State, Action>>
       >
     >
   {
@@ -539,38 +509,32 @@ extension SwitchStore {
     >
   )
   where
-    Content == WithViewStore<
-      State,
-      Action,
+    Content == _ConditionalContent<
       _ConditionalContent<
         _ConditionalContent<
-          _ConditionalContent<
-            CaseLet<State, Action, State1, Action1, Content1>,
-            CaseLet<State, Action, State2, Action2, Content2>
-          >,
-          _ConditionalContent<
-            CaseLet<State, Action, State3, Action3, Content3>,
-            CaseLet<State, Action, State4, Action4, Content4>
-          >
+          CaseLet<State, Action, State1, Action1, Content1>,
+          CaseLet<State, Action, State2, Action2, Content2>
         >,
-        Default<DefaultContent>
-      >
+        _ConditionalContent<
+          CaseLet<State, Action, State3, Action3, Content3>,
+          CaseLet<State, Action, State4, Action4, Content4>
+        >
+      >,
+      Default<DefaultContent>
     >
   {
     let content = content().value
-    self.init(store) { _ in
-      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
-        if content.0.toCaseState(viewStore.state) != nil {
-          content.0
-        } else if content.1.toCaseState(viewStore.state) != nil {
-          content.1
-        } else if content.2.toCaseState(viewStore.state) != nil {
-          content.2
-        } else if content.3.toCaseState(viewStore.state) != nil {
-          content.3
-        } else {
-          content.4
-        }
+    self.init(store) { state in
+      if content.0.toCaseState(state) != nil {
+        content.0
+      } else if content.1.toCaseState(state) != nil {
+        content.1
+      } else if content.2.toCaseState(state) != nil {
+        content.2
+      } else if content.3.toCaseState(state) != nil {
+        content.3
+      } else {
+        content.4
       }
     }
   }
@@ -615,22 +579,18 @@ extension SwitchStore {
     >
   )
   where
-    Content == WithViewStore<
-      State,
-      Action,
+    Content == _ConditionalContent<
       _ConditionalContent<
         _ConditionalContent<
-          _ConditionalContent<
-            CaseLet<State, Action, State1, Action1, Content1>,
-            CaseLet<State, Action, State2, Action2, Content2>
-          >,
-          _ConditionalContent<
-            CaseLet<State, Action, State3, Action3, Content3>,
-            CaseLet<State, Action, State4, Action4, Content4>
-          >
+          CaseLet<State, Action, State1, Action1, Content1>,
+          CaseLet<State, Action, State2, Action2, Content2>
         >,
-        Default<_ExhaustivityCheckView<State, Action>>
-      >
+        _ConditionalContent<
+          CaseLet<State, Action, State3, Action3, Content3>,
+          CaseLet<State, Action, State4, Action4, Content4>
+        >
+      >,
+      Default<_ExhaustivityCheckView<State, Action>>
     >
   {
     let content = content()
@@ -684,43 +644,37 @@ extension SwitchStore {
     >
   )
   where
-    Content == WithViewStore<
-      State,
-      Action,
+    Content == _ConditionalContent<
       _ConditionalContent<
         _ConditionalContent<
-          _ConditionalContent<
-            CaseLet<State, Action, State1, Action1, Content1>,
-            CaseLet<State, Action, State2, Action2, Content2>
-          >,
-          _ConditionalContent<
-            CaseLet<State, Action, State3, Action3, Content3>,
-            CaseLet<State, Action, State4, Action4, Content4>
-          >
+          CaseLet<State, Action, State1, Action1, Content1>,
+          CaseLet<State, Action, State2, Action2, Content2>
         >,
         _ConditionalContent<
-          CaseLet<State, Action, State5, Action5, Content5>,
-          Default<DefaultContent>
+          CaseLet<State, Action, State3, Action3, Content3>,
+          CaseLet<State, Action, State4, Action4, Content4>
         >
+      >,
+      _ConditionalContent<
+        CaseLet<State, Action, State5, Action5, Content5>,
+        Default<DefaultContent>
       >
     >
   {
     let content = content().value
-    self.init(store) { _ in
-      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
-        if content.0.toCaseState(viewStore.state) != nil {
-          content.0
-        } else if content.1.toCaseState(viewStore.state) != nil {
-          content.1
-        } else if content.2.toCaseState(viewStore.state) != nil {
-          content.2
-        } else if content.3.toCaseState(viewStore.state) != nil {
-          content.3
-        } else if content.4.toCaseState(viewStore.state) != nil {
-          content.4
-        } else {
-          content.5
-        }
+    self.init(store) { state in
+      if content.0.toCaseState(state) != nil {
+        content.0
+      } else if content.1.toCaseState(state) != nil {
+        content.1
+      } else if content.2.toCaseState(state) != nil {
+        content.2
+      } else if content.3.toCaseState(state) != nil {
+        content.3
+      } else if content.4.toCaseState(state) != nil {
+        content.4
+      } else {
+        content.5
       }
     }
   }
@@ -767,24 +721,20 @@ extension SwitchStore {
     >
   )
   where
-    Content == WithViewStore<
-      State,
-      Action,
+    Content == _ConditionalContent<
       _ConditionalContent<
         _ConditionalContent<
-          _ConditionalContent<
-            CaseLet<State, Action, State1, Action1, Content1>,
-            CaseLet<State, Action, State2, Action2, Content2>
-          >,
-          _ConditionalContent<
-            CaseLet<State, Action, State3, Action3, Content3>,
-            CaseLet<State, Action, State4, Action4, Content4>
-          >
+          CaseLet<State, Action, State1, Action1, Content1>,
+          CaseLet<State, Action, State2, Action2, Content2>
         >,
         _ConditionalContent<
-          CaseLet<State, Action, State5, Action5, Content5>,
-          Default<_ExhaustivityCheckView<State, Action>>
+          CaseLet<State, Action, State3, Action3, Content3>,
+          CaseLet<State, Action, State4, Action4, Content4>
         >
+      >,
+      _ConditionalContent<
+        CaseLet<State, Action, State5, Action5, Content5>,
+        Default<_ExhaustivityCheckView<State, Action>>
       >
     >
   {
@@ -842,48 +792,42 @@ extension SwitchStore {
     >
   )
   where
-    Content == WithViewStore<
-      State,
-      Action,
+    Content == _ConditionalContent<
       _ConditionalContent<
         _ConditionalContent<
-          _ConditionalContent<
-            CaseLet<State, Action, State1, Action1, Content1>,
-            CaseLet<State, Action, State2, Action2, Content2>
-          >,
-          _ConditionalContent<
-            CaseLet<State, Action, State3, Action3, Content3>,
-            CaseLet<State, Action, State4, Action4, Content4>
-          >
+          CaseLet<State, Action, State1, Action1, Content1>,
+          CaseLet<State, Action, State2, Action2, Content2>
         >,
         _ConditionalContent<
-          _ConditionalContent<
-            CaseLet<State, Action, State5, Action5, Content5>,
-            CaseLet<State, Action, State6, Action6, Content6>
-          >,
-          Default<DefaultContent>
+          CaseLet<State, Action, State3, Action3, Content3>,
+          CaseLet<State, Action, State4, Action4, Content4>
         >
+      >,
+      _ConditionalContent<
+        _ConditionalContent<
+          CaseLet<State, Action, State5, Action5, Content5>,
+          CaseLet<State, Action, State6, Action6, Content6>
+        >,
+        Default<DefaultContent>
       >
     >
   {
     let content = content().value
-    self.init(store) { _ in
-      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
-        if content.0.toCaseState(viewStore.state) != nil {
-          content.0
-        } else if content.1.toCaseState(viewStore.state) != nil {
-          content.1
-        } else if content.2.toCaseState(viewStore.state) != nil {
-          content.2
-        } else if content.3.toCaseState(viewStore.state) != nil {
-          content.3
-        } else if content.4.toCaseState(viewStore.state) != nil {
-          content.4
-        } else if content.5.toCaseState(viewStore.state) != nil {
-          content.5
-        } else {
-          content.6
-        }
+    self.init(store) { state in
+      if content.0.toCaseState(state) != nil {
+        content.0
+      } else if content.1.toCaseState(state) != nil {
+        content.1
+      } else if content.2.toCaseState(state) != nil {
+        content.2
+      } else if content.3.toCaseState(state) != nil {
+        content.3
+      } else if content.4.toCaseState(state) != nil {
+        content.4
+      } else if content.5.toCaseState(state) != nil {
+        content.5
+      } else {
+        content.6
       }
     }
   }
@@ -932,27 +876,23 @@ extension SwitchStore {
     >
   )
   where
-    Content == WithViewStore<
-      State,
-      Action,
+    Content == _ConditionalContent<
       _ConditionalContent<
         _ConditionalContent<
-          _ConditionalContent<
-            CaseLet<State, Action, State1, Action1, Content1>,
-            CaseLet<State, Action, State2, Action2, Content2>
-          >,
-          _ConditionalContent<
-            CaseLet<State, Action, State3, Action3, Content3>,
-            CaseLet<State, Action, State4, Action4, Content4>
-          >
+          CaseLet<State, Action, State1, Action1, Content1>,
+          CaseLet<State, Action, State2, Action2, Content2>
         >,
         _ConditionalContent<
-          _ConditionalContent<
-            CaseLet<State, Action, State5, Action5, Content5>,
-            CaseLet<State, Action, State6, Action6, Content6>
-          >,
-          Default<_ExhaustivityCheckView<State, Action>>
+          CaseLet<State, Action, State3, Action3, Content3>,
+          CaseLet<State, Action, State4, Action4, Content4>
         >
+      >,
+      _ConditionalContent<
+        _ConditionalContent<
+          CaseLet<State, Action, State5, Action5, Content5>,
+          CaseLet<State, Action, State6, Action6, Content6>
+        >,
+        Default<_ExhaustivityCheckView<State, Action>>
       >
     >
   {
@@ -1013,53 +953,47 @@ extension SwitchStore {
     >
   )
   where
-    Content == WithViewStore<
-      State,
-      Action,
+    Content == _ConditionalContent<
       _ConditionalContent<
         _ConditionalContent<
-          _ConditionalContent<
-            CaseLet<State, Action, State1, Action1, Content1>,
-            CaseLet<State, Action, State2, Action2, Content2>
-          >,
-          _ConditionalContent<
-            CaseLet<State, Action, State3, Action3, Content3>,
-            CaseLet<State, Action, State4, Action4, Content4>
-          >
+          CaseLet<State, Action, State1, Action1, Content1>,
+          CaseLet<State, Action, State2, Action2, Content2>
         >,
         _ConditionalContent<
-          _ConditionalContent<
-            CaseLet<State, Action, State5, Action5, Content5>,
-            CaseLet<State, Action, State6, Action6, Content6>
-          >,
-          _ConditionalContent<
-            CaseLet<State, Action, State7, Action7, Content7>,
-            Default<DefaultContent>
-          >
+          CaseLet<State, Action, State3, Action3, Content3>,
+          CaseLet<State, Action, State4, Action4, Content4>
+        >
+      >,
+      _ConditionalContent<
+        _ConditionalContent<
+          CaseLet<State, Action, State5, Action5, Content5>,
+          CaseLet<State, Action, State6, Action6, Content6>
+        >,
+        _ConditionalContent<
+          CaseLet<State, Action, State7, Action7, Content7>,
+          Default<DefaultContent>
         >
       >
     >
   {
     let content = content().value
-    self.init(store) { _ in
-      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
-        if content.0.toCaseState(viewStore.state) != nil {
-          content.0
-        } else if content.1.toCaseState(viewStore.state) != nil {
-          content.1
-        } else if content.2.toCaseState(viewStore.state) != nil {
-          content.2
-        } else if content.3.toCaseState(viewStore.state) != nil {
-          content.3
-        } else if content.4.toCaseState(viewStore.state) != nil {
-          content.4
-        } else if content.5.toCaseState(viewStore.state) != nil {
-          content.5
-        } else if content.6.toCaseState(viewStore.state) != nil {
-          content.6
-        } else {
-          content.7
-        }
+    self.init(store) { state in
+      if content.0.toCaseState(state) != nil {
+        content.0
+      } else if content.1.toCaseState(state) != nil {
+        content.1
+      } else if content.2.toCaseState(state) != nil {
+        content.2
+      } else if content.3.toCaseState(state) != nil {
+        content.3
+      } else if content.4.toCaseState(state) != nil {
+        content.4
+      } else if content.5.toCaseState(state) != nil {
+        content.5
+      } else if content.6.toCaseState(state) != nil {
+        content.6
+      } else {
+        content.7
       }
     }
   }
@@ -1110,29 +1044,25 @@ extension SwitchStore {
     >
   )
   where
-    Content == WithViewStore<
-      State,
-      Action,
+    Content == _ConditionalContent<
       _ConditionalContent<
         _ConditionalContent<
-          _ConditionalContent<
-            CaseLet<State, Action, State1, Action1, Content1>,
-            CaseLet<State, Action, State2, Action2, Content2>
-          >,
-          _ConditionalContent<
-            CaseLet<State, Action, State3, Action3, Content3>,
-            CaseLet<State, Action, State4, Action4, Content4>
-          >
+          CaseLet<State, Action, State1, Action1, Content1>,
+          CaseLet<State, Action, State2, Action2, Content2>
         >,
         _ConditionalContent<
-          _ConditionalContent<
-            CaseLet<State, Action, State5, Action5, Content5>,
-            CaseLet<State, Action, State6, Action6, Content6>
-          >,
-          _ConditionalContent<
-            CaseLet<State, Action, State7, Action7, Content7>,
-            Default<_ExhaustivityCheckView<State, Action>>
-          >
+          CaseLet<State, Action, State3, Action3, Content3>,
+          CaseLet<State, Action, State4, Action4, Content4>
+        >
+      >,
+      _ConditionalContent<
+        _ConditionalContent<
+          CaseLet<State, Action, State5, Action5, Content5>,
+          CaseLet<State, Action, State6, Action6, Content6>
+        >,
+        _ConditionalContent<
+          CaseLet<State, Action, State7, Action7, Content7>,
+          Default<_ExhaustivityCheckView<State, Action>>
         >
       >
     >
@@ -1197,58 +1127,52 @@ extension SwitchStore {
     >
   )
   where
-    Content == WithViewStore<
-      State,
-      Action,
+    Content == _ConditionalContent<
       _ConditionalContent<
         _ConditionalContent<
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State1, Action1, Content1>,
-              CaseLet<State, Action, State2, Action2, Content2>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State3, Action3, Content3>,
-              CaseLet<State, Action, State4, Action4, Content4>
-            >
+            CaseLet<State, Action, State1, Action1, Content1>,
+            CaseLet<State, Action, State2, Action2, Content2>
           >,
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State5, Action5, Content5>,
-              CaseLet<State, Action, State6, Action6, Content6>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State7, Action7, Content7>,
-              CaseLet<State, Action, State8, Action8, Content8>
-            >
+            CaseLet<State, Action, State3, Action3, Content3>,
+            CaseLet<State, Action, State4, Action4, Content4>
           >
         >,
-        Default<DefaultContent>
-      >
+        _ConditionalContent<
+          _ConditionalContent<
+            CaseLet<State, Action, State5, Action5, Content5>,
+            CaseLet<State, Action, State6, Action6, Content6>
+          >,
+          _ConditionalContent<
+            CaseLet<State, Action, State7, Action7, Content7>,
+            CaseLet<State, Action, State8, Action8, Content8>
+          >
+        >
+      >,
+      Default<DefaultContent>
     >
   {
     let content = content().value
-    self.init(store) { _ in
-      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
-        if content.0.toCaseState(viewStore.state) != nil {
-          content.0
-        } else if content.1.toCaseState(viewStore.state) != nil {
-          content.1
-        } else if content.2.toCaseState(viewStore.state) != nil {
-          content.2
-        } else if content.3.toCaseState(viewStore.state) != nil {
-          content.3
-        } else if content.4.toCaseState(viewStore.state) != nil {
-          content.4
-        } else if content.5.toCaseState(viewStore.state) != nil {
-          content.5
-        } else if content.6.toCaseState(viewStore.state) != nil {
-          content.6
-        } else if content.7.toCaseState(viewStore.state) != nil {
-          content.7
-        } else {
-          content.8
-        }
+    self.init(store) { state in
+      if content.0.toCaseState(state) != nil {
+        content.0
+      } else if content.1.toCaseState(state) != nil {
+        content.1
+      } else if content.2.toCaseState(state) != nil {
+        content.2
+      } else if content.3.toCaseState(state) != nil {
+        content.3
+      } else if content.4.toCaseState(state) != nil {
+        content.4
+      } else if content.5.toCaseState(state) != nil {
+        content.5
+      } else if content.6.toCaseState(state) != nil {
+        content.6
+      } else if content.7.toCaseState(state) != nil {
+        content.7
+      } else {
+        content.8
       }
     }
   }
@@ -1301,34 +1225,30 @@ extension SwitchStore {
     >
   )
   where
-    Content == WithViewStore<
-      State,
-      Action,
+    Content == _ConditionalContent<
       _ConditionalContent<
         _ConditionalContent<
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State1, Action1, Content1>,
-              CaseLet<State, Action, State2, Action2, Content2>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State3, Action3, Content3>,
-              CaseLet<State, Action, State4, Action4, Content4>
-            >
+            CaseLet<State, Action, State1, Action1, Content1>,
+            CaseLet<State, Action, State2, Action2, Content2>
           >,
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State5, Action5, Content5>,
-              CaseLet<State, Action, State6, Action6, Content6>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State7, Action7, Content7>,
-              CaseLet<State, Action, State8, Action8, Content8>
-            >
+            CaseLet<State, Action, State3, Action3, Content3>,
+            CaseLet<State, Action, State4, Action4, Content4>
           >
         >,
-        Default<_ExhaustivityCheckView<State, Action>>
-      >
+        _ConditionalContent<
+          _ConditionalContent<
+            CaseLet<State, Action, State5, Action5, Content5>,
+            CaseLet<State, Action, State6, Action6, Content6>
+          >,
+          _ConditionalContent<
+            CaseLet<State, Action, State7, Action7, Content7>,
+            CaseLet<State, Action, State8, Action8, Content8>
+          >
+        >
+      >,
+      Default<_ExhaustivityCheckView<State, Action>>
     >
   {
     let content = content()
@@ -1394,63 +1314,57 @@ extension SwitchStore {
     >
   )
   where
-    Content == WithViewStore<
-      State,
-      Action,
+    Content == _ConditionalContent<
       _ConditionalContent<
         _ConditionalContent<
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State1, Action1, Content1>,
-              CaseLet<State, Action, State2, Action2, Content2>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State3, Action3, Content3>,
-              CaseLet<State, Action, State4, Action4, Content4>
-            >
+            CaseLet<State, Action, State1, Action1, Content1>,
+            CaseLet<State, Action, State2, Action2, Content2>
           >,
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State5, Action5, Content5>,
-              CaseLet<State, Action, State6, Action6, Content6>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State7, Action7, Content7>,
-              CaseLet<State, Action, State8, Action8, Content8>
-            >
+            CaseLet<State, Action, State3, Action3, Content3>,
+            CaseLet<State, Action, State4, Action4, Content4>
           >
         >,
         _ConditionalContent<
-          CaseLet<State, Action, State9, Action9, Content9>,
-          Default<DefaultContent>
+          _ConditionalContent<
+            CaseLet<State, Action, State5, Action5, Content5>,
+            CaseLet<State, Action, State6, Action6, Content6>
+          >,
+          _ConditionalContent<
+            CaseLet<State, Action, State7, Action7, Content7>,
+            CaseLet<State, Action, State8, Action8, Content8>
+          >
         >
+      >,
+      _ConditionalContent<
+        CaseLet<State, Action, State9, Action9, Content9>,
+        Default<DefaultContent>
       >
     >
   {
     let content = content().value
-    self.init(store) { _ in
-      return WithViewStore(store, removeDuplicates: { enumTag($0) == enumTag($1) }) { viewStore in
-        if content.0.toCaseState(viewStore.state) != nil {
-          content.0
-        } else if content.1.toCaseState(viewStore.state) != nil {
-          content.1
-        } else if content.2.toCaseState(viewStore.state) != nil {
-          content.2
-        } else if content.3.toCaseState(viewStore.state) != nil {
-          content.3
-        } else if content.4.toCaseState(viewStore.state) != nil {
-          content.4
-        } else if content.5.toCaseState(viewStore.state) != nil {
-          content.5
-        } else if content.6.toCaseState(viewStore.state) != nil {
-          content.6
-        } else if content.7.toCaseState(viewStore.state) != nil {
-          content.7
-        } else if content.8.toCaseState(viewStore.state) != nil {
-          content.8
-        } else {
-          content.9
-        }
+    self.init(store) { state in
+      if content.0.toCaseState(state) != nil {
+        content.0
+      } else if content.1.toCaseState(state) != nil {
+        content.1
+      } else if content.2.toCaseState(state) != nil {
+        content.2
+      } else if content.3.toCaseState(state) != nil {
+        content.3
+      } else if content.4.toCaseState(state) != nil {
+        content.4
+      } else if content.5.toCaseState(state) != nil {
+        content.5
+      } else if content.6.toCaseState(state) != nil {
+        content.6
+      } else if content.7.toCaseState(state) != nil {
+        content.7
+      } else if content.8.toCaseState(state) != nil {
+        content.8
+      } else {
+        content.9
       }
     }
   }
@@ -1505,36 +1419,32 @@ extension SwitchStore {
     >
   )
   where
-    Content == WithViewStore<
-      State,
-      Action,
+    Content == _ConditionalContent<
       _ConditionalContent<
         _ConditionalContent<
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State1, Action1, Content1>,
-              CaseLet<State, Action, State2, Action2, Content2>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State3, Action3, Content3>,
-              CaseLet<State, Action, State4, Action4, Content4>
-            >
+            CaseLet<State, Action, State1, Action1, Content1>,
+            CaseLet<State, Action, State2, Action2, Content2>
           >,
           _ConditionalContent<
-            _ConditionalContent<
-              CaseLet<State, Action, State5, Action5, Content5>,
-              CaseLet<State, Action, State6, Action6, Content6>
-            >,
-            _ConditionalContent<
-              CaseLet<State, Action, State7, Action7, Content7>,
-              CaseLet<State, Action, State8, Action8, Content8>
-            >
+            CaseLet<State, Action, State3, Action3, Content3>,
+            CaseLet<State, Action, State4, Action4, Content4>
           >
         >,
         _ConditionalContent<
-          CaseLet<State, Action, State9, Action9, Content9>,
-          Default<_ExhaustivityCheckView<State, Action>>
+          _ConditionalContent<
+            CaseLet<State, Action, State5, Action5, Content5>,
+            CaseLet<State, Action, State6, Action6, Content6>
+          >,
+          _ConditionalContent<
+            CaseLet<State, Action, State7, Action7, Content7>,
+            CaseLet<State, Action, State8, Action8, Content8>
+          >
         >
+      >,
+      _ConditionalContent<
+        CaseLet<State, Action, State9, Action9, Content9>,
+        Default<_ExhaustivityCheckView<State, Action>>
       >
     >
   {

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -1584,8 +1584,8 @@ public struct _CaseLetMismatchView<State, Action>: View {
   public var body: some View {
     #if DEBUG
       let message = """
-        A "CaseLet" at "\(self.fileID):\(self.line)" was encountered when state was set to another \
-        case:
+        Warning: A "CaseLet" at "\(self.fileID):\(self.line)" was encountered when state was set \
+        to another case:
 
             \(debugCaseOutput(self.store.wrappedValue.state.value))
 


### PR DESCRIPTION
Rather than rely on many, many overloads of `SwitchStore.init` to strictly accept only `CaseLet`s and an optional, final `Default` view, let's introduce a single initializer without constraints that is passed the current state whenever the case changes. This state can be switched on and route to the appropriate view via `CaseLet`.

The pros:

  * We get exhaustive switching at compile time.

  * We get more flexibility in the view layer. Previously, any customization needed to be pushed into the `CaseLet` builder, but now `CaseLet` can freely apply view modifiers.

  * We can deprecate and eventually remove the many, many initializer overloads, and hopefully slim down binary size in the process, and improve view builder compile times when dealing with `SwitchStore`. We can also deprecate and eventually remove `Default`.

  * The current overloads only support up to 10 cases, but now we'd support any number.

The cons:

  * It's slightly more verbose and repetitive. You have a `SwitchStore` and then a `switch` inside it with many `case`s with `CaseLet`s inside them, and the `case .screen:` is followed by `CaseLet(/State.screen, ...)`.

  * One is free to extract the state's associated value(s) and use it to render a view, but this view will be inert and will not re-render if the value it depends on changes in the store. This can lead to some surprises, but we can document against the pattern, and maybe in the future we can use something like macros to prevent this from being possible.

    ```swift
    SwitchStore(store) {
      switch $0 {
      case let .loggedIn(loggedInState):
        Text("Welcome, \(loggedInState.user.name)!")
        // 👆 This will not re-render if the user's name changes.
      // ...
      }
    }
    ```

  * ~~You can still get things wrong if you're not careful: there's nothing enforcing that the `case` you switch on is the same case you send to `CaseLet`, so `case .screenA: CaseLet(/State.screenB, ...)` is possible. While unlikely, it's still a copy-paste error in waiting.~~

    _Edit: While this is possible, we've added a runtime warning that will emit when it happens._