### PR TITLE
Fix CI: Actually pass configuration to make

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Select Xcode 14.3
         run: sudo xcode-select -s /Applications/Xcode_14.3.app
       - name: Run ${{ matrix.config }} tests
-        run: CONFIG=${{ matrix.config }} make test-library
+        run: make CONFIG=${{ matrix.config }} test-library
 
   library-swift-5-6:
     name: Library (swift-5.6)
@@ -42,7 +42,7 @@ jobs:
       - name: Select Xcode 13.4.1
         run: sudo xcode-select -s /Applications/Xcode_13.4.1.app
       - name: Run ${{ matrix.config }} tests
-        run: CONFIG=${{ matrix.config }} make test-library
+        run: make CONFIG=${{ matrix.config }} test-library
 
   library-evolution:
     name: Library (evolution)

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ PLATFORM_WATCHOS = watchOS Simulator,id=$(call udid_for,Watch)
 default: test-all
 
 test-all: test-examples
-	CONFIG=debug test-library 
-	CONFIG=release test-library
+	$(MAKE) CONFIG=debug test-library
+	$(MAKE) CONFIG=release test-library
 
 test-library:
 	for platform in "$(PLATFORM_IOS)" "$(PLATFORM_MACOS)" "$(PLATFORM_MAC_CATALYST)" "$(PLATFORM_TVOS)" "$(PLATFORM_WATCHOS)"; do \


### PR DESCRIPTION
Make doesn't override env vars in the traditional way, so portions of our CI (library tests) were only running tests in debug mode. This should fix.