### PR TITLE
Only dismiss alert/dialog state when receiving a domain-specific action

### DIFF
--- a/Sources/ComposableArchitecture/Internal/EphemeralState.swift
+++ b/Sources/ComposableArchitecture/Internal/EphemeralState.swift
@@ -4,21 +4,39 @@
 /// with they go away. Such features do not manage any behavior on the inside.
 ///
 /// Alerts and confirmation dialogs are examples of this kind of state.
-public protocol _EphemeralState {}
+public protocol _EphemeralState {
+  static var actionType: Any.Type { get }
+}
 
-extension AlertState: _EphemeralState {}
+extension AlertState: _EphemeralState {
+  public static var actionType: Any.Type { Action.self }
+}
 
 @available(iOS 13, macOS 12, tvOS 13, watchOS 6, *)
-extension ConfirmationDialogState: _EphemeralState {}
+extension ConfirmationDialogState: _EphemeralState {
+  public static var actionType: Any.Type { Action.self }
+}
+
+@usableFromInline
+func ephemeralType<State>(of state: State) -> (any _EphemeralState.Type)? {
+  (State.self as? any _EphemeralState.Type)
+    ?? EnumMetadata(type(of: state)).flatMap { metadata in
+      metadata.associatedValueType(forTag: metadata.tag(of: state))
+        as? any _EphemeralState.Type
+    }
+}
 
 @usableFromInline
 func isEphemeral<State>(_ state: State) -> Bool {
-  if State.self is _EphemeralState.Type {
-    return true
-  } else if let metadata = EnumMetadata(type(of: state)) {
-    return metadata.associatedValueType(forTag: metadata.tag(of: state))
-      is _EphemeralState.Type
-  } else {
-    return false
+  ephemeralType(of: state) != nil
+}
+
+extension _EphemeralState {
+  @usableFromInline
+  static func canSend<Action>(_ action: Action) -> Bool {
+    return Action.self == Self.actionType
+      || EnumMetadata(Action.self).flatMap { metadata in
+        metadata.associatedValueType(forTag: metadata.tag(of: action)) == Self.actionType
+      } == true
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -353,9 +353,10 @@ public struct _PresentationReducer<Base: Reducer, Destination: Reducer>: Reducer
         .map { self.toPresentationAction.embed(.presented($0)) }
         ._cancellable(navigationIDPath: destinationNavigationIDPath)
       baseEffects = self.base.reduce(into: &state, action: action)
-      if isEphemeral(destinationState),
+      if let ephemeralType = ephemeralType(of: destinationState),
         destinationNavigationIDPath
-          == state[keyPath: self.toPresentationState].wrappedValue.map(self.navigationIDPath(for:))
+          == state[keyPath: self.toPresentationState].wrappedValue.map(self.navigationIDPath(for:)),
+        ephemeralType.canSend(destinationAction)
       {
         state[keyPath: self.toPresentationState].wrappedValue = nil
       }

--- a/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
@@ -2427,4 +2427,110 @@ final class PresentationReducerTests: BaseTCATestCase {
     // NB: Another action needs to come into the `ifLet` to cancel the child action
     await store.send(.tapAfter)
   }
+
+  func testPresentation_leaveAlertPresentedForNonAlertActions() async {
+    if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
+      struct Child: Reducer {
+        struct State: Equatable {
+          var count = 0
+        }
+        enum Action: Equatable {
+          case decrementButtonTapped
+          case incrementButtonTapped
+        }
+        func reduce(into state: inout State, action: Action) -> Effect<Action> {
+          switch action {
+          case .decrementButtonTapped:
+            state.count -= 1
+            return .none
+          case .incrementButtonTapped:
+            state.count += 1
+            return .none
+          }
+        }
+      }
+
+      struct Parent: Reducer {
+        struct State: Equatable {
+          @PresentationState var destination: Destination.State?
+          var isDeleted = false
+        }
+        enum Action: Equatable {
+          case destination(PresentationAction<Destination.Action>)
+          case presentAlert
+          case presentChild
+        }
+
+        var body: some ReducerOf<Self> {
+          Reduce { state, action in
+            switch action {
+            case .destination(.presented(.alert(.deleteButtonTapped))):
+              state.isDeleted = true
+              return .none
+            case .destination:
+              return .none
+            case .presentAlert:
+              state.destination = .alert(
+                AlertState {
+                  TextState("Uh oh!")
+                } actions: {
+                  ButtonState(role: .destructive, action: .deleteButtonTapped) {
+                    TextState("Delete")
+                  }
+                }
+              )
+              return .none
+            case .presentChild:
+              state.destination = .child(Child.State())
+              return .none
+            }
+          }
+          .ifLet(\.$destination, action: /Action.destination) {
+            Destination()
+          }
+        }
+        struct Destination: Reducer {
+          enum State: Equatable {
+            case alert(AlertState<Action.Alert>)
+            case child(Child.State)
+          }
+          enum Action: Equatable {
+            case alert(Alert)
+            case child(Child.Action)
+
+            enum Alert: Equatable {
+              case deleteButtonTapped
+            }
+          }
+          var body: some ReducerOf<Self> {
+            Scope(state: /State.alert, action: /Action.alert) {}
+            Scope(state: /State.child, action: /Action.child) {
+              Child()
+            }
+          }
+        }
+      }
+
+      let store = TestStore(initialState: Parent.State()) {
+        Parent()
+      }
+
+      await store.send(.presentAlert) {
+        $0.destination = .alert(
+          AlertState {
+            TextState("Uh oh!")
+          } actions: {
+            ButtonState(role: .destructive, action: .deleteButtonTapped) {
+              TextState("Delete")
+            }
+          }
+        )
+      }
+
+      await store.send(.destination(.presented(.child(.decrementButtonTapped)))) { _ in
+        // nothing should happen, but sending a child state action whilst the alert
+        // is presented causes the alert to dismiss
+      }
+    }
+  }
 }

--- a/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
@@ -2510,6 +2510,7 @@ final class PresentationReducerTests: BaseTCATestCase {
           }
         }
       }
