### PR TITLE
Added the ability to specify an animation or transaction with `Store.send`

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -820,10 +820,9 @@ public struct StoreTask: Hashable, Sendable {
 		self.rawValue = rawValue
 	}
 	
-	/// Cancels the underlying task and waits for it to finish.
-	public func cancel() async {
+	/// Cancels the underlying task.
+	public func cancel() {
 		self.rawValue?.cancel()
-		await self.finish()
 	}
 	
 	/// Waits for the task to finish.

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -202,7 +202,7 @@ public final class Store<State, Action> {
   ///   - action: An action.
   ///   - animation: An animation.
   @discardableResult
-  public func send(_ action: Action, animation: Animation?) -> ViewStoreTask {
+  public func send(_ action: Action, animation: Animation?) -> StoreTask {
     send(action, transaction: Transaction(animation: animation))
   }
 
@@ -214,7 +214,7 @@ public final class Store<State, Action> {
   ///   - action: An action.
   ///   - transaction: A transaction.
   @discardableResult
-  public func send(_ action: Action, transaction: Transaction) -> ViewStoreTask {
+  public func send(_ action: Action, transaction: Transaction) -> StoreTask {
     withTransaction(transaction) {
       .init(rawValue: self.send(action, originatingFrom: nil))
     }

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -814,7 +814,7 @@ extension ScopedReducer: AnyScopedReducer {
 ///
 /// See ``TestStoreTask`` for the analog returned from ``TestStore``.
 public struct StoreTask: Hashable, Sendable {
-	fileprivate let rawValue: Task<Void, Never>?
+	internal let rawValue: Task<Void, Never>?
 	
 	internal init(rawValue: Task<Void, Never>?) {
 		self.rawValue = rawValue

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -798,3 +798,44 @@ extension ScopedReducer: AnyScopedReducer {
     return childStore
   }
 }
+
+/// The type returned from ``Store/send(_:)`` that represents the lifecycle of the effect
+/// started from sending an action.
+///
+/// You can use this value to tie the effect's lifecycle _and_ cancellation to an asynchronous
+/// context, such as the `task` view modifier.
+///
+/// ```swift
+/// .task { await store.send(.task).finish() }
+/// ```
+///
+/// > Note: Unlike Swift's `Task` type, ``StoreTask`` automatically sets up a cancellation
+/// > handler between the current async context and the task.
+///
+/// See ``TestStoreTask`` for the analog returned from ``TestStore``.
+public struct StoreTask: Hashable, Sendable {
+	fileprivate let rawValue: Task<Void, Never>?
+	
+	internal init(rawValue: Task<Void, Never>?) {
+		self.rawValue = rawValue
+	}
+	
+	/// Cancels the underlying task and waits for it to finish.
+	public func cancel() async {
+		self.rawValue?.cancel()
+		await self.finish()
+	}
+	
+	/// Waits for the task to finish.
+	public func finish() async {
+		await self.rawValue?.cancellableValue
+	}
+	
+	/// A Boolean value that indicates whether the task should stop executing.
+	///
+	/// After the value of this property becomes `true`, it remains `true` indefinitely. There is no
+	/// way to uncancel a task.
+	public var isCancelled: Bool {
+		self.rawValue?.isCancelled ?? true
+	}
+}

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import SwiftUI
 
 /// A store represents the runtime that powers the application. It is the object that you will pass
 /// around to views that need to interact with the application.
@@ -191,6 +192,32 @@ public final class Store<State, Action> {
   /// - Parameter action: An action.
   public func send(_ action: Action) {
     _ = self.send(action, originatingFrom: nil)
+  }
+
+  /// Sends an action to the store with a given animation.
+  ///
+  /// See ``Store/send(_:)`` for more info.
+  ///
+  /// - Parameters:
+  ///   - action: An action.
+  ///   - animation: An animation.
+  @discardableResult
+  public func send(_ action: Action, animation: Animation?) -> ViewStoreTask {
+    send(action, transaction: Transaction(animation: animation))
+  }
+
+  /// Sends an action to the store with a given transaction.
+  ///
+  /// See ``Store/send(_:)`` for more info.
+  ///
+  /// - Parameters:
+  ///   - action: An action.
+  ///   - transaction: A transaction.
+  @discardableResult
+  public func send(_ action: Action, transaction: Transaction) -> ViewStoreTask {
+    withTransaction(transaction) {
+      .init(rawValue: self.send(action, originatingFrom: nil))
+    }
   }
 
   /// Scopes the store to one that exposes child state and actions.

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -264,7 +264,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
 
   /// Sends an action to the store.
   ///
-  /// This method returns a ``ViewStoreTask``, which represents the lifecycle of the effect started
+  /// This method returns a ``StoreTask``, which represents the lifecycle of the effect started
   /// from sending an action. You can use this value to tie the effect's lifecycle _and_
   /// cancellation to an asynchronous context, such as SwiftUI's `task` view modifier:
   ///
@@ -279,10 +279,10 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
   /// > result can be fed back into the store.
   ///
   /// - Parameter action: An action.
-  /// - Returns: A ``ViewStoreTask`` that represents the lifecycle of the effect executed when
+  /// - Returns: A ``StoreTask`` that represents the lifecycle of the effect executed when
   ///   sending the action.
   @discardableResult
-  public func send(_ action: ViewAction) -> ViewStoreTask {
+  public func send(_ action: ViewAction) -> StoreTask {
     .init(rawValue: self._send(action))
   }
 
@@ -294,7 +294,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
   ///   - action: An action.
   ///   - animation: An animation.
   @discardableResult
-  public func send(_ action: ViewAction, animation: Animation?) -> ViewStoreTask {
+  public func send(_ action: ViewAction, animation: Animation?) -> StoreTask {
     send(action, transaction: Transaction(animation: animation))
   }
 
@@ -306,7 +306,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
   ///   - action: An action.
   ///   - transaction: A transaction.
   @discardableResult
-  public func send(_ action: ViewAction, transaction: Transaction) -> ViewStoreTask {
+  public func send(_ action: ViewAction, transaction: Transaction) -> StoreTask {
     withTransaction(transaction) {
       self.send(action)
     }
@@ -728,23 +728,7 @@ extension ViewStore where ViewState == Void {
   }
 }
 
-/// The type returned from ``ViewStore/send(_:)`` that represents the lifecycle of the effect
-/// started from sending an action.
-///
-/// You can use this value to tie the effect's lifecycle _and_ cancellation to an asynchronous
-/// context, such as the `task` view modifier.
-///
-/// ```swift
-/// .task { await viewStore.send(.task).finish() }
-/// ```
-///
-/// > Note: Unlike Swift's `Task` type, ``ViewStoreTask`` automatically sets up a cancellation
-/// > handler between the current async context and the task.
-///
-/// See ``TestStoreTask`` for the analog returned from ``TestStore``.
-
-/// > Warning: ViewStoreTask is deprecated. Use ``store.send(_:)`` directly on the ``Store`` instead."
-@available(*, deprecated, message: "Use 'store.send(action)' directly on the 'Store' instead.")
+@available(*, deprecated, renamed: "StoreTask")
 public typealias ViewStoreTask = StoreTask
 
 /// A publisher of store state.

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -745,6 +745,10 @@ extension ViewStore where ViewState == Void {
 public struct ViewStoreTask: Hashable, Sendable {
   fileprivate let rawValue: Task<Void, Never>?
 
+  internal init(rawValue: Task<Void, Never>?) {
+	self.rawValue = rawValue
+  }
+
   /// Cancels the underlying task and waits for it to finish.
   public func cancel() async {
     self.rawValue?.cancel()

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -742,32 +742,10 @@ extension ViewStore where ViewState == Void {
 /// > handler between the current async context and the task.
 ///
 /// See ``TestStoreTask`` for the analog returned from ``TestStore``.
-public struct ViewStoreTask: Hashable, Sendable {
-  fileprivate let rawValue: Task<Void, Never>?
 
-  internal init(rawValue: Task<Void, Never>?) {
-	self.rawValue = rawValue
-  }
-
-  /// Cancels the underlying task and waits for it to finish.
-  public func cancel() async {
-    self.rawValue?.cancel()
-    await self.finish()
-  }
-
-  /// Waits for the task to finish.
-  public func finish() async {
-    await self.rawValue?.cancellableValue
-  }
-
-  /// A Boolean value that indicates whether the task should stop executing.
-  ///
-  /// After the value of this property becomes `true`, it remains `true` indefinitely. There is no
-  /// way to uncancel a task.
-  public var isCancelled: Bool {
-    self.rawValue?.isCancelled ?? true
-  }
-}
+/// > Warning: ViewStoreTask is deprecated. Use ``store.send(_:)`` directly on the ``Store`` instead."
+@available(*, deprecated, message: "Use 'store.send(action)' directly on the 'Store' instead.")
+public typealias ViewStoreTask = StoreTask
 
 /// A publisher of store state.
 @dynamicMemberLookup


### PR DESCRIPTION
v0.55 deprecates the `WithViewStore` initialiser that takes Void state and recommends using `Store.send` instead, however there isn't parity with the `ViewStore` APIs as those do let you specify an animation or transaction parameter, while Store.send doesn't. This PR adds those methods for full parity