### PR TITLE
Warn when sending actions from cancelled effects

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -11,7 +11,7 @@ private let readMe = """
   happens.
 
   Then, navigate to another screen and take screenshots there, and observe that this screen does \
-  *not* count those screenshots. The notifications effect is automatically cancelled when leaving \
+  *not* count those screenshots. The notifications effect is automatically canceled when leaving \
   the screen, and restarted when entering the screen.
   """
 

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -265,12 +265,12 @@ public struct Send<Action>: Sendable {
     guard !Task.isCancelled else {
       runtimeWarn(
         """
-        A cancelled effect tried to send an action at "\(fileID):\(line)". …
+        A canceled effect tried to send an action at "\(fileID):\(line)". …
 
           Action:
             \(debugCaseOutput(action))
 
-        Cancelled effects cannot send actions back into the system.
+        Canceled effects cannot send actions back into the system.
 
         Invoke "try Task.checkCancellation()" before sending actions from cancellable effects to \
         participate in cooperative cancellation.
@@ -385,10 +385,10 @@ extension EffectPublisher {
   }
 
   /// Concatenates this effect and another into a single effect that first runs this effect, and
-  /// after it completes or is cancelled, runs the other.
+  /// after it completes or is canceled, runs the other.
   ///
   /// - Parameter other: Another effect.
-  /// - Returns: An effect that runs this effect, and after it completes or is cancelled, runs the
+  /// - Returns: An effect that runs this effect, and after it completes or is canceled, runs the
   ///   other.
   @inlinable
   @_disfavoredOverload

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -160,7 +160,6 @@ extension EffectPublisher where Failure == Never {
         operation: .run(priority) { send in
           await escaped.yield {
             do {
-              try Task.checkCancellation()
               try await operation(send)
             } catch is CancellationError {
               return

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -160,6 +160,7 @@ extension EffectPublisher where Failure == Never {
         operation: .run(priority) { send in
           await escaped.yield {
             do {
+              try Task.checkCancellation()
               try await operation(send)
             } catch is CancellationError {
               return

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -119,7 +119,7 @@ extension EffectPublisher {
 /// Execute an operation with a cancellation identifier.
 ///
 /// If the operation is in-flight when `Task.cancel(id:)` is called with the same identifier, the
-/// operation will be cancelled.
+/// operation will be canceled.
 ///
 /// ```
 /// enum CancelID { case timer }

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -29,6 +29,7 @@ extension EffectPublisher where Failure == Never {
         operation: .run(priority) { send in
           await escaped.yield {
             do {
+              try Task.checkCancellation()
               try await send(operation())
             } catch is CancellationError {
               return

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -29,7 +29,6 @@ extension EffectPublisher where Failure == Never {
         operation: .run(priority) { send in
           await escaped.yield {
             do {
-              try Task.checkCancellation()
               try await send(operation())
             } catch is CancellationError {
               return

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1993,7 +1993,7 @@ extension TestStore where ScopedState: Equatable {
         if self.reducer.inFlightEffects.isEmpty {
           suggestion = """
             There are no in-flight effects that could deliver this action. Could the effect you \
-            expected to deliver this action have been cancelled?
+            expected to deliver this action have been canceled?
             """
         } else {
           let timeoutMessage =
@@ -2238,7 +2238,7 @@ extension TestStore {
     XCTFailHelper(
       """
       \(self.reducer.inFlightEffects.count) in-flight effect\
-      \(self.reducer.inFlightEffects.count == 1 ? " was" : "s were") cancelled, originating from:
+      \(self.reducer.inFlightEffects.count == 1 ? " was" : "s were") canceled, originating from:
 
       \(actions)
       """,

--- a/Tests/ComposableArchitectureTests/EffectRunTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectRunTests.swift
@@ -100,20 +100,22 @@ final class EffectRunTests: BaseTCATestCase {
         }
       }
     }
-    XCTExpectFailure {
-      $0.compactDescription == """
-        A canceled effect tried to send an action at \
-        "ComposableArchitectureTests/EffectRunTests.swift:\(line!)". …
+    #if DEBUG
+      XCTExpectFailure {
+        $0.compactDescription == """
+          A canceled effect tried to send an action at \
+          "ComposableArchitectureTests/EffectRunTests.swift:\(line!)". …
 
-          Action:
-            EffectRunTests.Action.response
+            Action:
+              EffectRunTests.Action.response
 
-        Canceled effects cannot send actions back into the system.
+          Canceled effects cannot send actions back into the system.
 
-        Invoke "try Task.checkCancellation()" before sending actions from cancellable effects to \
-        participate in cooperative cancellation.
-        """
-    }
+          Invoke "try Task.checkCancellation()" before sending actions from cancellable effects to \
+          participate in cooperative cancellation.
+          """
+      }
+    #endif
     await store.send(.tapped).finish()
   }
 

--- a/Tests/ComposableArchitectureTests/EffectRunTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectRunTests.swift
@@ -102,13 +102,13 @@ final class EffectRunTests: BaseTCATestCase {
     }
     XCTExpectFailure {
       $0.compactDescription == """
-        A cancelled effect tried to send an action at \
+        A canceled effect tried to send an action at \
         "ComposableArchitectureTests/EffectRunTests.swift:\(line!)". …
 
           Action:
             EffectRunTests.Action.response
 
-        Cancelled effects cannot send actions back into the system.
+        Canceled effects cannot send actions back into the system.
 
         Invoke "try Task.checkCancellation()" before sending actions from cancellable effects to \
         participate in cooperative cancellation.

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -271,20 +271,22 @@ final class EffectTests: BaseTCATestCase {
         receiveValue: { _ in XCTFail() }
       )
 
-    XCTExpectFailure {
-      $0.compactDescription == """
-        A canceled effect tried to send an action at \
-        "ComposableArchitectureTests/EffectTests.swift:\(line)". …
+    #if DEBUG
+      XCTExpectFailure {
+        $0.compactDescription == """
+          A canceled effect tried to send an action at \
+          "ComposableArchitectureTests/EffectTests.swift:\(line)". …
 
-          Action:
-            Int
+            Action:
+              Int
 
-        Canceled effects cannot send actions back into the system.
+          Canceled effects cannot send actions back into the system.
 
-        Invoke "try Task.checkCancellation()" before sending actions from cancellable effects to \
-        participate in cooperative cancellation.
-        """
-    }
+          Invoke "try Task.checkCancellation()" before sending actions from cancellable effects to \
+          participate in cooperative cancellation.
+          """
+      }
+    #endif
 
     cancellable.cancel()
 


### PR DESCRIPTION
Today it is possible to cancel a running effect that is sending actions back into the system and, if the effect does not participate in cooperative cancellation, be none the wiser.

This PR adds a runtime warning whenever this happens. In general it shouldn't emit, as cooperatively-cancelling code will have already thrown an error, but in those cases in which you're not in cooperative code, it's nice to let the developer know.