### PR TITLE
`TestStore.init(initialState:reducer:prepareDependencies:file:line:)` is deprecated

### DIFF
--- a/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
@@ -731,7 +731,9 @@
         }
       }
 
-      let store = TestStore(initialState: Feature.State(), reducer: Feature())
+      let store = TestStore(initialState: Feature.State()) {
+        Feature()
+      }
       store.exhaustivity = .off
 
       await store.send(.tap)
@@ -760,7 +762,9 @@
         }
       }
 
-      let store = TestStore(initialState: Feature.State(), reducer: Feature())
+      let store = TestStore(initialState: Feature.State()) {
+        Feature()
+      }
       store.exhaustivity = .off
 
       await store.send(.tap)
@@ -796,7 +800,9 @@
         }
       }
 
-      let store = TestStore(initialState: Feature.State(), reducer: Feature())
+      let store = TestStore(initialState: Feature.State()) {
+        Feature()
+      }
       store.exhaustivity = .off
 
       await store.send(.tap)


### PR DESCRIPTION
`TestStore.init(initialState:reducer:prepareDependencies:file:line:)` is deprecated, so I rewrote it to `TestStore.init(initialState:reducer:withDependencies:file:line:)`.