### PR TITLE
Update StackBasedNavigation.md to use `.run` instead using `.fireAndForget`

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
@@ -217,8 +217,8 @@ case let .path(.element(id: id, action: .editItem(.saveButtonTapped))):
   else { return .none }
 
   state.path.pop(from: id)
-  return .fireAndForget {
-    self.database.save(editItemState.item)
+  return .run {
+    await self.database.save(editItemState.item)
   }
 ```
 
@@ -277,7 +277,7 @@ struct Feature: ReducerProtocol {
   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .closeButtonTapped:
-      return .fireAndForget { await self.dismiss() }
+      return .run { await self.dismiss() }
     // ...
     } 
   }
@@ -344,7 +344,7 @@ struct CounterFeature: ReducerProtocol {
     case .incrementButtonTapped:
       state.count += 1
       return state.count >= 5
-        ? .fireAndForget { await self.dismiss() }
+        ? .run { await self.dismiss() }
         : .none
     }
   }

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
@@ -217,7 +217,7 @@ case let .path(.element(id: id, action: .editItem(.saveButtonTapped))):
   else { return .none }
 
   state.path.pop(from: id)
-  return .run {
+  return .run { _ in
     await self.database.save(editItemState.item)
   }
 ```
@@ -277,7 +277,7 @@ struct Feature: ReducerProtocol {
   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .closeButtonTapped:
-      return .run { await self.dismiss() }
+      return .run { _ in await self.dismiss() }
     // ...
     } 
   }
@@ -344,7 +344,7 @@ struct CounterFeature: ReducerProtocol {
     case .incrementButtonTapped:
       state.count += 1
       return state.count >= 5
-        ? .run { await self.dismiss() }
+        ? .run { _ in await self.dismiss() }
         : .none
     }
   }


### PR DESCRIPTION
I found several modifications regarding the use of 'Effect' in the [Navigation document](architecture/blob/main/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md). I updated the deprecated methods in the code snippets.

This PR is related to the [issue #2158](https://github.com/pointfreeco/swift-composable-architecture/issues/2158)