### PR TITLE
0.x: Fix deprecation warning on TestStore

### DIFF
--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -543,7 +543,7 @@ public final class TestStore<State, Action, ScopedState, ScopedAction, Environme
   ///     accessed during the test. These dependencies will be used when producing the initial
   ///     state.
   public init<R: Reducer>(
-    initialState: @autoclosure () -> State,
+    initialState: @autoclosure () -> R.State,
     @ReducerBuilder<State, Action> reducer: () -> R,
     withDependencies prepareDependencies: (inout DependencyValues) -> Void = { _ in
     },
@@ -581,7 +581,7 @@ public final class TestStore<State, Action, ScopedState, ScopedAction, Environme
       """
   )
   public convenience init<R: Reducer>(
-    initialState: @autoclosure () -> State,
+    initialState: @autoclosure () -> R.State,
     @ReducerBuilder<State, Action> reducer: () -> R,
     observe toScopedState: @escaping (State) -> ScopedState,
     withDependencies prepareDependencies: (inout DependencyValues) -> Void = { _ in },
@@ -615,7 +615,7 @@ public final class TestStore<State, Action, ScopedState, ScopedAction, Environme
       """
   )
   public init<R: Reducer>(
-    initialState: @autoclosure () -> State,
+    initialState: @autoclosure () -> R.State,
     @ReducerBuilder<State, Action> reducer: () -> R,
     observe toScopedState: @escaping (State) -> ScopedState,
     send fromScopedAction: @escaping (ScopedAction) -> Action,
@@ -656,7 +656,7 @@ public final class TestStore<State, Action, ScopedState, ScopedAction, Environme
   ///     state.
   @available(*, deprecated, message: "State must be equatable to perform assertions.")
   public init<R: Reducer>(
-    initialState: @autoclosure () -> State,
+    initialState: @autoclosure () -> R.State,
     @ReducerBuilder<State, Action> reducer: () -> R,
     withDependencies prepareDependencies: (inout DependencyValues) -> Void = { _ in
     },

--- a/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
@@ -2242,7 +2242,7 @@ final class PresentationReducerTests: BaseTCATestCase {
     }
 
     let mainQueue = DispatchQueue.test
-    let store = TestStore(initialState: Parent.State()) {
+    let store = TestStore(initialState: .init()) {
       Parent()
     } withDependencies: {
       $0.mainQueue = mainQueue.eraseToAnyScheduler()


### PR DESCRIPTION
This PR cherry-picks the [fix](https://github.com/pointfreeco/swift-composable-architecture/pull/2347) for an incorrect `TestStore` deprecation warning onto the `prerelase/1.0` branch. 

I'm opening the PR because it seemed an easy fix and should help folks getting rid of some noise while preparing for `1.0`. For instance, in highly tested codebases these incorrect warnings could hide the important deprecations that `0.57`/`0.58` should help fixing. It would be nice to include this into a `0.58.2` or `0.59` release 🙂 