### PR TITLE
Small clarification for timer test in tutorial.

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-02-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-02-code-0006.swift
@@ -14,6 +14,9 @@ final class CounterFeatureTests: XCTestCase {
     await store.receive(.timerTick) {
       $0.count = 1
     }
+    // ✅ Test Suite 'Selected tests' passed at 2023-08-04 11:17:44.823.
+    //        Executed 1 test, with 0 failures (0 unexpected) in 1.044 (1.046) seconds
+    //    or:
     // ❌ Expected to receive an action, but received none after 0.1 seconds.
     await store.send(.toggleTimerButtonTapped) {
       $0.isTimerRunning = false

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-TestingYourFeature.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-TestingYourFeature.tutorial
@@ -170,7 +170,7 @@
       This is happening because the timer takes a full second to 
       emit, but the test store will only wait around for a certain amount of time to receive an
       action, and if it doesn't, it creates a test failure. This is because the test store doesn't
-      want your tests to be slow, and so it rather you take control over your dependency on time to
+      want your tests to be slow, and so it would rather you take control over your dependency on time to
       write a faster, more deterministic test.
       
       @Step {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-TestingYourFeature.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-TestingYourFeature.tutorial
@@ -161,14 +161,17 @@
       }
       
       @Step {
-        Run tests to see that, unfortunately, the test fails. This is happening because our timer
-        takes a full second to emit, but the test store will only wait around for a small amount
-        of time to receive an action, and if it doesn't, it creates a test failure. This is 
-        because the test store doesn't want your tests to be slow, and so rather you take control
-        over your dependency on time to write a faster, more deterministic test.
+        If you run the test now you may find that sometimes it passes, albeit taking over a second 
+        to run, or sometimes it fails. 
         
         @Code(name: "CounterFeatureTests.swift", file: 01-03-02-code-0006.swift)
       }
+      
+      This is happening because the timer takes a full second to 
+      emit, but the test store will only wait around for a certain amount of time to receive an
+      action, and if it doesn't, it creates a test failure. This is because the test store doesn't
+      want your tests to be slow, and so it rather you take control over your dependency on time to
+      write a faster, more deterministic test.
       
       @Step {
         One thing we can do to force the ``ComposableArchitecture/TestStore`` to wait for more time


### PR DESCRIPTION
A couple of people brought up that the timer test does now tend to pass since we upped the default timeout in `TestStore` to 1 second. So, let's add a little nuance to the discussion.