### PR TITLE
Typo in withTaskCancellation debounce documentation

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -133,9 +133,9 @@ extension EffectPublisher {
 /// // ...
 ///
 /// return .run { send in
-///   await withTaskCancellation(id: CancelID.response, cancelInFlight: true) {
+///   try await withTaskCancellation(id: CancelID.response, cancelInFlight: true) {
 ///     try await self.clock.sleep(for: .seconds(0.3))
-///     await .send(
+///     await send(
 ///       .debouncedResponse(TaskResult { try await environment.request() })
 ///     )
 ///   }


### PR DESCRIPTION
Noticed when trying `release/1.0` and moving from the old `EffectTask` debounce to the `.run` debounce that the comment docs don't match reality

Missing a try on the `withTaskCancellation` call, and a dot on the `send` call that shouldn't be there

Pointed this at main because it's there too, and I assume changes will be merged into the 1.0 branch