### PR TITLE
Update PresentationReducer Documentation

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -162,7 +162,7 @@ extension PresentationState: CustomReflectable {
 /// ```swift
 /// struct ParentFeature: ReducerProtocol {
 ///   // ...
-///   struct Action {
+///   enum Action {
 ///     case child(PresentationAction<Child.Action>)
 ///      // ...
 ///   }


### PR DESCRIPTION
This PR changes `struct Action` to `enum Action` in the documentation for `PresentationReducer`.