### PR TITLE
Update code examples of Tree-based navigation documentation

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
@@ -265,23 +265,23 @@ struct InventoryView: View {
       // ...
     }
     .sheet(
-      store: self.store.scope(state: \.destination, action: { .destination($0) }),
-      state: /InventoryFeature.State.addItem,
-      action: /InventoryFeature.Action.addItem
+      store: self.store.scope(state: \.$destination, action: { .destination($0) }),
+      state: /InventoryFeature.Destination.State.addItem,
+      action: InventoryFeature.Destination.Action.addItem
     ) { store in 
       AddFeatureView(store: store)
     }
     .popover(
-      store: self.store.scope(state: \.destination, action: { .destination($0) }),
-      state: /InventoryFeature.State.editItem,
-      action: /InventoryFeature.Action.editItem
+      store: self.store.scope(state: \.$destination, action: { .destination($0) }),
+      state: /InventoryFeature.Destination.State.editItem,
+      action: InventoryFeature.Destination.Action.editItem
     ) { store in 
       EditFeatureView(store: store)
     }
     .navigationDestination(
-      store: self.store.scope(state: \.destination, action: { .destination($0) }),
-      state: /InventoryFeature.State.detailItem,
-      action: /InventoryFeature.Action.detailItem
+      store: self.store.scope(state: \.$destination, action: { .destination($0) }),
+      state: /InventoryFeature.Destination.State.detailItem,
+      action: InventoryFeature.Destination.Action.detailItem
     ) { store in 
       DetailFeatureView(store: store)
     }


### PR DESCRIPTION
# Description
I don't know if contributions just to the documentation are welcome, but I think I spotted a few instances of outdated or incorrect sample code in Tree-based navigations.

1. The store scope misses the `$` e.g:
```diff
- store: self.store.scope(state: \.destination, action: { .destination($0) }),
+ store: self.store.scope(state: \.$destination, action: { .destination($0) }),
```
2. The Destination model is missing when isolating the specific state and action, e.g:
```diff
- state: /InventoryFeature.State.addItem,
+ state: /InventoryFeature.Destination.State.addItem,
```
3. The forward slash can be removed when isolating to action
```diff
- action: /InventoryFeature.Action.addItem
+ action: InventoryFeature.Destination.Action.addItem
```

I got stuck here a little bit, while following along your excellent documentation, so updating it might help others as well ✌🏻 