### PR TITLE
Fix view state binding equatability

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/03-NavigationStack.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-NavigationStack.swift
@@ -121,19 +121,19 @@ struct NavigationDemoView: View {
       switch $0 {
       case .screenA:
         CaseLet(
-          state: /NavigationDemo.Path.State.screenA,
+          /NavigationDemo.Path.State.screenA,
           action: NavigationDemo.Path.Action.screenA,
           then: ScreenAView.init(store:)
         )
       case .screenB:
         CaseLet(
-          state: /NavigationDemo.Path.State.screenB,
+          /NavigationDemo.Path.State.screenB,
           action: NavigationDemo.Path.Action.screenB,
           then: ScreenBView.init(store:)
         )
       case .screenC:
         CaseLet(
-          state: /NavigationDemo.Path.State.screenC,
+          /NavigationDemo.Path.State.screenC,
           action: NavigationDemo.Path.Action.screenC,
           then: ScreenCView.init(store:)
         )

--- a/Examples/Standups/StandupsTests/AppFeatureTests.swift
+++ b/Examples/Standups/StandupsTests/AppFeatureTests.swift
@@ -94,7 +94,10 @@ final class AppFeatureTests: XCTestCase {
 
     var savedStandup = standup
     savedStandup.title = "Blob"
-    XCTAssertEqual(savedData.value, try! JSONEncoder().encode([savedStandup]))
+    XCTAssertNoDifference(
+      try JSONDecoder().decode([Standup].self, from: savedData.value!),
+      [savedStandup]
+    )
   }
 
   func testRecording() async {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Reduce.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Reduce.swift
@@ -17,7 +17,7 @@ public struct Reduce<State, Action>: ReducerProtocol {
   ///
   /// - Parameter reduce: A function that is called when ``reduce(into:action:)`` is invoked.
   @inlinable
-  public init(_ reduce: @escaping (inout State, Action) -> EffectTask<Action>) {
+  public init(_ reduce: @escaping (_ state: inout State, _ action: Action) -> EffectTask<Action>) {
     self.init(internal: reduce)
   }
 

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -56,7 +56,7 @@ public struct BindingState<Value> {
     deprecated,
     message:
       """
-      Chaining onto properties of bindable state is deprecated. Push '@BindingState' use to the child state, instead.
+      Chaining onto properties of binding state is deprecated. Instead of pattern matching into a deeper property of binding state, use 'ReducerProtocol.onChange(of:)' to detect changes to nested properties of binding state. Instead of using 'viewStore.binding(\\.$nested.property)', use dynamic member lookup ('viewStore.$nested.property').
       """
   )
   public subscript<Subject>(

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -245,7 +245,7 @@ public struct WithViewStore<ViewState, ViewAction, Content: View>: View {
   ///   changes to the view state will cause the `WithViewStore` to re-compute its view.
   ///   - fromViewAction: A function that transforms view actions into store action.
   ///   - isDuplicate: A function to determine when two `ViewState` values are equal. When values
-  ///     are equal, repeat view computations are removed,
+  ///     are equal, repeat view computations are removed.
   ///   - content: A function that can generate content from a view store.
   public init<State, Action>(
     _ store: Store<State, Action>,
@@ -334,7 +334,7 @@ public struct WithViewStore<ViewState, ViewAction, Content: View>: View {
   ///   - toViewState: A function that transforms store state into observable view state. All
   ///   changes to the view state will cause the `WithViewStore` to re-compute its view.
   ///   - isDuplicate: A function to determine when two `ViewState` values are equal. When values
-  ///     are equal, repeat view computations are removed,
+  ///     are equal, repeat view computations are removed.
   ///   - content: A function that can generate content from a view store.
   public init<State>(
     _ store: Store<State, ViewAction>,
@@ -367,7 +367,7 @@ public struct WithViewStore<ViewState, ViewAction, Content: View>: View {
   /// - Parameters:
   ///   - store: A store.
   ///   - isDuplicate: A function to determine when two `ViewState` values are equal. When values
-  ///     are equal, repeat view computations are removed,
+  ///     are equal, repeat view computations are removed.
   ///   - content: A function that can generate content from a view store.
   @available(
     iOS,
@@ -505,7 +505,7 @@ extension WithViewStore where ViewState: Equatable, Content: View {
   ///   changes to the view state will cause the `WithViewStore` to re-compute its view.
   ///   - fromViewAction: A function that transforms view actions into store action.
   ///   - isDuplicate: A function to determine when two `ViewState` values are equal. When values
-  ///     are equal, repeat view computations are removed,
+  ///     are equal, repeat view computations are removed.
   ///   - content: A function that can generate content from a view store.
   public init<State, Action>(
     _ store: Store<State, Action>,
@@ -593,7 +593,7 @@ extension WithViewStore where ViewState: Equatable, Content: View {
   ///   - toViewState: A function that transforms store state into observable view state. All
   ///   changes to the view state will cause the `WithViewStore` to re-compute its view.
   ///   - isDuplicate: A function to determine when two `ViewState` values are equal. When values
-  ///     are equal, repeat view computations are removed,
+  ///     are equal, repeat view computations are removed.
   ///   - content: A function that can generate content from a view store.
   public init<State>(
     _ store: Store<State, ViewAction>,

--- a/Sources/swift-composable-architecture-benchmark/StoreSuite.swift
+++ b/Sources/swift-composable-architecture-benchmark/StoreSuite.swift
@@ -9,7 +9,7 @@ let storeSuite = BenchmarkSuite(name: "Store") {
 
   for level in 1...levels {
     $0.benchmark("Nested send tap: \(level)") {
-      _ = store.send(tap(level: level))
+      store.send(tap(level: level))
     } setUp: {
       store = Store(initialState: state(level: level)) {
         Feature()
@@ -21,7 +21,7 @@ let storeSuite = BenchmarkSuite(name: "Store") {
   }
   for level in 1...levels {
     $0.benchmark("Nested send none: \(level)") {
-      _ = store.send(none(level: level))
+      store.send(none(level: level))
     } setUp: {
       store = Store(initialState: state(level: level)) {
         Feature()

--- a/Tests/ComposableArchitectureTests/Reducers/BindingReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/BindingReducerTests.swift
@@ -74,7 +74,6 @@ final class BindingTests: BaseTCATestCase {
     XCTAssertEqual(count.wrappedValue, 1)
   }
 
-
   func testNestedBindingState() {
     let store = Store(initialState: BindingTest.State()) { BindingTest() }
 

--- a/Tests/ComposableArchitectureTests/Reducers/BindingReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/BindingReducerTests.swift
@@ -67,8 +67,11 @@ final class BindingTests: BaseTCATestCase {
     }
     let viewStore = ViewStore(store, observe: { ViewState(count: $0.$count) })
     let initialState = viewStore.state
-    viewStore.$count.wrappedValue += 1
+    let count = viewStore.$count
+    count.wrappedValue += 1
     XCTAssertNotEqual(initialState, viewStore.state)
+
+    XCTAssertEqual(count.wrappedValue, 1)
   }
 
 

--- a/Tests/ComposableArchitectureTests/Reducers/BindingReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/BindingReducerTests.swift
@@ -47,6 +47,31 @@ final class BindingTests: BaseTCATestCase {
     )
   }
 
+  func testViewEquality() {
+    struct Feature: ReducerProtocol {
+      struct State: Equatable {
+        @BindingState var count = 0
+      }
+      enum Action: BindableAction, Equatable {
+        case binding(BindingAction<State>)
+      }
+      var body: some ReducerProtocolOf<Self> {
+        BindingReducer()
+      }
+    }
+    struct ViewState: Equatable {
+      @BindingViewState var count: Int
+    }
+    let store = Store(initialState: Feature.State()) {
+      Feature()
+    }
+    let viewStore = ViewStore(store, observe: { ViewState(count: $0.$count) })
+    let initialState = viewStore.state
+    viewStore.$count.wrappedValue += 1
+    XCTAssertNotEqual(initialState, viewStore.state)
+  }
+
+
   func testNestedBindingState() {
     let store = Store(initialState: BindingTest.State()) { BindingTest() }
 

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -11,7 +11,7 @@ final class StoreTests: BaseTCATestCase {
 
     XCTAssertEqual(store.effectCancellables.count, 0)
 
-    _ = store.send(())
+    store.send(())
 
     XCTAssertEqual(store.effectCancellables.count, 0)
   }
@@ -36,7 +36,7 @@ final class StoreTests: BaseTCATestCase {
 
     XCTAssertEqual(store.effectCancellables.count, 0)
 
-    _ = store.send(.start)
+    store.send(.start)
 
     XCTAssertEqual(store.effectCancellables.count, 1)
 
@@ -795,7 +795,7 @@ final class StoreTests: BaseTCATestCase {
       $0.date = .constant(Date(timeIntervalSinceReferenceDate: 1_234_567_890))
     }
 
-    _ = store.send(.tap)
+    store.send(.tap)
     XCTAssertEqual(store.state.value.date, Date(timeIntervalSinceReferenceDate: 1_234_567_890))
   }
 
@@ -879,7 +879,7 @@ final class StoreTests: BaseTCATestCase {
       .sink { _ in storeStateCount2 += 1 }
       .store(in: &self.cancellables)
 
-    _ = store.send(.tap)
+    store.send(.tap)
     XCTAssertEqual(removeDuplicatesCount1, 0)
     XCTAssertEqual(stateScopeCount1, 2)
     XCTAssertEqual(viewStoreCount1, 0)
@@ -888,7 +888,7 @@ final class StoreTests: BaseTCATestCase {
     XCTAssertEqual(stateScopeCount2, 2)
     XCTAssertEqual(viewStoreCount2, 0)
     XCTAssertEqual(storeStateCount2, 1)
-    _ = store.send(.tap)
+    store.send(.tap)
     XCTAssertEqual(removeDuplicatesCount1, 0)
     XCTAssertEqual(stateScopeCount1, 3)
     XCTAssertEqual(viewStoreCount1, 0)
@@ -898,7 +898,7 @@ final class StoreTests: BaseTCATestCase {
     XCTAssertEqual(viewStoreCount2, 0)
     XCTAssertEqual(storeStateCount2, 1)
 
-    _ = store.send(.child(.dismiss))
+    store.send(.child(.dismiss))
     _ = (childViewStore1, childViewStore2, childStore1, childStore2)
   }
 }


### PR DESCRIPTION
Fixes #2253.

If a store state change results in only updating a view store's `BindingViewState`, it was considered equivalent, since the `Binding` would always contain the latest value. This PR fixes things by holding a snapshot of state in `BindingViewState` instead.