### PR TITLE
`Effect.fireAndForget` is soft deprecated

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0005.swift
@@ -18,7 +18,7 @@ struct AddContactFeature: ReducerProtocol {
   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .cancelButtonTapped:
-      return .fireAndForget { await self.dismiss() }
+      return .run { _ in await self.dismiss() }
 
     case .delegate:
       return .none

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0006.swift
@@ -18,7 +18,7 @@ struct AddContactFeature: ReducerProtocol {
   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .cancelButtonTapped:
-      return .fireAndForget { await self.dismiss() }
+      return .run { _ in await self.dismiss() }
 
     case .delegate:
       return .none


### PR DESCRIPTION
fireAndForget was used in the official tutorial.
Since `Effect.fireAndForget` is soft deprecated in version 0.53.0, I rewrote it to `Effect.run`.
#2099 
Is there a reason why fireAndForget is used?