### PR TITLE
Added `Equatable` Protocol to Code Examples in Tutorial Docs.

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-01-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-01-code-0003.swift
@@ -1,11 +1,11 @@
 import ComposableArchitecture
 
 struct CounterFeature: Reducer {
-  struct State {
+  struct State: Equatable {
 
   }
 
-  enum Action {
+  enum Action: Equatable {
 
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-01-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-01-code-0004.swift
@@ -1,11 +1,11 @@
 import ComposableArchitecture
 
 struct CounterFeature: Reducer {
-  struct State {
+  struct State: Equatable {
     var count = 0
   }
 
-  enum Action {
+  enum Action: Equatable {
     case decrementButtonTapped
     case incrementButtonTapped
   }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-01-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-01-code-0005.swift
@@ -1,11 +1,11 @@
 import ComposableArchitecture
 
 struct CounterFeature: Reducer {
-  struct State {
+  struct State: Equatable {
     var count = 0
   }
 
-  enum Action {
+  enum Action: Equatable {
     case decrementButtonTapped
     case incrementButtonTapped
   }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-01-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-01-code-0006.swift
@@ -1,11 +1,11 @@
 import ComposableArchitecture
 
 struct CounterFeature: Reducer {
-  struct State {
+  struct State: Equatable {
     var count = 0
   }
 
-  enum Action {
+  enum Action: Equatable {
     case decrementButtonTapped
     case incrementButtonTapped
   }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-01-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-01-code-0003.swift
@@ -5,7 +5,7 @@ struct CounterFeature: Reducer {
     var count = 0
   }
 
-  enum Action {
+  enum Action: Equatable {
     case decrementButtonTapped
     case incrementButtonTapped
   }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-01-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-01-code-0004.swift
@@ -7,7 +7,7 @@ struct CounterFeature: Reducer {
     var isLoading = false
   }
 
-  enum Action {
+  enum Action: Equatable {
     case decrementButtonTapped
     case factButtonTapped
     case incrementButtonTapped

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-01-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-01-code-0005.swift
@@ -7,7 +7,7 @@ struct CounterFeature: Reducer {
     var isLoading = false
   }
 
-  enum Action {
+  enum Action: Equatable {
     case decrementButtonTapped
     case factButtonTapped
     case incrementButtonTapped

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0001.swift
@@ -7,7 +7,7 @@ struct CounterFeature: Reducer {
     var isLoading = false
   }
 
-  enum Action {
+  enum Action: Equatable {
     case decrementButtonTapped
     case factButtonTapped
     case incrementButtonTapped

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0002.swift
@@ -7,7 +7,7 @@ struct CounterFeature: Reducer {
     var isLoading = false
   }
 
-  enum Action {
+  enum Action: Equatable {
     case decrementButtonTapped
     case factButtonTapped
     case incrementButtonTapped

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0003.swift
@@ -7,7 +7,7 @@ struct CounterFeature: Reducer {
     var isLoading = false
   }
 
-  enum Action {
+  enum Action: Equatable {
     case decrementButtonTapped
     case factButtonTapped
     case incrementButtonTapped

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0004.swift
@@ -7,7 +7,7 @@ struct CounterFeature: Reducer {
     var isLoading = false
   }
 
-  enum Action {
+  enum Action: Equatable {
     case decrementButtonTapped
     case factButtonTapped
     case factResponse(String)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0005.swift
@@ -7,7 +7,7 @@ struct CounterFeature: Reducer {
     var isLoading = false
   }
 
-  enum Action {
+  enum Action: Equatable {
     case decrementButtonTapped
     case factButtonTapped
     case factResponse(String)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0002.swift
@@ -8,7 +8,7 @@ struct CounterFeature: Reducer {
     var isTimerRunning = false
   }
 
-  enum Action {
+  enum Action: Equatable {
     case decrementButtonTapped
     case factButtonTapped
     case factResponse(String)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0003.swift
@@ -8,7 +8,7 @@ struct CounterFeature: Reducer {
     var isTimerRunning = false
   }
 
-  enum Action {
+  enum Action: Equatable {
     case decrementButtonTapped
     case factButtonTapped
     case factResponse(String)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0004.swift
@@ -8,7 +8,7 @@ struct CounterFeature: Reducer {
     var isTimerRunning = false
   }
 
-  enum Action {
+  enum Action: Equatable {
     case decrementButtonTapped
     case factButtonTapped
     case factResponse(String)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0005.swift
@@ -8,7 +8,7 @@ struct CounterFeature: Reducer {
     var isTimerRunning = false
   }
 
-  enum Action {
+  enum Action: Equatable {
     case decrementButtonTapped
     case factButtonTapped
     case factResponse(String)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0006.swift
@@ -8,7 +8,7 @@ struct CounterFeature: Reducer {
     var isTimerRunning = false
   }
 
-  enum Action {
+  enum Action: Equatable {
     case decrementButtonTapped
     case factButtonTapped
     case factResponse(String)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-02-code-0008.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-02-code-0008.swift
@@ -8,7 +8,7 @@ struct CounterFeature: Reducer {
     var isTimerRunning = false
   }
 
-  enum Action {
+  enum Action: Equatable {
     case decrementButtonTapped
     case factButtonTapped
     case factResponse(String)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-04-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-04-code-0005.swift
@@ -8,7 +8,7 @@ struct CounterFeature: Reducer {
     var isTimerRunning = false
   }
 
-  enum Action {
+  enum Action: Equatable {
     case decrementButtonTapped
     case factButtonTapped
     case factResponse(String)


### PR DESCRIPTION
I've added the missing `Equatable` protocol to the code examples in the tutorial documentation.

The behavior of the code is likely unaffected, but there might be confusion due to its deviation from the example provided in the [README](https://github.com/pointfreeco/swift-composable-architecture#basic-usage).