### PR TITLE
Clean up test store deprecation messages

### DIFF
--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -2622,7 +2622,7 @@ extension TestStore {
   )
   public func receive(
     _ expectedAction: Action,
-    assert updateStateToExpectedResult: ((inout ScopedState) throws -> Void)? = nil,
+    assert updateStateToExpectedResult: ((_ state: inout ScopedState) throws -> Void)? = nil,
     file: StaticString = #file,
     line: UInt = #line
   ) async {
@@ -2635,7 +2635,7 @@ extension TestStore {
   )
   public func send(
     _ action: ScopedAction,
-    assert updateStateToExpectedResult: ((inout ScopedState) throws -> Void)? = nil,
+    assert updateStateToExpectedResult: ((_ state: inout ScopedState) throws -> Void)? = nil,
     file: StaticString = #file,
     line: UInt = #line
   ) async -> TestStoreTask {

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -2618,7 +2618,7 @@ extension TestStore {
   @available(
     *,
     unavailable,
-    message: "'State' and 'Action' must conform to Equatable to assert against received actions."
+    message: "'State' and 'Action' must conform to 'Equatable' to assert against received actions."
   )
   public func receive(
     _ expectedAction: Action,
@@ -2631,7 +2631,7 @@ extension TestStore {
   @MainActor
   @discardableResult
   @available(
-    *, unavailable, message: "'State' must conform to Equatable to assert against sent actions."
+    *, unavailable, message: "'State' must conform to 'Equatable' to assert against sent actions."
   )
   public func send(
     _ action: ScopedAction,

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -2618,7 +2618,7 @@ extension TestStore {
   @available(
     *,
     unavailable,
-    message: "State and Action must conform to Equatable to receive actions."
+    message: "'State' and 'Action' must conform to Equatable to assert against received actions."
   )
   public func receive(
     _ expectedAction: Action,
@@ -2630,7 +2630,9 @@ extension TestStore {
 
   @MainActor
   @discardableResult
-  @available(*, unavailable, message: "State must conform to Equatable to send actions.")
+  @available(
+    *, unavailable, message: "'State' must conform to Equatable to assert against sent actions."
+  )
   public func send(
     _ action: ScopedAction,
     assert updateStateToExpectedResult: ((inout ScopedState) throws -> Void)? = nil,


### PR DESCRIPTION
The messaging stood out to me as a little confusing in isolation:

> **Warning**: 'send(_:assert:file:line:)' is unavailable: State must conform to Equatable to send actions.

So I think a little clarification reads better.

> **Warning**: 'send(_:assert:file:line:)' is unavailable: 'State' must conform to 'Equatable' to assert against sent actions.
