### PR TITLE
Don't pass file and line to runtime warnings

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -171,7 +171,6 @@ extension EffectPublisher where Failure == Never {
     priority: TaskPriority? = nil,
     operation: @escaping @Sendable () async throws -> Action,
     catch handler: (@Sendable (Error) async -> Action)? = nil,
-    file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) -> Self {
@@ -197,9 +196,7 @@ extension EffectPublisher where Failure == Never {
 
                     All non-cancellation errors must be explicitly handled via the "catch" \
                     parameter on "EffectTask.task", or via a "do" block.
-                    """,
-                    file: file,
-                    line: line
+                    """
                   )
                 #endif
                 return
@@ -255,7 +252,6 @@ extension EffectPublisher where Failure == Never {
     priority: TaskPriority? = nil,
     operation: @escaping @Sendable (Send<Action>) async throws -> Void,
     catch handler: (@Sendable (Error, Send<Action>) async -> Void)? = nil,
-    file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) -> Self {
@@ -280,9 +276,7 @@ extension EffectPublisher where Failure == Never {
 
                     All non-cancellation errors must be explicitly handled via the "catch" parameter \
                     on "EffectTask.run", or via a "do" block.
-                    """,
-                    file: file,
-                    line: line
+                    """
                   )
                 #endif
                 return

--- a/Sources/ComposableArchitecture/Effects/TaskResult.swift
+++ b/Sources/ComposableArchitecture/Effects/TaskResult.swift
@@ -211,27 +211,28 @@ extension TaskResult: Equatable where Success: Equatable {
     case let (.success(lhs), .success(rhs)):
       return lhs == rhs
     case let (.failure(lhs), .failure(rhs)):
-      return _isEqual(lhs, rhs) ?? {
-        #if DEBUG
-          let lhsType = type(of: lhs)
-          if TaskResultDebugging.emitRuntimeWarnings, lhsType == type(of: rhs) {
-            let lhsTypeName = typeName(lhsType)
-            runtimeWarn(
-              """
-              "\(lhsTypeName)" is not equatable. …
+      return _isEqual(lhs, rhs)
+        ?? {
+          #if DEBUG
+            let lhsType = type(of: lhs)
+            if TaskResultDebugging.emitRuntimeWarnings, lhsType == type(of: rhs) {
+              let lhsTypeName = typeName(lhsType)
+              runtimeWarn(
+                """
+                "\(lhsTypeName)" is not equatable. …
 
-              To test two values of this type, it must conform to the "Equatable" protocol. For \
-              example:
+                To test two values of this type, it must conform to the "Equatable" protocol. For \
+                example:
 
-                  extension \(lhsTypeName): Equatable {}
+                    extension \(lhsTypeName): Equatable {}
 
-              See the documentation of "TaskResult" for more information.
-              """
-            )
-          }
-        #endif
-        return false
-      }()
+                See the documentation of "TaskResult" for more information.
+                """
+              )
+            }
+          #endif
+          return false
+        }()
     default:
       return false
     }

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -738,9 +738,7 @@ extension AnyReducer {
           To fix this make sure that actions for this reducer can only be sent to a view store \
           when its state contains an element at this index. In SwiftUI applications, use \
           "ForEachStore".
-          """,
-          file: file,
-          line: line
+          """
         )
         return .none
       }

--- a/Sources/ComposableArchitecture/Internal/RuntimeWarnings.swift
+++ b/Sources/ComposableArchitecture/Internal/RuntimeWarnings.swift
@@ -5,19 +5,13 @@ import Foundation
 @inline(__always)
 func runtimeWarn(
   _ message: @autoclosure () -> String,
-  category: String? = "ComposableArchitecture",
-  file: StaticString? = nil,
-  line: UInt? = nil
+  category: String? = "ComposableArchitecture"
 ) {
   #if DEBUG
     let message = message()
     let category = category ?? "Runtime Warning"
     if _XCTIsTesting {
-      if let file = file, let line = line {
-        XCTFail(message, file: file, line: line)
-      } else {
-        XCTFail(message)
-      }
+      XCTFail(message)
     } else {
       #if canImport(os)
         os_log(

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
@@ -691,9 +691,7 @@ public struct AnyReducer<State, Action, Environment> {
           • This action was sent to the store while state was another case. Make sure that \
           actions for this reducer can only be sent to a view store when state is non-"nil". \
           In SwiftUI applications, use "SwitchStore".
-          """,
-          file: file,
-          line: line
+          """
         )
         return .none
       }
@@ -931,9 +929,7 @@ public struct AnyReducer<State, Action, Environment> {
           • This action was sent to the store while state was "nil". Make sure that actions for \
           this reducer can only be sent to a view store when state is non-"nil". In SwiftUI \
           applications, use "IfLetStore".
-          """,
-          file: file,
-          line: line
+          """
         )
         return .none
       }
@@ -1052,9 +1048,7 @@ public struct AnyReducer<State, Action, Environment> {
           To fix this make sure that actions for this reducer can only be sent to a view store \
           when its state contains an element at this id. In SwiftUI applications, use \
           "ForEachStore".
-          """,
-          file: file,
-          line: line
+          """
         )
         return .none
       }
@@ -1120,9 +1114,7 @@ public struct AnyReducer<State, Action, Environment> {
           • This action was sent to the store while its state contained no element at this \
           key. To fix this make sure that actions for this reducer can only be sent to a view \
           store when its state contains an element at this key.
-          """,
-          file: file,
-          line: line
+          """
         )
         return .none
       }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -55,7 +55,6 @@ extension ReducerProtocol {
     _ toElementsState: WritableKeyPath<State, IdentifiedArray<ID, ElementState>>,
     action toElementAction: CasePath<Action, (ID, ElementAction)>,
     @ReducerBuilder<ElementState, ElementAction> element: () -> Element,
-    file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) -> _ForEachReducer<Self, ID, Element>
@@ -65,7 +64,6 @@ extension ReducerProtocol {
       toElementsState: toElementsState,
       toElementAction: toElementAction,
       element: element(),
-      file: file,
       fileID: fileID,
       line: line
     )
