### PR TITLE
Fix Swift version comment for `ReducerProtocolOf` typealias

### DIFF
--- a/Sources/ComposableArchitecture/ReducerProtocol.swift
+++ b/Sources/ComposableArchitecture/ReducerProtocol.swift
@@ -249,10 +249,10 @@ extension ReducerProtocol where Body: ReducerProtocol, Body.State == State, Body
   }
 }
 
-// NB: This is available only in Swift 5.7.1 due to the following bug:
+// NB: This is available starting from Swift 5.7.1 due to the following bug:
 //     https://github.com/apple/swift/issues/60550
 #if swift(>=5.7.1)
-  /// A convenience for constraining a ``ReducerProtocol`` conformance. Available only in Swift
+  /// A convenience for constraining a ``ReducerProtocol`` conformance. Available starting from Swift
   /// 5.7.1.
   ///
   /// This allows you to specify the `body` of a ``ReducerProtocol`` conformance like so:


### PR DESCRIPTION
This PR corrects the comment associated with the `ReducerProtocolOf` typealias. Previously, the comment inaccurately stated that the feature was "only in Swift 5.7.1". The revised comment now specifies that the feature is available "starting from Swift 5.7.1", more accurately reflecting that it can be accessed in Swift 5.7.1 and all subsequent versions.

Changes made:
- Updated the comment for the `ReducerProtocolOf` typealias to accurately reflect its Swift version availability.

This update ensures clearer and more accurate documentation for developers.

---

Related Documents:
- https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/reducerprotocolof