### PR TITLE
Tear down presentation state on dismissal

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -404,6 +404,10 @@ public struct _PresentationReducer<Base: Reducer, Destination: Reducer>: Reducer
       dismissEffects = .none
     }
 
+    if presentationIdentityChanged, state[keyPath: self.toPresentationState].wrappedValue == nil {
+      state[keyPath: self.toPresentationState].isPresented = false
+    }
+
     let presentEffects: Effect<Base.Action>
     if presentationIdentityChanged || !state[keyPath: self.toPresentationState].isPresented,
       let presentationState = state[keyPath: self.toPresentationState].wrappedValue,

--- a/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
@@ -792,16 +792,11 @@ final class PresentationReducerTests: BaseTCATestCase {
   func testPresentation_rehydratedDestination_childDismissal() async {
     struct ChildFeature: Reducer {
       struct State: Equatable {}
-      enum Action: Equatable {
-        case cancel
-        case save
-      }
+      enum Action: Equatable { case cancel }
       @Dependency(\.dismiss) var dismiss
       var body: some Reducer<State, Action> {
         Reduce { _, action in
-          .run { _ in
-            await dismiss()
-          }
+          .run { _ in await dismiss() }
         }
       }
     }
@@ -844,32 +839,18 @@ final class PresentationReducerTests: BaseTCATestCase {
     }
     let store = TestStore(initialState: ParentFeature.State()) { ParentFeature() }
 
-    _ = await store.send(.childContainer(.openChild)) { state in
+    await store.send(.childContainer(.openChild)) { state in
       state.childContainer.child = ChildFeature.State()
     }
-
-    _ = await store.send(.childContainer(.child(.presented(.cancel))))
-
+    await store.send(.childContainer(.child(.presented(.cancel))))
     await store.receive(.childContainer(.child(.dismiss))) { state in
       state.childContainer.child = nil
     }
 
-    _ = await store.send(.childContainer(.openChild)) { state in
+    await store.send(.childContainer(.openChild)) { state in
       state.childContainer.child = ChildFeature.State()
     }
-
-    _ = await store.send(.childContainer(.child(.presented(.cancel))))
-
-    await store.receive(.childContainer(.child(.dismiss))) { state in
-      state.childContainer.child = nil
-    }
-
-    _ = await store.send(.childContainer(.openChild)) { state in
-      state.childContainer.child = ChildFeature.State()
-    }
-
-    _ = await store.send(.childContainer(.child(.presented(.cancel))))
-
+    await store.send(.childContainer(.child(.presented(.cancel))))
     await store.receive(.childContainer(.child(.dismiss))) { state in
       state.childContainer.child = nil
     }


### PR DESCRIPTION
When a store is initialized with presentation state that is already presented, we use a flag on `@PresentationState` to determine if we need to integrate the `\.dismiss` effect to allow the child to dismiss itself.

This flag currently stays `true` for the lifetime of the presenting feature, which means if a parent re-presents a feature after dismissal, the `\.dismiss` effect will fail to do anything when called from the child.

This PR ensures that the flag is reset to `false` when a presenter detects that a child feature has been dismissed, fixing this bug.