### PR TITLE
Fix stack case study

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -2,6 +2,7 @@ import ComposableArchitecture
 import SwiftUI
 
 struct RootView: View {
+  @State var isNavigationStackCaseStudyPresented = false
   let store: StoreOf<Root>
 
   var body: some View {
@@ -161,15 +162,10 @@ struct RootView: View {
         }
 
         Section(header: Text("Navigation")) {
-          NavigationLink(
-            "Stack",
-            destination: NavigationDemoView(
-              store: self.store.scope(
-                state: \.navigationStack,
-                action: Root.Action.navigationStack
-              )
-            )
-          )
+          Button("Stack") {
+            self.isNavigationStackCaseStudyPresented = true
+          }
+          .buttonStyle(.plain)
 
           NavigationLink(
             "Navigate and load data",
@@ -256,6 +252,14 @@ struct RootView: View {
       }
       .navigationTitle("Case Studies")
       .onAppear { self.store.send(.onAppear) }
+      .sheet(isPresented: self.$isNavigationStackCaseStudyPresented) {
+        NavigationDemoView(
+          store: self.store.scope(
+            state: \.navigationStack,
+            action: Root.Action.navigationStack
+          )
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
We originally took advantage of the fact that `NavigationView` could nest `NavigationStack`, though it was a little funky. We independently updated the root to be a `NavigationStack`, though, which unfortunately broke the stack case study since nested `NavigationStack`s are not supported in SwiftUI.

Fixes #2396.