### PR TITLE
Improve TestStore failures on init.

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
@@ -363,7 +363,7 @@ case .destination(.presented(.editItem(.saveButtonTapped))):
   else { return .none }
 
   state.destination = nil
-  return .fireAndForget {
+  return .run { _ in
     self.database.save(editItemState.item)
   }
 ```
@@ -417,7 +417,7 @@ struct Feature: Reducer {
   func reduce(into state: inout State, action: Action) -> Effect<Action> {
     switch action {
     case .closeButtonTapped:
-      return .fireAndForget { await self.dismiss() }
+      return .run { _ in await self.dismiss() }
     } 
   }
 }
@@ -480,7 +480,7 @@ struct CounterFeature: Reducer {
     case .incrementButtonTapped:
       state.count += 1
       return state.count >= 5
-        ? .fireAndForget { await self.dismiss() }
+        ? .run { _ in await self.dismiss() }
         : .none
     }
   }

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -517,8 +517,10 @@ public final class TestStore<State, Action> {
     R.Action == Action,
     State: Equatable
   {
-    let reducer = Dependencies.withDependencies(prepareDependencies) {
-      TestReducer(Reduce(reducer()), initialState: initialState())
+    let reducer = XCTFailContext.$current.withValue(XCTFailContext(file: file, line: line)) {
+      Dependencies.withDependencies(prepareDependencies) {
+        TestReducer(Reduce(reducer()), initialState: initialState())
+      }
     }
     self.file = file
     self.line = line
@@ -552,8 +554,10 @@ public final class TestStore<State, Action> {
     R.State == State,
     R.Action == Action
   {
-    let reducer = Dependencies.withDependencies(prepareDependencies) {
-      TestReducer(Reduce(reducer()), initialState: initialState())
+    let reducer = XCTFailContext.$current.withValue(XCTFailContext(file: file, line: line)) {
+      Dependencies.withDependencies(prepareDependencies) {
+        TestReducer(Reduce(reducer()), initialState: initialState())
+      }
     }
     self.file = file
     self.line = line


### PR DESCRIPTION
Right now if a test failure occurs while creating a reducer/state (e.g. accessing a dependency that hasn't been overridden), the test failure doesn't show up in the best spot. This uses the new `XCTFailContext` from xctest-dynamic-overlay to improve the situation.