### PR TITLE
Fix integration test and incorrect deprecation warning on TestStore

### DIFF
--- a/Examples/Integration/IntegrationUITests/PresentationTests.swift
+++ b/Examples/Integration/IntegrationUITests/PresentationTests.swift
@@ -47,17 +47,21 @@ final class PresentationTests: BaseIntegrationTests {
   }
 
   func testSheet_IdentityChange() async throws {
-    self.app.buttons["Open sheet"].tap()
-    XCTAssertEqual(self.app.staticTexts["Count: 0"].exists, true)
+    if #available(iOS 17, *) {
+      throw XCTSkip("Changing identity of sheet in iOS 17 causes a crash.")
+    } else {
+      self.app.buttons["Open sheet"].tap()
+      XCTAssertEqual(self.app.staticTexts["Count: 0"].exists, true)
 
-    self.app.buttons["Start effect"].tap()
-    XCTAssertEqual(self.app.staticTexts["Count: 1"].exists, true)
+      self.app.buttons["Start effect"].tap()
+      XCTAssertEqual(self.app.staticTexts["Count: 1"].exists, true)
 
-    self.app.buttons["Reset identity"].tap()
-    XCTAssertEqual(self.app.staticTexts["Count: 1"].exists, true)
+      self.app.buttons["Reset identity"].tap()
+      XCTAssertEqual(self.app.staticTexts["Count: 1"].exists, true)
 
-    try await Task.sleep(for: .seconds(3))
-    XCTAssertEqual(self.app.staticTexts["Count: 999"].exists, false)
+      try await Task.sleep(for: .seconds(3))
+      XCTAssertEqual(self.app.staticTexts["Count: 999"].exists, false)
+    }
   }
 
   func testPopover_ChildDismiss() {

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 CONFIG = debug
-PLATFORM_IOS = iOS Simulator,id=$(call udid_for,iPhone)
+PLATFORM_IOS = iOS Simulator,id=$(call udid_for,iPhone,iOS-16)
 PLATFORM_MACOS = macOS
 PLATFORM_MAC_CATALYST = macOS,variant=Mac Catalyst
-PLATFORM_TVOS = tvOS Simulator,id=$(call udid_for,TV)
-PLATFORM_WATCHOS = watchOS Simulator,id=$(call udid_for,Watch)
+PLATFORM_TVOS = tvOS Simulator,id=$(call udid_for,TV,tvOS-16)
+PLATFORM_WATCHOS = watchOS Simulator,id=$(call udid_for,Watch,watchOS-9)
 
-default: test-all
+# default: test-all
 
 test-all: test-examples
 	$(MAKE) CONFIG=debug test-library
@@ -27,7 +27,7 @@ build-for-library-evolution:
 		-Xswiftc -emit-module-interface \
 		-Xswiftc -enable-library-evolution
 
-DOC_WARNINGS := $(shell xcodebuild clean docbuild \
+DOC_WARNINGS = $(shell xcodebuild clean docbuild \
 	-scheme ComposableArchitecture \
 	-destination platform="$(PLATFORM_MACOS)" \
 	-quiet \
@@ -61,5 +61,5 @@ format:
 .PHONY: format test-all test-swift test-workspace
 
 define udid_for
-$(shell xcrun simctl list --json devices available $(1) | jq -r '.devices | to_entries | map(select(.value | add)) | sort_by(.key) | last.value | last.udid')
+$(shell xcrun simctl list --json devices available $(1) | jq -r '.devices | to_entries | map(select(.value | add)) | sort_by(.key) | .[] | select(.key | contains("$(2)")) | .value | last.udid')
 endef

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -505,7 +505,7 @@ public final class TestStore<State, Action> {
   ///     accessed during the test. These dependencies will be used when producing the initial
   ///     state.
   public init<R: Reducer>(
-    initialState: @autoclosure () -> State,
+    initialState: @autoclosure () -> R.State,
     @ReducerBuilder<State, Action> reducer: () -> R,
     withDependencies prepareDependencies: (inout DependencyValues) -> Void = { _ in
     },
@@ -541,7 +541,7 @@ public final class TestStore<State, Action> {
   ///     state.
   @available(*, deprecated, message: "State must be equatable to perform assertions.")
   public init<R: Reducer>(
-    initialState: @autoclosure () -> State,
+    initialState: @autoclosure () -> R.State,
     @ReducerBuilder<State, Action> reducer: () -> R,
     withDependencies prepareDependencies: (inout DependencyValues) -> Void = { _ in
     },

--- a/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
@@ -2240,9 +2240,9 @@ final class PresentationReducerTests: BaseTCATestCase {
         }
       }
     }
-
+    
     let mainQueue = DispatchQueue.test
-    let store = TestStore(initialState: Parent.State()) {
+    let store = TestStore(initialState: .init()) {
       Parent()
     } withDependencies: {
       $0.mainQueue = mainQueue.eraseToAnyScheduler()

--- a/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
@@ -2240,7 +2240,7 @@ final class PresentationReducerTests: BaseTCATestCase {
         }
       }
     }
-    
+
     let mainQueue = DispatchQueue.test
     let store = TestStore(initialState: .init()) {
       Parent()


### PR DESCRIPTION
Fixes two things:

* Right now an integration test crashes due to an iOS 17 bug, so we are just not going to run that test on iOS 17. We should also really file a bug report with Apple about it.
* When using shortened syntax for state initialization (i.e. `initialState: .init()`) in `TestStore` you get an incorrect deprecation warning.