### PR TITLE
Demonstration of compiler type resolution issues with Swift 5.8 and `CombineReducers`

### DIFF
--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -4,6 +4,67 @@ import CustomDump
 import XCTest
 import os.signpost
 
+public extension ReducerProtocol {
+    @inlinable
+    func onChange<ChildState: Equatable>(
+        of toLocalState: @escaping (State) -> ChildState,
+        perform additionalEffects: @escaping (ChildState, inout State, Action) -> EffectTask<
+            Action
+        >
+    ) -> some ReducerProtocol<State, Action> {
+        self.onChange(of: toLocalState) { additionalEffects($1, &$2, $3) }
+    }
+
+    @inlinable
+    func onChange<ChildState: Equatable>(
+        of toLocalState: @escaping (State) -> ChildState,
+        perform additionalEffects: @escaping (ChildState, ChildState, inout State, Action) -> EffectTask<
+            Action
+        >
+    ) -> some ReducerProtocol<State, Action> {
+        ChangeReducer(base: self, toLocalState: toLocalState, perform: additionalEffects)
+    }
+}
+
+@usableFromInline
+struct ChangeReducer<Base: ReducerProtocol, ChildState: Equatable>: ReducerProtocol {
+    @usableFromInline let base: Base
+
+    @usableFromInline let toLocalState: (Base.State) -> ChildState
+
+    @usableFromInline let perform:
+        (ChildState, ChildState, inout Base.State, Base.Action) -> EffectTask<
+            Base.Action
+        >
+
+    @usableFromInline
+    init(
+        base: Base,
+        toLocalState: @escaping (Base.State) -> ChildState,
+        perform: @escaping (ChildState, ChildState, inout Base.State, Base.Action) -> EffectTask<
+            Base.Action
+        >
+    ) {
+        self.base = base
+        self.toLocalState = toLocalState
+        self.perform = perform
+    }
+
+    @inlinable
+    public func reduce(into state: inout Base.State, action: Base.Action) -> EffectTask<
+        Base.Action
+    > {
+        let previousLocalState = self.toLocalState(state)
+        let effects = self.base.reduce(into: &state, action: action)
+        let localState = self.toLocalState(state)
+
+        return previousLocalState != localState
+            ? .merge(effects, self.perform(previousLocalState, localState, &state, action))
+            : effects
+    }
+}
+
+
 @MainActor
 final class ReducerTests: BaseTCATestCase {
   var cancellables: Set<AnyCancellable> = []
@@ -79,15 +140,28 @@ final class ReducerTests: BaseTCATestCase {
   #endif
 
   func testCombine() async {
+    struct State: Equatable {
+      var counter: Int
+    }
+
     enum Action: Equatable {
       case increment
     }
 
     struct One: ReducerProtocol {
-      typealias State = Int
       let effect: @Sendable () async -> Void
       func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
-        state += 1
+        state.counter += 1
+        return .fireAndForget {
+          await self.effect()
+        }
+      }
+    }
+
+    struct Two: ReducerProtocol {
+      let effect: @Sendable () async -> Void
+      func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+        state.counter += 1
         return .fireAndForget {
           await self.effect()
         }
@@ -97,8 +171,64 @@ final class ReducerTests: BaseTCATestCase {
     var first = false
     var second = false
 
+    let _store = Store(
+      initialState: State(counter: 0),
+      reducer: CombineReducers {
+        One(effect: { @MainActor in first = true })
+        Two(effect: { @MainActor in second = true })
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }.onChange(of: \.counter) { _, _, _ in
+          .send(.increment)
+      }
+    )
+
     let store = TestStore(
-      initialState: 0,
+      initialState: State(counter: 0),
       reducer: CombineReducers {
         One(effect: { @MainActor in first = true })
         One(effect: { @MainActor in second = true })
@@ -106,7 +236,7 @@ final class ReducerTests: BaseTCATestCase {
     )
 
     await store
-      .send(.increment) { $0 = 2 }
+      .send(.increment) { $0.counter = 2 }
       .finish()
 
     XCTAssertTrue(first)


### PR DESCRIPTION
This is a demonstration of code that compiles pretty quickly in Xcode 14.2 (Swift 5.7) and which doesn't compile on Xcode 14.3 (Swift 5.8). The compiler will eventually bail out saying it wasn't possible to type check the expression in reasonably time.

<img width="193" alt="image" src="https://user-images.githubusercontent.com/4175766/236444753-31e8babf-c7cd-455c-93d7-e6a67684f43c.png">

<img width="1380" alt="image" src="https://user-images.githubusercontent.com/4175766/236444702-49b7ffee-8475-43e0-8737-da156abfc2c4.png">

I created this as a PR as it seemed like the easiest way to provide you with an example. Feel free to close the PR or do whatever you want with it as it's obviously not meant to be a contribution to the project 😄 