### PR TITLE
Add `TestStore.bindings` for testing bindable view state

### DIFF
--- a/Examples/TicTacToe/TicTacToe.xcodeproj/xcshareddata/xcschemes/TicTacToe.xcscheme
+++ b/Examples/TicTacToe/TicTacToe.xcodeproj/xcshareddata/xcschemes/TicTacToe.xcscheme
@@ -52,29 +52,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "GameSwiftUITests"
-               BuildableName = "GameSwiftUITests"
-               BlueprintName = "GameSwiftUITests"
-               ReferencedContainer = "container:tic-tac-toe">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "LoginCoreTests"
                BuildableName = "LoginCoreTests"
                BlueprintName = "LoginCoreTests"
-               ReferencedContainer = "container:tic-tac-toe">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LoginSwiftUITests"
-               BuildableName = "LoginSwiftUITests"
-               BlueprintName = "LoginSwiftUITests"
                ReferencedContainer = "container:tic-tac-toe">
             </BuildableReference>
          </TestableReference>
@@ -92,29 +72,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NewGameSwiftUITests"
-               BuildableName = "NewGameSwiftUITests"
-               BlueprintName = "NewGameSwiftUITests"
-               ReferencedContainer = "container:tic-tac-toe">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "TwoFactorCoreTests"
                BuildableName = "TwoFactorCoreTests"
                BlueprintName = "TwoFactorCoreTests"
-               ReferencedContainer = "container:tic-tac-toe">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "TwoFactorSwiftUITests"
-               BuildableName = "TwoFactorSwiftUITests"
-               BlueprintName = "TwoFactorSwiftUITests"
                ReferencedContainer = "container:tic-tac-toe">
             </BuildableReference>
          </TestableReference>

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStore.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStore.md
@@ -35,6 +35,8 @@ While the most common way of interacting with a test store's state is via its
 also access it directly throughout a test.
 
 - ``state``
+- ``bindings``
+- ``bindings(action:)``
 
 ### Deprecations
 

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1861,8 +1861,70 @@ extension TestStore {
   }
 }
 
-/// The type returned from ``TestStore/send(_:assert:file:line:)`` that represents the lifecycle of
-/// the effect started from sending an action.
+extension TestStore {
+  /// Returns a binding view store for this store.
+  ///
+  /// Useful for testing view state of a store.
+  ///
+  /// ```swift
+  /// let store = TestStore(LoginFeature.State()) {
+  ///   Login.Feature()
+  /// }
+  /// await store.send(.view(.set(\.$email, "blob@pointfree.co"))) {
+  ///   $0.email = "blob@pointfree.co"
+  /// }
+  /// XCTAssertTrue(LoginView.ViewState(store.bindings).isFormDisabled)
+  ///
+  /// await store.send(.view(.set(\.$password, "whats-the-point?"))) {
+  ///   $0.password = "blob@pointfree.co"
+  ///   $0.isFormValid
+  /// }
+  /// XCTAssertFalse(LoginView.ViewState(store.bindings).isFormDisabled)
+  /// ```
+  ///
+  /// - Parameter toViewAction: A case path from action to a bindable view action.
+  /// - Returns: A binding view store.
+  public func bindings<ViewAction: BindableAction>(
+    action toViewAction: CasePath<Action, ViewAction>
+  ) -> BindingViewStore<State> where State == ViewAction.State {
+    BindingViewStore(
+      store: Store(initialState: self.state) {
+        BindingReducer(action: toViewAction.extract(from:))
+      }
+      .scope(state: { $0 }, action: toViewAction.embed)
+    )
+  }
+}
+
+extension TestStore where Action: BindableAction, State == Action.State {
+  /// Returns a binding view store for this store.
+  ///
+  /// Useful for testing view state of a store.
+  ///
+  /// ```swift
+  /// let store = TestStore(LoginFeature.State()) {
+  ///   Login.Feature()
+  /// }
+  /// await store.send(.set(\.$email, "blob@pointfree.co")) {
+  ///   $0.email = "blob@pointfree.co"
+  /// }
+  /// XCTAssertTrue(LoginView.ViewState(store.bindings).isFormDisabled)
+  ///
+  /// await store.send(.set(\.$password, "whats-the-point?")) {
+  ///   $0.password = "blob@pointfree.co"
+  ///   $0.isFormValid
+  /// }
+  /// XCTAssertFalse(LoginView.ViewState(store.bindings).isFormDisabled)
+  /// ```
+  ///
+  /// - Returns: A binding view store.
+  public var bindings: BindingViewStore<State> {
+    self.bindings(action: .self)
+  }
+}
+
+/// The type returned from ``TestStore/send(_:assert:file:line:)-1ax61`` that represents the
+/// lifecycle of the effect started from sending an action.
 ///
 /// You can use this value in tests to cancel the effect started from sending an action:
 ///
