### PR TITLE
Allow chaining into `BindingViewState`

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -358,6 +358,7 @@ extension ViewStore where ViewAction: BindableAction, ViewAction.State == ViewSt
 /// bindable in SwiftUI views.
 ///
 /// Read <doc:Bindings> for more information.
+@dynamicMemberLookup
 @propertyWrapper
 public struct BindingViewState<Value> {
   let binding: Binding<Value>
@@ -375,6 +376,12 @@ public struct BindingViewState<Value> {
 
   public var projectedValue: Binding<Value> {
     self.binding
+  }
+
+  public subscript<Subject>(
+    dynamicMember keyPath: WritableKeyPath<Value, Subject>
+  ) -> BindingViewState<Subject> {
+    BindingViewState<Subject>(binding: self.binding[dynamicMember: keyPath])
   }
 }
 

--- a/Tests/ComposableArchitectureTests/Reducers/BindingReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/BindingReducerTests.swift
@@ -84,6 +84,20 @@ final class BindingTests: BaseTCATestCase {
     XCTAssertEqual(viewStore.state, .init(nested: .init(field: "Hello!")))
   }
 
+  func testNestedBindingViewState() {
+    struct ViewState: Equatable {
+      @BindingViewState var field: String
+    }
+
+    let store = Store(initialState: BindingTest.State()) { BindingTest() }
+
+    let viewStore = ViewStore(store, observe: { ViewState(field: $0.$nested.field) })
+
+    viewStore.$field.wrappedValue = "Hello"
+
+    XCTAssertEqual(store.withState { $0.nested.field }, "Hello!")
+  }
+
   func testBindingActionUpdatesRespectsPatternMatching() async {
     let testStore = TestStore(
       initialState: BindingTest.State(nested: BindingTest.State.Nested(field: ""))


### PR DESCRIPTION
Currently, `BindingViewStore`s can only directly derive `BindingViewState` for a view state struct, and then the view store can derive a binding and use dynamic member lookup to pluck out a field for a view. This means potentially exposing view state to far more state than necessary.

To prevent this we can add dynamic member lookup to the binding view state itself, which allows a view state struct to chip away any state it doesn't care about.