### PR TITLE
Weaken `BindingViewStore`'s dynamic member lookup

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -240,9 +240,7 @@ public struct BindingViewStore<State> {
     set { self = newValue }
   }
 
-  public subscript<Value: Equatable>(
-    dynamicMember keyPath: WritableKeyPath<State, Value>
-  ) -> Value {
+  public subscript<Value>(dynamicMember keyPath: KeyPath<State, Value>) -> Value {
     self.wrappedValue[keyPath: keyPath]
   }
 


### PR DESCRIPTION
Right now it requires a writably, equatable property, but that prevents accessing `let` constants on state.