### PR TITLE
Fix  compile error  below Xcode 14.3

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
@@ -1,5 +1,5 @@
 extension ReducerProtocol {
-  #if swift(>=5.7)
+  #if swift(>=5.8)
     /// Enhances a reducer with debug logging of received actions and state mutations for the given
     /// printer.
     ///


### PR DESCRIPTION
I am using Xcode 14.2.
I am getting compile errors due to the new changes to debugReducer.
It seems that @_docmentation is available in 5.8 and later.

https://www.swift.org/blog/swift-5.8-released/
https://forums.swift.org/t/swift-5-8-documentation/63346