### PR TITLE
Call prepareDependencies once when initializing TestStore.

### DIFF
--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -663,22 +663,18 @@ public final class TestStore<State, Action, ScopedState, ScopedAction, Environme
     Environment == Void
   {
     var dependencies = DependencyValues._current
-    let initialState = withDependencies {
+    let reducer = withDependencies {
       prepareDependencies(&dependencies)
       $0 = dependencies
     } operation: {
-      initialState()
+      TestReducer(Reduce(reducer()), initialState: initialState())
     }
-
-    let reducer = TestReducer(
-      Reduce(withDependencies(prepareDependencies) { reducer() }), initialState: initialState
-    )
     self._environment = .init(wrappedValue: ())
     self.file = file
     self.fromScopedAction = fromScopedAction
     self.line = line
     self.reducer = reducer
-    self.store = Store(initialState: initialState, reducer: reducer)
+    self.store = Store(initialState: reducer.state, reducer: reducer)
     self.timeout = 100 * NSEC_PER_MSEC
     self.toScopedState = toScopedState
     self.dependencies = dependencies
@@ -708,22 +704,18 @@ public final class TestStore<State, Action, ScopedState, ScopedAction, Environme
     Environment == Void
   {
     var dependencies = DependencyValues._current
-    prepareDependencies(&dependencies)
-    let initialState = withDependencies {
+    let reducer = withDependencies {
+      prepareDependencies(&dependencies)
       $0 = dependencies
     } operation: {
-      initialState()
+      TestReducer(Reduce(reducer()), initialState: initialState())
     }
-
-    let reducer = TestReducer(
-      Reduce(withDependencies(prepareDependencies) { reducer() }), initialState: initialState
-    )
     self._environment = .init(wrappedValue: ())
     self.file = file
     self.fromScopedAction = { $0 }
     self.line = line
     self.reducer = reducer
-    self.store = Store(initialState: initialState, reducer: reducer)
+    self.store = Store(initialState: reducer.state, reducer: reducer)
     self.timeout = 100 * NSEC_PER_MSEC
     self.toScopedState = { $0 }
     self.dependencies = dependencies

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -395,14 +395,15 @@ final class TestStoreTests: BaseTCATestCase {
   }
 
   func testPrepareDependenciesCalledOnce() {
-    let count = LockIsolated(0)
-    _ = TestStore(initialState: 0) {
+    var count = 0
+    let store = TestStore(initialState: 0) {
       EmptyReducer<Int, Void>()
     } withDependencies: { _ in
-      count.withValue { $0 += 1 }
+      count += 1
     }
 
-    XCTAssertEqual(count.value, 1)
+    XCTAssertEqual(count, 1)
+    _ = store
   }
 
   func testEffectEmitAfterSkipInFlightEffects() async {

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -394,6 +394,17 @@ final class TestStoreTests: BaseTCATestCase {
     }
   }
 
+  func testPrepareDependenciesCalledOnce() {
+    let count = LockIsolated(0)
+    _ = TestStore(initialState: 0) {
+      EmptyReducer<Int, Void>()
+    } withDependencies: { _ in
+      count.withValue { $0 += 1 }
+    }
+
+    XCTAssertEqual(count.value, 1)
+  }
+
   func testEffectEmitAfterSkipInFlightEffects() async {
     let mainQueue = DispatchQueue.test
     enum Action: Equatable { case tap, response }


### PR DESCRIPTION
@alexito4 brought up in Slack that `prepareDependencies` was called twice when creating a `TestStore`. On the hand one probably shouldn't do work in `prepareDependencies` that couldn't be done twice, but on the other hand the call site does make it look like it's a simple setup function (and even copies the `withDependencies` style from swift-dependencies), so it probably should only be called once.