### PR TITLE
Add TestStoreOf typealias

### DIFF
--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -990,6 +990,21 @@ public final class TestStore<State, Action, ScopedState, ScopedAction, Environme
   }
 }
 
+/// A convenience type alias for referring to a test store of a given reducer's domain.
+///
+/// Instead of specifying five generics:
+///
+/// ```swift
+/// let testStore: TestStore<Feature.State, Feature.Action, Feature.State, Feature.Action, Void>
+/// ```
+///
+/// You can specify a single generic:
+///
+/// ```swift
+/// let testStore: TestStoreOf<Feature>
+/// ```
+public typealias TestStoreOf<R: ReducerProtocol> = TestStore<R.State, R.Action, R.State, R.Action, Void>
+
 extension TestStore where ScopedState: Equatable {
   /// Sends an action to the store and asserts when state changes.
   ///


### PR DESCRIPTION
I kept finding myself wishing for a convenience initialiser for `TestStore` when I'm not scoping or using an environment, so I don't have to type out/copy and paste the rather verbose `TestStore<Reducer.State, Reducer.Action, Reducer.State, Reducer.Action, Void>`.

After adding it to my own project and liking it, I thought I may as well try my first PR here.

If you feel it's unnecessary, then no worries.