### PR TITLE
Fix the typos in the tutorial reference

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-04-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-04-code-0006.swift
@@ -19,7 +19,7 @@ final class CounterFeatureTests: XCTestCase {
     //    accessed from a test context:
     //
     //   Location:
-    //     TCATest/ContentView.swift:70
+    //     TCATest/CounterFeature.swift:70
     //   Dependency:
     //     NumberFactClient
     //

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-01-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-01-code-0001.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct ContentView: View {
+struct ContactsView: View {
   let store: StoreOf<ContactsFeature>
 
   var body: some View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-01-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-01-code-0002.swift
@@ -1,6 +1,6 @@
-struct ContentView_Previews: PreviewProvider {
+struct ContactsView_Previews: PreviewProvider {
   static var previews: some View {
-    ContentView(
+    ContactsView(
       store: Store(
         initialState: ContactsFeature.State(
           contacts: [

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-02-code-0008.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-02-code-0008.swift
@@ -1,4 +1,4 @@
-struct ContentView: View {
+struct ContactsView: View {
   let store: StoreOf<ContactsFeature>
 
   var body: some View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-02-code-0009.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-02-code-0009.swift
@@ -1,4 +1,4 @@
-struct ContentView: View {
+struct ContactsView: View {
   let store: StoreOf<ContactsFeature>
 
   var body: some View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-01-code-0006-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-01-code-0006-previous.swift
@@ -1,4 +1,4 @@
-struct ContentView: View {
+struct ContactsView: View {
   let store: StoreOf<ContactsFeature>
 
   var body: some View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-01-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-01-code-0006.swift
@@ -1,4 +1,4 @@
-struct ContentView: View {
+struct ContactsView: View {
   let store: StoreOf<ContactsFeature>
 
   var body: some View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-01-code-0007.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-01-code-0007.swift
@@ -1,4 +1,4 @@
-struct ContentView: View {
+struct ContactsView: View {
   let store: StoreOf<ContactsFeature>
 
   var body: some View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0015-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0015-previous.swift
@@ -1,4 +1,4 @@
-struct ContentView: View {
+struct ContactsView: View {
   let store: StoreOf<ContactsFeature>
 
   var body: some View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0015.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0015.swift
@@ -1,4 +1,4 @@
-struct ContentView: View {
+struct ContactsView: View {
   let store: StoreOf<ContactsFeature>
 
   var body: some View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0016.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0016.swift
@@ -1,4 +1,4 @@
-struct ContentView: View {
+struct ContactsView: View {
   let store: StoreOf<ContactsFeature>
 
   var body: some View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0017.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0017.swift
@@ -1,4 +1,4 @@
-struct ContentView: View {
+struct ContactsView: View {
   let store: StoreOf<ContactsFeature>
 
   var body: some View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0018.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0018.swift
@@ -1,4 +1,4 @@
-struct ContentView: View {
+struct ContactsView: View {
   let store: StoreOf<ContactsFeature>
 
   var body: some View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003-previous.swift
@@ -1,4 +1,4 @@
-struct ContentView: View {
+struct ContactsView: View {
   let store: StoreOf<ContactsFeature>
 
   var body: some View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003.swift
@@ -1,4 +1,4 @@
-struct ContentView: View {
+struct ContactsView: View {
   let store: StoreOf<ContactsFeature>
 
   var body: some View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0004.swift
@@ -1,4 +1,4 @@
-struct ContentView: View {
+struct ContactsView: View {
   let store: StoreOf<ContactsFeature>
 
   var body: some View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0005-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0005-previous.swift
@@ -1,4 +1,4 @@
-struct ContentView: View {
+struct ContactsView: View {
   let store: StoreOf<ContactsFeature>
 
   var body: some View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0005.swift
@@ -1,4 +1,4 @@
-struct ContentView: View {
+struct ContactsView: View {
   let store: StoreOf<ContactsFeature>
 
   var body: some View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-NavigationStacks.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-NavigationStacks.tutorial
@@ -121,7 +121,7 @@
       }
       
       @Step {
-        Go to the `ContentView` that holds the view for the contacts list. Swap out the
+        Go to the `ContactsView` that holds the view for the contacts list. Swap out the
         `NavigationStack` for a ``ComposableArchitecture/NavigationStackStore``. This is a type
         specifically tuned for driving stacks from a ``ComposableArchitecture/Store``. 
         You hand it a store that is scoped down to ``ComposableArchitecture/StackState`` and


### PR DESCRIPTION
I believe that **`ContentView`** is a typo.

<img width="848" alt="ContentViewTypo" src="https://github.com/pointfreeco/swift-composable-architecture/assets/13725729/9c9fd2f3-a44b-4557-be54-bf9b687d380b">
