### PR TITLE
Deprecate `Store.scope(state:)` for view store `observe`

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -112,11 +112,11 @@ struct AlertAndConfirmationDialogView: View {
     }
     .navigationTitle("Alerts & Dialogs")
     .alert(
-      self.store.scope(state: \.alert),
+      self.store.scope(state: \.alert, action: { $0 }),
       dismiss: .alertDismissed
     )
     .confirmationDialog(
-      self.store.scope(state: \.confirmationDialog),
+      self.store.scope(state: \.confirmationDialog, action: { $0 }),
       dismiss: .confirmationDialogDismissed
     )
   }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -139,7 +139,7 @@ struct AnimationsView: View {
         Button("Reset") { viewStore.send(.resetButtonTapped) }
           .padding([.horizontal, .bottom])
       }
-      .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
+      .alert(self.store.scope(state: \.alert, action: { $0 }), dismiss: .alertDismissed)
       .navigationBarTitleDisplayMode(.inline)
     }
   }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
@@ -218,7 +218,7 @@ struct SharedStateCounterView: View {
       }
       .padding(.top)
       .navigationTitle("Shared State Demo")
-      .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
+      .alert(self.store.scope(state: \.alert, action: { $0 }), dismiss: .alertDismissed)
     }
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -180,7 +180,7 @@ struct WebSocketView: View {
           Text("Received messages")
         }
       }
-      .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
+      .alert(self.store.scope(state: \.alert, action: { $0 }), dismiss: .alertDismissed)
       .navigationTitle("Web Socket")
     }
   }

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -77,7 +77,7 @@ struct FavoriteButton<ID: Hashable & Sendable>: View {
         Image(systemName: "heart")
           .symbolVariant(viewStore.isFavorite ? .fill : .none)
       }
-      .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
+      .alert(self.store.scope(state: \.alert, action: { $0 }), dismiss: .alertDismissed)
     }
   }
 }

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
@@ -141,7 +141,10 @@ struct SpeechRecognitionView: View {
         }
       }
       .padding()
-      .alert(self.store.scope(state: \.alert), dismiss: .authorizationStateAlertDismissed)
+      .alert(
+        self.store.scope(state: \.alert, action: { $0 }),
+        dismiss: .authorizationStateAlertDismissed
+      )
     }
   }
 }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameUIKit/GameViewController.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameUIKit/GameViewController.swift
@@ -29,7 +29,7 @@ public final class GameViewController: UIViewController {
 
   public init(store: StoreOf<Game>) {
     self.store = store
-    self.viewStore = ViewStore(store.scope(state: ViewState.init))
+    self.viewStore = ViewStore(store, observe: ViewState.init)
     super.init(nibName: nil, bundle: nil)
   }
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -95,7 +95,7 @@ public struct LoginView: View {
         .disabled(viewStore.isLoginButtonDisabled)
       }
       .disabled(viewStore.isFormDisabled)
-      .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
+      .alert(self.store.scope(state: \.alert, action: { $0 }), dismiss: .alertDismissed)
     }
     .navigationTitle("Login")
   }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginUIKit/LoginViewController.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginUIKit/LoginViewController.swift
@@ -40,7 +40,7 @@ public class LoginViewController: UIViewController {
 
   public init(store: StoreOf<Login>) {
     self.store = store
-    self.viewStore = ViewStore(store.scope(state: ViewState.init, action: Login.Action.init))
+    self.viewStore = ViewStore(store, observe: ViewState.init, send: Login.Action.init)
     super.init(nibName: nil, bundle: nil)
   }
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/NewGameUIKit/NewGameViewController.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/NewGameUIKit/NewGameViewController.swift
@@ -33,7 +33,7 @@ public class NewGameViewController: UIViewController {
 
   public init(store: StoreOf<NewGame>) {
     self.store = store
-    self.viewStore = ViewStore(store.scope(state: ViewState.init, action: NewGame.Action.init))
+    self.viewStore = ViewStore(store, observe: ViewState.init, send: NewGame.Action.init)
     super.init(nibName: nil, bundle: nil)
   }
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
@@ -66,7 +66,7 @@ public struct TwoFactorView: View {
           }
         }
       }
-      .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
+      .alert(self.store.scope(state: \.alert, action: { $0 }), dismiss: .alertDismissed)
       .disabled(viewStore.isFormDisabled)
       .navigationTitle("Confirmation Code")
     }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorUIKit/TwoFactorViewController.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorUIKit/TwoFactorViewController.swift
