### PR TITLE
Make internal helper @MainActor.

### DIFF
--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1834,6 +1834,7 @@ extension TestStore where ScopedState: Equatable {
     }
   }
 
+  @MainActor
   private func receiveAction(
     matching predicate: (Action) -> Bool,
     timeout nanoseconds: UInt64?,
@@ -2057,6 +2058,7 @@ extension TestStore {
   ///
   /// - Parameter strict: When `true` and there are no in-flight actions to cancel, a test failure
   ///   will be reported.
+  @MainActor
   public func skipInFlightEffects(
     strict: Bool = true,
     file: StaticString = #file,


### PR DESCRIPTION
There was an internal helper in `TestStore` that wasn't `@MainActor` and it could cause trouble. Eventually for 1.0 we'd probably prefer if `TestStore` was just `@MainActor` entirely, but we will explore that later.