### PR TITLE
0.x: Hard deprecate more soft-deprecated APIs

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -56,10 +56,7 @@ extension WithViewStore {
 }
 
 extension EffectPublisher where Failure == Never {
-  @available(iOS, deprecated: 9999, message: "Use 'Effect.run' and pass the action to 'send'.")
-  @available(macOS, deprecated: 9999, message: "Use 'Effect.run' and pass the action to 'send'.")
-  @available(tvOS, deprecated: 9999, message: "Use 'Effect.run' and pass the action to 'send'.")
-  @available(watchOS, deprecated: 9999, message: "Use 'Effect.run' and pass the action to 'send'.")
+  @available(*, deprecated, message: "Use 'Effect.run' and pass the action to 'send'.")
   public static func task(
     priority: TaskPriority? = nil,
     operation: @escaping @Sendable () async throws -> Action,
@@ -101,10 +98,7 @@ extension EffectPublisher where Failure == Never {
     }
   }
 
-  @available(iOS, deprecated: 9999, message: "Use 'Effect.run' and ignore 'send' instead.")
-  @available(macOS, deprecated: 9999, message: "Use 'Effect.run' and ignore 'send' instead.")
-  @available(tvOS, deprecated: 9999, message: "Use 'Effect.run' and ignore 'send' instead.")
-  @available(watchOS, deprecated: 9999, message: "Use 'Effect.run' and ignore 'send' instead.")
+  @available(*, deprecated, message: "Use 'Effect.run' and ignore 'send' instead.")
   public static func fireAndForget(
     priority: TaskPriority? = nil,
     _ work: @escaping @Sendable () async throws -> Void
@@ -114,10 +108,7 @@ extension EffectPublisher where Failure == Never {
 }
 
 extension Store {
-  @available(iOS, deprecated: 9999, message: "Pass a closure as the reducer.")
-  @available(macOS, deprecated: 9999, message: "Pass a closure as the reducer.")
-  @available(tvOS, deprecated: 9999, message: "Pass a closure as the reducer.")
-  @available(watchOS, deprecated: 9999, message: "Pass a closure as the reducer.")
+  @available(*, deprecated, message: "Pass a closure as the reducer.")
   public convenience init<R: Reducer>(
     initialState: @autoclosure () -> R.State,
     reducer: R,

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -318,10 +318,7 @@ extension ViewStore where ViewAction: BindableAction, ViewAction.State == ViewSt
     )
   }
 
-  @available(iOS, deprecated: 9999, message: "Use 'viewStore.$value' instead.")
-  @available(macOS, deprecated: 9999, message: "Use 'viewStore.$value' instead.")
-  @available(tvOS, deprecated: 9999, message: "Use 'viewStore.$value' instead.")
-  @available(watchOS, deprecated: 9999, message: "Use 'viewStore.$value' instead.")
+  @available(*, deprecated, message: "Use 'viewStore.$value' instead.")
   public func binding<Value: Equatable>(
     _ keyPath: WritableKeyPath<ViewState, BindingState<Value>>,
     fileID: StaticString = #fileID,

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -1191,23 +1191,8 @@ extension SwitchStore {
 }
 
 @available(
-  iOS,
-  deprecated: 9999,
-  message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
-)
-@available(
-  macOS,
-  deprecated: 9999,
-  message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
-)
-@available(
-  tvOS,
-  deprecated: 9999,
-  message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
-)
-@available(
-  watchOS,
-  deprecated: 9999,
+  *,
+  deprecated,
   message: "Use the 'SwitchStore.init' that can 'switch' over a given 'state' instead."
 )
 public struct _ExhaustivityCheckView<State, Action>: View {


### PR DESCRIPTION
A few of the deprecated APIs removed in 1.0 were only soft-deprecated, which could make migrating a little more difficult. Let's ensure these APIs are deprecated on a 0.59.0 release to make upgrading a little less annoying.