@@ -2072,6 +2134,10 @@ class TestReducer<State, Action>: Reducer {
     let origin: Origin
     let file: StaticString
     let line: UInt
+
+    fileprivate var action: Action {
+      self.origin.action
+    }
 
     enum Origin {
       case receive(Action)

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1873,13 +1873,19 @@ extension TestStore {
   /// await store.send(.view(.set(\.$email, "blob@pointfree.co"))) {
   ///   $0.email = "blob@pointfree.co"
   /// }
-  /// XCTAssertTrue(LoginView.ViewState(store.bindings).isFormDisabled)
+  /// XCTAssertTrue(
+  ///   LoginView.ViewState(store.bindings(action: /LoginFeature.Action.view))
+  ///     .isLoginButtonDisabled
+  /// )
   ///
   /// await store.send(.view(.set(\.$password, "whats-the-point?"))) {
   ///   $0.password = "blob@pointfree.co"
-  ///   $0.isFormValid
+  ///   $0.isFormValid = true
   /// }
-  /// XCTAssertFalse(LoginView.ViewState(store.bindings).isFormDisabled)
+  /// XCTAssertFalse(
+  ///   LoginView.ViewState(store.bindings(action: /LoginFeature.Action.view))
+  ///     .isLoginButtonDisabled
+  /// )
   /// ```
   ///
   /// - Parameter toViewAction: A case path from action to a bindable view action.
@@ -1908,13 +1914,13 @@ extension TestStore where Action: BindableAction, State == Action.State {
   /// await store.send(.set(\.$email, "blob@pointfree.co")) {
   ///   $0.email = "blob@pointfree.co"
   /// }
-  /// XCTAssertTrue(LoginView.ViewState(store.bindings).isFormDisabled)
+  /// XCTAssertTrue(LoginView.ViewState(store.bindings).isLoginButtonDisabled)
   ///
   /// await store.send(.set(\.$password, "whats-the-point?")) {
   ///   $0.password = "blob@pointfree.co"
-  ///   $0.isFormValid
+  ///   $0.isFormValid = true
   /// }
-  /// XCTAssertFalse(LoginView.ViewState(store.bindings).isFormDisabled)
+  /// XCTAssertFalse(LoginView.ViewState(store.bindings).isLoginButtonDisabled)
   /// ```
   ///
   /// - Returns: A binding view store.

--- a/Tests/ComposableArchitectureTests/BindableStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/BindableStoreTests.swift
@@ -167,7 +167,7 @@ final class BindableStoreTests: XCTestCase {
             return .none
           case .view(.loginButtonTapped):
             state.isRequestInFlight = true
-            return .none  // TODO: Login request
+            return .none  // NB: Login request
           }
         }
       }

--- a/Tests/ComposableArchitectureTests/BindableStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/BindableStoreTests.swift
@@ -80,4 +80,143 @@ final class BindableStoreTests: XCTestCase {
       }
     }
   }
