### PR TITLE
Fix TaskResult Action enum name in Documentation

### DIFF
--- a/Sources/ComposableArchitecture/Effects/TaskResult.swift
+++ b/Sources/ComposableArchitecture/Effects/TaskResult.swift
@@ -17,7 +17,7 @@ import XCTestDynamicOverlay
 /// effect:
 ///
 /// ```swift
-/// enum FeatureAction: Equatable {
+/// enum Action: Equatable {
 ///   case factButtonTapped
 ///   case factResponse(TaskResult<String>)
 /// }


### PR DESCRIPTION
- Type `FeatureAction` is now Type `Action` which is conformance of `Reducer`

```diff
- enum FeatureAction: Equatable {
+ enum Action: Equatable {
   case factButtonTapped
   case factResponse(TaskResult<String>)
}
```