### PR TITLE
Resolve CaseStudies crash

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/03-NavigationStack.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-NavigationStack.swift
@@ -121,19 +121,19 @@ struct NavigationDemoView: View {
       switch $0 {
       case .screenA:
         CaseLet(
-          state: /NavigationDemo.Path.State.screenA,
+          /NavigationDemo.Path.State.screenA,
           action: NavigationDemo.Path.Action.screenA,
           then: ScreenAView.init(store:)
         )
       case .screenB:
         CaseLet(
-          state: /NavigationDemo.Path.State.screenB,
+          /NavigationDemo.Path.State.screenB,
           action: NavigationDemo.Path.Action.screenB,
           then: ScreenBView.init(store:)
         )
       case .screenC:
         CaseLet(
-          state: /NavigationDemo.Path.State.screenC,
+          /NavigationDemo.Path.State.screenC,
           action: NavigationDemo.Path.Action.screenC,
           then: ScreenCView.init(store:)
         )


### PR DESCRIPTION
I resolved CaseStudies' compile error.
The 'state' argument label in `CaseLet` init should have been omitted.

<img width="626" alt="image" src="https://github.com/pointfreeco/swift-composable-architecture/assets/71127966/4942e080-607a-4b0d-ae03-663b2da9dda5">