### PR TITLE
Update remaining 'bindable state' to 'binding state'

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -3,11 +3,11 @@ import SwiftUI
 
 private let readMe = """
   This file demonstrates how to handle two-way bindings in the Composable Architecture using \
-  bindable state and actions.
+  binding state and actions.
 
-  Bindable state and actions allow you to safely eliminate the boilerplate caused by needing to \
+  Binding state and actions allow you to safely eliminate the boilerplate caused by needing to \
   have a unique action for every UI control. Instead, all UI bindings can be consolidated into a \
-  single `binding` action that holds onto a `BindingAction` value, and all bindable state can be \
+  single `binding` action that holds onto a `BindingAction` value, and all binding state can be \
   safeguarded with the `BindingState` property wrapper.
 
   It is instructive to compare this case study to the "Binding Basics" case study.

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
@@ -91,7 +91,7 @@ struct SettingsView: View {
 }
 ```
 
-### Bindable state, actions, and reducers
+### Binding state, actions, and reducers
 
 Deriving ad hoc bindings requires many manual steps that can feel tedious, especially for screens
 with many controls driven by many bindings. Because of this, the Composable Architecture comes with
@@ -232,7 +232,7 @@ struct Settings: ReducerProtocol {
 ```
 
 Binding actions are constructed and sent to the store by calling
-``ViewStore/binding(_:file:fileID:line:)`` with a key path to the bindable state:
+``ViewStore/binding(_:file:fileID:line:)`` with a key path to the binding state:
 
 ```swift
 TextField("Display name", text: viewStore.binding(\.$displayName))

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToTheReducerProtocol.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToTheReducerProtocol.md
@@ -460,18 +460,18 @@ Reducer { state, action, environment in
 ```
 
 In reducer builders, use the new top-level ``BindingReducer`` type to specify when to apply
-mutations to bindable state:
+mutations to binding state:
 
 ```swift
 var body: some ReducerProtocol<State, Action> {
   Reduce { state, action in
-    // Logic to run before bindable state mutations are applied
+    // Logic to run before binding state mutations are applied
   }
 
-  BindingReducer()  // Apply bindable state mutations
+  BindingReducer()  // Apply binding state mutations
 
   Reduce { state, action in
-    // Logic to run after bindable state mutations are applied
+    // Logic to run after binding state mutations are applied
   }
 }
 ```

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -597,7 +597,7 @@ extension ViewStore where ViewAction: BindableAction, ViewAction.State == ViewSt
     *, deprecated,
     message:
       """
-      Dynamic member lookup is no longer supported for bindable state. Instead of dot-chaining on \
+      Dynamic member lookup is no longer supported for binding state. Instead of dot-chaining on \
       the view store, e.g. 'viewStore.$value', invoke the 'binding' method on view store with a \
       key path to the value, e.g. 'viewStore.binding(\\.$value)'. For more on this change, see: \
       https://github.com/pointfreeco/swift-composable-architecture/pull/810

--- a/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
-/// A reducer that updates bindable state when it receives binding actions.
+/// A reducer that updates binding state when it receives binding actions.
 public struct BindingReducer<State, Action>: ReducerProtocol
 where Action: BindableAction, State == Action.State {
-  /// Initializes a reducer that updates bindable state when it receives binding actions.
+  /// Initializes a reducer that updates binding state when it receives binding actions.
   @inlinable
   public init() {
     self.init(internal: ())

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -12,10 +12,10 @@ import SwiftUI
 @dynamicMemberLookup
 @propertyWrapper
 public struct BindingState<Value> {
-  /// The underlying value wrapped by the bindable state.
+  /// The underlying value wrapped by the binding state.
   public var wrappedValue: Value
 
-  /// Creates bindable state from the value of another bindable state.
+  /// Creates binding state from the value of another binding state.
   public init(wrappedValue: Value) {
     self.wrappedValue = wrappedValue
   }
@@ -35,10 +35,10 @@ public struct BindingState<Value> {
     set { self = newValue }
   }
 
-  /// Returns bindable state to the resulting value of a given key path.
+  /// Returns binding state to the resulting value of a given key path.
   ///
   /// - Parameter keyPath: A key path to a specific resulting value.
-  /// - Returns: A new bindable state.
+  /// - Returns: A new binding state.
   public subscript<Subject>(
     dynamicMember keyPath: WritableKeyPath<Value, Subject>
   ) -> BindingState<Subject> {
@@ -124,9 +124,9 @@ extension BindableAction {
 }
 
 extension ViewStore where ViewAction: BindableAction, ViewAction.State == ViewState {
-  /// Returns a binding to the resulting bindable state of a given key path.
+  /// Returns a binding to the resulting binding state of a given key path.
   ///
-  /// - Parameter keyPath: A key path to a specific bindable state.
+  /// - Parameter keyPath: A key path to a specific binding state.
   /// - Returns: A new binding.
   public func binding<Value: Equatable>(
     _ keyPath: WritableKeyPath<ViewState, BindingState<Value>>,
@@ -199,7 +199,7 @@ public struct BindingAction<Root>: Equatable {
 
 extension BindingAction {
   /// Returns an action that describes simple mutations to some root state at a writable key path
-  /// to bindable state.
+  /// to binding state.
   ///
   /// - Parameters:
   ///   - keyPath: A key path to the property that should be mutated. This property must be
@@ -297,7 +297,7 @@ extension BindingAction {
   /// view-specific domain that contains only the state and actions the view needs. Not only will
   /// this minimize the number of times a view's `body` is computed, it will prevent the view
   /// from accessing state or sending actions outside its purview. We can define it with its own
-  /// bindable state and bindable action:
+  /// binding state and bindable action:
   ///
   /// ```swift
   /// extension MyFeatureView {
@@ -318,7 +318,7 @@ extension BindingAction {
   /// In order to transform a `BindingAction<ViewState>` sent from the view domain into a
   /// `BindingAction<MyFeature.State>`, we need a writable key path from `MyFeature.State` to
   /// `ViewState`. We can synthesize one by defining a computed property on `MyFeature.State` with a
-  /// getter and a setter. The setter should communicate any mutations to bindable state back to the
+  /// getter and a setter. The setter should communicate any mutations to binding state back to the
   /// parent state:
   ///
   /// ```swift


### PR DESCRIPTION
In #1855, `@BindableState` was renamed to `@BindingState`.
However, there are still some unchanged keywords in the repository.
This PR updates all remaining `bindable state` to `binding state` for consistency.