### PR TITLE
Fix potential threading issue in `Store.send`

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -546,7 +546,7 @@ public final class Store<State, Action> {
     }
 
     guard !tasks.wrappedValue.isEmpty else { return nil }
-    return Task {
+    return Task { @MainActor in
       await withTaskCancellationHandler {
         var index = tasks.wrappedValue.startIndex
         while index < tasks.wrappedValue.endIndex {


### PR DESCRIPTION
While `Store.send`'s internal access to `Box<[Task]>` does seem mutually exclusive between the synchronous body of the method and the `Task` that is spun off at the very end, we should probably be a little more diligent with the threading model here. We even had `@MainActor` on this task at some time, but may have pruned it a bit aggressively.