### PR TITLE
Fix mismatched reducer names

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -13,7 +13,7 @@ import Combine
 /// ```swift
 /// struct ParentFeature: Reducer {
 ///   struct State {
-///     @PresentationState var child: Child.State?
+///     @PresentationState var child: ChildFeature.State?
 ///      // ...
 ///   }
 ///   // ...
@@ -163,7 +163,7 @@ extension PresentationState: CustomReflectable {
 /// struct ParentFeature: Reducer {
 ///   // ...
 ///   enum Action {
-///     case child(PresentationAction<Child.Action>)
+///     case child(PresentationAction<ChildFeature.Action>)
 ///      // ...
 ///   }
 ///   // ...
@@ -212,7 +212,7 @@ extension Reducer {
   ///     // ...
   ///   }
   ///
-  ///   var body: some Reducer<State, Action> {
+  ///   var body: some ReducerOf<Self> {
   ///     Reduce { state, action in
   ///       // Core logic for parent feature
   ///     }


### PR DESCRIPTION
Hi, while reviewing the PresentationReducer and StackReducer, I noticed that some of the documentation uses names like `ParentFeature / Parent` and `ChildFeature / Child` together, which can be a bit confusing. Throughout the library, the terms `Parent` and `Child` are more commonly used, including the tests.

For now, I've made the necessary changes, not in the test code. If you prefer me to rename every ParentFeature to Parent and ChildFeature to Child, please let me know. Additionally, I've considered changing the Reducer<State, Action> to `ReducerOf<Self>`. For the consistency, I've only modified what's in the PresentationReducer.swift. If you have any better suggestions or feedback, I'd love to hear them. Thanks!