### PR TITLE
Add Store.send(_ action:) return StoreTask

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -190,8 +190,9 @@ public final class Store<State, Action> {
   /// store is available, prefer ``ViewStore/send(_:)``.
   ///
   /// - Parameter action: An action.
-  public func send(_ action: Action) {
-    _ = self.send(action, originatingFrom: nil)
+  @discardableResult
+  public func send(_ action: Action) -> StoreTask {
+    .init(rawValue: self.send(action, originatingFrom: nil))
   }
 
   /// Sends an action to the store with a given animation.

--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -46,9 +46,7 @@ extension View {
                 }
               case let .animatedSend(action, animation):
                 if let action = action {
-                  withAnimation(animation) {
-                    store.send(.presented(fromDestinationAction(action)))
-                  }
+                  store.send(.presented(fromDestinationAction(action)), animation: animation)
                 }
               }
             } label: {

--- a/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
@@ -51,9 +51,7 @@ extension View {
                 }
               case let .animatedSend(action, animation):
                 if let action = action {
-                  withAnimation(animation) {
-                    store.send(.presented(fromDestinationAction(action)))
-                  }
+                  store.send(.presented(fromDestinationAction(action)), animation: animation)
                 }
               }
             } label: {


### PR DESCRIPTION
I think the addition of Store.send is very innovative because it makes it clear that the View does not need to observe changes in State.
However, I noticed that Store.send is not returning a StoreTask, unlike ViewStore.send.

I want Store.send to also use `.task { await store.send(.task).finish() }`, just like ViewStore.

Is there any reason why Store.send isn't implemented that way?
If so, you can ignore this PR.

Thanks. 