### PR TITLE
[Documentation] Fixed action type: `struct` to `enum`

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToTheReducerProtocol.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToTheReducerProtocol.md
@@ -274,7 +274,7 @@ like so:
 struct FeatureState { 
   // ...
 }
-struct FeatureAction { 
+enum FeatureAction { 
   // ...
 }
 struct FeatureEnvironment { 


### PR DESCRIPTION
There is a minor modification on the article: "Migration to the Reducer Protocol". 
The given code snippet declares the action as `struct` type, but it should be `enum`.