### PR TITLE
Expose `StorePublisher` directly on `Store`

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/UIKit.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/UIKit.md
@@ -14,4 +14,5 @@ While the Composable Architecture was designed with SwiftUI in mind, it comes wi
 
 ### Subscribing to state changes
 
+- ``Store/publisher``
 - ``ViewStore/publisher``

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -673,6 +673,19 @@ public final class Store<State, Action> {
     #endif
     self.threadCheck(status: .`init`)
   }
+
+  /// A publisher that emits when state changes.
+  ///
+  /// This publisher supports dynamic member lookup so that you can pluck out a specific field in
+  /// the state:
+  ///
+  /// ```swift
+  /// store.publisher.alert
+  ///   .sink { ... }
+  /// ```
+  public var publisher: StorePublisher<State> {
+    StorePublisher(store: self, upstream: self.state)
+  }
 }
 
 /// A convenience type alias for referring to a store of a given reducer's domain.
@@ -792,6 +805,44 @@ extension ScopedReducer: AnyScopedReducer {
         childStore.state.value = newValue
       }
     return childStore
+  }
+}
+
+/// A publisher of store state.
+@dynamicMemberLookup
+public struct StorePublisher<State>: Publisher {
+  public typealias Output = State
+  public typealias Failure = Never
+
+  let store: Any
+  let upstream: AnyPublisher<State, Never>
+
+  init<P: Publisher>(
+    store: Any,
+    upstream: P
+  ) where P.Output == Output, P.Failure == Failure {
+    self.store = store
+    self.upstream = upstream.eraseToAnyPublisher()
+  }
+
+  public func receive<S: Subscriber>(subscriber: S) where S.Input == Output, S.Failure == Failure {
+    self.upstream.subscribe(
+      AnySubscriber(
+        receiveSubscription: subscriber.receive(subscription:),
+        receiveValue: subscriber.receive(_:),
+        receiveCompletion: { [store = self.store] in
+          subscriber.receive(completion: $0)
+          _ = store
+        }
+      )
+    )
+  }
+
+  /// Returns the resulting publisher of a given key path.
+  public subscript<Value: Equatable>(
+    dynamicMember keyPath: KeyPath<State, Value>
+  ) -> StorePublisher<Value> {
+    .init(store: self.store, upstream: self.upstream.map(keyPath).removeDuplicates())
   }
 }
 

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -212,7 +212,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
   ///   `viewStore.publisher.sink` closures should be completely independent of each other. Later
   ///   closures cannot assume that earlier ones have already run.
   public var publisher: StorePublisher<ViewState> {
-    StorePublisher(viewStore: self)
+    StorePublisher(store: self, upstream: self._state)
   }
 
   /// The current state.
@@ -660,49 +660,6 @@ extension ViewStore where ViewState == Void {
 
 @available(*, deprecated, renamed: "StoreTask")
 public typealias ViewStoreTask = StoreTask
-
-/// A publisher of store state.
-@dynamicMemberLookup
-public struct StorePublisher<State>: Publisher {
-  public typealias Output = State
-  public typealias Failure = Never
-
-  public let upstream: AnyPublisher<State, Never>
-  public let viewStore: Any
-
-  fileprivate init<Action>(viewStore: ViewStore<State, Action>) {
-    self.viewStore = viewStore
-    self.upstream = viewStore._state.eraseToAnyPublisher()
-  }
-
-  public func receive<S: Subscriber>(subscriber: S) where S.Input == Output, S.Failure == Failure {
-    self.upstream.subscribe(
-      AnySubscriber(
-        receiveSubscription: subscriber.receive(subscription:),
-        receiveValue: subscriber.receive(_:),
-        receiveCompletion: { [viewStore = self.viewStore] in
-          subscriber.receive(completion: $0)
-          _ = viewStore
-        }
-      )
-    )
-  }
-
-  private init<P: Publisher>(
-    upstream: P,
-    viewStore: Any
-  ) where P.Output == Output, P.Failure == Failure {
-    self.upstream = upstream.eraseToAnyPublisher()
-    self.viewStore = viewStore
-  }
-
-  /// Returns the resulting publisher of a given key path.
-  public subscript<Value: Equatable>(
-    dynamicMember keyPath: KeyPath<State, Value>
-  ) -> StorePublisher<Value> {
-    .init(upstream: self.upstream.map(keyPath).removeDuplicates(), viewStore: self.viewStore)
-  }
-}
 
 private struct HashableWrapper<Value>: Hashable {
   let rawValue: Value


### PR DESCRIPTION
Now that `ViewStore`s have a limited future, we should surface functionality that was `ViewStore`-only to the `Store` instead.

While we could probably start discouraging using `ViewStore` at all in UIKit apps by deprecating the existing API, it's pretty close to the 11th hour of shipping 1.0, and we are probably better off deprecating `ViewStore` all at once when the Observation framework is released.