+      let line = #line - 6
 
       let store = TestStore(initialState: Parent.State()) {
         Parent()
@@ -2527,10 +2528,15 @@ final class PresentationReducerTests: BaseTCATestCase {
         )
       }
 
-      await store.send(.destination(.presented(.child(.decrementButtonTapped)))) { _ in
-        // nothing should happen, but sending a child state action whilst the alert
-        // is presented causes the alert to dismiss
+      XCTExpectFailure {
+        $0.compactDescription.hasPrefix(
+          """
+          A "Scope" at "\(#fileID):\(line)" received a child action when child state was set to a \
+          different case. …
+          """
+        )
       }
+      await store.send(.destination(.presented(.child(.decrementButtonTapped))))
     }
   }
 }

--- a/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
@@ -2528,14 +2528,16 @@ final class PresentationReducerTests: BaseTCATestCase {
         )
       }
 
-      XCTExpectFailure {
-        $0.compactDescription.hasPrefix(
-          """
-          A "Scope" at "\(#fileID):\(line)" received a child action when child state was set to a \
-          different case. …
-          """
-        )
-      }
+      #if DEBUG
+        XCTExpectFailure {
+          $0.compactDescription.hasPrefix(
+            """
+            A "Scope" at "\(#fileID):\(line)" received a child action when child state was set to a \
+            different case. …
+            """
+          )
+        }
+      #endif
       await store.send(.destination(.presented(.child(.decrementButtonTapped))))
     }
   }


### PR DESCRIPTION
Fixes #2463.

While receiving an action from another domain is a programmer error and will emit a runtime warning, we should avoid having this error negatively impact the end user experience by dismissing alerts and dialogs when they shouldn't be. This PR addresses things by expanding the ephemeral state protocol to describe its action type, and comparing this action type to whatever it can extract from the given action using CasePaths' enum metadata runtime APIs.