### PR TITLE
Enhance `Reducer.ifLet` child effect cancellation

### DIFF
--- a/Sources/ComposableArchitecture/Internal/NavigationID.swift
+++ b/Sources/ComposableArchitecture/Internal/NavigationID.swift
@@ -12,6 +12,7 @@ private enum NavigationIDPathKey: DependencyKey {
   static let testValue = NavigationIDPath()
 }
 
+@usableFromInline
 struct NavigationIDPath: Hashable, Sendable {
   fileprivate var path: [NavigationID]
 

--- a/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
@@ -15,7 +15,7 @@ import OrderedCollections
 /// compares to SwiftUI's `NavigationPath` type.
 public struct StackState<Element> {
   var _dictionary: OrderedDictionary<StackElementID, Element>
-  fileprivate var _mounted: Set<StackElementID> = []
+  fileprivate var _mounted: OrderedSet<StackElementID> = []
 
   @Dependency(\.stackElementID) private var stackElementID
 

--- a/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
@@ -38,12 +38,7 @@ public struct StackState<Element> {
   /// Accesses the value associated with the given id for reading and writing.
   public subscript(id id: StackElementID) -> Element? {
     _read { yield self._dictionary[id] }
-    _modify {
-      yield &self._dictionary[id]
-      if !self._dictionary.keys.contains(id) {
-        self._mounted.remove(id)
-      }
-    }
+    _modify { yield &self._dictionary[id] }
     set {
       switch (self.ids.contains(id), newValue, _XCTIsTesting) {
       case (true, _, _), (false, .some, true):
@@ -54,9 +49,6 @@ public struct StackState<Element> {
         }
       case (false, .none, _):
         break
-      }
-      if newValue == nil {
-        self._mounted.remove(id)
       }
     }
   }
@@ -94,7 +86,7 @@ public struct StackState<Element> {
   ///
   /// - Parameter id: The identifier of an element in the stack.
   public mutating func pop(from id: StackElementID) {
-    guard let index = self._dictionary.keys.firstIndex(of: id)
+    guard let index = self.ids.firstIndex(of: id)
     else { return }
     self.removeSubrange(index...)
   }
@@ -103,7 +95,7 @@ public struct StackState<Element> {
   ///
   /// - Parameter id: The identifier of an element in the stack.
   public mutating func pop(to id: StackElementID) {
-    guard let index = self._dictionary.keys.firstIndex(of: id)
+    guard let index = self.ids.firstIndex(of: id)
     else { return }
     self.removeSubrange(index.advanced(by: 1)...)
   }
@@ -118,11 +110,11 @@ extension StackState: RandomAccessCollection, RangeReplaceableCollection {
   public init() {
     self._dictionary = [:]
   }
+  public mutating func removeAll(keepingCapacity keepCapacity: Bool = false) {
+    self._dictionary.removeAll(keepingCapacity: keepCapacity)
+  }
   public mutating func replaceSubrange<C: Collection>(_ subrange: Range<Int>, with newElements: C)
   where C.Element == Element {
-    for id in self.ids[subrange] {
-      self._mounted.remove(id)
-    }
     self._dictionary.removeSubrange(subrange)
     for (offset, element) in zip(subrange.lowerBound..., newElements) {
       self._dictionary.updateValue(element, forKey: self.stackElementID.next(), insertingAt: offset)
@@ -308,7 +300,7 @@ public struct _StackReducer<Base: Reducer, Destination: Reducer>: Reducer {
   }
 
   public func reduce(into state: inout Base.State, action: Base.Action) -> Effect<Base.Action> {
-    let idsBefore = state[keyPath: self.toStackState].ids
+    let idsBefore = state[keyPath: self.toStackState]._mounted
     let destinationEffects: Effect<Base.Action>
     let baseEffects: Effect<Base.Action>
 
@@ -425,7 +417,6 @@ public struct _StackReducer<Base: Reducer, Destination: Reducer>: Reducer {
     }
 
     let idsAfter = state[keyPath: self.toStackState].ids
-    let idsMounted = state[keyPath: self.toStackState]._mounted
 
     let cancelEffects: Effect<Base.Action> =
       areOrderedSetsDuplicates(idsBefore, idsAfter)
@@ -436,12 +427,11 @@ public struct _StackReducer<Base: Reducer, Destination: Reducer>: Reducer {
         }
       )
     let presentEffects: Effect<Base.Action> =
-      idsAfter.count == idsMounted.count
+      areOrderedSetsDuplicates(idsBefore, idsAfter)
       ? .none
       : .merge(
-        idsAfter.subtracting(idsMounted).map { elementID in
+        idsAfter.subtracting(idsBefore).map { elementID in
           let navigationDestinationID = self.navigationIDPath(for: elementID)
-          state[keyPath: self.toStackState]._mounted.insert(elementID)
           return .concatenate(
             .publisher { Empty(completeImmediately: false) }
               ._cancellable(
@@ -454,6 +444,8 @@ public struct _StackReducer<Base: Reducer, Destination: Reducer>: Reducer {
           ._cancellable(id: OnFirstAppearID(), navigationIDPath: .init())
         }
       )
+
+    state[keyPath: self.toStackState]._mounted = idsAfter
 
     return .merge(
       destinationEffects,

--- a/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
@@ -2424,6 +2424,7 @@ final class PresentationReducerTests: BaseTCATestCase {
     await store.send(.tapAfter) {
       $0.child = nil
     }
+    // NB: Another action needs to come into the `ifLet` to cancel the child action
     await store.send(.tapAfter)
   }
 }

--- a/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
@@ -2334,7 +2334,7 @@ final class PresentationReducerTests: BaseTCATestCase {
     }
   }
 
-  func testCancellation1() async {
+  func testOuterCancellation() async {
     struct Child: Reducer {
       struct State: Equatable {}
       enum Action: Equatable { case onAppear }
@@ -2360,12 +2360,12 @@ final class PresentationReducerTests: BaseTCATestCase {
       var body: some ReducerOf<Self> {
         Reduce { state, action in
           switch action {
+          case .child:
+            return .none
           case .tapAfter:
             return .none
           case .tapBefore:
             state.child = nil
-            return .none
-          case .child:
             return .none
           case .tapChild:
             return .none
@@ -2391,12 +2391,12 @@ final class PresentationReducerTests: BaseTCATestCase {
 
         Reduce { state, action in
           switch action {
+          case .child:
+            return .none
           case .tapAfter:
             state.child = nil
             return .none
           case .tapBefore:
-            return .none
-          case .child:
             return .none
           case .tapChild:
             return .none
@@ -2424,5 +2424,6 @@ final class PresentationReducerTests: BaseTCATestCase {
     await store.send(.tapAfter) {
       $0.child = nil
     }
+    await store.send(.tapAfter)
   }
 }

--- a/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
@@ -2333,4 +2333,88 @@ final class PresentationReducerTests: BaseTCATestCase {
       $0.child = nil
     }
   }
+
+  func testCancellation1() async {
+    struct Child: Reducer {
+      struct State: Equatable {}
+      enum Action: Equatable { case onAppear }
+      var body: some ReducerOf<Self> {
+        Reduce { state, action in
+          .run { _ in
+            try await Task.never()
+          }
+        }
+      }
+    }
+
+    struct Parent: Reducer {
+      struct State: Equatable {
+        @PresentationState var child: Child.State?
+      }
+      enum Action: Equatable {
+        case child(PresentationAction<Child.Action>)
+        case tapAfter
+        case tapBefore
+        case tapChild
+      }
+      var body: some ReducerOf<Self> {
+        Reduce { state, action in
+          switch action {
+          case .tapAfter:
+            return .none
+          case .tapBefore:
+            state.child = nil
+            return .none
+          case .child:
+            return .none
+          case .tapChild:
+            return .none
+          }
+        }
+
+        Reduce { state, action in
+          switch action {
+          case .child:
+            return .none
+          case .tapAfter:
+            return .none
+          case .tapBefore:
+            return .none
+          case .tapChild:
+            state.child = Child.State()
+            return .none
+          }
+        }
+        .ifLet(\.$child, action: /Action.child) {
+          Child()
+        }
+
+        Reduce { state, action in
+          switch action {
+          case .tapAfter:
+            state.child = nil
+            return .none
+          case .tapBefore:
+            return .none
+          case .child:
+            return .none
+          case .tapChild:
+            return .none
+          }
+        }
+      }
+    }
+
+    let store = TestStore(initialState: Parent.State()) {
+      Parent()
+    }
+
+    await store.send(.tapChild) {
+      $0.child = Child.State()
+    }
+    await store.send(.child(.presented(.onAppear)))
+    await store.send(.tapBefore) {
+      $0.child = nil
+    }
+  }
 }

--- a/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
@@ -2416,5 +2416,13 @@ final class PresentationReducerTests: BaseTCATestCase {
     await store.send(.tapBefore) {
       $0.child = nil
     }
+
+    await store.send(.tapChild) {
+      $0.child = Child.State()
+    }
+    await store.send(.child(.presented(.onAppear)))
+    await store.send(.tapAfter) {
+      $0.child = nil
+    }
   }
 }


### PR DESCRIPTION
Right now, `ifLet` checks the presented state before and after it runs the parent reducer, and if it changes, it cancels any in-flight effects for the previous state. It will not, however, detect when child state changes _outside_ the parent reducer, _e.g._:

```swift
Reduce { state, action in
  // ...
  state.child = nil // or `= .someOther(child)`
}

Reduce { state, action in
  // ...
}
.ifLet(\.$child, action: /Action.child) {
  Child()
}
```

While we generally recommend structuring reducers in a way in which this doesn't happen, as a library we should attempt to improve the situation. In our case `@PresentationState` already uses some internal state to detect if it needs to install the child's dismiss effects, _e.g._ if it was deep-linked into at app launch. We can leverage this same state to detect if it needs to tear down the previous child's effects.

This PR's solution should improve cancellation in these edge cases, but it may not (and may not be able to) handle every case.

~~We should explore an equivalent solution for `.forEach`.~~