### PR TITLE
[FIX] Fixed API description to use the recent name: `EffectTask` -> `Effect`

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -25,7 +25,7 @@ public struct Effect<Action> {
 /// Instead of specifying the action:
 ///
 /// ```swift
-/// let effect: EffectTask<Feature.Action>
+/// let effect: Effect<Feature.Action>
 /// ```
 ///
 /// You can specify the reducer:


### PR DESCRIPTION
There's a very minor modification on API description of ``EffectOf``.

The description uses `EffectTask` in the code snippet, but it should be `Effect`.

I also searched for EffectTask, but there are no more results of its usage.