### PR TITLE
Fix withTaskCancellation documentation

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -153,7 +153,7 @@ extension EffectPublisher {
   /// operation will be cancelled.
   ///
   /// ```
-  /// enum CancelID.self {}
+  /// enum CancelID {}
   ///
   /// await withTaskCancellation(id: CancelID.self) {
   ///   // ...


### PR DESCRIPTION
Remove `.self` from enum type