### PR TITLE
Fix 'EffectPublisher.run' deprecation message

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Publisher.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher.swift
@@ -289,7 +289,7 @@ extension EffectPublisher {
     tvOS, deprecated: 9999, message: "Use the async version of 'EffectTask.run', instead."
   )
   @available(
-    watchOS, deprecated: 9999, message: "Use the async version of 'Effect.run', instead."
+    watchOS, deprecated: 9999, message: "Use the async version of 'EffectTask.run', instead."
   )
   public static func run(
     _ work: @escaping (EffectPublisher.Subscriber) -> Cancellable


### PR DESCRIPTION
I just saw while working on a migration to 'EffectTask'.
The friend who develops watchOS may misunderstand, so it looks better to fix it. 🤗