### PR TITLE
Add TaskResult.cancellable to allow for cancellation errors to not be wrapped as part of the result

### DIFF
--- a/Sources/ComposableArchitecture/Effects/TaskResult.swift
+++ b/Sources/ComposableArchitecture/Effects/TaskResult.swift
@@ -124,6 +124,21 @@ public enum TaskResult<Success: Sendable>: Sendable {
       self = .failure(error)
     }
   }
+  
+  /// Throwing variant of `init(catching:)` that only throws `CancellationError`s if the task this is run within is cancelled.
+  /// This is useful if you don't want cancellation errors to be processed by a reducer like other errors.
+  ///
+  /// - Parameter body: An async, throwing closure.
+  @inlinable
+  public static func cancellable(catching body: @Sendable () async throws -> Success) async throws -> Self {
+    do {
+      return .success(try await body())
+    } catch let error as CancellationError {
+      throw error
+    } catch {
+      return .failure(error)
+    }
+  }
 
   /// Transforms a `Result` into a `TaskResult`, erasing its `Failure` to `Error`.
   ///


### PR DESCRIPTION
In the app I'm working on at work presently, I've found that normal TaskResults aren't as ideal when used in a context where tasks can be cancelled, as those cancellation errors could be processed by the reducer at a point where I don't want them to be (like after nilling out some optional state that an ifLet reducer uses). I also would prefer to not need to filter out cancellation errors from my reducers if a taskresult that can be cancelled would have that cancellation error fed into a reducer action. 

For tasks that I know can be cancelled and that I want to keep free of cancellation errors, I've added this static function in my own codebase which has helped. Usage-wise it looks like this:
```swift
case .someAction:
  return .run { send in
    try await send(.responseAction(TaskResult.cancellable { try await someOperation() }))
  }
}
```

Cancellation errors are thrown so that they could be handled and ignored by EffectTask, while non-cancellation errors are still wrapped in the TaskResult to be processed by the reducer.

I figured this would be valuable to other folks using TaskResult, hence this PR. I would argue that this behavior should instead go in `TaskResult.init(catching:)` but I don't want to introduce a source-incompatible change that would require lots of people adding `try` everywhere, especially if they may not want this behavior yet.
