### PR TITLE
Add TestStore.assert.

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStore.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStore.md
@@ -20,6 +20,7 @@
 - ``receive(_:timeout:assert:file:line:)-1rwdd``
 - ``receive(_:timeout:assert:file:line:)-8xkqt``
 - ``receive(_:timeout:assert:file:line:)-2ju31``
+- ``assert(assert:file:line:)``
 - ``finish(timeout:file:line:)``
 - ``TestStoreTask``
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStore.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStore.md
@@ -20,7 +20,7 @@
 - ``receive(_:timeout:assert:file:line:)-1rwdd``
 - ``receive(_:timeout:assert:file:line:)-8xkqt``
 - ``receive(_:timeout:assert:file:line:)-2ju31``
-- ``assert(assert:file:line:)``
+- ``assert(_:file:line:)``
 - ``finish(timeout:file:line:)``
 - ``TestStoreTask``
 

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1075,6 +1075,10 @@ extension TestStore where ScopedState: Equatable {
   /// }
   /// ```
   ///
+  /// > Note: This helper is only intended to be used with non-exhaustive test stores. It is not
+  /// needed in exhaustive test stores since any assertion you may make inside the trailing closure
+  /// has already been handled by a previous `send` or `receive`.
+  ///
   /// - Parameters:
   ///   - updateStateToExpectedResult: A closure that asserts against the current state of the test
   ///   store.

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1053,6 +1053,52 @@ extension TestStore where ScopedState: Equatable {
     return .init(rawValue: task, timeout: self.timeout)
   }
 
+  /// Assert against the current state of the store.
+  ///
+  /// The trailing closure provided is given a mutable argument that represents the current state,
+  /// and you can provide any mutations you want to the state. If your mutations cause the argument
+  /// to differ from the current state of the test store, a test failure will be triggered.
+  ///
+  /// This tool is most useful in non-exhaustive test stores (see
+  /// <doc:Testing#Non-exhaustive-testing>), which allow you to assert on a subset of the things
+  /// happening inside your features. For example, you can send an action in a child feature
+  /// without asserting on how many changes in the system, and then tell the test store to
+  /// ``finish(timeout:file:line:)`` by executing all of its effects and receiving all actions.
+  /// After that is done you can assert on the final state of the store:
+  ///
+  /// ```swift
+  /// store.exhaustivity = .off
+  /// await store.send(.child(.closeButtonTapped))
+  /// await store.finish()
+  /// store.assert {
+  ///   $0.child = nil
+  /// }
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - updateStateToExpectedResult: A closure that asserts against the current state of the test
+  ///   store.
+  @MainActor
+  public func assert(
+    assert updateStateToExpectedResult: ((inout ScopedState) throws -> Void)?,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    let expectedState = self.toScopedState(self.state)
+    let currentState = self.reducer.state
+    do {
+      try self.expectedStateShouldMatch(
+        expected: expectedState,
+        actual: self.toScopedState(currentState),
+        updateStateToExpectedResult: updateStateToExpectedResult,
+        file: file,
+        line: line
+      )
+    } catch {
+      XCTFail("Threw error: \(error)", file: file, line: line)
+    }
+  }
+
   /// Sends an action to the store and asserts when state changes.
   ///
   /// This method returns a ``TestStoreTask``, which represents the lifecycle of the effect started

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1084,7 +1084,7 @@ extension TestStore where ScopedState: Equatable {
   ///   store.
   @MainActor
   public func assert(
-    assert updateStateToExpectedResult: ((inout ScopedState) throws -> Void)?,
+    _ updateStateToExpectedResult: ((inout ScopedState) throws -> Void)?,
     file: StaticString = #file,
     line: UInt = #line
   ) {

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -432,6 +432,7 @@ final class TestStoreTests: BaseTCATestCase {
     }
   }
 
+  #if DEBUG
   func testAssert_ExhaustiveTestStore() async {
     let store = TestStore(initialState: 0) {
       EmptyReducer<Int, Void>()
@@ -450,6 +451,7 @@ final class TestStoreTests: BaseTCATestCase {
         """
     }
   }
+  #endif
 
   func testAssert_NonExhaustiveTestStore() async {
     let store = TestStore(initialState: 0) {
@@ -462,6 +464,7 @@ final class TestStoreTests: BaseTCATestCase {
     }
   }
 
+  #if DEBUG
   func testAssert_NonExhaustiveTestStore_Failure() async {
     let store = TestStore(initialState: 0) {
       EmptyReducer<Int, Void>()
@@ -483,6 +486,7 @@ final class TestStoreTests: BaseTCATestCase {
         """
     }
   }
+  #endif
 }
 
 private struct Client: DependencyKey {

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -431,6 +431,58 @@ final class TestStoreTests: BaseTCATestCase {
       $0 = 42
     }
   }
+
+  func testAssert_ExhaustiveTestStore() async {
+    let store = TestStore(initialState: 0) {
+      EmptyReducer<Int, Void>()
+    }
+
+    XCTExpectFailure {
+      store.assert {
+        $0 = 0
+      }
+    } issueMatcher: {
+      $0.compactDescription == """
+        Expected state to change, but no change occurred.
+
+        The trailing closure made no observable modifications to state. If no change to state is \
+        expected, omit the trailing closure.
+        """
+    }
+  }
+
+  func testAssert_NonExhaustiveTestStore() async {
+    let store = TestStore(initialState: 0) {
+      EmptyReducer<Int, Void>()
+    }
+    store.exhaustivity = .off
+
+    store.assert {
+      $0 = 0
+    }
+  }
+
+  func testAssert_NonExhaustiveTestStore_Failure() async {
+    let store = TestStore(initialState: 0) {
+      EmptyReducer<Int, Void>()
+    }
+    store.exhaustivity = .off
+
+    XCTExpectFailure {
+      store.assert {
+        $0 = 1
+      }
+    } issueMatcher: {
+      $0.compactDescription == """
+        A state change does not match expectation: …
+
+            − 1
+            + 0
+
+        (Expected: −, Actual: +)
+        """
+    }
+  }
 }
 
 private struct Client: DependencyKey {


### PR DESCRIPTION
Stephen and I discussed this helper this morning. It can be handy in non-exhaustive test stores where you want an ergonomic way to assert on the current state of the store without having to explicitly `receive` an action.