### PR TITLE
Remove inlineable attributes to work around Swift compiler bug.

### DIFF
--- a/Sources/ComposableArchitecture/Internal/NavigationID.swift
+++ b/Sources/ComposableArchitecture/Internal/NavigationID.swift
@@ -1,7 +1,7 @@
 @_spi(Reflection) import CasePaths
 
 extension DependencyValues {
-  @usableFromInline
+  //@usableFromInline
   var navigationIDPath: NavigationIDPath {
     get { self[NavigationIDPathKey.self] }
     set { self[NavigationIDPathKey.self] = newValue }
@@ -13,11 +13,11 @@ private enum NavigationIDPathKey: DependencyKey {
   static let testValue = NavigationIDPath()
 }
 
-@usableFromInline
+//@usableFromInline
 struct NavigationIDPath: Hashable, Sendable {
   fileprivate var path: [NavigationID]
 
-  @usableFromInline
+  //@usableFromInline
   init(path: [NavigationID] = []) {
     self.path = path
   }
@@ -28,7 +28,7 @@ struct NavigationIDPath: Hashable, Sendable {
     }
   }
 
-  @usableFromInline
+  //@usableFromInline
   func appending(_ element: NavigationID) -> Self {
     .init(path: self.path + [element])
   }
@@ -36,7 +36,7 @@ struct NavigationIDPath: Hashable, Sendable {
   public var id: Self { self }
 }
 
-@usableFromInline
+//@usableFromInline
 struct NavigationID: Hashable, @unchecked Sendable {
   private let kind: Kind
   private let identifier: AnyHashableSendable?
@@ -70,7 +70,7 @@ struct NavigationID: Hashable, @unchecked Sendable {
     }
   }
 
-  @usableFromInline
+  //@usableFromInline
   init<Value, Root>(
     base: Value,
     keyPath: KeyPath<Root, Value?>
@@ -84,7 +84,7 @@ struct NavigationID: Hashable, @unchecked Sendable {
     }
   }
 
-  @usableFromInline
+  //@usableFromInline
   init<Value, Root>(
     id: StackElementID,
     keyPath: KeyPath<Root, StackState<Value>>
@@ -94,7 +94,7 @@ struct NavigationID: Hashable, @unchecked Sendable {
     self.identifier = AnyHashableSendable(id)
   }
 
-  @usableFromInline
+  //@usableFromInline
   init<Value, Root, ID: Hashable>(
     id: ID,
     keyPath: KeyPath<Root, IdentifiedArray<ID, Value>>
@@ -104,7 +104,7 @@ struct NavigationID: Hashable, @unchecked Sendable {
     self.identifier = AnyHashableSendable(id)
   }
 
-  @usableFromInline
+  //@usableFromInline
   init<Value, Root>(
     root: Root,
     value: Value,
@@ -119,14 +119,14 @@ struct NavigationID: Hashable, @unchecked Sendable {
     }
   }
 
-  @usableFromInline
+  //@usableFromInline
   static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.kind == rhs.kind
       && lhs.identifier == rhs.identifier
       && lhs.tag == rhs.tag
   }
 
-  @usableFromInline
+  //@usableFromInline
   func hash(into hasher: inout Hasher) {
     hasher.combine(self.kind)
     hasher.combine(self.identifier)

--- a/Sources/ComposableArchitecture/Internal/NavigationID.swift
+++ b/Sources/ComposableArchitecture/Internal/NavigationID.swift
@@ -1,7 +1,6 @@
 @_spi(Reflection) import CasePaths
 
 extension DependencyValues {
-  //@usableFromInline
   var navigationIDPath: NavigationIDPath {
     get { self[NavigationIDPathKey.self] }
     set { self[NavigationIDPathKey.self] = newValue }
@@ -13,11 +12,9 @@ private enum NavigationIDPathKey: DependencyKey {
   static let testValue = NavigationIDPath()
 }
 
-//@usableFromInline
 struct NavigationIDPath: Hashable, Sendable {
   fileprivate var path: [NavigationID]
 
-  //@usableFromInline
   init(path: [NavigationID] = []) {
     self.path = path
   }
@@ -28,7 +25,6 @@ struct NavigationIDPath: Hashable, Sendable {
     }
   }
 
-  //@usableFromInline
   func appending(_ element: NavigationID) -> Self {
     .init(path: self.path + [element])
   }
@@ -36,7 +32,6 @@ struct NavigationIDPath: Hashable, Sendable {
   public var id: Self { self }
 }
 
-//@usableFromInline
 struct NavigationID: Hashable, @unchecked Sendable {
   private let kind: Kind
   private let identifier: AnyHashableSendable?
@@ -70,7 +65,6 @@ struct NavigationID: Hashable, @unchecked Sendable {
     }
   }
 
-  //@usableFromInline
   init<Value, Root>(
     base: Value,
     keyPath: KeyPath<Root, Value?>
@@ -84,7 +78,6 @@ struct NavigationID: Hashable, @unchecked Sendable {
     }
   }
 
-  //@usableFromInline
   init<Value, Root>(
     id: StackElementID,
     keyPath: KeyPath<Root, StackState<Value>>
@@ -94,7 +87,6 @@ struct NavigationID: Hashable, @unchecked Sendable {
     self.identifier = AnyHashableSendable(id)
   }
 
-  //@usableFromInline
   init<Value, Root, ID: Hashable>(
     id: ID,
     keyPath: KeyPath<Root, IdentifiedArray<ID, Value>>
@@ -104,7 +96,6 @@ struct NavigationID: Hashable, @unchecked Sendable {
     self.identifier = AnyHashableSendable(id)
   }
 
-  //@usableFromInline
   init<Value, Root>(
     root: Root,
     value: Value,
@@ -119,14 +110,12 @@ struct NavigationID: Hashable, @unchecked Sendable {
     }
   }
 
-  //@usableFromInline
   static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.kind == rhs.kind
       && lhs.identifier == rhs.identifier
       && lhs.tag == rhs.tag
   }
 
-  //@usableFromInline
   func hash(into hasher: inout Hasher) {
     hasher.combine(self.kind)
     hasher.combine(self.identifier)

--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -112,7 +112,6 @@ public struct _ForEachReducer<
     self.line = line
   }
 
-  //@inlinable
   public func reduce(
     into state: inout Parent.State, action: Parent.Action
   ) -> EffectTask<Parent.Action> {
@@ -141,7 +140,6 @@ public struct _ForEachReducer<
     )
   }
 
-  //@inlinable
   func reduceForEach(
     into state: inout Parent.State, action: Parent.Action
   ) -> EffectTask<Parent.Action> {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -93,7 +93,6 @@ public struct _ForEachReducer<
   @usableFromInline
   let line: UInt
 
-  //@usableFromInline
   @Dependency(\.navigationIDPath) var navigationIDPath
 
   @usableFromInline

--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -93,7 +93,7 @@ public struct _ForEachReducer<
   @usableFromInline
   let line: UInt
 
-  @usableFromInline
+  //@usableFromInline
   @Dependency(\.navigationIDPath) var navigationIDPath
 
   @usableFromInline
@@ -113,7 +113,7 @@ public struct _ForEachReducer<
     self.line = line
   }
 
-  @inlinable
+  //@inlinable
   public func reduce(
     into state: inout Parent.State, action: Parent.Action
   ) -> EffectTask<Parent.Action> {
@@ -142,7 +142,7 @@ public struct _ForEachReducer<
     )
   }
 
-  @inlinable
+  //@inlinable
   func reduceForEach(
     into state: inout Parent.State, action: Parent.Action
   ) -> EffectTask<Parent.Action> {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
@@ -108,7 +108,6 @@ public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>
     self.line = line
   }
 
-  //@inlinable
   public func reduce(
     into state: inout Parent.State, action: Parent.Action
   ) -> EffectTask<Parent.Action> {
@@ -136,7 +135,6 @@ public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>
     )
   }
 
-  //@inlinable
   func reduceChild(
     into state: inout Parent.State, action: Parent.Action
   ) -> EffectTask<Parent.Action> {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
@@ -89,7 +89,7 @@ public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>
   @usableFromInline
   let line: UInt
 
-  @usableFromInline
+  //@usableFromInline
   @Dependency(\.navigationIDPath) var navigationIDPath
 
   @usableFromInline
@@ -109,7 +109,7 @@ public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>
     self.line = line
   }
 
-  @inlinable
+  //@inlinable
   public func reduce(
     into state: inout Parent.State, action: Parent.Action
   ) -> EffectTask<Parent.Action> {
@@ -137,7 +137,7 @@ public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>
     )
   }
 
-  @inlinable
+  //@inlinable
   func reduceChild(
     into state: inout Parent.State, action: Parent.Action
   ) -> EffectTask<Parent.Action> {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
@@ -89,7 +89,6 @@ public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>
   @usableFromInline
   let line: UInt
 
-  //@usableFromInline
   @Dependency(\.navigationIDPath) var navigationIDPath
 
   @usableFromInline

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
@@ -126,7 +126,6 @@ public struct _IfLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: Re
     self.line = line
   }
 
-  //@inlinable
   public func reduce(
     into state: inout Parent.State, action: Parent.Action
   ) -> EffectTask<Parent.Action> {
@@ -162,7 +161,6 @@ public struct _IfLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: Re
     )
   }
 
-  //@inlinable
   func reduceChild(
     into state: inout Parent.State, action: Parent.Action
   ) -> EffectTask<Parent.Action> {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
@@ -107,7 +107,6 @@ public struct _IfLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: Re
   @usableFromInline
   let line: UInt
 
-  ////@usableFromInline
   @Dependency(\.navigationIDPath) var navigationIDPath
 
   @usableFromInline

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
@@ -107,7 +107,7 @@ public struct _IfLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: Re
   @usableFromInline
   let line: UInt
 
-  @usableFromInline
+  ////@usableFromInline
   @Dependency(\.navigationIDPath) var navigationIDPath
 
   @usableFromInline
@@ -127,7 +127,7 @@ public struct _IfLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: Re
     self.line = line
   }
 
-  @inlinable
+  //@inlinable
   public func reduce(
     into state: inout Parent.State, action: Parent.Action
   ) -> EffectTask<Parent.Action> {
@@ -163,7 +163,7 @@ public struct _IfLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: Re
     )
   }
 
-  @inlinable
+  //@inlinable
   func reduceChild(
     into state: inout Parent.State, action: Parent.Action
   ) -> EffectTask<Parent.Action> {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -303,7 +303,6 @@ public struct _PresentationReducer<
   @usableFromInline let fileID: StaticString
   @usableFromInline let line: UInt
 
-  //@usableFromInline
   @Dependency(\.navigationIDPath) var navigationIDPath
 
   @usableFromInline
@@ -437,7 +436,6 @@ public struct _PresentationReducer<
     )
   }
 
