### PR TITLE
Fix ViewStore.init that should be ViewState.init in Bindings.md

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
@@ -357,7 +357,7 @@ struct NotificationSettingsView: View {
   }
 
   var body: some View {
-    WithViewStore(self.store, observe: ViewStore.init) { viewStore in
+    WithViewStore(self.store, observe: ViewState.init) { viewStore in
       // ...
     }
   }


### PR DESCRIPTION
Another documentation sample code fix.

Not sure how I missed this in #2256, but the `observe` parameter should be `ViewState.init`–not `ViewStore.init`.