### PR TITLE
Fix typos in DocC

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
@@ -453,7 +453,7 @@ the child domain without explicitly communicating with the parent.
 
 ## Testing
 
-A huge benefit of properly modeling your domains for navigation is that testing because quite easy.
+A huge benefit of properly modeling your domains for navigation is that testing becomes quite easy.
 Further, using "non-exhaustive testing" (see <doc:Testing#Non-exhaustive-testing>) can be very 
 useful for testing navigation since you often only want to assert on a few high level details and 
 not all state mutations and effects.
@@ -476,7 +476,7 @@ struct CounterFeature: ReducerProtocol {
   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .decrementButtonTapped:
-      state.count += 1
+      state.count -= 1
       return .none
 
     case .incrementButtonTapped:

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/WhatIsNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/WhatIsNavigation.md
@@ -8,7 +8,7 @@ as well as their tradeoffs.
 State-driven navigation broadly falls into 2 main categories: tree-based, where you use optionals
 and enums to model navigation, and stack-based, where you use flat collections to model navigation.
 Nearly all navigations will use a combination of the two styles, but it is important to know
-their strenghts and weaknesses.
+their strengths and weaknesses.
 
 * [Tree-based navigation](#Tree-based-navigation)
 * [Stack-based navigation](#Stack-based-navigation)


### PR DESCRIPTION
Fixed some typos in documentations below.
- `WhatIsNavigation.md`
- `TreeBasedNavigation.md`