### PR TITLE
Updated code snippet to use `body` for `Reducer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,33 +163,35 @@ struct Feature: Reducer {
   struct State: Equatable { /* ... */ }
   enum Action: Equatable { /* ... */ }
   
-  func reduce(into state: inout State, action: Action) -> Effect<Action> {
-    switch action {
-    case .factAlertDismissed:
-      state.numberFactAlert = nil
-      return .none
+  var body: some ReducerOf<Self> {
+    Reduce { state, action in
+      switch action {
+      case .factAlertDismissed:
+        state.numberFactAlert = nil
+        return .none
 
-    case .decrementButtonTapped:
-      state.count -= 1
-      return .none
+      case .decrementButtonTapped:
+        state.count -= 1
+        return .none
 
-    case .incrementButtonTapped:
-      state.count += 1
-      return .none
+      case .incrementButtonTapped:
+        state.count += 1
+        return .none
 
-    case .numberFactButtonTapped:
-      return .run { [count = state.count] send in
-        let (data, _) = try await URLSession.shared.data(
-          from: URL(string: "http://numbersapi.com/\(count)/trivia")!
-        )
-        await send(
-          .numberFactResponse(String(decoding: data, as: UTF8.self))
-        )
+      case .numberFactButtonTapped:
+        return .run { [count = state.count] send in
+          let (data, _) = try await URLSession.shared.data(
+            from: URL(string: "http://numbersapi.com/\(count)/trivia")!
+          )
+          await send(
+            .numberFactResponse(String(decoding: data, as: UTF8.self))
+          )
+        }
+
+      case let .numberFactResponse(fact):
+        state.numberFactAlert = fact
+        return .none
       }
-
-    case let .numberFactResponse(fact):
-      state.numberFactAlert = fact
-      return .none
     }
   }
 }


### PR DESCRIPTION
Since version 1.0,

I think that composable architecture recommends to use `body` computed property rather than `reduce` method.

I modified main `README.md` file on this repository.
