### PR TITLE
Fix macOS dismissal

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
@@ -221,7 +221,12 @@ public struct PresentationStore<
             : nil
         },
         compactSend: {
-          $0 == nil && self.toID(self.viewStore.state) == id ? .dismiss : nil
+          guard
+            $0 == nil,
+            self.viewStore.wrappedValue != nil,
+            id == nil || self.toID(self.viewStore.state) == id
+          else { return nil }
+          return .dismiss
         }
       ),
       DestinationContent(


### PR DESCRIPTION
Fixes #2182.

The `id` used for comparison appears to sometimes be `nil`, for example on macOS when drilling out of a `navigationDestination`. This PR adds a little nuance to the dismissal logic of `presentationModifier`:

  * It explicitly checks that something is presented
  * It always sends `dismiss` if the cached `id` was `nil`

We should maybe have some integration tests for macOS for this...