### PR TITLE
Update StackBasedNavigation.md

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
@@ -429,7 +429,7 @@ use the `XCTModify` helper:
 
 ```swift
 await store.send(.path(.element(id: 0, action: .incrementButtonTapped))) {
-  XCTModify(&$0[id: 0], case: /Feature.Path.State.counter) {
+  XCTModify(&$0.path[id: 0], case: /Feature.Path.State.counter) {
     $0.count = 4
   }
 }
@@ -439,7 +439,7 @@ The `XCTModify` function takes an `inout` piece of enum state as its first argum
 path for its second argument, and then uses the case path to extract the payload in that case, 
 allow you to perform a mutation to it, and embed the data back into the enum. So, in the code
 above we are subscripting into ID 0, isolating the `.counter` case of the `Path.State` enum, 
-and mutating the `count` to be 4 since it incremented by one. Further, if the case of `$0[id: 0]`
+and mutating the `count` to be 4 since it incremented by one. Further, if the case of `$0.path[id: 0]`
 didn't match the case path, then a test failure would be emitted.
 
 Another option is to use ``StackState/subscript(id:case:)`` to simultaneously subscript into an 
@@ -447,7 +447,7 @@ ID on the stack _and_ a case of the path enum:
 
 ```swift
 await store.send(.path(.element(id: 0, action: .incrementButtonTapped))) {
-  $0[id: 0, case: /Feature.Path.State.counter]?.count = 4
+  $0.path[id: 0, case: /Feature.Path.State.counter]?.count = 4
 }
 ```
 
@@ -458,7 +458,7 @@ Continuing with the test, we can send it one more time to see that the count goe
 
 ```swift
 await store.send(.path(.element(id: 0, action: .incrementButtonTapped))) {
-  XCTModify(&$0[id: 0], case: /Feature.Path.State.counter) {
+  XCTModify(&$0.path[id: 0], case: /Feature.Path.State.counter) {
     $0.count = 5
   }
 }


### PR DESCRIPTION
It seems in the test cases in StackBasedNavigation.md instead of $0[id:] should be $0.path[id:]