@@ -88,9 +86,6 @@ public struct _ForEachReducer<
   let element: Element
 
   @usableFromInline
-  let file: StaticString
-
-  @usableFromInline
   let fileID: StaticString
 
   @usableFromInline
@@ -102,7 +97,6 @@ public struct _ForEachReducer<
     toElementsState: WritableKeyPath<Parent.State, IdentifiedArray<ID, Element.State>>,
     toElementAction: CasePath<Parent.Action, (ID, Element.Action)>,
     element: Element,
-    file: StaticString,
     fileID: StaticString,
     line: UInt
   ) {
@@ -110,7 +104,6 @@ public struct _ForEachReducer<
     self.toElementsState = toElementsState
     self.toElementAction = toElementAction
     self.element = element
-    self.file = file
     self.fileID = fileID
     self.line = line
   }
@@ -149,9 +142,7 @@ public struct _ForEachReducer<
         • This action was sent to the store while its state contained no element at this ID. To \
         fix this make sure that actions for this reducer can only be sent from a view store when \
         its state contains an element at this id. In SwiftUI applications, use "ForEachStore".
-        """,
-        file: self.file,
-        line: self.line
+        """
       )
       return .none
     }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
@@ -51,7 +51,6 @@ extension ReducerProtocol {
     _ toCaseState: CasePath<State, CaseState>,
     action toCaseAction: CasePath<Action, CaseAction>,
     @ReducerBuilder<CaseState, CaseAction> then case: () -> Case,
-    file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) -> _IfCaseLetReducer<Self, Case>
@@ -61,7 +60,6 @@ extension ReducerProtocol {
       child: `case`(),
       toChildState: toCaseState,
       toChildAction: toCaseAction,
-      file: file,
       fileID: fileID,
       line: line
     )
@@ -82,9 +80,6 @@ public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>
   let toChildAction: CasePath<Parent.Action, Child.Action>
 
   @usableFromInline
-  let file: StaticString
-
-  @usableFromInline
   let fileID: StaticString
 
   @usableFromInline
@@ -96,7 +91,6 @@ public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>
     child: Child,
     toChildState: CasePath<Parent.State, Child.State>,
     toChildAction: CasePath<Parent.Action, Child.Action>,
-    file: StaticString,
     fileID: StaticString,
     line: UInt
   ) {
@@ -104,7 +98,6 @@ public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>
     self.child = child
     self.toChildState = toChildState
     self.toChildAction = toChildAction
-    self.file = file
     self.fileID = fileID
     self.line = line
   }
@@ -148,9 +141,7 @@ public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>
         • This action was sent to the store while state was another case. Make sure that actions \
         for this reducer can only be sent from a view store when state is set to the appropriate \
         case. In SwiftUI applications, use "SwitchStore".
-        """,
-        file: self.file,
-        line: self.line
+        """
       )
       return .none
     }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
