### PR TITLE
Scope an actionless store

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -742,3 +742,17 @@ extension ScopedReducer: AnyScopedReducer {
     return childStore
   }
 }
+
+extension Store where Action == Never {
+    /// Scopes an actionless store to one that exposes child state and actions.
+    ///
+    /// - Parameters:
+    ///   - toChildState: A function that transforms `State` into `ChildState`.
+    /// - Returns: A new store with its domain (state and action) transformed.
+    public func scope<ChildState>(
+      state toChildState: @escaping (State) -> ChildState
+    ) -> Store<ChildState, Never> {
+        func absurd<A>(_: Never) -> A { }
+        return self.scope(state: toChildState, action: absurd)
+    }
+}


### PR DESCRIPTION
With the deprecation of `func scope<ChildState>(state toChildState: @escaping (State) -> ChildState ) -> Store<ChildState, Action>`, when we are creating an actionless store it must be written like 

```Feature(store: store.scope(state: ChildState.init, action: { $0 }).actionless```

which doesn't read very well and can be confusing. This PR aims to fix that by providing a `scope` on an actionless store.

Keen to get some feedback and this or hear about another way to solve this.