### PR TITLE
Soft-deprecate `Effect.task` and `Effect.fireAndForget`

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "a239970dade6a147f4cfb6ce3144c7dd84bff794",
-        "version" : "0.9.2"
+        "revision" : "0625932976b3ae23949f6b816d13bd97f3b40b7c",
+        "version" : "0.10.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "ad0a6a0dd4d4741263e798f4f5029589c9b5da73",
-        "version" : "0.4.2"
+        "revision" : "25c9b6789b4b7ada649a3808e6d8de1489082a33",
+        "version" : "0.5.0"
       }
     },
     {

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -47,9 +47,9 @@ struct EffectsBasics: ReducerProtocol {
       // Return an effect that re-increments the count after 1 second if the count is negative
       return state.count >= 0
         ? .none
-        : .task {
+        : .run { send in
           try await self.clock.sleep(for: .seconds(1))
-          return .decrementDelayResponse
+          await send(.decrementDelayResponse)
         }
         .cancellable(id: CancelID.delay)
 
@@ -71,8 +71,8 @@ struct EffectsBasics: ReducerProtocol {
       state.numberFact = nil
       // Return an effect that fetches a number fact from the API and returns the
       // value back to the reducer's `numberFactResponse` action.
-      return .task { [count = state.count] in
-        await .numberFactResponse(TaskResult { try await self.factClient.fetch(count) })
+      return .run { [count = state.count] send in
+        await send(.numberFactResponse(TaskResult { try await self.factClient.fetch(count) }))
       }
 
     case let .numberFactResponse(.success(response)):

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -47,8 +47,8 @@ struct EffectsCancellation: ReducerProtocol {
       state.currentFact = nil
       state.isFactRequestInFlight = true
 
-      return .task { [count = state.count] in
-        await .factResponse(TaskResult { try await self.factClient.fetch(count) })
+      return .run { [count = state.count] send in
+        await send(.factResponse(TaskResult { try await self.factClient.fetch(count) }))
       }
       .cancellable(id: CancelID.factRequest)
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -1,5 +1,5 @@
 import ComposableArchitecture
-import SwiftUI
+@preconcurrency import SwiftUI
 
 private let readMe = """
   This application demonstrates how to make use of SwiftUI's `refreshable` API in the Composable \
@@ -53,10 +53,12 @@ struct Refreshable: ReducerProtocol {
 
     case .refresh:
       state.fact = nil
-      return .task { [count = state.count] in
-        await .factResponse(TaskResult { try await self.factClient.fetch(count) })
+      return .run { [count = state.count] send in
+        await send(
+          .factResponse(TaskResult { try await self.factClient.fetch(count) }),
+          animation: .default
+        )
       }
-      .animation()
       .cancellable(id: CancelID.factRequest)
     }
   }

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -101,11 +101,11 @@ struct WebSocket: ReducerProtocol {
     case .sendButtonTapped:
       let messageToSend = state.messageToSend
       state.messageToSend = ""
-      return .task {
+      return .run { send in
         try await self.webSocket.send(WebSocketClient.ID(), .string(messageToSend))
-        return .sendResponse(didSucceed: true)
-      } catch: { _ in
-        .sendResponse(didSucceed: false)
+        await send(.sendResponse(didSucceed: true))
+      } catch: { _, send in
+        await send(.sendResponse(didSucceed: false))
       }
       .cancellable(id: WebSocketClient.ID())
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -50,9 +50,9 @@ struct LoadThenNavigateList: ReducerProtocol {
         for row in state.rows {
           state.rows[id: row.id]?.isActivityIndicatorVisible = row.id == navigatedId
         }
-        return .task {
+        return .run { send in
           try await self.clock.sleep(for: .seconds(1))
-          return .setNavigationSelectionDelayCompleted(navigatedId)
+          await send(.setNavigationSelectionDelayCompleted(navigatedId))
         }
         .cancellable(id: CancelID.load, cancelInFlight: true)
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -42,9 +42,9 @@ struct NavigateAndLoadList: ReducerProtocol {
 
       case let .setNavigation(selection: .some(id)):
         state.selection = Identified(nil, id: id)
-        return .task {
+        return .run { send in
           try await self.clock.sleep(for: .seconds(1))
-          return .setNavigationSelectionDelayCompleted
+          await send(.setNavigationSelectionDelayCompleted)
         }
         .cancellable(id: CancelID.load, cancelInFlight: true)
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -37,9 +37,9 @@ struct LoadThenNavigate: ReducerProtocol {
 
       case .setNavigation(isActive: true):
         state.isActivityIndicatorVisible = true
-        return .task {
+        return .run { send in
           try await self.clock.sleep(for: .seconds(1))
-          return .setNavigationIsActiveDelayCompleted
+          await send(.setNavigationIsActiveDelayCompleted)
         }
         .cancellable(id: CancelID.load)
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -30,9 +30,9 @@ struct NavigateAndLoad: ReducerProtocol {
       switch action {
       case .setNavigation(isActive: true):
         state.isNavigationActive = true
-        return .task {
+        return .run { send in
           try await self.clock.sleep(for: .seconds(1))
-          return .setNavigationIsActiveDelayCompleted
+          await send(.setNavigationIsActiveDelayCompleted)
         }
         .cancellable(id: CancelID.load)
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -37,9 +37,9 @@ struct LoadThenPresent: ReducerProtocol {
 
       case .setSheet(isPresented: true):
         state.isActivityIndicatorVisible = true
-        return .task {
+        return .run { send in
           try await self.clock.sleep(for: .seconds(1))
-          return .setSheetIsPresentedDelayCompleted
+          await send(.setSheetIsPresentedDelayCompleted)
         }
         .cancellable(id: CancelID.load)
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -30,9 +30,9 @@ struct PresentAndLoad: ReducerProtocol {
       switch action {
       case .setSheet(isPresented: true):
         state.isSheetPresented = true
-        return .task {
+        return .run { send in
           try await self.clock.sleep(for: .seconds(1))
-          return .setSheetIsPresentedDelayCompleted
+          await send(.setSheetIsPresentedDelayCompleted)
         }
         .cancellable(id: CancelID.load)
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -50,8 +50,8 @@ struct Favoriting<ID: Hashable & Sendable>: ReducerProtocol {
     case .buttonTapped:
       state.isFavorite.toggle()
 
-      return .task { [id = state.id, isFavorite = state.isFavorite, favorite] in
-        await .response(TaskResult { try await favorite(id, isFavorite) })
+      return .run { [id = state.id, isFavorite = state.isFavorite, favorite] send in
+        await send(.response(TaskResult { try await favorite(id, isFavorite) }))
       }
       .cancellable(id: CancelID(id: state.id), cancelInFlight: true)
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-LongLivingTests.swift
@@ -6,7 +6,7 @@ import XCTest
 @MainActor
 final class LongLivingEffectsTests: XCTestCase {
   func testReducer() async {
-    let (screenshots, takeScreenshot) = AsyncStream<Void>.streamWithContinuation()
+    let (screenshots, takeScreenshot) = AsyncStream.makeStream(of: Void.self)
 
     let store = TestStore(initialState: LongLivingEffects.State()) {
       LongLivingEffects()

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
@@ -6,8 +6,8 @@ import XCTest
 @MainActor
 final class WebSocketTests: XCTestCase {
   func testWebSocketHappyPath() async {
-    let actions = AsyncStream<WebSocketClient.Action>.streamWithContinuation()
-    let messages = AsyncStream<TaskResult<WebSocketClient.Message>>.streamWithContinuation()
+    let actions = AsyncStream.makeStream(of: WebSocketClient.Action.self)
+    let messages = AsyncStream.makeStream(of: TaskResult<WebSocketClient.Message>.self)
 
     let store = TestStore(initialState: WebSocket.State()) {
       WebSocket()
@@ -57,8 +57,8 @@ final class WebSocketTests: XCTestCase {
   }
 
   func testWebSocketSendFailure() async {
-    let actions = AsyncStream<WebSocketClient.Action>.streamWithContinuation()
-    let messages = AsyncStream<TaskResult<WebSocketClient.Message>>.streamWithContinuation()
+    let actions = AsyncStream.makeStream(of: WebSocketClient.Action.self)
+    let messages = AsyncStream.makeStream(of: TaskResult<WebSocketClient.Message>.self)
 
     let store = TestStore(initialState: WebSocket.State()) {
       WebSocket()
@@ -103,7 +103,7 @@ final class WebSocketTests: XCTestCase {
   }
 
   func testWebSocketPings() async {
-    let actions = AsyncStream<WebSocketClient.Action>.streamWithContinuation()
+    let actions = AsyncStream.makeStream(of: WebSocketClient.Action.self)
     let clock = TestClock()
     var pingsCount = 0
 
@@ -137,7 +137,7 @@ final class WebSocketTests: XCTestCase {
   }
 
   func testWebSocketConnectError() async {
-    let actions = AsyncStream<WebSocketClient.Action>.streamWithContinuation()
+    let actions = AsyncStream.makeStream(of: WebSocketClient.Action.self)
 
     let store = TestStore(initialState: WebSocket.State()) {
       WebSocket()

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 @MainActor
 final class ReusableComponentsDownloadComponentTests: XCTestCase {
-  let download = AsyncThrowingStream<DownloadClient.Event, Error>.streamWithContinuation()
+  let download = AsyncThrowingStream.makeStream(of: DownloadClient.Event.self)
 
   func testDownloadFlow() async {
     let store = TestStore(

--- a/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
@@ -27,9 +27,9 @@ struct LazyNavigation: ReducerProtocol {
 
       case .setNavigation(isActive: true):
         state.isActivityIndicatorHidden = false
-        return .task {
+        return .run { send in
           try await self.clock.sleep(for: .seconds(1))
-          return .setNavigationIsActiveDelayCompleted
+          await send(.setNavigationIsActiveDelayCompleted)
         }
         .cancellable(id: CancelID.load)
 

--- a/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
@@ -23,9 +23,9 @@ struct EagerNavigation: ReducerProtocol {
       switch action {
       case .setNavigation(isActive: true):
         state.isNavigationActive = true
-        return .task {
+        return .run { send in
           try await self.clock.sleep(for: .seconds(1))
-          return .setNavigationIsActiveDelayCompleted
+          await send(.setNavigationIsActiveDelayCompleted)
         }
         .cancellable(id: CancelID.load)
 

--- a/Examples/Search/Search/SearchView.swift
+++ b/Examples/Search/Search/SearchView.swift
@@ -80,8 +80,8 @@ struct Search: ReducerProtocol {
       guard !state.searchQuery.isEmpty else {
         return .none
       }
-      return .task { [query = state.searchQuery] in
-        await .searchResponse(TaskResult { try await self.weatherClient.search(query) })
+      return .run { [query = state.searchQuery] send in
+        await send(.searchResponse(TaskResult { try await self.weatherClient.search(query) }))
       }
       .cancellable(id: CancelID.location)
 
@@ -96,10 +96,12 @@ struct Search: ReducerProtocol {
     case let .searchResultTapped(location):
       state.resultForecastRequestInFlight = location
 
-      return .task {
-        await .forecastResponse(
-          location.id,
-          TaskResult { try await self.weatherClient.forecast(location) }
+      return .run { send in
+        await send(
+          .forecastResponse(
+            location.id,
+            TaskResult { try await self.weatherClient.forecast(location) }
+          )
         )
       }
       .cancellable(id: CancelID.weather, cancelInFlight: true)

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
@@ -35,7 +35,7 @@ struct SpeechRecognition: ReducerProtocol {
 
       guard state.isRecording
       else {
-        return .fireAndForget {
+        return .run { _ in
           await self.speechClient.finishTask()
         }
       }

--- a/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
+++ b/Examples/SpeechRecognition/SpeechRecognitionTests/SpeechRecognitionTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 @MainActor
 final class SpeechRecognitionTests: XCTestCase {
-  let recognitionTask = AsyncThrowingStream<SpeechRecognitionResult, Error>.streamWithContinuation()
+  let recognitionTask = AsyncThrowingStream.makeStream(of: SpeechRecognitionResult.self)
 
   func testDenyAuthorization() async {
     let store = TestStore(initialState: SpeechRecognition.State()) {

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginCore/LoginCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginCore/LoginCore.swift
@@ -15,7 +15,7 @@ public struct Login: ReducerProtocol, Sendable {
     public init() {}
   }
 
-  public enum Action: Equatable {
+  public enum Action: Equatable, Sendable {
     case alertDismissed
     case emailChanged(String)
     case passwordChanged(String)
@@ -60,13 +60,15 @@ public struct Login: ReducerProtocol, Sendable {
 
       case .loginButtonTapped:
         state.isLoginRequestInFlight = true
-        return .task { [email = state.email, password = state.password] in
-          .loginResponse(
-            await TaskResult {
-              try await self.authenticationClient.login(
-                .init(email: email, password: password)
-              )
-            }
+        return .run { [email = state.email, password = state.password] send in
+          await send(
+            .loginResponse(
+              await TaskResult {
+                try await self.authenticationClient.login(
+                  .init(email: email, password: password)
+                )
+              }
+            )
           )
         }
 
@@ -75,7 +77,7 @@ public struct Login: ReducerProtocol, Sendable {
 
       case .twoFactorDismissed:
         state.twoFactor = nil
-        return .cancel(id: TwoFactor.TearDownToken.self)
+        return .cancel(id: TwoFactor.CancelID.tearDown)
       }
     }
     .ifLet(\.twoFactor, action: /Action.twoFactor) {

--- a/Examples/VoiceMemos/VoiceMemos/RecordingMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/RecordingMemo.swift
@@ -35,13 +35,13 @@ struct RecordingMemo: ReducerProtocol {
   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .audioRecorderDidFinish(.success(true)):
-      return .task { [state] in .delegate(.didFinish(.success(state))) }
+      return .send(.delegate(.didFinish(.success(state))))
 
     case .audioRecorderDidFinish(.success(false)):
-      return .task { .delegate(.didFinish(.failure(Failed()))) }
+      return .send(.delegate(.didFinish(.failure(Failed()))))
 
     case let .audioRecorderDidFinish(.failure(error)):
-      return .task { .delegate(.didFinish(.failure(error))) }
+      return .send(.delegate(.didFinish(.failure(error))))
 
     case .delegate:
       return .none

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -39,15 +39,15 @@ struct VoiceMemos: ReducerProtocol {
         return .none
 
       case .openSettingsButtonTapped:
-        return .fireAndForget {
+        return .run { _ in
           await self.openSettings()
         }
 
       case .recordButtonTapped:
         switch state.audioRecorderPermission {
         case .undetermined:
-          return .task {
-            await .recordPermissionResponse(self.requestRecordPermission())
+          return .run { send in
+            await send(.recordPermissionResponse(self.requestRecordPermission()))
           }
 
         case .denied:

--- a/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
+++ b/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
@@ -11,7 +11,7 @@ final class VoiceMemosTests: XCTestCase {
     // NB: Combine's concatenation behavior is different in 13.3
     guard #available(iOS 13.4, *) else { return }
 
-    let didFinish = AsyncThrowingStream<Bool, Error>.streamWithContinuation()
+    let didFinish = AsyncThrowingStream.makeStream(of: Bool.self)
 
     let store = TestStore(initialState: VoiceMemos.State()) {
       VoiceMemos()
@@ -98,7 +98,7 @@ final class VoiceMemosTests: XCTestCase {
 
   func testRecordMemoFailure() async {
     struct SomeError: Error, Equatable {}
-    let didFinish = AsyncThrowingStream<Bool, Error>.streamWithContinuation()
+    let didFinish = AsyncThrowingStream.makeStream(of: Bool.self)
 
     let store = TestStore(initialState: VoiceMemos.State()) {
       VoiceMemos()
@@ -139,7 +139,7 @@ final class VoiceMemosTests: XCTestCase {
   // record.
   func testRecordMemoFailure_NonExhaustive() async {
     struct SomeError: Error, Equatable {}
-    let didFinish = AsyncThrowingStream<Bool, Error>.streamWithContinuation()
+    let didFinish = AsyncThrowingStream.makeStream(of: Bool.self)
 
     let store = TestStore(initialState: VoiceMemos.State()) {
       VoiceMemos()

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.14.0"),
     .package(url: "https://github.com/apple/swift-collections", from: "1.0.2"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.10.0"),
-    .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "0.4.2"),
+    .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "0.5.0"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "0.7.0"),
     .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "0.7.1"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.8.4"),

--- a/README.md
+++ b/README.md
@@ -173,15 +173,17 @@ struct Feature: ReducerProtocol {
         return .none
 
       case .numberFactButtonTapped:
-        return .task { [count = state.count] in
-          await .numberFactResponse(
-            TaskResult {
-              String(
-                decoding: try await URLSession.shared
-                  .data(from: URL(string: "http://numbersapi.com/\(count)/trivia")!).0,
-                as: UTF8.self
-              )
-            }
+        return .run { [count = state.count] send in
+          await send(
+            .numberFactResponse(
+              TaskResult {
+                String(
+                  decoding: try await URLSession.shared
+                    .data(from: URL(string: "http://numbersapi.com/\(count)/trivia")!).0,
+                  as: UTF8.self
+                )
+              }
+            )
           )
         }
 
@@ -391,8 +393,10 @@ Then we can use it in the `reduce` implementation:
 
 ```swift
 case .numberFactButtonTapped:
-  return .task { [count = state.count] in 
-    await .numberFactResponse(TaskResult { try await self.numberFact(count) })
+  return .run { [count = state.count] send in 
+    await send(
+      .numberFactResponse(TaskResult { try await self.numberFact(count) })
+    )
   }
 ```
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
@@ -119,15 +119,17 @@ struct Feature: ReducerProtocol {
         return .none
 
       case .numberFactButtonTapped:
-        return .task { [count = state.count] in 
-          await .numberFactResponse(
-            TaskResult { 
-              String(
-                decoding: try await URLSession.shared
-                  .data(from: URL(string: "http://numbersapi.com/\(count)/trivia")!).0,
-                as: UTF8.self
-              )
-            }
+        return .run { [count = state.count] send in
+          await send(
+            .numberFactResponse(
+              TaskResult { 
+                String(
+                  decoding: try await URLSession.shared
+                    .data(from: URL(string: "http://numbersapi.com/\(count)/trivia")!).0,
+                  as: UTF8.self
+                )
+              }
+            )
           )
         }
 
@@ -328,8 +330,10 @@ Then we can use it in the `reduce` implementation:
 
 ```swift
 case .numberFactButtonTapped:
-  return .task { [count = state.count] in 
-    await .numberFactResponse(TaskResult { try await self.numberFact(count) })
+  return .run { [count = state.count] send in 
+    await send(
+      .numberFactResponse(TaskResult { try await self.numberFact(count) })
+    )
   }
 ```
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -400,7 +400,7 @@ and then delivering the result in an action:
 
 ```swift
 case .buttonTapped:
-  return .task {
+  return .run { send in
     var result = // ...
     for (index, value) in someLargeCollection.enumerated() {
       // Some intense computation with value
@@ -410,7 +410,7 @@ case .buttonTapped:
         await Task.yield()
       }
     }
-    return .computationResponse(result)
+    await send(.computationResponse(result))
   }
 
 case let .computationResponse(result):

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftConcurrency.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftConcurrency.md
@@ -7,16 +7,11 @@ and functions that are not thread-safe in concurrent contexts. Many of these war
 for the time being, but in Swift 6 most (if not all) of these warnings will become errors, and so
 you will need to know how to prove to the compiler that your types are safe to use concurrently.
 
-There are 3 primary ways to create an ``EffectTask`` in the library:
-
-  * ``EffectPublisher/task(priority:operation:catch:file:fileID:line:)``
-  * ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)``
-  * ``EffectPublisher/fireAndForget(priority:_:)``
-
-Each of these constructors takes a `@Sendable`, asynchronous closure, which restricts the types of
-closures you can use for your effects. In particular, the closure can only capture `Sendable`
-variables that are bound with `let`. Mutable variables and non-`Sendable` types are simply not
-allowed to be passed to `@Sendable` closures.
+There primary way to create an ``EffectTask`` in the library is via
+``EffectPublisher/run(priority:operation:catch:file:fileID:line:)``. It takes a `@Sendable`,
+asynchronous closure, which restricts the types of closures you can use for your effects. In
+particular, the closure can only capture `Sendable` variables that are bound with `let`. Mutable
+variables and non-`Sendable` types are simply not allowed to be passed to `@Sendable` closures.
 
 There are two primary ways you will run into this restriction when building a feature in the
 Composable Architecture: accessing state from within an effect, and accessing a dependency from
@@ -29,20 +24,20 @@ from within `@Sendable` closures:
 
 ```swift
 struct Feature: ReducerProtocol {
-  struct State { … }
-  enum Action { … }
+  struct State { /* ... */ }
+  enum Action { /* ... */ }
 
   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .buttonTapped:
-      return .task {
-        try await Task.sleep(nanoseconds: NSEC_PER_SEC)
-        return .delayed(state.count) 
-        // 🛑 Mutable capture of 'inout' parameter 'state' is 
+      return .run { send in
+        try await Task.sleep(for: .seconds(1))
+        await send(.delayed(state.count))
+        // 🛑 Mutable capture of 'inout' parameter 'state' is
         //    not allowed in concurrently-executing code
       }
 
-      …
+      // ...
     }
   }
 }
@@ -52,9 +47,9 @@ To work around this you must explicitly capture the state as an immutable value 
 closure:
 
 ```swift
-return .task { [state] in 
-  try await Task.sleep(nanoseconds: NSEC_PER_SEC)
-  return .delayed(state.count) // ✅
+return .run { [state] send in
+  try await Task.sleep(for: .seconds(1))
+  await send(.delayed(state.count))  // ✅
 }
 ```
 
@@ -62,8 +57,8 @@ You can also capture just the minimal parts of the state you need for the effect
 variable name for the capture:
 
 ```swift
-return .task { [count = state.count] in 
-  try await Task.sleep(nanoseconds: NSEC_PER_SEC)
+return .run { [count = state.count] send in
+  try await Task.sleep(for: .seconds(1))
   return .delayed(count) // ✅
 }
 ```

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/EffectDeprecations.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/EffectDeprecations.md
@@ -15,7 +15,9 @@ Avoid using deprecated APIs in your app. Select a method to see the replacement 
 
 ### Creating an effect
 
+- ``EffectPublisher/task(priority:operation:catch:file:fileID:line:)``
 - ``EffectPublisher/task(priority:operation:)``
+- ``EffectPublisher/fireAndForget(priority:_:)``
 
 ### Cancellation
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
@@ -5,9 +5,7 @@
 ### Creating an effect
 
 - ``EffectPublisher/none``
-- ``EffectPublisher/task(priority:operation:catch:file:fileID:line:)``
 - ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)``
-- ``EffectPublisher/fireAndForget(priority:_:)``
 - ``EffectPublisher/send(_:)``
 - ``TaskResult``
 

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -90,12 +90,9 @@ extension EffectPublisher {
 /// There are 2 distinct ways to create an `Effect`: one using Swift's native concurrency tools, and
 /// the other using Apple's Combine framework:
 ///
-/// * If using Swift's native structured concurrency tools then there are 3 main ways to create an
-/// effect, depending on if you want to emit one single action back into the system, or any number
-/// of actions, or just execute some work without emitting any actions:
-///   * ``EffectPublisher/task(priority:operation:catch:file:fileID:line:)``
-///   * ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)``
-///   * ``EffectPublisher/fireAndForget(priority:_:)``
+/// * If using Swift's native structured concurrency tools then there is one main way to create an
+/// effect: ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)``.
+///
 /// * If using Combine in your application, in particular for the dependencies of your feature
 /// then you can create effects by making use of any of Combine's operators, and then erasing the
 /// publisher type to ``EffectPublisher`` with either `eraseToEffect` or `catchToEffect`. Note that

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -110,105 +110,11 @@ extension EffectPublisher {
 /// > then it must receive values on the main thread.
 /// >
 /// > This is only an issue if using the Combine interface of ``EffectPublisher`` as mentioned
-/// > above. If  you are using Swift's concurrency tools and the `.task`, `.run`, and
-/// > `.fireAndForget` functions on ``EffectTask``, then threading is automatically handled for you.
+/// > above. If you are using Swift's concurrency tools and the `.run` function on ``EffectTask``,
+/// > then threading is automatically handled for you.
 public typealias EffectTask<Action> = EffectPublisher<Action, Never>
 
 extension EffectPublisher where Failure == Never {
-  /// Wraps an asynchronous unit of work in an effect.
-  ///
-  /// This function is useful for executing work in an asynchronous context and capturing the result
-  /// in an ``EffectTask`` so that the reducer, a non-asynchronous context, can process it.
-  ///
-  /// For example, if your dependency exposes an `async` function, you can use
-  /// ``task(priority:operation:catch:file:fileID:line:)`` to provide an asynchronous context for
-  /// invoking that endpoint:
-  ///
-  /// ```swift
-  /// struct Feature: ReducerProtocol {
-  ///   struct State { … }
-  ///   enum FeatureAction {
-  ///     case factButtonTapped
-  ///     case factResponse(TaskResult<String>)
-  ///   }
-  ///   @Dependency(\.numberFact) var numberFact
-  ///
-  ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
-  ///     switch action {
-  ///       case .factButtonTapped:
-  ///         return .task { [number = state.number] in
-  ///           await .factResponse(TaskResult { try await self.numberFact.fetch(number) })
-  ///         }
-  ///
-  ///       case .factResponse(.success(fact)):
-  ///         // do something with fact
-  ///
-  ///       case .factResponse(.failure):
-  ///         // handle error
-  ///
-  ///       ...
-  ///     }
-  ///   }
-  /// }
-  /// ```
-  ///
-  /// The above code sample makes use of ``TaskResult`` in order to automatically bundle the success
-  /// or failure of the `numberFact` endpoint into a single type that can be sent in an action.
-  ///
-  /// The closure provided to ``task(priority:operation:catch:file:fileID:line:)`` is allowed to
-  /// throw, but any non-cancellation errors thrown will cause a runtime warning when run in the
-  /// simulator or on a device, and will cause a test failure in tests. To catch non-cancellation
-  /// errors use the `catch` trailing closure.
-  ///
-  /// - Parameters:
-  ///   - priority: Priority of the underlying task. If `nil`, the priority will come from
-  ///     `Task.currentPriority`.
-  ///   - operation: The operation to execute.
-  ///   - catch: An error handler, invoked if the operation throws an error other than
-  ///     `CancellationError`.
-  /// - Returns: An effect wrapping the given asynchronous work.
-  public static func task(
-    priority: TaskPriority? = nil,
-    operation: @escaping @Sendable () async throws -> Action,
-    catch handler: (@Sendable (Error) async -> Action)? = nil,
-    fileID: StaticString = #fileID,
-    line: UInt = #line
-  ) -> Self {
-    withEscapedDependencies { escaped in
-      Self(
-        operation: .run(priority) { send in
-          await escaped.yield {
-            do {
-              try await send(operation())
-            } catch is CancellationError {
-              return
-            } catch {
-              guard let handler = handler else {
-                #if DEBUG
-                  var errorDump = ""
-                  customDump(error, to: &errorDump, indent: 4)
-                  runtimeWarn(
-                    """
-                    An "EffectTask.task" returned from "\(fileID):\(line)" threw an unhandled \
-                    error. …
-
-                    \(errorDump)
-
-                    All non-cancellation errors must be explicitly handled via the "catch" \
-                    parameter on "EffectTask.task", or via a "do" block.
-                    """
-                  )
-                #endif
-                return
-              }
-              await send(handler(error))
-            }
-          }
-        }
-      )
-    }
-  }
-
   /// Wraps an asynchronous unit of work that can emit any number of times in an effect.
   ///
   /// This effect is similar to ``task(priority:operation:catch:file:fileID:line:)`` except it is
@@ -287,35 +193,6 @@ extension EffectPublisher where Failure == Never {
         }
       )
     }
-  }
-
-  /// Creates an effect that executes some work in the real world that doesn't need to feed data
-  /// back into the store. If an error is thrown, the effect will complete and the error will be
-  /// ignored.
-  ///
-  /// This effect is handy for executing some asynchronous work that your feature doesn't need to
-  /// react to. One such example is analytics:
-  ///
-  /// ```swift
-  /// case .buttonTapped:
-  ///   return .fireAndForget {
-  ///     try self.analytics.track("Button Tapped")
-  ///   }
-  /// ```
-  ///
-  /// The closure provided to ``fireAndForget(priority:_:)`` is allowed to throw, and any error
-  /// thrown will be ignored.
-  ///
-  /// - Parameters:
-  ///   - priority: Priority of the underlying task. If `nil`, the priority will come from
-  ///     `Task.currentPriority`.
-  ///   - work: A closure encapsulating some work to execute in the real world.
-  /// - Returns: An effect.
-  public static func fireAndForget(
-    priority: TaskPriority? = nil,
-    _ work: @escaping @Sendable () async throws -> Void
-  ) -> Self {
-    Self.run(priority: priority) { _ in try? await work() }
   }
 
   /// Initializes an effect that immediately emits the action passed in.

--- a/Sources/ComposableArchitecture/Effects/Animation.swift
+++ b/Sources/ComposableArchitecture/Effects/Animation.swift
@@ -6,8 +6,8 @@ extension EffectPublisher {
   ///
   /// ```swift
   /// case .buttonTapped:
-  ///   return .task {
-  ///     .activityResponse(await self.apiClient.fetchActivity())
+  ///   return .run { send in
+  ///     await send(.activityResponse(self.apiClient.fetchActivity()))
   ///   }
   ///   .animation()
   /// ```
@@ -24,8 +24,8 @@ extension EffectPublisher {
   /// case .buttonTapped:
   ///   var transaction = Transaction(animation: .default)
   ///   transaction.disablesAnimations = true
-  ///   return .task {
-  ///     .activityResponse(await self.apiClient.fetchActivity())
+  ///   return .run { send in
+  ///     await send(.activityResponse(self.apiClient.fetchActivity()))
   ///   }
   ///   .transaction(transaction)
   /// ```

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -134,11 +134,11 @@ extension EffectPublisher {
   ///
   /// // ...
   ///
-  /// return .task {
+  /// return .run { send in
   ///   await withTaskCancellation(id: CancelID.response, cancelInFlight: true) {
   ///     try await self.clock.sleep(for: .seconds(0.3))
-  ///     return await .debouncedResponse(
-  ///       TaskResult { try await environment.request() }
+  ///     await .send(
+  ///       .debouncedResponse(TaskResult { try await environment.request() })
   ///     )
   ///   }
   /// }

--- a/Sources/ComposableArchitecture/Effects/Publisher.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher.swift
@@ -575,22 +575,22 @@ extension Publisher {
   @available(
     iOS, deprecated: 9999.0,
     message:
-      "Iterate over 'Publisher.values' in the static version of 'Effect.fireAndForget', instead."
+      "Iterate over 'Publisher.values' in the static version of 'Effect.run', instead."
   )
   @available(
     macOS, deprecated: 9999.0,
     message:
-      "Iterate over 'Publisher.values' in the static version of 'Effect.fireAndForget', instead."
+      "Iterate over 'Publisher.values' in the static version of 'Effect.run', instead."
   )
   @available(
     tvOS, deprecated: 9999.0,
     message:
-      "Iterate over 'Publisher.values' in the static version of 'Effect.fireAndForget', instead."
+      "Iterate over 'Publisher.values' in the static version of 'Effect.run', instead."
   )
   @available(
     watchOS, deprecated: 9999.0,
     message:
-      "Iterate over 'Publisher.values' in the static version of 'Effect.fireAndForget', instead."
+      "Iterate over 'Publisher.values' in the static version of 'Effect.run', instead."
   )
   public func fireAndForget<NewOutput, NewFailure>(
     outputType: NewOutput.Type = NewOutput.self,

--- a/Sources/ComposableArchitecture/Effects/TaskResult.swift
+++ b/Sources/ComposableArchitecture/Effects/TaskResult.swift
@@ -31,7 +31,7 @@ import XCTestDynamicOverlay
 /// }
 /// ```
 ///
-/// And finally you can use ``EffectPublisher/task(priority:operation:catch:file:fileID:line:)`` to
+/// And finally you can use ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)`` to
 /// construct an effect in the reducer that invokes the `numberFact` endpoint and wraps its response
 /// in a ``TaskResult`` by using its catching initializer, ``TaskResult/init(catching:)``:
 ///

--- a/Sources/ComposableArchitecture/Effects/TaskResult.swift
+++ b/Sources/ComposableArchitecture/Effects/TaskResult.swift
@@ -37,9 +37,11 @@ import XCTestDynamicOverlay
 ///
 /// ```swift
 /// case .factButtonTapped:
-///   return .task {
-///     await .factResponse(
-///       TaskResult { try await self.numberFact.fetch(state.number) }
+///   return .run { send in
+///     await send(
+///       .factResponse(
+///         TaskResult { try await self.numberFact.fetch(state.number) }
+///       )
 ///     )
 ///   }
 ///

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -5,6 +5,65 @@ import XCTestDynamicOverlay
 
 // MARK: - Deprecated after 0.52.0
 
+extension EffectPublisher where Failure == Never {
+  @available(iOS, deprecated: 9999, message: "Use 'Effect.run' and pass the action to 'send'.")
+  @available(macOS, deprecated: 9999, message: "Use 'Effect.run' and pass the action to 'send'.")
+  @available(tvOS, deprecated: 9999, message: "Use 'Effect.run' and pass the action to 'send'.")
+  @available(watchOS, deprecated: 9999, message: "Use 'Effect.run' and pass the action to 'send'.")
+  public static func task(
+    priority: TaskPriority? = nil,
+    operation: @escaping @Sendable () async throws -> Action,
+    catch handler: (@Sendable (Error) async -> Action)? = nil,
+    fileID: StaticString = #fileID,
+    line: UInt = #line
+  ) -> Self {
+    withEscapedDependencies { escaped in
+      Self(
+        operation: .run(priority) { send in
+          await escaped.yield {
+            do {
+              try await send(operation())
+            } catch is CancellationError {
+              return
+            } catch {
+              guard let handler = handler else {
+                #if DEBUG
+                  var errorDump = ""
+                  customDump(error, to: &errorDump, indent: 4)
+                  runtimeWarn(
+                    """
+                    An "EffectTask.task" returned from "\(fileID):\(line)" threw an unhandled \
+                    error. …
+
+                    \(errorDump)
+
+                    All non-cancellation errors must be explicitly handled via the "catch" \
+                    parameter on "EffectTask.task", or via a "do" block.
+                    """
+                  )
+                #endif
+                return
+              }
+              await send(handler(error))
+            }
+          }
+        }
+      )
+    }
+  }
+
+  @available(iOS, deprecated: 9999, message: "Use 'Effect.run' and ignore 'send' instead.")
+  @available(macOS, deprecated: 9999, message: "Use 'Effect.run' and ignore 'send' instead.")
+  @available(tvOS, deprecated: 9999, message: "Use 'Effect.run' and ignore 'send' instead.")
+  @available(watchOS, deprecated: 9999, message: "Use 'Effect.run' and ignore 'send' instead.")
+  public static func fireAndForget(
+    priority: TaskPriority? = nil,
+    _ work: @escaping @Sendable () async throws -> Void
+  ) -> Self {
+    Self.run(priority: priority) { _ in try? await work() }
+  }
+}
+
 extension Store {
   @available(iOS, deprecated: 9999, message: "Pass a closure as the reducer.")
   @available(macOS, deprecated: 9999, message: "Pass a closure as the reducer.")
@@ -800,7 +859,7 @@ extension Store {
             let task = self.send(fromChildAction(childAction))
             childState = extractChildState(self.state.value) ?? childState
             if let task = task {
-              return .fireAndForget { await task.cancellableValue }
+              return .run { _ in await task.cancellableValue }
             } else {
               return .none
             }

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerDebug.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerDebug.swift
@@ -220,7 +220,7 @@ extension AnyReducer {
         case .publisher:
           return .fireAndForget { print() }.merge(with: effects)
         case .run:
-          return .fireAndForget { () async in print() }.merge(with: effects)
+          return .run { _ in print() }.merge(with: effects)
         }
       }
     #else

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -656,7 +656,7 @@ public typealias StoreOf<R: ReducerProtocol> = Store<R.State, R.Action>
         self.isSending = false
       }
       if let action = self.fromScopedAction(state, action), let task = self.rootStore.send(action) {
-        return .fireAndForget { await task.cancellableValue }
+        return .run { _ in await task.cancellableValue }
       } else {
         return .none
       }
@@ -746,7 +746,7 @@ public typealias StoreOf<R: ReducerProtocol> = Store<R.State, R.Action>
           let task = self.root.send(rootAction)
           rescopedState = toRescopedState(scopedStore.state.value)
           if let task = task {
-            return .fireAndForget { await task.cancellableValue }
+            return .run { _ in await task.cancellableValue }
           } else {
             return .none
           }

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -2283,7 +2283,7 @@ public struct TestStoreTask: Hashable, Sendable {
 class TestReducer<State, Action>: ReducerProtocol {
   let base: Reduce<State, Action>
   var dependencies = DependencyValues()
-  let effectDidSubscribe = AsyncStream<Void>.streamWithContinuation()
+  let effectDidSubscribe = AsyncStream.makeStream(of: Void.self)
   var inFlightEffects: Set<LongLivingEffect> = []
   var receivedActions: [(action: Action, state: State)] = []
   var state: State

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -949,8 +949,8 @@ extension TestStore where ScopedState: Equatable {
   /// ```
   ///
   /// This method suspends in order to allow any effects to start. For example, if you track an
-  /// analytics event in a ``EffectPublisher/fireAndForget(priority:_:)`` when an action is sent,
-  /// you can assert on that behavior immediately after awaiting `store.send`:
+  /// analytics event in an effect when an action is sent, you can assert on that behavior
+  /// immediately after awaiting `store.send`:
   ///
   /// ```swift
   /// @MainActor

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -332,8 +332,8 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
   ///     switch action {
   ///     case .pulledToRefresh:
   ///       state.isLoading = true
-  ///       return .task {
-  ///         await .receivedResponse(TaskResult { try await self.fetch() })
+  ///       return .run { send in
+  ///         await send(.receivedResponse(TaskResult { try await self.fetch() }))
   ///       }
   ///
   ///     case let .receivedResponse(result):

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -131,9 +131,9 @@ final class ComposableArchitectureTests: BaseTCATestCase {
 
           case .incr:
             state += 1
-            return .task { [state] in
+            return .run { [state] send in
               try await mainQueue.sleep(for: .seconds(1))
-              return .response(state * state)
+              await send(.response(state * state))
             }
             .cancellable(id: CancelID.sleep)
 

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -82,7 +82,7 @@ final class ComposableArchitectureTests: BaseTCATestCase {
   func testLongLivingEffects() async {
     enum Action { case end, incr, start }
 
-    let effect = AsyncStream<Void>.streamWithContinuation()
+    let effect = AsyncStream.makeStream(of: Void.self)
 
     let store = TestStore(initialState: 0) {
       Reduce<Int, Action> { state, action in

--- a/Tests/ComposableArchitectureTests/DependencyKeyWritingReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/DependencyKeyWritingReducerTests.swift
@@ -91,11 +91,11 @@ final class DependencyKeyWritingReducerTests: BaseTCATestCase {
         switch action {
         case .tap:
           state.count += 1
-          return .task { .response(self.myValue) }
+          return .run { send in await send(.response(self.myValue)) }
 
         case let .response(value):
           state.count = value
-          return .task { .otherResponse(self.myValue) }
+          return .run { send in await send(.otherResponse(self.myValue)) }
 
         case let .otherResponse(value):
           state.count = value

--- a/Tests/ComposableArchitectureTests/TaskCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/TaskCancellationTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class TaskCancellationTests: BaseTCATestCase {
   func testCancellation() async throws {
     enum CancelID { case task }
-    let (stream, continuation) = AsyncStream<Void>.streamWithContinuation()
+    let (stream, continuation) = AsyncStream.makeStream(of: Void.self)
     let task = Task {
       try await withTaskCancellation(id: CancelID.task) {
         continuation.yield()

--- a/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
@@ -40,7 +40,7 @@
 
     func testStateChangeFailure() {
       struct State: Equatable { var count = 0 }
-      let store = TestStore(initialState: .init()) {
+      let store = TestStore(initialState: State()) {
         Reduce<State, Void> { state, action in
           state.count += 1
           return .none
@@ -63,7 +63,7 @@
 
     func testUnexpectedStateChangeOnSendFailure() {
       struct State: Equatable { var count = 0 }
-      let store = TestStore(initialState: .init()) {
+      let store = TestStore(initialState: State()) {
         Reduce<State, Void> { state, action in
           state.count += 1
           return .none
@@ -87,7 +87,7 @@
     func testUnexpectedStateChangeOnReceiveFailure() {
       struct State: Equatable { var count = 0 }
       enum Action { case first, second }
-      let store = TestStore(initialState: .init()) {
+      let store = TestStore(initialState: State()) {
         Reduce<State, Action> { state, action in
           switch action {
           case .first: return .init(value: .second)


### PR DESCRIPTION
See https://github.com/pointfreeco/swift-composable-architecture/discussions/1520