@@ -48,7 +48,6 @@ extension ReducerProtocol {
     _ toWrappedState: WritableKeyPath<State, WrappedState?>,
     action toWrappedAction: CasePath<Action, WrappedAction>,
     @ReducerBuilder<WrappedState, WrappedAction> then wrapped: () -> Wrapped,
-    file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) -> _IfLetReducer<Self, Wrapped>
@@ -58,7 +57,6 @@ extension ReducerProtocol {
       child: wrapped(),
       toChildState: toWrappedState,
       toChildAction: toWrappedAction,
-      file: file,
       fileID: fileID,
       line: line
     )
@@ -79,9 +77,6 @@ public struct _IfLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: Re
   let toChildAction: CasePath<Parent.Action, Child.Action>
 
   @usableFromInline
-  let file: StaticString
-
-  @usableFromInline
   let fileID: StaticString
 
   @usableFromInline
@@ -93,7 +88,6 @@ public struct _IfLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: Re
     child: Child,
     toChildState: WritableKeyPath<Parent.State, Child.State?>,
     toChildAction: CasePath<Parent.Action, Child.Action>,
-    file: StaticString,
     fileID: StaticString,
     line: UInt
   ) {
@@ -101,7 +95,6 @@ public struct _IfLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: Re
     self.child = child
     self.toChildState = toChildState
     self.toChildAction = toChildAction
-    self.file = file
     self.fileID = fileID
     self.line = line
   }
@@ -142,9 +135,7 @@ public struct _IfLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: Re
         • This action was sent to the store while state was "nil". Make sure that actions for this \
         reducer can only be sent from a view store when state is non-"nil". In SwiftUI \
         applications, use "IfLetStore".
-        """,
-        file: self.file,
-        line: self.line
+        """
       )
       return .none
     }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
