### PR TITLE
Fix assertion values

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/03-04-code-0008.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/03-04-code-0008.swift
@@ -13,9 +13,9 @@ final class CounterFeatureTests: XCTestCase {
     await store.send(.factButtonTapped) {
       $0.isLoading = true
     }
-    await store.receive(.factResponse("0 is a good number")) {
+    await store.receive(.factResponse("0 is a good number.")) {
       $0.isLoading = false
-      $0.fact = "0 is a good number"
+      $0.fact = "0 is a good number."
     }
   }
 }


### PR DESCRIPTION
It's just a small bug in tests when assertion values don't contain a comma character.