### PR TITLE
Fix TaskResult Example in Documentation

### DIFF
--- a/Sources/ComposableArchitecture/Effects/TaskResult.swift
+++ b/Sources/ComposableArchitecture/Effects/TaskResult.swift
@@ -45,7 +45,7 @@ import XCTestDynamicOverlay
 ///     )
 ///   }
 ///
-/// case .factResponse(.success(fact)):
+/// case let .factResponse(.success(fact)):
 ///   // do something with fact
 ///
 /// case .factResponse(.failure):


### PR DESCRIPTION
- Fix enum case with Associated Value having no 'let' to get local value.
- hope it helps!

```diff
- case .factResponse(.success(fact)):
+ case let .factResponse(.success(fact)):
```