### PR TITLE
Add @warn_unqualified_access to alert modifiers

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -8,6 +8,7 @@ extension View {
   /// - Parameters:
   ///   - store: A store that is focused on ``PresentationState`` and ``PresentationAction`` for an
   ///     alert.
+  @warn_unqualified_access
   public func alert<ButtonAction>(
     store: Store<PresentationState<AlertState<ButtonAction>>, PresentationAction<ButtonAction>>
   ) -> some View {
@@ -23,6 +24,7 @@ extension View {
   ///   - toDestinationState: A transformation to extract alert state from the presentation state.
   ///   - fromDestinationAction: A transformation to embed alert actions into the presentation
   ///     action.
+  @warn_unqualified_access
   public func alert<State, Action, ButtonAction>(
     store: Store<PresentationState<State>, PresentationAction<Action>>,
     state toDestinationState: @escaping (_ state: State) -> AlertState<ButtonAction>?,

--- a/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
@@ -8,6 +8,7 @@ extension View {
   /// - Parameters:
   ///   - store: A store that is focused on ``PresentationState`` and ``PresentationAction`` for a
   ///     dialog.
+  @warn_unqualified_access
   public func confirmationDialog<ButtonAction>(
     store: Store<
       PresentationState<ConfirmationDialogState<ButtonAction>>,
@@ -26,6 +27,7 @@ extension View {
   ///   - toDestinationState: A transformation to extract dialog state from the presentation state.
   ///   - fromDestinationAction: A transformation to embed dialog actions into the presentation
   ///     action.
+  @warn_unqualified_access
   public func confirmationDialog<State, Action, ButtonAction>(
     store: Store<PresentationState<State>, PresentationAction<Action>>,
     state toDestinationState: @escaping (_ state: State) -> ConfirmationDialogState<ButtonAction>?,

--- a/Sources/ComposableArchitecture/SwiftUI/Deprecated/ActionSheet.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Deprecated/ActionSheet.swift
@@ -29,6 +29,7 @@ extension View {
     deprecated: 100000,
     message: "use 'View.confirmationDialog(store:)' instead."
   )
+  @warn_unqualified_access
   public func actionSheet<ButtonAction>(
     store: Store<
       PresentationState<ConfirmationDialogState<ButtonAction>>, PresentationAction<ButtonAction>
@@ -65,6 +66,7 @@ extension View {
     deprecated: 100000,
     message: "use 'View.confirmationDialog(store:state:action:)' instead."
   )
+  @warn_unqualified_access
   public func actionSheet<State, Action, ButtonAction>(
     store: Store<PresentationState<State>, PresentationAction<Action>>,
     state toDestinationState: @escaping (_ state: State) -> ConfirmationDialogState<ButtonAction>?,

--- a/Sources/ComposableArchitecture/SwiftUI/Deprecated/LegacyAlert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Deprecated/LegacyAlert.swift
@@ -15,6 +15,7 @@ extension View {
   @available(
     watchOS, introduced: 6, deprecated: 100000, message: "use `View.alert(store:) instead."
   )
+  @warn_unqualified_access
   public func legacyAlert<ButtonAction>(
     store: Store<PresentationState<AlertState<ButtonAction>>, PresentationAction<ButtonAction>>
   ) -> some View {
@@ -54,6 +55,7 @@ extension View {
     deprecated: 100000,
     message: "use `View.alert(store:state:action:) instead."
   )
+  @warn_unqualified_access
   public func legacyAlert<State, Action, ButtonAction>(
     store: Store<PresentationState<State>, PresentationAction<Action>>,
     state toDestinationState: @escaping (_ state: State) -> AlertState<ButtonAction>?,

--- a/Sources/ComposableArchitecture/SwiftUI/FullScreenCover.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/FullScreenCover.swift
@@ -18,6 +18,7 @@ import SwiftUI
     ///   - content: A closure returning the content of the modal view.
     @available(iOS 14, tvOS 14, watchOS 7, *)
     @available(macOS, unavailable)
+    @warn_unqualified_access
     public func fullScreenCover<State, Action, Content: View>(
       store: Store<PresentationState<State>, PresentationAction<Action>>,
       onDismiss: (() -> Void)? = nil,
@@ -49,6 +50,7 @@ import SwiftUI
     ///   - content: A closure returning the content of the modal view.
     @available(iOS 14, tvOS 14, watchOS 7, *)
     @available(macOS, unavailable)
+    @warn_unqualified_access
     public func fullScreenCover<State, Action, DestinationState, DestinationAction, Content: View>(
       store: Store<PresentationState<State>, PresentationAction<Action>>,
       state toDestinationState: @escaping (_ state: State) -> DestinationState?,

--- a/Sources/ComposableArchitecture/SwiftUI/NavigationDestination.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/NavigationDestination.swift
@@ -16,6 +16,7 @@ extension View {
   ///     `nil`-ed out, the system pops the view from the stack.
   ///   - destination: A closure returning the content of the destination view.
   @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  @warn_unqualified_access
   public func navigationDestination<State, Action, Destination: View>(
     store: Store<PresentationState<State>, PresentationAction<Action>>,
     @ViewBuilder destination: @escaping (_ store: Store<State, Action>) -> Destination
@@ -46,6 +47,7 @@ extension View {
   ///     action.
   ///   - destination: A closure returning the content of the destination view.
   @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  @warn_unqualified_access
   public func navigationDestination<
     State, Action, DestinationState, DestinationAction, Destination: View
   >(

--- a/Sources/ComposableArchitecture/SwiftUI/Popover.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Popover.swift
@@ -17,6 +17,7 @@ extension View {
   ///   - content: A closure returning the content of the popover.
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
+  @warn_unqualified_access
   public func popover<State, Action, Content: View>(
     store: Store<PresentationState<State>, PresentationAction<Action>>,
     attachmentAnchor: PopoverAttachmentAnchor = .rect(.bounds),
@@ -49,6 +50,7 @@ extension View {
   ///   - content: A closure returning the content of the popover.
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
+  @warn_unqualified_access
   public func popover<State, Action, DestinationState, DestinationAction, Content: View>(
     store: Store<PresentationState<State>, PresentationAction<Action>>,
     state toDestinationState: @escaping (_ state: State) -> DestinationState?,

--- a/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 extension View {
   @_spi(Presentation)
+  @warn_unqualified_access
   public func presentation<State, Action, Content: View>(
     store: Store<PresentationState<State>, PresentationAction<Action>>,
     @ViewBuilder body: @escaping (
@@ -17,6 +18,7 @@ extension View {
 
   @_disfavoredOverload
   @_spi(Presentation)
+  @warn_unqualified_access
   public func presentation<State, Action, Content: View>(
     store: Store<PresentationState<State>, PresentationAction<Action>>,
     @ViewBuilder body: @escaping (
@@ -35,6 +37,7 @@ extension View {
   }
 
   @_spi(Presentation)
+  @warn_unqualified_access
   public func presentation<
     State,
     Action,
@@ -60,6 +63,7 @@ extension View {
 
   @_disfavoredOverload
   @_spi(Presentation)
+  @warn_unqualified_access
   public func presentation<
     State,
     Action,
@@ -86,6 +90,7 @@ extension View {
   }
 
   @_spi(Presentation)
+  @warn_unqualified_access
   @ViewBuilder
   public func presentation<
     State,

--- a/Sources/ComposableArchitecture/SwiftUI/Sheet.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Sheet.swift
@@ -13,6 +13,7 @@ extension View {
   ///     system dismisses the currently displayed sheet.
   ///   - onDismiss: The closure to execute when dismissing the modal view.
   ///   - content: A closure returning the content of the modal view.
+  @warn_unqualified_access
   public func sheet<State, Action, Content: View>(
     store: Store<PresentationState<State>, PresentationAction<Action>>,
     onDismiss: (() -> Void)? = nil,
@@ -40,6 +41,7 @@ extension View {
   ///     action.
   ///   - onDismiss: The closure to execute when dismissing the modal view.
   ///   - content: A closure returning the content of the modal view.
+  @warn_unqualified_access
   public func sheet<State, Action, DestinationState, DestinationAction, Content: View>(
     store: Store<PresentationState<State>, PresentationAction<Action>>,
     state toDestinationState: @escaping (_ state: State) -> DestinationState?,


### PR DESCRIPTION
Add the @warn_unqualified_access decorator to alert modifiers to prevent silly wrong usage mistakes such as 
```swift
struct ContentView: View {
    let store: StoreOf<Feature>
    
    var body: some View {
        Text("Hello world")
        alert( // Missing dot. The @warn_unqualified_access will generate a warning `Use of 'alert' treated as a reference to instance method in protocol 'View'`
            store: store.scope(
                state: \.$destination,
                action: { .destination($0) }
            ),
            state: /Feature.Destination.State.alert,
            action: Feature.Destination.Action.alert
        )
    }
}
``` 