+
+  func testTestStoreBindings() async {
+    struct LoginFeature: Reducer {
+      struct State: Equatable {
+        @BindingState var email = ""
+        public var isFormValid = false
+        public var isRequestInFlight = false
+        @BindingState var password = ""
+      }
+      enum Action: Equatable, BindableAction {
+        case binding(BindingAction<State>)
+        case loginButtonTapped
+      }
+      var body: some ReducerOf<Self> {
+        BindingReducer()
+        Reduce { state, action in
+          switch action {
+          case .binding:
+            state.isFormValid = !state.email.isEmpty && !state.password.isEmpty
+            return .none
+          case .loginButtonTapped:
+            state.isRequestInFlight = true
+            return .none  // TODO: Login request
+          }
+        }
+      }
+    }
+
+    struct LoginViewState: Equatable {
+      @BindingViewState var email: String
+      var isFormDisabled: Bool
+      var isLoginButtonDisabled: Bool
+      @BindingViewState var password: String
+
+      init(_ store: BindingViewStore<LoginFeature.State>) {
+        self._email = store.$email
+        self.isFormDisabled = store.isRequestInFlight
+        self.isLoginButtonDisabled = !store.isFormValid || store.isRequestInFlight
+        self._password = store.$password
+      }
+    }
+
+    let store = TestStore(initialState: LoginFeature.State()) {
+      LoginFeature()
+    }
+    await store.send(.set(\.$email, "blob@pointfree.co")) {
+      $0.email = "blob@pointfree.co"
+    }
+    XCTAssertFalse(LoginViewState(store.bindings).isFormDisabled)
+    XCTAssertTrue(LoginViewState(store.bindings).isLoginButtonDisabled)
+    await store.send(.set(\.$password, "blob123")) {
+      $0.password = "blob123"
+      $0.isFormValid = true
+    }
+    XCTAssertFalse(LoginViewState(store.bindings).isFormDisabled)
+    XCTAssertFalse(LoginViewState(store.bindings).isLoginButtonDisabled)
+    await store.send(.loginButtonTapped) {
+      $0.isRequestInFlight = true
+    }
+    XCTAssertTrue(LoginViewState(store.bindings).isFormDisabled)
+    XCTAssertTrue(LoginViewState(store.bindings).isLoginButtonDisabled)
+  }
+
+  func testTestStoreBindings_ViewAction() async {
+    struct LoginFeature: Reducer {
+      struct State: Equatable {
+        @BindingState var email = ""
+        public var isFormValid = false
+        public var isRequestInFlight = false
+        @BindingState var password = ""
+      }
+      enum Action: Equatable {
+        case view(View)
+        enum View: Equatable, BindableAction {
+          case binding(BindingAction<State>)
+          case loginButtonTapped
+        }
+      }
+      var body: some ReducerOf<Self> {
+        BindingReducer(action: /Action.view)
+        Reduce { state, action in
+          switch action {
+          case .view(.binding):
+            state.isFormValid = !state.email.isEmpty && !state.password.isEmpty
+            return .none
+          case .view(.loginButtonTapped):
+            state.isRequestInFlight = true
+            return .none  // TODO: Login request
+          }
+        }
+      }
+    }
+
+    struct LoginViewState: Equatable {
+      @BindingViewState var email: String
+      var isFormDisabled: Bool
+      var isLoginButtonDisabled: Bool
+      @BindingViewState var password: String
+
+      init(_ store: BindingViewStore<LoginFeature.State>) {
+        self._email = store.$email
+        self.isFormDisabled = store.isRequestInFlight
+        self.isLoginButtonDisabled = !store.isFormValid || store.isRequestInFlight
+        self._password = store.$password
+      }
+    }
+
+    let store = TestStore(initialState: LoginFeature.State()) {
+      LoginFeature()
+    }
+    await store.send(.view(.set(\.$email, "blob@pointfree.co"))) {
+      $0.email = "blob@pointfree.co"
+    }
+    XCTAssertFalse(
+      LoginViewState(store.bindings(action: /LoginFeature.Action.view)).isFormDisabled
+    )
+    XCTAssertTrue(
+      LoginViewState(store.bindings(action: /LoginFeature.Action.view)).isLoginButtonDisabled
+    )
+    await store.send(.view(.set(\.$password, "blob123"))) {
+      $0.password = "blob123"
+      $0.isFormValid = true
+    }
+    XCTAssertFalse(
+      LoginViewState(store.bindings(action: /LoginFeature.Action.view)).isFormDisabled
+    )
+    XCTAssertFalse(
+      LoginViewState(store.bindings(action: /LoginFeature.Action.view)).isLoginButtonDisabled
+    )
+    await store.send(.view(.loginButtonTapped)) {
+      $0.isRequestInFlight = true
+    }
+    XCTAssertTrue(
+      LoginViewState(store.bindings(action: /LoginFeature.Action.view)).isFormDisabled
+    )
+    XCTAssertTrue(
+      LoginViewState(store.bindings(action: /LoginFeature.Action.view)).isLoginButtonDisabled
+    )
+  }
 }

--- a/Tests/ComposableArchitectureTests/BindableStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/BindableStoreTests.swift
@@ -102,7 +102,7 @@ final class BindableStoreTests: XCTestCase {
             return .none
           case .loginButtonTapped:
             state.isRequestInFlight = true
-            return .none  // TODO: Login request
+            return .none  // NB: Login request
           }
         }
       }


### PR DESCRIPTION
Because `@BindingViewState` is populated by a live store, there is no way to easily test `ViewState` structs that use `@BindingViewState`. This adds a `bindings` property on `TestStore` (`bindings(action:)` method when using view actions) that makes it possible to write assertions against view state.