### PR TITLE
Deprecate old alert APIs in favor of new presentation APIs

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -23,73 +23,82 @@ private let readMe = """
 
 struct AlertAndConfirmationDialog: Reducer {
   struct State: Equatable {
-    var alert: AlertState<Action>?
-    var confirmationDialog: ConfirmationDialogState<Action>?
+    @PresentationState var alert: AlertState<Action.Alert>?
+    @PresentationState var confirmationDialog: ConfirmationDialogState<Action.ConfirmationDialog>?
     var count = 0
   }
 
   enum Action: Equatable {
+    case alert(PresentationAction<Alert>)
     case alertButtonTapped
-    case alertDismissed
+    case confirmationDialog(PresentationAction<ConfirmationDialog>)
     case confirmationDialogButtonTapped
-    case confirmationDialogDismissed
-    case decrementButtonTapped
-    case incrementButtonTapped
+
+    enum Alert: Equatable {
+      case incrementButtonTapped
+    }
+    enum ConfirmationDialog: Equatable {
+      case incrementButtonTapped
+      case decrementButtonTapped
+    }
   }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action> {
-    switch action {
-    case .alertButtonTapped:
-      state.alert = AlertState {
-        TextState("Alert!")
-      } actions: {
-        ButtonState(role: .cancel) {
-          TextState("Cancel")
+  var body: some Reducer<State, Action> {
+    Reduce { state, action in
+      switch action {
+      case .alert(.presented(.incrementButtonTapped)),
+        .confirmationDialog(.presented(.incrementButtonTapped)):
+        state.alert = AlertState { TextState("Incremented!") }
+        state.count += 1
+        return .none
+
+      case .alert:
+        return .none
+
+      case .alertButtonTapped:
+        state.alert = AlertState {
+          TextState("Alert!")
+        } actions: {
+          ButtonState(role: .cancel) {
+            TextState("Cancel")
+          }
+          ButtonState(action: .incrementButtonTapped) {
+            TextState("Increment")
+          }
+        } message: {
+          TextState("This is an alert")
         }
-        ButtonState(action: .incrementButtonTapped) {
-          TextState("Increment")
+        return .none
+
+      case .confirmationDialog(.presented(.decrementButtonTapped)):
+        state.alert = AlertState { TextState("Decremented!") }
+        state.count -= 1
+        return .none
+
+      case .confirmationDialog:
+        return .none
+
+      case .confirmationDialogButtonTapped:
+        state.confirmationDialog = ConfirmationDialogState {
+          TextState("Confirmation dialog")
+        } actions: {
+          ButtonState(role: .cancel) {
+            TextState("Cancel")
+          }
+          ButtonState(action: .incrementButtonTapped) {
+            TextState("Increment")
+          }
+          ButtonState(action: .decrementButtonTapped) {
+            TextState("Decrement")
+          }
+        } message: {
+          TextState("This is a confirmation dialog.")
         }
-      } message: {
-        TextState("This is an alert")
+        return .none
       }
-      return .none
-
-    case .alertDismissed:
-      state.alert = nil
-      return .none
-
-    case .confirmationDialogButtonTapped:
-      state.confirmationDialog = ConfirmationDialogState {
-        TextState("Confirmation dialog")
-      } actions: {
-        ButtonState(role: .cancel) {
-          TextState("Cancel")
-        }
-        ButtonState(action: .incrementButtonTapped) {
-          TextState("Increment")
-        }
-        ButtonState(action: .decrementButtonTapped) {
-          TextState("Decrement")
-        }
-      } message: {
-        TextState("This is a confirmation dialog.")
-      }
-      return .none
-
-    case .confirmationDialogDismissed:
-      state.confirmationDialog = nil
-      return .none
-
-    case .decrementButtonTapped:
-      state.alert = AlertState { TextState("Decremented!") }
-      state.count -= 1
-      return .none
-
-    case .incrementButtonTapped:
-      state.alert = AlertState { TextState("Incremented!") }
-      state.count += 1
-      return .none
     }
+    .ifLet(\.$alert, action: /Action.alert)
+    .ifLet(\.$confirmationDialog, action: /Action.confirmationDialog)
   }
 }
 
@@ -112,12 +121,10 @@ struct AlertAndConfirmationDialogView: View {
     }
     .navigationTitle("Alerts & Dialogs")
     .alert(
-      self.store.scope(state: \.alert, action: { $0 }),
-      dismiss: .alertDismissed
+      store: self.store.scope(state: \.$alert, action: { .alert($0) })
     )
     .confirmationDialog(
-      self.store.scope(state: \.confirmationDialog, action: { $0 }),
-      dismiss: .confirmationDialogDismissed
+      store: self.store.scope(state: \.$confirmationDialog, action: { .confirmationDialog($0) })
     )
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndConfirmationDialogsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndConfirmationDialogsTests.swift
@@ -57,10 +57,8 @@ final class AlertsAndConfirmationDialogsTests: XCTestCase {
     }
     await store.send(.confirmationDialog(.presented(.incrementButtonTapped))) {
       $0.alert = AlertState { TextState("Incremented!") }
-      $0.count = 1
-    }
-    await store.send(.confirmationDialog(.dismiss)) {
       $0.confirmationDialog = nil
+      $0.count = 1
     }
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndConfirmationDialogsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndConfirmationDialogsTests.swift
@@ -24,11 +24,11 @@ final class AlertsAndConfirmationDialogsTests: XCTestCase {
         TextState("This is an alert")
       }
     }
-    await store.send(.incrementButtonTapped) {
+    await store.send(.alert(.presented(.incrementButtonTapped))) {
       $0.alert = AlertState { TextState("Incremented!") }
       $0.count = 1
     }
-    await store.send(.alertDismissed) {
+    await store.send(.alert(.dismiss)) {
       $0.alert = nil
     }
   }
@@ -55,11 +55,11 @@ final class AlertsAndConfirmationDialogsTests: XCTestCase {
         TextState("This is a confirmation dialog.")
       }
     }
-    await store.send(.incrementButtonTapped) {
+    await store.send(.confirmationDialog(.presented(.incrementButtonTapped))) {
       $0.alert = AlertState { TextState("Incremented!") }
       $0.count = 1
     }
-    await store.send(.confirmationDialogDismissed) {
+    await store.send(.confirmationDialog(.dismiss)) {
       $0.confirmationDialog = nil
     }
   }

--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -66,7 +66,7 @@ extension View {
   *,
   deprecated,
   message: """
