### PR TITLE
Fix cancellation ID existentials in iOS 14

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -28,7 +28,7 @@ extension EffectPublisher {
   ///   - cancelInFlight: Determines if any in-flight effect with the same identifier should be
   ///     canceled before starting this new one.
   /// - Returns: A new effect that is capable of being canceled by an identifier.
-  public func cancellable(id: AnyHashable, cancelInFlight: Bool = false) -> Self {
+  public func cancellable<ID: Hashable & Sendable>(id: ID, cancelInFlight: Bool = false) -> Self {
     @Dependency(\.navigationIDPath) var navigationIDPath
 
     switch self.operation {
@@ -96,7 +96,7 @@ extension EffectPublisher {
   /// - Parameter id: An effect identifier.
   /// - Returns: A new effect that will cancel any currently in-flight effect with the given
   ///   identifier.
-  public static func cancel(id: AnyHashable) -> Self {
+  public static func cancel<ID: Hashable & Sendable>(id: ID) -> Self {
     @Dependency(\.navigationIDPath) var navigationIDPath
 
     return .fireAndForget {
@@ -150,8 +150,8 @@ extension EffectPublisher {
 /// - Throws: An error thrown by the operation.
 /// - Returns: A value produced by operation.
 @_unsafeInheritExecutor
-public func withTaskCancellation<T: Sendable>(
-  id: AnyHashable,
+public func withTaskCancellation<ID: Hashable & Sendable, T: Sendable>(
+  id: ID,
   cancelInFlight: Bool = false,
   operation: @Sendable @escaping () async throws -> T
 ) async rethrows -> T {
@@ -191,14 +191,14 @@ extension Task where Success == Never, Failure == Never {
   }
 }
 
-@_spi(Internals) public struct _CancelID: Hashable {
+@_spi(Internals) public struct _CancelID: Hashable, Sendable {
   let discriminator: ObjectIdentifier
-  let id: AnyHashable
+  let id: AnyHashableSendable
   let navigationIDPath: NavigationIDPath
 
-  init(id: AnyHashable, navigationIDPath: NavigationIDPath) {
-    self.discriminator = ObjectIdentifier(type(of: id.base))
-    self.id = id
+  init<ID: Hashable & Sendable>(id: ID, navigationIDPath: NavigationIDPath) {
+    self.discriminator = ObjectIdentifier(type(of: id))
+    self.id = AnyHashableSendable(id)
     self.navigationIDPath = navigationIDPath
   }
 }
@@ -229,9 +229,9 @@ extension Result: _ErrorMechanism {}
 public class CancellablesCollection {
   var storage: [_CancelID: Set<AnyCancellable>] = [:]
 
-  func insert(
+  func insert<ID: Hashable & Sendable>(
     _ cancellable: AnyCancellable,
-    at id: AnyHashable,
+    at id: ID,
     path: NavigationIDPath
   ) {
     for navigationIDPath in path.prefixes {
@@ -240,9 +240,9 @@ public class CancellablesCollection {
     }
   }
 
-  func remove(
+  func remove<ID: Hashable & Sendable>(
     _ cancellable: AnyCancellable,
-    at id: AnyHashable,
+    at id: ID,
     path: NavigationIDPath
   ) {
     for navigationIDPath in path.prefixes {
@@ -254,8 +254,8 @@ public class CancellablesCollection {
     }
   }
 
-  func cancel(
-    id: AnyHashable,
+  func cancel<ID: Hashable & Sendable>(
+    id: ID,
     path: NavigationIDPath
   ) {
     let cancelID = _CancelID(id: id, navigationIDPath: path)
@@ -263,8 +263,8 @@ public class CancellablesCollection {
     self.storage[cancelID] = nil
   }
 
-  func exists(
-    at id: AnyHashable,
+  func exists<ID: Hashable & Sendable>(
+    at id: ID,
     path: NavigationIDPath
   ) -> Bool {
     return self.storage[_CancelID(id: id, navigationIDPath: path)] != nil

--- a/Sources/ComposableArchitecture/Effects/Publisher/Debouncing.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Debouncing.swift
@@ -44,8 +44,8 @@ extension EffectPublisher {
     deprecated: 9999,
     message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'EffectTask.run', instead."
   )
-  public func debounce<S: Scheduler>(
-    id: AnyHashable,
+  public func debounce<ID: Hashable, S: Scheduler>(
+    id: ID,
     for dueTime: S.SchedulerTimeType.Stride,
     scheduler: S,
     options: S.SchedulerOptions? = nil

--- a/Sources/ComposableArchitecture/Effects/Publisher/Throttling.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Throttling.swift
@@ -14,8 +14,8 @@ extension EffectPublisher {
   ///     `false`, the publisher emits the first element received during the interval.
   /// - Returns: An effect that emits either the most-recent or first element received during the
   ///   specified interval.
-  public func throttle<S: Scheduler>(
-    id: AnyHashable,
+  public func throttle<ID: Hashable, S: Scheduler>(
+    id: ID,
     for interval: S.SchedulerTimeType.Stride,
     scheduler: S,
     latest: Bool

--- a/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
@@ -94,8 +94,8 @@ extension EffectPublisher where Failure == Never {
   @available(
     watchOS, deprecated: 9999, message: "Use 'clock.timer' in an 'Effect.run', instead."
   )
-  public static func timer<S: Scheduler>(
-    id: AnyHashable,
+  public static func timer<ID: Hashable, S: Scheduler>(
+    id: ID,
     every interval: S.SchedulerTimeType.Stride,
     tolerance: S.SchedulerTimeType.Stride? = nil,
     on scheduler: S,

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -465,8 +465,8 @@ public struct _PresentedID: Hashable {
 }
 
 extension Task where Success == Never, Failure == Never {
-  internal static func _cancel(
-    id: AnyHashable,
+  internal static func _cancel<ID: Hashable>(
+    id: ID,
     navigationID: NavigationIDPath
   ) {
     withDependencies {
@@ -477,8 +477,8 @@ extension Task where Success == Never, Failure == Never {
   }
 }
 extension EffectPublisher {
-  internal func _cancellable(
-    id: AnyHashable = _PresentedID(),
+  internal func _cancellable<ID: Hashable>(
+    id: ID = _PresentedID(),
     navigationIDPath: NavigationIDPath,
     cancelInFlight: Bool = false
   ) -> Self {
@@ -488,8 +488,8 @@ extension EffectPublisher {
       self.cancellable(id: id, cancelInFlight: cancelInFlight)
     }
   }
-  internal static func _cancel(
-    id: AnyHashable = _PresentedID(),
+  internal static func _cancel<ID: Hashable>(
+    id: ID = _PresentedID(),
     navigationID: NavigationIDPath
   ) -> Self {
     withDependencies {


### PR DESCRIPTION
Fixes #2233.

On iOS 14, `DismissEffect` is broken because effect cancellation uses `AnyHashable` throughout, which can lead to nested `AnyHashable(AnyHashable(...))` IDs, which can hash differently depending on the level of nesting. By preserving the hashable ID up to being stored in the internal cancellation token type, we can avoid a hash lookup failure that prevents a dismissal from happening.