### PR TITLE
Fix WithViewStore argument label in Bindings.md

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
@@ -357,7 +357,7 @@ struct NotificationSettingsView: View {
   }
 
   var body: some View {
-    WithViewStore(self.store, ViewStore.init) { viewStore in
+    WithViewStore(self.store, observe: ViewStore.init) { viewStore in
       // ...
     }
   }


### PR DESCRIPTION
This adds a missing argument label to documentation sample code.