### PR TITLE
Fixed tree-based navigation: dismiss action is not sent when navigating back

### DIFF
--- a/Examples/Integration/IntegrationUITests/PresentationTests.swift
+++ b/Examples/Integration/IntegrationUITests/PresentationTests.swift
@@ -288,6 +288,17 @@ final class PresentationTests: BaseIntegrationTests {
     XCTAssertEqual(self.app.staticTexts["Count: 0"].exists, false)
   }
 
+  func testNavigationDestination_BackButtonDismiss() async throws {
+    self.app.buttons["Open navigation destination"].tap()
+    XCTAssertEqual(self.app.staticTexts["Count: 0"].exists, true)
+
+    self.app.navigationBars.buttons.element.tap()
+    XCTAssertEqual(self.app.staticTexts["Count: 0"].exists, false)
+
+    self.app.buttons["Open navigation destination"].tap()
+    XCTAssertEqual(self.app.staticTexts["Count: 0"].exists, true)
+  }
+
   func testNavigationDestination_EffectsCancelOnDismiss() async throws {
     self.app.buttons["Open navigation destination"].tap()
     XCTAssertEqual(self.app.staticTexts["Count: 0"].exists, true)

--- a/Sources/ComposableArchitecture/SwiftUI/NavigationDestination.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/NavigationDestination.swift
@@ -19,11 +19,12 @@ extension View {
     store: Store<PresentationState<State>, PresentationAction<Action>>,
     @ViewBuilder destination: @escaping (Store<State, Action>) -> Destination
   ) -> some View {
-    self.presentation(store: store) { `self`, $isPresented, destinationContent in
-      self.navigationDestination(isPresented: $isPresented) {
-        destinationContent(destination)
-      }
-    }
+    self.navigationDestination(
+      store: store,
+      state: { $0 },
+      action: { $0 },
+      destination: destination
+    )
   }
 
   /// Associates a destination view with a store that can be used to push the view onto a
@@ -54,9 +55,12 @@ extension View {
       Destination
   ) -> some View {
     self.presentation(
-      store: store, state: toDestinationState, action: fromDestinationAction
-    ) { `self`, $isPresented, destinationContent in
-      self.navigationDestination(isPresented: $isPresented) {
+      store: store,
+      state: toDestinationState,
+      id: { _ in ObjectIdentifier(State.self) },
+      action: fromDestinationAction
+    ) { `self`, $item, destinationContent in
+      self.navigationDestination(isPresented: $item.isPresent()) {
         destinationContent(destination)
       }
     }

--- a/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
@@ -10,12 +10,7 @@ extension View {
       _ destination: DestinationContent<State, Action>
     ) -> Content
   ) -> some View {
-    self.presentation(
-      store: store,
-      state: { $0 },
-      id: { _ in ObjectIdentifier(State.self) },
-      action: { $0 }
-    ) { `self`, $item, destination in
+    self.presentation(store: store) { `self`, $item, destination in
       body(self, $item.isPresent(), destination)
     }
   }
@@ -57,10 +52,7 @@ extension View {
     ) -> Content
   ) -> some View {
     self.presentation(
-      store: store,
-      state: toDestinationState,
-      id: { _ in ObjectIdentifier(State.self) },
-      action: fromDestinationAction
+      store: store, state: toDestinationState, action: fromDestinationAction
     ) { `self`, $item, destination in
       body(self, $item.isPresent(), destination)
     }
@@ -93,8 +85,9 @@ extension View {
     )
   }
 
+  @_spi(Presentation)
   @ViewBuilder
-  private func presentation<
+  public func presentation<
     State,
     Action,
     DestinationState,

--- a/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
@@ -231,7 +231,6 @@ public struct PresentationStore<
         )
       )
     )
-    .id(id)
   }
 }
 

--- a/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
@@ -10,7 +10,12 @@ extension View {
       _ destination: DestinationContent<State, Action>
     ) -> Content
   ) -> some View {
-    self.presentation(store: store) { `self`, $item, destination in
+    self.presentation(
+      store: store,
+      state: { $0 },
+      id: { _ in ObjectIdentifier(State.self) },
+      action: { $0 }
+    ) { `self`, $item, destination in
       body(self, $item.isPresent(), destination)
     }
   }
@@ -52,7 +57,10 @@ extension View {
     ) -> Content
   ) -> some View {
     self.presentation(
-      store: store, state: toDestinationState, action: fromDestinationAction
+      store: store,
+      state: toDestinationState,
+      id: { _ in ObjectIdentifier(State.self) },
+      action: fromDestinationAction
     ) { `self`, $item, destination in
       body(self, $item.isPresent(), destination)
     }

--- a/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
@@ -231,6 +231,7 @@ public struct PresentationStore<
         )
       )
     )
+    .id(id)
   }
 }
 


### PR DESCRIPTION
Fixed https://github.com/pointfreeco/swift-composable-architecture/issues/2182.

Added `.id(id)` modifier to update value of `id` in `compactSend` closure when presenting a child feature.