@@ -100,7 +100,6 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
   enum StatePath {
     case casePath(
       CasePath<ParentState, Child.State>,
-      file: StaticString,
       fileID: StaticString,
       line: UInt
     )
@@ -225,12 +224,11 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
     state toChildState: CasePath<ParentState, ChildState>,
     action toChildAction: CasePath<ParentAction, ChildAction>,
     @ReducerBuilder<ChildState, ChildAction> child: () -> Child,
-    file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) where ChildState == Child.State, ChildAction == Child.Action {
     self.init(
-      toChildState: .casePath(toChildState, file: file, fileID: fileID, line: line),
+      toChildState: .casePath(toChildState, fileID: fileID, line: line),
       toChildAction: toChildAction,
       child: child()
     )
@@ -243,7 +241,7 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
     guard let childAction = self.toChildAction.extract(from: action)
     else { return .none }
     switch self.toChildState {
-    case let .casePath(toChildState, file, fileID, line):
+    case let .casePath(toChildState, fileID, line):
       guard var childState = toChildState.extract(from: state) else {
         runtimeWarn(
           """
@@ -272,9 +270,7 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
           • This action was sent to the store while state was another case. Make sure that actions \
           for this reducer can only be sent from a view store when state is set to the appropriate \
           case. In SwiftUI applications, use "SwitchStore".
-          """,
-          file: file,
-          line: line
+          """
         )
         return .none
       }

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -130,7 +130,6 @@ extension ViewStore where ViewAction: BindableAction, ViewAction.State == ViewSt
   /// - Returns: A new binding.
   public func binding<Value: Equatable>(
     _ keyPath: WritableKeyPath<ViewState, BindingState<Value>>,
-    file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) -> Binding<Value> {
@@ -139,8 +138,7 @@ extension ViewStore where ViewAction: BindableAction, ViewAction.State == ViewSt
       send: { value in
         #if DEBUG
           let debugger = BindableActionViewStoreDebugger(
-            value: value, bindableActionType: ViewAction.self, file: file, fileID: fileID,
-            line: line
+            value: value, bindableActionType: ViewAction.self, fileID: fileID, line: line
           )
           let set: (inout ViewState) -> Void = {
             $0[keyPath: keyPath].wrappedValue = value
@@ -398,7 +396,6 @@ extension BindingAction: CustomDumpReflectable {
   private final class BindableActionViewStoreDebugger<Value> {
     let value: Value
     let bindableActionType: Any.Type
-    let file: StaticString
     let fileID: StaticString
     let line: UInt
     var wasCalled = false
@@ -406,13 +403,11 @@ extension BindingAction: CustomDumpReflectable {
     init(
       value: Value,
       bindableActionType: Any.Type,
-      file: StaticString,
       fileID: StaticString,
       line: UInt
     ) {
       self.value = value
       self.bindableActionType = bindableActionType
-      self.file = file
       self.fileID = fileID
       self.line = line
     }
@@ -428,9 +423,7 @@ extension BindingAction: CustomDumpReflectable {
               \(typeName(self.bindableActionType)).binding(.set(_, \(self.value)))
 
           To fix this, invoke "BindingReducer()" from your feature reducer's "body".
-          """,
-          file: self.file,
-          line: self.line
+          """
         )
         return
       }

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -72,7 +72,6 @@ public struct CaseLet<EnumState, EnumAction, CaseState, CaseAction, Content: Vie
   public let fromCaseAction: (CaseAction) -> EnumAction
   public let content: (Store<CaseState, CaseAction>) -> Content
 
-  private let file: StaticString
   private let fileID: StaticString
   private let line: UInt
 
@@ -91,14 +90,12 @@ public struct CaseLet<EnumState, EnumAction, CaseState, CaseAction, Content: Vie
     _ toCaseState: @escaping (EnumState) -> CaseState?,
     action fromCaseAction: @escaping (CaseAction) -> EnumAction,
     @ViewBuilder then content: @escaping (Store<CaseState, CaseAction>) -> Content,
-    file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) {
     self.toCaseState = toCaseState
     self.fromCaseAction = fromCaseAction
     self.content = content
-    self.file = file
     self.fileID = fileID
     self.line = line
   }
@@ -111,14 +108,12 @@ public struct CaseLet<EnumState, EnumAction, CaseState, CaseAction, Content: Vie
     state toCaseState: @escaping (EnumState) -> CaseState?,
     action fromCaseAction: @escaping (CaseAction) -> EnumAction,
     @ViewBuilder then content: @escaping (Store<CaseState, CaseAction>) -> Content,
-    file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) {
     self.toCaseState = toCaseState
     self.fromCaseAction = fromCaseAction
     self.content = content
-    self.file = file
     self.fileID = fileID
     self.line = line
   }
@@ -132,7 +127,6 @@ public struct CaseLet<EnumState, EnumAction, CaseState, CaseAction, Content: Vie
       then: self.content,
       else: {
         _CaseLetMismatchView<EnumState, EnumAction>(
-          file: self.file,
           fileID: self.fileID,
           line: self.line
         )
@@ -276,7 +270,6 @@ extension SwitchStore {
   )
   public init<State1, Action1, Content1>(
     _ store: Store<State, Action>,
-    file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line,
     @ViewBuilder content: () -> CaseLet<State, Action, State1, Action1, Content1>
@@ -289,7 +282,7 @@ extension SwitchStore {
   {
     self.init(store) {
       content()
-      Default { _ExhaustivityCheckView<State, Action>(file: file, fileID: fileID, line: line) }
+      Default { _ExhaustivityCheckView<State, Action>(fileID: fileID, line: line) }
     }
   }
 
@@ -366,7 +359,6 @@ extension SwitchStore {
   )
   public init<State1, Action1, Content1, State2, Action2, Content2>(
     _ store: Store<State, Action>,
-    file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line,
     @ViewBuilder content: () -> TupleView<
@@ -389,7 +381,7 @@ extension SwitchStore {
     self.init(store) {
       content.value.0
       content.value.1
-      Default { _ExhaustivityCheckView<State, Action>(file: file, fileID: fileID, line: line) }
+      Default { _ExhaustivityCheckView<State, Action>(fileID: fileID, line: line) }
     }
   }
 
@@ -477,7 +469,6 @@ extension SwitchStore {
   )
   public init<State1, Action1, Content1, State2, Action2, Content2, State3, Action3, Content3>(
     _ store: Store<State, Action>,
-    file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line,
     @ViewBuilder content: () -> TupleView<
@@ -505,7 +496,7 @@ extension SwitchStore {
       content.value.0
       content.value.1
       content.value.2
-      Default { _ExhaustivityCheckView<State, Action>(file: file, fileID: fileID, line: line) }
+      Default { _ExhaustivityCheckView<State, Action>(fileID: fileID, line: line) }
     }
   }
 
@@ -605,7 +596,6 @@ extension SwitchStore {
     State4, Action4, Content4
   >(
     _ store: Store<State, Action>,
-    file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line,
     @ViewBuilder content: () -> TupleView<
@@ -638,7 +628,7 @@ extension SwitchStore {
       content.value.1
       content.value.2
       content.value.3
-      Default { _ExhaustivityCheckView<State, Action>(file: file, fileID: fileID, line: line) }
+      Default { _ExhaustivityCheckView<State, Action>(fileID: fileID, line: line) }
     }
   }
 
@@ -746,7 +736,6 @@ extension SwitchStore {
     State5, Action5, Content5
   >(
     _ store: Store<State, Action>,
-    file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line,
     @ViewBuilder content: () -> TupleView<
@@ -784,7 +773,7 @@ extension SwitchStore {
       content.value.2
       content.value.3
       content.value.4
-      Default { _ExhaustivityCheckView<State, Action>(file: file, fileID: fileID, line: line) }
+      Default { _ExhaustivityCheckView<State, Action>(fileID: fileID, line: line) }
     }
   }
 
@@ -900,7 +889,6 @@ extension SwitchStore {
     State6, Action6, Content6
   >(
     _ store: Store<State, Action>,
-    file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line,
     @ViewBuilder content: () -> TupleView<
@@ -943,7 +931,7 @@ extension SwitchStore {
       content.value.3
       content.value.4
       content.value.5
-      Default { _ExhaustivityCheckView<State, Action>(file: file, fileID: fileID, line: line) }
+      Default { _ExhaustivityCheckView<State, Action>(fileID: fileID, line: line) }
     }
   }
 
@@ -1067,7 +1055,6 @@ extension SwitchStore {
     State7, Action7, Content7
   >(
     _ store: Store<State, Action>,
-    file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line,
     @ViewBuilder content: () -> TupleView<
@@ -1115,7 +1102,7 @@ extension SwitchStore {
       content.value.4
       content.value.5
       content.value.6
-      Default { _ExhaustivityCheckView<State, Action>(file: file, fileID: fileID, line: line) }
+      Default { _ExhaustivityCheckView<State, Action>(fileID: fileID, line: line) }
     }
   }
 
@@ -1247,7 +1234,6 @@ extension SwitchStore {
     State8, Action8, Content8
   >(
     _ store: Store<State, Action>,
-    file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line,
     @ViewBuilder content: () -> TupleView<
@@ -1300,7 +1286,7 @@ extension SwitchStore {
       content.value.5
       content.value.6
       content.value.7
-      Default { _ExhaustivityCheckView<State, Action>(file: file, fileID: fileID, line: line) }
+      Default { _ExhaustivityCheckView<State, Action>(fileID: fileID, line: line) }
     }
   }
 
@@ -1440,7 +1426,6 @@ extension SwitchStore {
     State9, Action9, Content9
   >(
     _ store: Store<State, Action>,
-    file: StaticString = #file,
     fileID: StaticString = #fileID,
     line: UInt = #line,
     @ViewBuilder content: () -> TupleView<
@@ -1498,7 +1483,7 @@ extension SwitchStore {
       content.value.6
       content.value.7
       content.value.8
-      Default { _ExhaustivityCheckView<State, Action>(file: file, fileID: fileID, line: line) }
+      Default { _ExhaustivityCheckView<State, Action>(fileID: fileID, line: line) }
     }
   }
 }
@@ -1525,14 +1510,13 @@ extension SwitchStore {
 )
 public struct _ExhaustivityCheckView<State, Action>: View {
   @EnvironmentObject private var store: StoreObservableObject<State, Action>
-  let file: StaticString
   let fileID: StaticString
   let line: UInt
 
   public var body: some View {
     #if DEBUG
       let message = """
-        Warning: SwitchStore.body@\(self.file):\(self.line)
+        Warning: SwitchStore.body@\(self.fileID):\(self.line)
 
         "\(debugCaseOutput(self.store.wrappedValue.state.value))" was encountered by a \
         "SwitchStore" that does not handle this case.
@@ -1564,9 +1548,7 @@ public struct _ExhaustivityCheckView<State, Action>: View {
 
           Make sure that you exhaustively provide a "CaseLet" view for each case in your state, \
           or provide a "Default" view at the end of the "SwitchStore".
-          """,
-          file: self.file,
-          line: self.line
+          """
         )
       }
     #else
@@ -1577,7 +1559,6 @@ public struct _ExhaustivityCheckView<State, Action>: View {
 
 public struct _CaseLetMismatchView<State, Action>: View {
   @EnvironmentObject private var store: StoreObservableObject<State, Action>
-  let file: StaticString
   let fileID: StaticString
   let line: UInt
 
@@ -1616,7 +1597,7 @@ public struct _CaseLetMismatchView<State, Action>: View {
       .foregroundColor(.white)
       .padding()
       .background(Color.red.edgesIgnoringSafeArea(.all))
-      .onAppear { runtimeWarn(message, file: self.file, line: self.line) }
+      .onAppear { runtimeWarn(message) }
     #else
       return EmptyView()
     #endif


### PR DESCRIPTION
Runtime warnings are not test helpers that should propagate XCTest failures to the original file/line, so we should always omit that information. This leads to better test failures that show up alongside the test, not buried in application code.