### PR TITLE
StoreTask.cancel is not an asynchronous method

### DIFF
--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -744,7 +744,7 @@ final class StoreTests: BaseTCATestCase {
     try await Task.sleep(nanoseconds: 100_000_000)
     XCTAssertEqual(viewStore.child, nil)
 
-    await childTask.cancel()
+    childTask.cancel()
     await mainQueue.advance(by: 1)
     try await Task.sleep(nanoseconds: 100_000_000)
     XCTTODO(

--- a/Tests/ComposableArchitectureTests/ViewStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/ViewStoreTests.swift
@@ -265,7 +265,7 @@ final class ViewStoreTests: BaseTCATestCase {
 
     XCTAssertEqual(viewStore.state, 0)
     let task = viewStore.send(.tap)
-    await task.cancel()
+    task.cancel()
     try await Task.sleep(nanoseconds: NSEC_PER_MSEC)
     XCTAssertEqual(viewStore.state, 0)
   }


### PR DESCRIPTION
StoreTask cancel has been changed to synchronous in #2282, so await is not necessary.