### PR TITLE
Don't show 'expected state to change' error in non-exhaustive test stores.

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerSignpost.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerSignpost.swift
@@ -149,14 +149,17 @@ extension EffectPublisher where Failure == Never {
 }
 
 @usableFromInline
-func debugCaseOutput(_ value: Any) -> String {
+func debugCaseOutput(
+  _ value: Any,
+  abbreviated: Bool = false
+) -> String {
   func debugCaseOutputHelp(_ value: Any) -> String {
     let mirror = Mirror(reflecting: value)
     switch mirror.displayStyle {
     case .enum:
       guard let child = mirror.children.first else {
         let childOutput = "\(value)"
-        return childOutput == "\(type(of: value))" ? "" : ".\(childOutput)"
+        return childOutput == "\(typeName(type(of: value)))" ? "" : ".\(childOutput)"
       }
       let childOutput = debugCaseOutputHelp(child.value)
       return ".\(child.label ?? "")\(childOutput.isEmpty ? "" : "(\(childOutput))")"
@@ -173,7 +176,7 @@ func debugCaseOutput(_ value: Any) -> String {
   }
 
   return (value as? CustomDebugStringConvertible)?.debugDescription
-    ?? "\(typeName(type(of: value)))\(debugCaseOutputHelp(value))"
+    ?? "\(abbreviated ? "" : typeName(type(of: value)))\(debugCaseOutputHelp(value))"
 }
 
 private func isUnlabeledArgument(_ label: String) -> Bool {

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1395,7 +1395,10 @@ extension TestStore where ScopedState: Equatable {
     }
 
     func tryUnnecessaryModifyFailure() {
-      guard expected == current && updateStateToExpectedResult != nil
+      guard
+        self.exhaustivity == .on,
+        expected == current,
+        updateStateToExpectedResult != nil
       else { return }
 
       XCTFailHelper(

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -879,14 +879,17 @@ public final class TestStore<State, Action, ScopedState, ScopedAction, Environme
 
   func completed() {
     if !self.reducer.receivedActions.isEmpty {
-      var actions = ""
-      customDump(self.reducer.receivedActions.map(\.action), to: &actions)
+      let actions = self.reducer.receivedActions
+        .map(\.action)
+        .map { "    • " + debugCaseOutput($0, abbreviated: true) }
+        .joined(separator: "\n")
       XCTFailHelper(
         """
         The store received \(self.reducer.receivedActions.count) unexpected \
         action\(self.reducer.receivedActions.count == 1 ? "" : "s") after this one: …
 
-        Unhandled actions: \(actions)
+          Unhandled actions:
+        \(actions)
         """,
         file: self.file,
         line: self.line
@@ -1163,7 +1166,7 @@ extension TestStore where ScopedState: Equatable {
   ///   store.
   @MainActor
   public func assert(
-    _ updateStateToExpectedResult: ((inout ScopedState) throws -> Void)?,
+    _ updateStateToExpectedResult: @escaping (inout ScopedState) throws -> Void,
     file: StaticString = #file,
     line: UInt = #line
   ) {
@@ -1174,6 +1177,7 @@ extension TestStore where ScopedState: Equatable {
         expected: expectedState,
         actual: self.toScopedState(currentState),
         updateStateToExpectedResult: updateStateToExpectedResult,
+        skipUnnecessaryModifyFailure: true,
         file: file,
         line: line
       )
@@ -1278,6 +1282,7 @@ extension TestStore where ScopedState: Equatable {
     expected: ScopedState,
     actual: ScopedState,
     updateStateToExpectedResult: ((inout ScopedState) throws -> Void)? = nil,
+    skipUnnecessaryModifyFailure: Bool = false,
     file: StaticString,
     line: UInt
   ) throws {
@@ -1396,7 +1401,7 @@ extension TestStore where ScopedState: Equatable {
 
     func tryUnnecessaryModifyFailure() {
       guard
-        self.exhaustivity == .on,
+        !skipUnnecessaryModifyFailure,
         expected == current,
         updateStateToExpectedResult != nil
       else { return }

--- a/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
@@ -131,9 +131,8 @@
         $0.compactDescription == """
           The store received 1 unexpected action after this one: …
 
-          Unhandled actions: [
-            [0]: .second
-          ]
+            Unhandled actions:
+              • .second
           """
       }
     }

--- a/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
@@ -809,6 +809,17 @@
       await store.receive(.response2, timeout: 1_000_000_000)
     }
 
+    func testNonExhaustive_ShowSkippedAssertions_ExpectedStateToChange() async {
+      let store = TestStore(initialState: 0) {
+        Reduce<Int, Void> { _, _ in .none }
+      }
+      store.exhaustivity = .off(showSkippedAssertions: true)
+
+      await store.send(()) {
+        $0 = 0
+      }
+    }
+
     // This example comes from Krzysztof Zabłocki's blog post:
     // https://www.merowing.info/exhaustive-testing-in-tca/
     func testKrzysztofExample1() {

--- a/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
@@ -814,10 +814,8 @@
         Reduce<Int, Void> { _, _ in .none }
       }
       store.exhaustivity = .off(showSkippedAssertions: true)
-
-      await store.send(()) {
-        $0 = 0
-      }
+      await store.send(()) { $0 = 0 }
+      store.assert { $0 = 0 }
     }
 
     // This example comes from Krzysztof Zabłocki's blog post:

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -432,27 +432,6 @@ final class TestStoreTests: BaseTCATestCase {
     }
   }
 
-  #if DEBUG
-    func testAssert_ExhaustiveTestStore() async {
-      let store = TestStore(initialState: 0) {
-        EmptyReducer<Int, Void>()
-      }
-
-      XCTExpectFailure {
-        store.assert {
-          $0 = 0
-        }
-      } issueMatcher: {
-        $0.compactDescription == """
-          Expected state to change, but no change occurred.
-
-          The trailing closure made no observable modifications to state. If no change to state is \
-          expected, omit the trailing closure.
-          """
-      }
-    }
-  #endif
-
   func testAssert_NonExhaustiveTestStore() async {
     let store = TestStore(initialState: 0) {
       EmptyReducer<Int, Void>()


### PR DESCRIPTION
Right now in non-exhaustive test stores showing skipped assertions, it is possible to get a skipped assertion complaining of "Expected state to change, but no change occurred.". That should only happen with exhaustive test stores.