-    Use 'View.alert(store:)' with 'PresentationState' and 'PresentationAction' instead.
+    Use 'View.alert(store:)' with 'PresentationState' and 'PresentationAction' instead, or use 'Alert.init(state:)' to create an alert in iOS 13.
     """
 )
 extension View {

--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -62,6 +62,13 @@ extension View {
   }
 }
 
+@available(
+  *,
+  deprecated,
+  message: """
+    Use 'View.alert(store:)' with 'PresentationState' and 'PresentationAction' instead.
+    """
+)
 extension View {
   /// Displays an alert when then store's state becomes non-`nil`, and dismisses it when it becomes
   /// `nil`.

--- a/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
@@ -67,6 +67,13 @@ extension View {
   }
 }
 
+@available(
+  *,
+  deprecated,
+  message: """
+    Use 'View.confirmationDialog(store:)' with 'PresentationState' and 'PresentationAction' instead.
+    """
+)
 extension View {
   /// Displays a dialog when the store's state becomes non-`nil`, and dismisses it when it becomes
   /// `nil`.

--- a/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
@@ -71,7 +71,7 @@ extension View {
   *,
   deprecated,
   message: """
-    Use 'View.confirmationDialog(store:)' with 'PresentationState' and 'PresentationAction' instead.
+    Use 'View.confirmationDialog(store:)' with 'PresentationState' and 'PresentationAction' instead, or use 'ActionSheet.init(state:)' to create a confirmation dialog in iOS 13.
     """
 )
 extension View {


### PR DESCRIPTION
An 11th hour deprecation/removal, but these APIs should be removed since they work differently depending on the iOS version (13-14 uses the old alert APIs, 15+ uses new, but this means different behavior on different OS versions).

We don't ship an alternative API for iOS 13, but SwiftUI Navigation comes with helpers for constructing `Alert` from `AlertState`, which can be used manually.