### PR TITLE
Make `ViewStoreTask.cancel` synchronous

### DIFF
--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -745,10 +745,9 @@ extension ViewStore where ViewState == Void {
 public struct ViewStoreTask: Hashable, Sendable {
   fileprivate let rawValue: Task<Void, Never>?
 
-  /// Cancels the underlying task and waits for it to finish.
-  public func cancel() async {
+  /// Cancels the underlying task.
+  public func cancel() {
     self.rawValue?.cancel()
-    await self.finish()
   }
 
   /// Waits for the task to finish.


### PR DESCRIPTION
Currently, `ViewStoreTask.cancel` works like `TestStoreTask`, where it'll cancel _and_ await cancellation to complete. This is needlessly limiting, and probably not what you want when interacting with cancellation.