### PR TITLE
Fix ordered set comparison check

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -134,6 +134,7 @@ public struct ForEachStore<
 private func areOrderedSetsDuplicates<ID: Hashable>(lhs: OrderedSet<ID>, rhs: OrderedSet<ID>)
   -> Bool
 {
+  guard lhs.count == rhs.count else { return false }
   var lhs = lhs
   var rhs = rhs
   if memcmp(&lhs, &rhs, MemoryLayout<OrderedSet<ID>>.size) == 0 {


### PR DESCRIPTION
For some reason, using `memcmp` with an empty ordered set and a non-empty ordered set returns true:

```swift
areOrderedSetsDuplicates([1, 2, 3], []) // true
```

Because of this, we should always check the count before delegating to `memcmp`. We should also be on the lookout for other exceptions in case `memcmp` is not appropriate to use here.