### PR TITLE
Deprecate `Effect.cancel(ids:)`

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -105,15 +105,6 @@ extension EffectPublisher {
       }
     }
   }
-
-  /// An effect that will cancel multiple currently in-flight effects with the given identifiers.
-  ///
-  /// - Parameter ids: An array of effect identifiers.
-  /// - Returns: A new effect that will cancel any currently in-flight effects with the given
-  ///   identifiers.
-  public static func cancel(ids: [AnyHashable]) -> Self {
-    .merge(ids.map(EffectPublisher.cancel(id:)))
-  }
 }
 
 /// Execute an operation with a cancellation identifier.

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -3,6 +3,15 @@ import Combine
 import SwiftUI
 import XCTestDynamicOverlay
 
+// MARK: - Deprecated after 0.54.1
+
+extension EffectPublisher {
+  @available(*, deprecated, message: "Use 'Effect.merge([.cancel(id: …), …])' instead.")
+  public static func cancel(ids: [AnyHashable]) -> Self {
+    .merge(ids.map(EffectPublisher.cancel(id:)))
+  }
+}
+
 // MARK: - Deprecated after 0.52.0
 
 extension WithViewStore {

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -216,6 +216,7 @@ final class EffectCancellationTests: BaseTCATestCase {
     XCTAssertEqual(output, [1, 2])
   }
 
+  @available(*, deprecated)
   func testMultipleCancellations() {
     let mainQueue = DispatchQueue.test
     var output: [AnyHashable] = []


### PR DESCRIPTION
This API has been more problematic than not, especially when folks accidentally type `.cancel(id:)` and pass a hashable array when they expect to be passing multiple tokens along to each cancel. Let's avoid the confusion by deprecating the functionality.

Cancelling multiple tokens at once should also be less common these days now that navigation tools bakes cancellation into dismissal.