-  //@usableFromInline
   func navigationIDPath(for state: Destination.State) -> NavigationIDPath {
     self.navigationIDPath.appending(
       NavigationID(
@@ -468,7 +466,6 @@ public struct _PresentedID: Hashable {
 }
 
 extension Task where Success == Never, Failure == Never {
-  //@usableFromInline
   internal static func _cancel(
     id: AnyHashable,
     navigationID: NavigationIDPath
@@ -481,7 +478,6 @@ extension Task where Success == Never, Failure == Never {
   }
 }
 extension EffectPublisher {
-  //@usableFromInline
   internal func _cancellable(
     id: AnyHashable = _PresentedID(),
     navigationIDPath: NavigationIDPath,
@@ -493,7 +489,6 @@ extension EffectPublisher {
       self.cancellable(id: id, cancelInFlight: cancelInFlight)
     }
   }
-  //@usableFromInline
   internal static func _cancel(
     id: AnyHashable = _PresentedID(),
     navigationID: NavigationIDPath

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -322,7 +322,6 @@ public struct _PresentationReducer<
     self.line = line
   }
 
-  //@inlinable
   public func reduce(
     into state: inout Base.State, action: Base.Action
   ) -> EffectTask<Base.Action> {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -303,7 +303,8 @@ public struct _PresentationReducer<
   @usableFromInline let fileID: StaticString
   @usableFromInline let line: UInt
 
-  @usableFromInline @Dependency(\.navigationIDPath) var navigationIDPath
+  //@usableFromInline
+  @Dependency(\.navigationIDPath) var navigationIDPath
 
   @usableFromInline
   init(
@@ -322,7 +323,7 @@ public struct _PresentationReducer<
     self.line = line
   }
 
-  @inlinable
+  //@inlinable
   public func reduce(
     into state: inout Base.State, action: Base.Action
   ) -> EffectTask<Base.Action> {
@@ -436,7 +437,7 @@ public struct _PresentationReducer<
     )
   }
 
-  @usableFromInline
+  //@usableFromInline
   func navigationIDPath(for state: Destination.State) -> NavigationIDPath {
     self.navigationIDPath.appending(
       NavigationID(
@@ -467,7 +468,7 @@ public struct _PresentedID: Hashable {
 }
 
 extension Task where Success == Never, Failure == Never {
-  @usableFromInline
+  //@usableFromInline
   internal static func _cancel(
     id: AnyHashable,
     navigationID: NavigationIDPath
@@ -480,7 +481,7 @@ extension Task where Success == Never, Failure == Never {
   }
 }
 extension EffectPublisher {
-  @usableFromInline
+  //@usableFromInline
   internal func _cancellable(
     id: AnyHashable = _PresentedID(),
     navigationIDPath: NavigationIDPath,
@@ -492,7 +493,7 @@ extension EffectPublisher {
       self.cancellable(id: id, cancelInFlight: cancelInFlight)
     }
   }
-  @usableFromInline
+  //@usableFromInline
   internal static func _cancel(
     id: AnyHashable = _PresentedID(),
     navigationID: NavigationIDPath


### PR DESCRIPTION
Fixes #2189

These `@usableFromInline` attributes seem to be running into a Swift compiler bug where under certain project set ups the following error occurs when building for release:

> error: <unknown>:0: unsupported relocation with subtraction expression, symbol '_$s12Dependencies16DependencyValuesV22ComposableArchitectureE16navigationIDPathAD010NavigationG0VvpACTKq' can not be undefined in a subtraction expression

We're not sure why some projects build just fine (such as all the demo apps in this repo) and others do not (such as the one shared in #2189). 

But either way it should be relatively harmless to remove these annotations. TBH the bodies of the `ifLet`, `forEach` and `ifCaseLet` reducers are probably so substantial that they do not benefit from inlining anyway. We also have some changes planned for the future of TCA that will greatly simplify those reducers, and so maybe at that time we revisit bringing back these inlineable attributes.