@@ -30,7 +30,7 @@ public final class TwoFactorViewController: UIViewController {
 
   public init(store: StoreOf<TwoFactor>) {
     self.store = store
-    self.viewStore = ViewStore(store.scope(state: ViewState.init, action: TwoFactor.Action.init))
+    self.viewStore = ViewStore(store, observe: ViewState.init, send: TwoFactor.Action.init)
     super.init(nibName: nil, bundle: nil)
   }
 

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -111,7 +111,7 @@ struct AppView: View {
 
   init(store: StoreOf<Todos>) {
     self.store = store
-    self.viewStore = ViewStore(self.store.scope(state: ViewState.init(state:)))
+    self.viewStore = ViewStore(self.store, observe: ViewState.init(state:))
   }
 
   struct ViewState: Equatable {

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -165,7 +165,7 @@ struct VoiceMemosView: View {
           .background(Color.init(white: 0.95))
         }
         .alert(
-          self.store.scope(state: \.alert),
+          self.store.scope(state: \.alert, action: { $0 }),
           dismiss: .alertDismissed
         )
         .navigationTitle("Voice memos")

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -184,7 +184,7 @@ struct AppView: View {
       TabView {
         ActivityView(
           store: self.store
-            .scope(state: \.activity, action: AppAction.activity
+            .scope(state: \.activity, action: AppAction.activity)
         )
         .badge("\(viewStore.unreadActivityCount)")
 

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -868,7 +868,7 @@ extension ForEachStore {
   {
     let data = store.state.value
     self.data = data
-    self.content = WithViewStore(store.scope(state: { $0.map { $0[keyPath: id] } })) { viewStore in
+    self.content = WithViewStore(store, observe: { $0.map { $0[keyPath: id] } }) { viewStore in
       ForEach(Array(viewStore.state.enumerated()), id: \.element) { index, _ in
         content(
           store.scope(

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -5,6 +5,23 @@ import XCTestDynamicOverlay
 
 // MARK: - Deprecated after 0.52.0
 
+extension Store {
+  @available(
+    *,
+    deprecated,
+    message: """
+      'Store.scope' requires an explicit 'action' transform and is intended to be used to transform a store of a parent domain into a store of a child domain.
+
+      When transforming store state into view state, use the 'observe' parameter when constructing a view store.
+      """
+  )
+  public func scope<ChildState>(
+    state toChildState: @escaping (State) -> ChildState
+  ) -> Store<ChildState, Action> {
+    self.scope(state: toChildState, action: { $0 })
+  }
+}
+
 extension EffectPublisher {
   @available(
     *,

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -316,18 +316,6 @@ public final class Store<State, Action> {
     #endif
   }
 
-  /// Scopes the store to one that exposes child state.
-  ///
-  /// A version of ``scope(state:action:)`` that leaves the action type unchanged.
-  ///
-  /// - Parameter toChildState: A function that transforms `State` into `ChildState`.
-  /// - Returns: A new store with its domain (state and action) transformed.
-  public func scope<ChildState>(
-    state toChildState: @escaping (State) -> ChildState
-  ) -> Store<ChildState, Action> {
-    self.scope(state: toChildState, action: { $0 })
-  }
-
   func filter(
     _ isSent: @escaping (State, Action) -> Bool
   ) -> Store<State, Action> {
@@ -485,7 +473,7 @@ public final class Store<State, Action> {
 
   /// Returns a "stateless" store by erasing state to `Void`.
   public var stateless: Store<Void, Action> {
-    self.scope(state: { _ in () })
+    self.scope(state: { _ in () }, action: { $0 })
   }
 
   /// Returns an "actionless" store by erasing action to `Never`.

--- a/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
@@ -9,7 +9,7 @@ import SwiftUI
 ///
 /// ```swift
 /// IfLetStore(
-///   store.scope(state: \SearchState.results, action: SearchAction.results),
+///   store.scope(state: \SearchState.results, action: SearchAction.results)
 /// ) {
 ///   SearchResultsView(store: $0)
 /// } else: {

--- a/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
@@ -59,10 +59,13 @@ public struct IfLetStore<State, Action, Content: View>: View {
           first: ifContent(
             store
               .filter { state, _ in state == nil ? !BindingLocal.isActive : true }
-              .scope {
-                state = $0 ?? state
-                return state
-              }
+              .scope(
+                state: {
+                  state = $0 ?? state
+                  return state
+                },
+                action: { $0 }
+              )
           )
         )
       } else {
@@ -88,10 +91,13 @@ public struct IfLetStore<State, Action, Content: View>: View {
         return ifContent(
           store
             .filter { state, _ in state == nil ? !BindingLocal.isActive : true }
-            .scope {
-              state = $0 ?? state
-              return state
-            }
+            .scope(
+              state: {
+                state = $0 ?? state
+                return state
+              },
+              action: { $0 }
+            )
         )
       } else {
         return nil

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -339,7 +339,7 @@ public struct WithViewStore<ViewState, ViewAction, Content: View>: View {
     line: UInt = #line
   ) {
     self.init(
-      store: store.scope(state: toViewState),
+      store: store.scope(state: toViewState, action: { $0 }),
       removeDuplicates: isDuplicate,
       content: content,
       file: file,
@@ -591,7 +591,7 @@ extension WithViewStore where ViewState: Equatable, Content: View {
     line: UInt = #line
   ) {
     self.init(
-      store: store.scope(state: toViewState),
+      store: store.scope(state: toViewState, action: { $0 }),
       removeDuplicates: ==,
       content: content,
       file: file,

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -54,10 +54,13 @@ extension Store {
       .sink { state in
         if var state = state {
           unwrap(
-            self.scope {
-              state = $0 ?? state
-              return state
-            }
+            self.scope(
+              state: {
+                state = $0 ?? state
+                return state
+              },
+              action: { $0 }
+            )
           )
         } else {
           `else`()

--- a/Tests/ComposableArchitectureTests/EffectDebounceTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectDebounceTests.swift
@@ -10,8 +10,7 @@ final class EffectDebounceTests: BaseTCATestCase {
     let mainQueue = DispatchQueue.test
     var values: [Int] = []
 
-    // NB: Explicit @MainActor is needed for Swift 5.5.2
-    @MainActor func runDebouncedEffect(value: Int) {
+    func runDebouncedEffect(value: Int) {
       struct CancelToken: Hashable {}
       Just(value)
         .eraseToEffect()
@@ -57,8 +56,7 @@ final class EffectDebounceTests: BaseTCATestCase {
     var values: [Int] = []
     var effectRuns = 0
 
-    // NB: Explicit @MainActor is needed for Swift 5.5.2
-    @MainActor func runDebouncedEffect(value: Int) {
+    func runDebouncedEffect(value: Int) {
       struct CancelToken: Hashable {}
 
       Deferred { () -> Just<Int> in

--- a/Tests/ComposableArchitectureTests/EffectRunTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectRunTests.swift
@@ -30,7 +30,7 @@ final class EffectRunTests: BaseTCATestCase {
         return .run { _ in
           struct Failure: Error {}
           throw Failure()
-        } catch: { @Sendable _, send in  // NB: Explicit '@Sendable' required in 5.5.2
+        } catch: { _, send in
           await send(.response)
         }
       case .response:
@@ -109,7 +109,7 @@ final class EffectRunTests: BaseTCATestCase {
           Task.cancel(id: CancelID.responseA)
           try Task.checkCancellation()
           await send(.responseA)
-        } catch: { @Sendable _, send in  // NB: Explicit '@Sendable' required in 5.5.2
+        } catch: { _, send in
           await send(.responseB)
         }
         .cancellable(id: CancelID.responseA)

--- a/Tests/ComposableArchitectureTests/EffectTaskTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTaskTests.swift
@@ -29,7 +29,7 @@ final class EffectTaskTests: BaseTCATestCase {
         return .task {
           struct Failure: Error {}
           throw Failure()
-        } catch: { @Sendable _ in  // NB: Explicit '@Sendable' required in 5.5.2
+        } catch: { _ in
           .response
         }
       case .response:
@@ -106,7 +106,7 @@ final class EffectTaskTests: BaseTCATestCase {
           Task.cancel(id: CancelID.responseA)
           try Task.checkCancellation()
           return .responseA
-        } catch: { @Sendable _ in  // NB: Explicit '@Sendable' required in 5.5.2
+        } catch: { _ in
           .responseB
         }
         .cancellable(id: CancelID.responseA)

--- a/Tests/ComposableArchitectureTests/EffectThrottleTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectThrottleTests.swift
@@ -14,9 +14,7 @@ final class EffectThrottleTests: BaseTCATestCase {
     var values: [Int] = []
     var effectRuns = 0
 
-    // NB: Explicit @MainActor is needed for Swift 5.5.2
-    @MainActor func runThrottledEffect(value: Int) {
-
+    func runThrottledEffect(value: Int) {
       Deferred { () -> Just<Int> in
         effectRuns += 1
         return Just(value)
@@ -71,9 +69,7 @@ final class EffectThrottleTests: BaseTCATestCase {
     var values: [Int] = []
     var effectRuns = 0
 
-    // NB: Explicit @MainActor is needed for Swift 5.5.2
-    @MainActor func runThrottledEffect(value: Int) {
-
+    func runThrottledEffect(value: Int) {
       Deferred { () -> Just<Int> in
         effectRuns += 1
         return Just(value)
@@ -140,8 +136,7 @@ final class EffectThrottleTests: BaseTCATestCase {
     var values: [Int] = []
     var effectRuns = 0
 
-    // NB: Explicit @MainActor is needed for Swift 5.5.2
-    @MainActor func runThrottledEffect(value: Int) {
+    func runThrottledEffect(value: Int) {
 
       Deferred { () -> Just<Int> in
         effectRuns += 1
@@ -188,8 +183,7 @@ final class EffectThrottleTests: BaseTCATestCase {
     var values: [Int] = []
     var effectRuns = 0
 
-    // NB: Explicit @MainActor is needed for Swift 5.5.2
-    @MainActor func runThrottledEffect(value: Int) {
+    func runThrottledEffect(value: Int) {
       Deferred { () -> Just<Int> in
         effectRuns += 1
         return Just(value)

--- a/Tests/ComposableArchitectureTests/MemoryManagementTests.swift
+++ b/Tests/ComposableArchitectureTests/MemoryManagementTests.swift
@@ -11,8 +11,8 @@ final class MemoryManagementTests: BaseTCATestCase {
       return .none
     }
     let store = Store(initialState: 0, reducer: counterReducer)
-      .scope(state: { "\($0)" })
-      .scope(state: { Int($0)! })
+      .scope(state: { "\($0)" }, action: { $0 })
+      .scope(state: { Int($0)! }, action: { $0 })
     let viewStore = ViewStore(store, observe: { $0 })
 
     var count = 0
@@ -57,7 +57,12 @@ final class MemoryManagementTests: BaseTCATestCase {
         }
       }
     )
-    let viewStore = ViewStore(store.scope(state: { $0 }).scope(state: { $0 }), observe: { $0 })
+    let viewStore = ViewStore(
+      store
+        .scope(state: { $0 }, action: { $0 })
+        .scope(state: { $0 }, action: { $0 }),
+      observe: { $0 }
+    )
 
     var values: [Bool] = []
     viewStore.publisher

--- a/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
+++ b/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
@@ -75,7 +75,7 @@
 
       let store = Store<Int, Void>(initialState: 0, reducer: EmptyReducer())
       Task {
-        _ = store.scope(state: { $0 })
+        _ = store.scope(state: { $0 }, action: { $0 })
       }
       _ = XCTWaiter.wait(for: [.init()], timeout: 0.5)
     }

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -191,7 +191,7 @@ final class TestStoreTests: BaseTCATestCase {
         predicateShouldBeCalledExpectation.fulfill()
         return action == .finished
       }
-      wait(for: [predicateShouldBeCalledExpectation], timeout: 0)
+      _ = { wait(for: [predicateShouldBeCalledExpectation], timeout: 0) }()
 
       XCTExpectFailure {
         store.send(.noop)

--- a/Tests/ComposableArchitectureTests/ViewStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/ViewStoreTests.swift
@@ -41,10 +41,10 @@ final class ViewStoreTests: BaseTCATestCase {
       reducer: EmptyReducer<State, Void>()
     )
 
-    let store1 = store.scope(state: { $0 })
-    let store2 = store1.scope(state: { $0 })
-    let store3 = store2.scope(state: { $0 })
-    let store4 = store3.scope(state: { $0 })
+    let store1 = store.scope(state: { $0 }, action: { $0 })
+    let store2 = store1.scope(state: { $0 }, action: { $0 })
+    let store3 = store2.scope(state: { $0 }, action: { $0 })
+    let store4 = store3.scope(state: { $0 }, action: { $0 })
 
     let viewStore1 = ViewStore(store1)
     let viewStore2 = ViewStore(store2)


### PR DESCRIPTION
Explicit scoping is most appropriate for transforming domains, which almost always requires an action transform. In the rare case it doesn't, we should prefer an explicit `{ $0 }`.

Scoping for the view has been deprecated for awhile for the `observe` parameter when creating view stores, so let's lead folks that direction.