### PR TITLE
Abbreviate nested binding action values

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "3a35f7892e7cf6ba28a78cd46a703c0be4e0c6dc",
-        "version" : "0.11.0"
+        "revision" : "4a87bb75be70c983a9548597e8783236feb3401e",
+        "version" : "0.11.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "0.11.0"),
     .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.14.1"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "0.1.1"),
-    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.11.0"),
+    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.11.1"),
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "0.6.0"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "0.7.0"),
     .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "0.8.0"),

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -225,15 +225,14 @@ extension BindingAction {
   }
 }
 
-extension BindingAction: CustomDumpReflectable {
-  public var customDumpMirror: Mirror {
-    Mirror(
-      self,
-      children: [
-        "set": (self.keyPath, self.value.base)
-      ],
-      displayStyle: .enum
-    )
+extension BindingAction: CustomDumpStringConvertible {
+  public var customDumpDescription: String {
+    var description = ".set("
+    customDump(self.keyPath, to: &description, maxDepth: 0)
+    description.append(", ")
+    customDump(self.value.base, to: &description, maxDepth: 0)
+    description.append(")")
+    return description
   }
 }
 

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -51,15 +51,50 @@
       var dump = ""
       customDump(action, to: &dump)
 
-      XCTAssertEqual(
-        dump,
-        #"""
-        BindingAction.set(
-          WritableKeyPath<DebugTests.State, BindingState<Int>>,
-          50
+      #if swift(>=5.9)
+        XCTAssertEqual(
+          dump,
+          #"""
+          .set(\State.$width, 50)
+          """#
         )
-        """#
-      )
+      #else
+        XCTAssertEqual(
+          dump,
+          #"""
+          .set(WritableKeyPath<DebugTests.State, BindingState<Int>>, 50)
+          """#
+        )
+      #endif
+    }
+
+    func testBindingAction_Nested() {
+      struct Settings: Equatable {
+        var isEnabled = false
+        var description = ""
+      }
+      struct State {
+        @BindingState var settings = Settings()
+      }
+      let action = BindingAction.set(\State.$settings, Settings(isEnabled: true))
+      var dump = ""
+      customDump(action, to: &dump)
+
+      #if swift(>=5.9)
+        XCTAssertEqual(
+          dump,
+          #"""
+          .set(\State.$settings, DebugTests.Settings(…))
+          """#
+        )
+      #else
+        XCTAssertEqual(
+          dump,
+          #"""
+          .set(WritableKeyPath<DebugTests.State, BindingState<DebugTests.Settings>>, Settings(…))
+          """#
+        )
+      #endif
     }
 
     @MainActor

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -91,7 +91,7 @@
         XCTAssertEqual(
           dump,
           #"""
-          .set(WritableKeyPath<DebugTests.State, BindingState<DebugTests.Settings>>, Settings(…))
+          .set(WritableKeyPath<DebugTests.State, BindingState<DebugTests.Settings>>, DebugTests.Settings(…))
           """#
         )
       #endif


### PR DESCRIPTION
Now that binding action key paths cannot use dynamic member lookup, dumps are a little more unwieldy to read when nested state is involved. Generally one can look at the state diff to figure out what changed, so let's abbreviate the action's state when we can.