### PR TITLE
Clean up skipInFlightEffects and write test on beahvior.

### DIFF
--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -2114,10 +2114,6 @@ extension TestStore {
       file: file,
       line: line
     )
-
-    for effect in self.reducer.inFlightEffects {
-      _ = EffectPublisher<Never, Never>.cancel(id: effect.id).sink { _ in }
-    }
     self.reducer.inFlightEffects = []
   }
 


### PR DESCRIPTION
This is from our backlog, but we have some unneeded code in `skipInFlightEffects` so deleting that. Also I wrote a test to capture the existing behavior that skipping effects only removes the effect from consideration as far as the test store is concerned, but does not actually cancel it. We can think more about if we _should_ cancel it in the future, or leave things as is.