### PR TITLE
Clean up and modernize docs/examples

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -8,246 +8,159 @@ struct RootView: View {
   var body: some View {
     NavigationStack {
       Form {
-        Section(header: Text("Getting started")) {
-          NavigationLink(
-            "Basics",
-            destination: CounterDemoView(
-              store: self.store.scope(
-                state: \.counter,
-                action: Root.Action.counter
-              )
+        Section {
+          NavigationLink("Basics") {
+            CounterDemoView(
+              store: self.store.scope(state: \.counter, action: { .counter($0) })
             )
-          )
-
-          NavigationLink(
-            "Combining reducers",
-            destination: TwoCountersView(
-              store: self.store.scope(
-                state: \.twoCounters,
-                action: Root.Action.twoCounters
-              )
+          }
+          NavigationLink("Combining reducers") {
+            TwoCountersView(
+              store: self.store.scope(state: \.twoCounters, action: { .twoCounters($0) })
             )
-          )
-
-          NavigationLink(
-            "Bindings",
-            destination: BindingBasicsView(
-              store: self.store.scope(
-                state: \.bindingBasics,
-                action: Root.Action.bindingBasics
-              )
+          }
+          NavigationLink("Bindings") {
+            BindingBasicsView(
+              store: self.store.scope(state: \.bindingBasics, action: { .bindingBasics($0) })
             )
-          )
-
-          NavigationLink(
-            "Form bindings",
-            destination: BindingFormView(
-              store: self.store.scope(
-                state: \.bindingForm,
-                action: Root.Action.bindingForm
-              )
+          }
+          NavigationLink("Form bindings") {
+            BindingFormView(
+              store: self.store.scope(state: \.bindingForm, action: { .bindingForm($0) })
             )
-          )
-
-          NavigationLink(
-            "Optional state",
-            destination: OptionalBasicsView(
-              store: self.store.scope(
-                state: \.optionalBasics,
-                action: Root.Action.optionalBasics
-              )
+          }
+          NavigationLink("Optional state") {
+            OptionalBasicsView(
+              store: self.store.scope(state: \.optionalBasics, action: { .optionalBasics($0) })
             )
-          )
-
-          NavigationLink(
-            "Shared state",
-            destination: SharedStateView(
-              store: self.store.scope(
-                state: \.shared,
-                action: Root.Action.shared
-              )
+          }
+          NavigationLink("Shared state") {
+            SharedStateView(
+              store: self.store.scope(state: \.shared, action: { .shared($0) })
             )
-          )
-
-          NavigationLink(
-            "Alerts and Confirmation Dialogs",
-            destination: AlertAndConfirmationDialogView(
+          }
+          NavigationLink("Alerts and Confirmation Dialogs") {
+            AlertAndConfirmationDialogView(
               store: self.store.scope(
                 state: \.alertAndConfirmationDialog,
-                action: Root.Action.alertAndConfirmationDialog
+                action: { .alertAndConfirmationDialog($0) }
               )
             )
-          )
-
-          NavigationLink(
-            "Focus State",
-            destination: FocusDemoView(
-              store: self.store.scope(
-                state: \.focusDemo,
-                action: Root.Action.focusDemo
-              )
+          }
+          NavigationLink("Focus State") {
+            FocusDemoView(
+              store: self.store.scope(state: \.focusDemo, action: { .focusDemo($0) })
             )
-          )
-
-          NavigationLink(
-            "Animations",
-            destination: AnimationsView(
-              store: self.store.scope(
-                state: \.animation,
-                action: Root.Action.animation
-              )
+          }
+          NavigationLink("Animations") {
+            AnimationsView(
+              store: self.store.scope(state: \.animation, action: { .animation($0) })
             )
-          )
+          }
+        } header: {
+          Text("Getting started")
         }
 
-        Section(header: Text("Effects")) {
-          NavigationLink(
-            "Basics",
-            destination: EffectsBasicsView(
-              store: self.store.scope(
-                state: \.effectsBasics,
-                action: Root.Action.effectsBasics
-              )
+        Section {
+          NavigationLink("Basics") {
+            EffectsBasicsView(
+              store: self.store.scope(state: \.effectsBasics, action: { .effectsBasics($0) })
             )
-          )
-
-          NavigationLink(
-            "Cancellation",
-            destination: EffectsCancellationView(
+          }
+          NavigationLink("Cancellation") {
+            EffectsCancellationView(
               store: self.store.scope(
                 state: \.effectsCancellation,
-                action: Root.Action.effectsCancellation)
+                action: { .effectsCancellation($0) }
+              )
             )
-          )
-
-          NavigationLink(
-            "Long-living effects",
-            destination: LongLivingEffectsView(
+          }
+          NavigationLink("Long-living effects") {
+            LongLivingEffectsView(
               store: self.store.scope(
                 state: \.longLivingEffects,
-                action: Root.Action.longLivingEffects
+                action: { .longLivingEffects($0) }
               )
             )
-          )
-
-          NavigationLink(
-            "Refreshable",
-            destination: RefreshableView(
-              store: self.store.scope(
-                state: \.refreshable,
-                action: Root.Action.refreshable
-              )
+          }
+          NavigationLink("Refreshable") {
+            RefreshableView(
+              store: self.store.scope(state: \.refreshable, action: { .refreshable($0) })
             )
-          )
-
-          NavigationLink(
-            "Timers",
-            destination: TimersView(
-              store: self.store.scope(
-                state: \.timers,
-                action: Root.Action.timers
-              )
+          }
+          NavigationLink("Timers") {
+            TimersView(
+              store: self.store.scope(state: \.timers, action: { .timers($0) })
             )
-          )
-
-          NavigationLink(
-            "Web socket",
-            destination: WebSocketView(
-              store: self.store.scope(
-                state: \.webSocket,
-                action: Root.Action.webSocket
-              )
+          }
+          NavigationLink("Web socket") {
+            WebSocketView(
+              store: self.store.scope(state: \.webSocket, action: { .webSocket($0) })
             )
-          )
+          }
+        } header: {
+          Text("Effects")
         }
 
-        Section(header: Text("Navigation")) {
+        Section {
           Button("Stack") {
             self.isNavigationStackCaseStudyPresented = true
           }
           .buttonStyle(.plain)
 
-          NavigationLink(
-            "Navigate and load data",
-            destination: NavigateAndLoadView(
+          NavigationLink("Navigate and load data") {
+            NavigateAndLoadView(
+              store: self.store.scope(state: \.navigateAndLoad, action: { .navigateAndLoad($0) })
+            )
+          }
+
+          NavigationLink("Lists: Navigate and load data") {
+            NavigateAndLoadListView(
               store: self.store.scope(
-                state: \.navigateAndLoad,
-                action: Root.Action.navigateAndLoad
+                state: \.navigateAndLoadList, action: { .navigateAndLoadList($0) }
               )
             )
-          )
-
-          NavigationLink(
-            "Lists: Navigate and load data",
-            destination: NavigateAndLoadListView(
-              store: self.store.scope(
-                state: \.navigateAndLoadList,
-                action: Root.Action.navigateAndLoadList
-              )
+          }
+          NavigationLink("Sheets: Present and load data") {
+            PresentAndLoadView(
+              store: self.store.scope(state: \.presentAndLoad, action: { .presentAndLoad($0) })
             )
-          )
-
-          NavigationLink(
-            "Sheets: Present and load data",
-            destination: PresentAndLoadView(
-              store: self.store.scope(
-                state: \.presentAndLoad,
-                action: Root.Action.presentAndLoad
-              )
+          }
+          NavigationLink("Sheets: Load data then present") {
+            LoadThenPresentView(
+              store: self.store.scope(state: \.loadThenPresent, action: { .loadThenPresent($0) })
             )
-          )
-
-          NavigationLink(
-            "Sheets: Load data then present",
-            destination: LoadThenPresentView(
-              store: self.store.scope(
-                state: \.loadThenPresent,
-                action: Root.Action.loadThenPresent
-              )
-            )
-          )
-
-          NavigationLink(
-            "Multiple destinations",
-            destination: MultipleDestinationsView(
+          }
+          NavigationLink("Multiple destinations") {
+            MultipleDestinationsView(
               store: self.store.scope(
                 state: \.multipleDestinations,
-                action: Root.Action.multipleDestinations
+                action: { .multipleDestinations($0) }
               )
             )
-          )
+          }
+        } header: {
+          Text("Navigation")
         }
 
-        Section(header: Text("Higher-order reducers")) {
-          NavigationLink(
-            "Reusable favoriting component",
-            destination: EpisodesView(
-              store: self.store.scope(
-                state: \.episodes,
-                action: Root.Action.episodes
-              )
+        Section {
+          NavigationLink("Reusable favoriting component") {
+            EpisodesView(
+              store: self.store.scope(state: \.episodes, action: { .episodes($0) })
             )
-          )
-
-          NavigationLink(
-            "Reusable offline download component",
-            destination: CitiesView(
-              store: self.store.scope(
-                state: \.map,
-                action: Root.Action.map
-              )
+          }
+          NavigationLink("Reusable offline download component") {
+            CitiesView(
+              store: self.store.scope(state: \.map, action: { .map($0) })
             )
-          )
-
-          NavigationLink(
-            "Recursive state and actions",
-            destination: NestedView(
-              store: self.store.scope(
-                state: \.nested,
-                action: Root.Action.nested
-              )
+          }
+          NavigationLink("Recursive state and actions") {
+            NestedView(
+              store: self.store.scope(state: \.nested, action: { .nested($0) })
             )
-          )
+          }
+        } header: {
+          Text("Higher-order reducers")
         }
       }
       .navigationTitle("Case Studies")
@@ -256,7 +169,7 @@ struct RootView: View {
         NavigationDemoView(
           store: self.store.scope(
             state: \.navigationStack,
-            action: Root.Action.navigationStack
+            action: { .navigationStack($0) }
           )
         )
       }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -135,7 +135,7 @@ struct AnimationsView: View {
           "Big mode",
           isOn:
             viewStore
-            .binding(get: \.isCircleScaled, send: Animations.Action.circleScaleToggleChanged)
+            .binding(get: \.isCircleScaled, send: { .circleScaleToggleChanged($0) })
             .animation(.interactiveSpring(response: 0.25, dampingFraction: 0.1))
         )
         .padding()

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -72,7 +72,7 @@ struct BindingBasicsView: View {
         HStack {
           TextField(
             "Type here",
-            text: viewStore.binding(get: \.text, send: BindingBasics.Action.textChanged)
+            text: viewStore.binding(get: \.text, send: { .textChanged($0) })
           )
           .disableAutocorrection(true)
           .foregroundStyle(viewStore.toggleIsOn ? Color.secondary : .primary)
@@ -82,13 +82,13 @@ struct BindingBasicsView: View {
 
         Toggle(
           "Disable other controls",
-          isOn: viewStore.binding(get: \.toggleIsOn, send: BindingBasics.Action.toggleChanged)
+          isOn: viewStore.binding(get: \.toggleIsOn, send: { .toggleChanged(isOn: $0) })
             .resignFirstResponder()
         )
 
         Stepper(
           "Max slider value: \(viewStore.stepCount)",
-          value: viewStore.binding(get: \.stepCount, send: BindingBasics.Action.stepCountChanged),
+          value: viewStore.binding(get: \.stepCount, send: { .stepCountChanged($0) }),
           in: 0...100
         )
         .disabled(viewStore.toggleIsOn)
@@ -96,10 +96,7 @@ struct BindingBasicsView: View {
         HStack {
           Text("Slider value: \(Int(viewStore.sliderValue))")
           Slider(
-            value: viewStore.binding(
-              get: \.sliderValue,
-              send: BindingBasics.Action.sliderValueChanged
-            ),
+            value: viewStore.binding(get: \.sliderValue, send: { .sliderValueChanged($0) }),
             in: 0...Double(viewStore.stepCount)
           )
           .tint(.accentColor)

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -44,17 +44,13 @@ struct TwoCountersView: View {
       HStack {
         Text("Counter 1")
         Spacer()
-        CounterView(
-          store: self.store.scope(state: \.counter1, action: TwoCounters.Action.counter1)
-        )
+        CounterView(store: self.store.scope(state: \.counter1, action: { .counter1($0) }))
       }
 
       HStack {
         Text("Counter 2")
         Spacer()
-        CounterView(
-          store: self.store.scope(state: \.counter2, action: TwoCounters.Action.counter2)
-        )
+        CounterView(store: self.store.scope(state: \.counter2, action: { .counter2($0) }))
       }
     }
     .buttonStyle(.borderless)

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -60,20 +60,15 @@ struct OptionalBasicsView: View {
         }
 
         IfLetStore(
-          self.store.scope(
-            state: \.optionalCounter,
-            action: OptionalBasics.Action.optionalCounter
-          ),
-          then: { store in
-            Text(template: "`CounterState` is non-`nil`")
-            CounterView(store: store)
-              .buttonStyle(.borderless)
-              .frame(maxWidth: .infinity)
-          },
-          else: {
-            Text(template: "`CounterState` is `nil`")
-          }
-        )
+          self.store.scope(state: \.optionalCounter, action: { .optionalCounter($0) })
+        ) { store in
+          Text(template: "`CounterState` is non-`nil`")
+          CounterView(store: store)
+            .buttonStyle(.borderless)
+            .frame(maxWidth: .infinity)
+        } else: {
+          Text(template: "`CounterState` is `nil`")
+        }
       }
     }
     .navigationTitle("Optional state")

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
@@ -162,10 +162,7 @@ struct SharedStateView: View {
   var body: some View {
     WithViewStore(self.store, observe: \.currentTab) { viewStore in
       VStack {
-        Picker(
-          "Tab",
-          selection: viewStore.binding(send: SharedState.Action.selectTab)
-        ) {
+        Picker("Tab", selection: viewStore.binding(send: { .selectTab($0) })) {
           Text("Counter")
             .tag(SharedState.Tab.counter)
 
@@ -176,12 +173,14 @@ struct SharedStateView: View {
 
         if viewStore.state == .counter {
           SharedStateCounterView(
-            store: self.store.scope(state: \.counter, action: SharedState.Action.counter))
+            store: self.store.scope(state: \.counter, action: { .counter($0) })
+          )
         }
 
         if viewStore.state == .profile {
           SharedStateProfileView(
-            store: self.store.scope(state: \.profile, action: SharedState.Action.profile))
+            store: self.store.scope(state: \.profile, action: { .profile($0) })
+          )
         }
 
         Spacer()

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -80,7 +80,7 @@ struct EffectsCancellationView: View {
         Section {
           Stepper(
             "\(viewStore.count)",
-            value: viewStore.binding(get: \.count, send: EffectsCancellation.Action.stepperChanged)
+            value: viewStore.binding(get: \.count, send: { .stepperChanged($0) })
           )
 
           if viewStore.isFactRequestInFlight {

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -163,8 +163,7 @@ struct WebSocketView: View {
             HStack {
               TextField(
                 "Type message here",
-                text: viewStore.binding(
-                  get: \.messageToSend, send: WebSocket.Action.messageToSendChanged)
+                text: viewStore.binding(get: \.messageToSend, send: { .messageToSendChanged($0) })
               )
               .textFieldStyle(.roundedBorder)
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -83,23 +83,18 @@ struct NavigateAndLoadListView: View {
         }
         ForEach(viewStore.rows) { row in
           NavigationLink(
-            destination: IfLetStore(
-              self.store.scope(
-                state: \.selection?.value,
-                action: NavigateAndLoadList.Action.counter
-              )
-            ) {
-              CounterView(store: $0)
-            } else: {
-              ProgressView()
-            },
+            "Load optional counter that starts from \(row.count)",
             tag: row.id,
             selection: viewStore.binding(
               get: \.selection?.id,
-              send: NavigateAndLoadList.Action.setNavigation(selection:)
+              send: { .setNavigation(selection: $0) }
             )
           ) {
-            Text("Load optional counter that starts from \(row.count)")
+            IfLetStore(self.store.scope(state: \.selection?.value, action: { .counter($0) })) {
+              CounterView(store: $0)
+            } else: {
+              ProgressView()
+            }
           }
         }
       }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Multiple-Destinations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Multiple-Destinations.swift
@@ -86,25 +86,25 @@ struct MultipleDestinationsView: View {
         }
       }
       .navigationDestination(
-        store: store.scope(state: \.$destination, action: { .destination($0) }),
+        store: self.store.scope(state: \.$destination, action: { .destination($0) }),
         state: /MultipleDestinations.Destination.State.drillDown,
         action: MultipleDestinations.Destination.Action.drillDown
-      ) {
-        CounterView(store: $0)
+      ) { store in
+        CounterView(store: store)
       }
       .popover(
-        store: store.scope(state: \.$destination, action: { .destination($0) }),
+        store: self.store.scope(state: \.$destination, action: { .destination($0) }),
         state: /MultipleDestinations.Destination.State.popover,
         action: MultipleDestinations.Destination.Action.popover
-      ) {
-        CounterView(store: $0)
+      ) { store in
+        CounterView(store: store)
       }
       .sheet(
-        store: store.scope(state: \.$destination, action: { .destination($0) }),
+        store: self.store.scope(state: \.$destination, action: { .destination($0) }),
         state: /MultipleDestinations.Destination.State.sheet,
         action: MultipleDestinations.Destination.Action.sheet
-      ) {
-        CounterView(store: $0)
+      ) { store in
+        CounterView(store: store)
       }
     }
   }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -67,22 +67,19 @@ struct NavigateAndLoadView: View {
           AboutView(readMe: readMe)
         }
         NavigationLink(
-          destination: IfLetStore(
-            self.store.scope(
-              state: \.optionalCounter,
-              action: NavigateAndLoad.Action.optionalCounter
-            )
+          "Load optional counter",
+          isActive: viewStore.binding(
+            get: \.isNavigationActive,
+            send: { .setNavigation(isActive: $0) }
+          )
+        ) {
+          IfLetStore(
+            self.store.scope(state: \.optionalCounter, action: { .optionalCounter($0) })
           ) {
             CounterView(store: $0)
           } else: {
             ProgressView()
-          },
-          isActive: viewStore.binding(
-            get: \.isNavigationActive,
-            send: NavigateAndLoad.Action.setNavigation(isActive:)
-          )
-        ) {
-          Text("Load optional counter")
+          }
         }
       }
     }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -74,10 +74,9 @@ struct LoadThenPresentView: View {
           }
         }
       }
-      .sheet(
-        store: store.scope(state: \.$counter, action: LoadThenPresent.Action.counter),
-        content: CounterView.init(store:)
-      )
+      .sheet(store: self.store.scope(state: \.$counter, action: { .counter($0) })) { store in
+        CounterView(store: store)
+      }
       .navigationTitle("Load and present")
     }
   }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -73,15 +73,10 @@ struct PresentAndLoadView: View {
       .sheet(
         isPresented: viewStore.binding(
           get: \.isSheetPresented,
-          send: PresentAndLoad.Action.setSheet(isPresented:)
+          send: { .setSheet(isPresented: $0) }
         )
       ) {
-        IfLetStore(
-          self.store.scope(
-            state: \.optionalCounter,
-            action: PresentAndLoad.Action.optionalCounter
-          )
-        ) {
+        IfLetStore(self.store.scope(state: \.optionalCounter, action: { .optionalCounter($0) })) {
           CounterView(store: $0)
         } else: {
           ProgressView()

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-NavigationStack.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-NavigationStack.swift
@@ -89,9 +89,7 @@ struct NavigationDemoView: View {
   let store: StoreOf<NavigationDemo>
 
   var body: some View {
-    NavigationStackStore(
-      self.store.scope(state: \.path, action: NavigationDemo.Action.path)
-    ) {
+    NavigationStackStore(self.store.scope(state: \.path, action: { .path($0) })) {
       Form {
         Section { Text(template: readMe) }
 
@@ -364,29 +362,27 @@ struct ScreenBView: View {
   let store: StoreOf<ScreenB>
 
   var body: some View {
-    WithViewStore(self.store, observe: { $0 }) { viewStore in
-      Form {
-        Section {
-          Text(
-            """
-            This screen demonstrates how to navigate to other screens without needing to compile \
-            any symbols from those screens. You can send an action into the system, and allow the \
-            root feature to intercept that action and push the next feature onto the stack.
-            """
-          )
-        }
-        Button("Decoupled navigation to screen A") {
-          viewStore.send(.screenAButtonTapped)
-        }
-        Button("Decoupled navigation to screen B") {
-          viewStore.send(.screenBButtonTapped)
-        }
-        Button("Decoupled navigation to screen C") {
-          viewStore.send(.screenCButtonTapped)
-        }
+    Form {
+      Section {
+        Text(
+          """
+          This screen demonstrates how to navigate to other screens without needing to compile \
+          any symbols from those screens. You can send an action into the system, and allow the \
+          root feature to intercept that action and push the next feature onto the stack.
+          """
+        )
       }
-      .navigationTitle("Screen B")
+      Button("Decoupled navigation to screen A") {
+        self.store.send(.screenAButtonTapped)
+      }
+      Button("Decoupled navigation to screen B") {
+        self.store.send(.screenBButtonTapped)
+      }
+      Button("Decoupled navigation to screen C") {
+        self.store.send(.screenCButtonTapped)
+      }
     }
+    .navigationTitle("Screen B")
   }
 }
 
@@ -454,7 +450,7 @@ struct ScreenCView: View {
         Section {
           NavigationLink(
             "Go to screen A",
-            state: NavigationDemo.Path.State.screenA(.init(count: viewStore.count))
+            state: NavigationDemo.Path.State.screenA(ScreenA.State(count: viewStore.count))
           )
           NavigationLink(
             "Go to screen B",

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -64,7 +64,7 @@ struct NestedView: View {
         }
 
         ForEachStore(
-          self.store.scope(state: \.rows, action: Nested.Action.row(id:action:))
+          self.store.scope(state: \.rows, action: { .row(id: $0, action: $1) })
         ) { rowStore in
           WithViewStore(rowStore, observe: \.name) { rowViewStore in
             NavigationLink(
@@ -73,7 +73,7 @@ struct NestedView: View {
               HStack {
                 TextField(
                   "Untitled",
-                  text: rowViewStore.binding(send: Nested.Action.nameTextFieldChanged)
+                  text: rowViewStore.binding(send: { .nameTextFieldChanged($0) })
                 )
                 Text("Next")
                   .font(.callout)

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -93,10 +93,7 @@ struct CityMapRowView: View {
           Spacer()
 
           DownloadComponentView(
-            store: self.store.scope(
-              state: \.downloadComponent,
-              action: CityMap.Action.downloadComponent
-            )
+            store: self.store.scope(state: \.downloadComponent, action: { .downloadComponent($0) })
           )
           .padding(.trailing, 8)
         }
@@ -125,10 +122,7 @@ struct CityMapDetailView: View {
           Spacer()
 
           DownloadComponentView(
-            store: self.store.scope(
-              state: \.downloadComponent,
-              action: CityMap.Action.downloadComponent
-            )
+            store: self.store.scope(state: \.downloadComponent, action: { .downloadComponent($0) })
           )
         }
 
@@ -165,7 +159,7 @@ struct CitiesView: View {
         AboutView(readMe: readMe)
       }
       ForEachStore(
-        self.store.scope(state: \.cityMaps, action: MapApp.Action.cityMaps(id:action:))
+        self.store.scope(state: \.cityMaps, action: { .cityMaps(id: $0, action: $1) })
       ) { cityMapStore in
         CityMapRowView(store: cityMapStore)
           .buttonStyle(.borderless)

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -122,12 +122,7 @@ struct EpisodeView: View {
 
         Spacer()
 
-        FavoriteButton(
-          store: self.store.scope(
-            state: \.favorite,
-            action: Episode.Action.favorite
-          )
-        )
+        FavoriteButton(store: self.store.scope(state: \.favorite, action: { .favorite($0) }))
       }
     }
   }
@@ -161,10 +156,7 @@ struct EpisodesView: View {
         AboutView(readMe: readMe)
       }
       ForEachStore(
-        self.store.scope(
-          state: \.episodes,
-          action: Episodes.Action.episode(id:action:)
-        )
+        self.store.scope(state: \.episodes, action: { .episode(id: $0, action: $1) })
       ) { rowStore in
         EpisodeView(store: rowStore)
       }

--- a/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
@@ -27,11 +27,11 @@ struct Counter: Reducer {
 }
 
 final class CounterViewController: UIViewController {
-  let viewStore: ViewStoreOf<Counter>
+  let store: StoreOf<Counter>
   private var cancellables: Set<AnyCancellable> = []
 
   init(store: StoreOf<Counter>) {
-    self.viewStore = ViewStore(store, observe: { $0 })
+    self.store = store
     super.init(nibName: nil, bundle: nil)
   }
 
@@ -68,18 +68,18 @@ final class CounterViewController: UIViewController {
       rootStackView.centerYAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.centerYAnchor),
     ])
 
-    self.viewStore.publisher
+    self.store.publisher
       .map { "\($0.count)" }
       .assign(to: \.text, on: countLabel)
       .store(in: &self.cancellables)
   }
 
   @objc func decrementButtonTapped() {
-    self.viewStore.send(.decrementButtonTapped)
+    self.store.send(.decrementButtonTapped)
   }
 
   @objc func incrementButtonTapped() {
-    self.viewStore.send(.incrementButtonTapped)
+    self.store.send(.incrementButtonTapped)
   }
 }
 

--- a/Examples/CaseStudies/UIKitCaseStudies/Internal/IfLetStoreController.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/Internal/IfLetStoreController.swift
@@ -20,7 +20,7 @@ final class IfLetStoreController<State, Action>: UIViewController {
   }
 
   init(
-    store: Store<State?, Action>,
+    _ store: Store<State?, Action>,
     then ifDestination: @escaping (Store<State, Action>) -> UIViewController,
     else elseDestination: @escaping () -> UIViewController
   ) {

--- a/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
@@ -55,11 +55,9 @@ struct LazyNavigation: Reducer {
 class LazyNavigationViewController: UIViewController {
   var cancellables: [AnyCancellable] = []
   let store: StoreOf<LazyNavigation>
-  let viewStore: ViewStoreOf<LazyNavigation>
 
   init(store: StoreOf<LazyNavigation>) {
     self.store = store
-    self.viewStore = ViewStore(store, observe: { $0 })
     super.init(nibName: nil, bundle: nil)
   }
 
@@ -93,22 +91,19 @@ class LazyNavigationViewController: UIViewController {
       rootStackView.centerYAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.centerYAnchor),
     ])
 
-    self.viewStore.publisher.isActivityIndicatorHidden
+    self.store.publisher.isActivityIndicatorHidden
       .assign(to: \.isHidden, on: activityIndicator)
       .store(in: &self.cancellables)
 
     self.store
-      .scope(state: \.optionalCounter, action: LazyNavigation.Action.optionalCounter)
-      .ifLet(
-        then: { [weak self] store in
-          self?.navigationController?.pushViewController(
-            CounterViewController(store: store), animated: true)
-        },
-        else: { [weak self] in
-          guard let self = self else { return }
-          _ = self.navigationController?.popToViewController(self, animated: true)
-        }
-      )
+      .scope(state: \.optionalCounter, action: { .optionalCounter($0) })
+      .ifLet { [weak self] store in
+        self?.navigationController?.pushViewController(
+          CounterViewController(store: store), animated: true)
+      } else: { [weak self] in
+        guard let self = self else { return }
+        _ = self.navigationController?.popToViewController(self, animated: true)
+      }
       .store(in: &self.cancellables)
   }
 
@@ -116,17 +111,17 @@ class LazyNavigationViewController: UIViewController {
     super.viewDidAppear(animated)
 
     if !self.isMovingToParent {
-      self.viewStore.send(.setNavigation(isActive: false))
+      self.store.send(.setNavigation(isActive: false))
     }
   }
 
   @objc private func loadOptionalCounterTapped() {
-    self.viewStore.send(.setNavigation(isActive: true))
+    self.store.send(.setNavigation(isActive: true))
   }
 
   override func viewDidDisappear(_ animated: Bool) {
     super.viewDidDisappear(animated)
-    self.viewStore.send(.onDisappear)
+    self.store.send(.onDisappear)
   }
 }
 

--- a/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
+++ b/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
@@ -8,24 +8,13 @@ struct RootView: View {
     NavigationView {
       Form {
         Section {
-          self.focusView
+          if #available(tvOS 14, *) {
+            FocusView(
+              store: self.store.scope(state: \.focus, action: { .focus($0) })
+            )
+          }
         }
       }
-    }
-  }
-
-  var focusView: AnyView? {
-    if #available(tvOS 14.0, *) {
-      return AnyView(
-        NavigationLink(
-          "Focus",
-          destination: FocusView(
-            store: self.store.scope(state: \.focus, action: Root.Action.focus)
-          )
-        )
-      )
-    } else {
-      return nil
     }
   }
 }

--- a/Examples/Integration/Integration/NavigationStackBindingTestCase.swift
+++ b/Examples/Integration/Integration/NavigationStackBindingTestCase.swift
@@ -32,12 +32,7 @@ struct NavigationStackBindingTestCaseView: View {
 
   var body: some View {
     WithViewStore(self.store, observe: { $0 }) { viewStore in
-      NavigationStack(
-        path: viewStore.binding(
-          get: \.path,
-          send: NavigationStackBindingTestCase.Action.navigationPathChanged
-        )
-      ) {
+      NavigationStack(path: viewStore.binding(get: \.path, send: { .navigationPathChanged($0) })) {
         VStack {
           Text("Root")
           Button("Go to child") {

--- a/Examples/Integration/Integration/NavigationStackTestCase.swift
+++ b/Examples/Integration/Integration/NavigationStackTestCase.swift
@@ -194,7 +194,7 @@ struct NavigationStackTestCaseView: View {
           }
         }
       }
-      .navigationTitle(Text("Root"))
+      .navigationTitle("Root")
     } destination: {
       ChildView(store: $0)
     }

--- a/Examples/Integration/Integration/PresentationTestCase.swift
+++ b/Examples/Integration/Integration/PresentationTestCase.swift
@@ -323,7 +323,7 @@ struct PresentationTestCaseView: View {
         "Custom alert!",
         isPresented:
           viewStore
-          .binding(get: \.destination, send: PresentationTestCase.Action.destination(.dismiss))
+          .binding(get: \.destination, send: .destination(.dismiss))
           .case(/PresentationTestCase.Destination.State.customAlert)
           .isPresent()
       ) {
@@ -509,7 +509,7 @@ private struct NavigationLinkDemoView: View {
           Text(viewStore.state)
 
           NavigationLinkStore(
-            self.store.scope(state: \.$child, action: NavigationLinkDemoFeature.Action.child)
+            self.store.scope(state: \.$child, action: { .child($0) })
           ) {
             viewStore.send(.navigationLinkButtonTapped)
           } destination: { store in
@@ -519,10 +519,7 @@ private struct NavigationLinkDemoView: View {
           }
 
           NavigationLinkStore(
-            self.store.scope(
-              state: \.$identifiedChild,
-              action: NavigationLinkDemoFeature.Action.identifiedChild
-            ),
+            self.store.scope(state: \.$identifiedChild, action: { .identifiedChild($0) }),
             id: UUID(uuidString: "deadbeef-dead-beef-dead-beefdeadbeef")!
           ) {
             viewStore.send(.identifiedNavigationLinkButtonTapped)

--- a/Examples/Search/Search/SearchView.swift
+++ b/Examples/Search/Search/SearchView.swift
@@ -125,9 +125,7 @@ struct SearchView: View {
             Image(systemName: "magnifyingglass")
             TextField(
               "New York, San Francisco, ...",
-              text: viewStore.binding(
-                get: \.searchQuery, send: Search.Action.searchQueryChanged
-              )
+              text: viewStore.binding(get: \.searchQuery, send: { .searchQueryChanged($0) })
             )
             .textFieldStyle(.roundedBorder)
             .autocapitalization(.none)
@@ -167,7 +165,7 @@ struct SearchView: View {
       }
       .task(id: viewStore.searchQuery) {
         do {
-          try await Task.sleep(nanoseconds: NSEC_PER_SEC / 3)
+          try await Task.sleep(for: .seconds(3))
           await viewStore.send(.searchQueryChangeDebounced).finish()
         } catch {}
       }

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
@@ -147,7 +147,7 @@ struct SpeechRecognitionView: View {
         }
       }
       .padding()
-      .alert(store: self.store.scope(state: \.$alert, action: SpeechRecognition.Action.alert))
+      .alert(store: self.store.scope(state: \.$alert, action: { .alert($0) }))
     }
   }
 }

--- a/Examples/Standups/Standups/AppFeature.swift
+++ b/Examples/Standups/Standups/AppFeature.swift
@@ -25,7 +25,7 @@ struct AppFeature: Reducer {
     Scope(state: \.standupsList, action: /Action.standupsList) {
       StandupsList()
     }
-    Reduce<State, Action> { state, action in
+    Reduce { state, action in
       switch action {
       case let .path(.element(id, .detail(.delegate(delegateAction)))):
         guard case let .some(.detail(detailState)) = state.path[id: id]
@@ -83,7 +83,7 @@ struct AppFeature: Reducer {
       Path()
     }
 
-    Reduce<State, Action> { state, action in
+    Reduce { state, action in
       return .run { [standups = state.standupsList.standups] _ in
         try await withTaskCancellation(id: CancelID.saveDebounce, cancelInFlight: true) {
           try await self.clock.sleep(for: .seconds(1))

--- a/Examples/Standups/Standups/RecordMeeting.swift
+++ b/Examples/Standups/Standups/RecordMeeting.swift
@@ -38,7 +38,7 @@ struct RecordMeeting: Reducer {
   @Dependency(\.speechClient) var speechClient
 
   var body: some ReducerOf<Self> {
-    Reduce<State, Action> { state, action in
+    Reduce { state, action in
       switch action {
       case .alert(.presented(.confirmDiscard)):
         return .run { _ in

--- a/Examples/Standups/Standups/StandupDetail.swift
+++ b/Examples/Standups/Standups/StandupDetail.swift
@@ -50,7 +50,7 @@ struct StandupDetail: Reducer {
   }
 
   var body: some ReducerOf<Self> {
-    Reduce<State, Action> { state, action in
+    Reduce { state, action in
       switch action {
       case .cancelEditButtonTapped:
         state.destination = nil

--- a/Examples/Standups/Standups/StandupForm.swift
+++ b/Examples/Standups/Standups/StandupForm.swift
@@ -31,7 +31,7 @@ struct StandupForm: Reducer {
 
   var body: some ReducerOf<Self> {
     BindingReducer()
-    Reduce<State, Action> { state, action in
+    Reduce { state, action in
       switch action {
       case .addAttendeeButtonTapped:
         let attendee = Attendee(id: Attendee.ID(self.uuid()))

--- a/Examples/Standups/Standups/StandupsList.swift
+++ b/Examples/Standups/Standups/StandupsList.swift
@@ -52,7 +52,7 @@ struct StandupsList: Reducer {
   @Dependency(\.uuid) var uuid
 
   var body: some ReducerOf<Self> {
-    Reduce<State, Action> { state, action in
+    Reduce { state, action in
       switch action {
       case .addStandupButtonTapped:
         state.destination = .add(StandupForm.State(standup: Standup(id: Standup.ID(self.uuid()))))

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -61,9 +61,9 @@ public struct LoginView: View {
         .disabled(viewStore.isLoginButtonDisabled)
       }
       .disabled(viewStore.isFormDisabled)
-      .alert(store: self.store.scope(state: \.$alert, action: Login.Action.alert))
+      .alert(store: self.store.scope(state: \.$alert, action: { .alert($0) }))
       .navigationDestination(
-        store: self.store.scope(state: \.$twoFactor, action: Login.Action.twoFactor),
+        store: self.store.scope(state: \.$twoFactor, action: { .twoFactor($0) }),
         destination: TwoFactorView.init
       )
     }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
@@ -36,7 +36,7 @@ public struct NewGameView: View {
         Section {
           TextField(
             "Blob Sr.",
-            text: viewStore.binding(get: \.xPlayerName, send: ViewAction.xPlayerNameChanged)
+            text: viewStore.binding(get: \.xPlayerName, send: { .xPlayerNameChanged($0) })
           )
           .autocapitalization(.words)
           .disableAutocorrection(true)
@@ -48,7 +48,7 @@ public struct NewGameView: View {
         Section {
           TextField(
             "Blob Jr.",
-            text: viewStore.binding(get: \.oPlayerName, send: ViewAction.oPlayerNameChanged)
+            text: viewStore.binding(get: \.oPlayerName, send: { .oPlayerNameChanged($0) })
           )
           .autocapitalization(.words)
           .disableAutocorrection(true)
@@ -65,7 +65,7 @@ public struct NewGameView: View {
       .navigationTitle("New Game")
       .navigationBarItems(trailing: Button("Logout") { viewStore.send(.logoutButtonTapped) })
       .navigationDestination(
-        store: self.store.scope(state: \.$game, action: NewGame.Action.game),
+        store: self.store.scope(state: \.$game, action: { .game($0) }),
         destination: GameView.init
       )
     }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
@@ -46,7 +46,7 @@ public struct TwoFactorView: View {
           }
         }
       }
-      .alert(store: self.store.scope(state: \.$alert, action: TwoFactor.Action.alert))
+      .alert(store: self.store.scope(state: \.$alert, action: { .alert($0) }))
       .disabled(viewStore.isFormDisabled)
       .navigationTitle("Confirmation Code")
     }

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -129,7 +129,7 @@ struct AppView: View {
 
           List {
             ForEachStore(
-              self.store.scope(state: \.filteredTodos, action: Todos.Action.todo(id:action:))
+              self.store.scope(state: \.filteredTodos, action: { .todo(id: $0, action: $1) })
             ) {
               TodoView(store: $0)
             }

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -139,7 +139,7 @@ struct VoiceMemosView: View {
         VStack {
           List {
             ForEachStore(
-              self.store.scope(state: \.voiceMemos, action: VoiceMemos.Action.voiceMemos)
+              self.store.scope(state: \.voiceMemos, action: { .voiceMemos(id: $0, action: $1) })
             ) {
               VoiceMemoView(store: $0)
             }
@@ -147,7 +147,7 @@ struct VoiceMemosView: View {
           }
 
           IfLetStore(
-            self.store.scope(state: \.$recordingMemo, action: VoiceMemos.Action.recordingMemo)
+            self.store.scope(state: \.$recordingMemo, action: { .recordingMemo($0) })
           ) { store in
             RecordingMemoView(store: store)
           } else: {
@@ -161,7 +161,7 @@ struct VoiceMemosView: View {
           .frame(maxWidth: .infinity)
           .background(Color.init(white: 0.95))
         }
-        .alert(store: self.store.scope(state: \.$alert, action: VoiceMemos.Action.alert))
+        .alert(store: self.store.scope(state: \.$alert, action: { .alert($0) }))
         .navigationTitle("Voice memos")
       }
     }

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -61,15 +61,15 @@ struct AppView: View {
     TabView {
       ActivityView(
         store: self.store
-          .scope(state: \.activity, action: AppFeature.Action.activity)
+          .scope(state: \.activity, action: { .activity($0) })
       )
       SearchView(
         store: self.store
-          .scope(state: \.search, action: AppFeature.Action.search)
+          .scope(state: \.search, action: { .search($0) })
       )
       ProfileView(
         store: self.store
-          .scope(state: \.profile, action: AppFeature.Action.profile)
+          .scope(state: \.profile, action: { .profile($0) })
       )
     }
   }
@@ -106,18 +106,18 @@ struct AppView: View {
   var body: some View {
     WithViewStore(self.store, observe: { $0 }) { viewStore in
       TabView(
-        selection: viewStore.binding(get: \.selectedTab, send: AppFeature.Action.tabSelected)
+        selection: viewStore.binding(get: \.selectedTab, send: { .tabSelected($0) })
       ) {
         ActivityView(
-          store: self.store.scope(state: \.activity, action: AppFeature.Action.activity)
+          store: self.store.scope(state: \.activity, action: { .activity($0) })
         )
         .tag(AppFeature.Tab.activity)
         SearchView(
-          store: self.store.scope(state: \.search, action: AppFeature.Action.search)
+          store: self.store.scope(state: \.search, action: { .search($0) })
         )
         .tag(AppFeature.Tab.search)
         ProfileView(
-          store: self.store.scope(state: \.profile, action: AppFeature.Action.profile)
+          store: self.store.scope(state: \.profile, action: { .profile($0) })
         )
         .tag(AppFeature.Tab.profile)
       }
@@ -137,7 +137,7 @@ the state the view needs. In this case the view only needs a single field:
 
 ```swift
 WithViewStore(self.store, observe: \.selectedTab) { viewStore in
-  TabView(selection: viewStore.binding(send: AppFeature.Action.tabSelected)) {
+  TabView(selection: viewStore.binding(send: { .tabSelected($0) }) {
     // ...
   }
 }
@@ -157,9 +157,9 @@ WithViewStore(
   observe: { (selectedTab: $0.selectedTab, unreadActivityCount: $0.activity.unreadCount) },
   removeDuplicates: ==
 ) { viewStore in 
-  TabView(selection: viewStore.binding(get: \.selectedTab, send: AppFeature.Action.tabSelected)) {
+  TabView(selection: viewStore.binding(get: \.selectedTab, send: { .tabSelected($0) }) {
     ActivityView(
-      store: self.store.scope(state: \.activity, action: AppFeature.Action.activity)
+      store: self.store.scope(state: \.activity, action: { .activity($0) })
     )
     .tag(AppFeature.Tab.activity)
     .badge("\(viewStore.unreadActivityCount)")
@@ -191,7 +191,7 @@ struct AppView: View {
       TabView {
         ActivityView(
           store: self.store
-            .scope(state: \.activity, action: AppFeature.Action.activity)
+            .scope(state: \.activity, action: { .activity($0) })
         )
         .badge("\(viewStore.unreadActivityCount)")
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
@@ -63,7 +63,7 @@ struct InventoryFeature: Reducer {
   enum Action: Equatable { /* ... */ }
   
   var body: some ReducerOf<Self> {
-    Reduce<State, Action> { state, action in 
+    Reduce { state, action in 
       switch action {
       case .addButtonTapped:
         // Populating this state performs the navigation

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -60,17 +60,17 @@ import SwiftUI
 ///   var body: some View {
 ///     TabView {
 ///       ActivityView(
-///         store: self.store.scope(state: \.activity, action: AppFeature.Action.activity)
+///         store: self.store.scope(state: \.activity, action: { .activity($0) })
 ///       )
 ///       .tabItem { Text("Activity") }
 ///
 ///       SearchView(
-///         store: self.store.scope(state: \.search, action: AppFeature.Action.search)
+///         store: self.store.scope(state: \.search, action: { .search($0) })
 ///       )
 ///       .tabItem { Text("Search") }
 ///
 ///       ProfileView(
-///         store: self.store.scope(state: \.profile, action: AppFeature.Action.profile)
+///         store: self.store.scope(state: \.profile, action: { .profile($0) })
 ///       )
 ///       .tabItem { Text("Profile") }
 ///     }

--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -75,7 +75,7 @@ import SwiftUI
 ///
 /// ```swift
 /// ForEachStore(
-///   self.store.scope(state: \.todos, action: AppAction.todo(id:action:))
+///   self.store.scope(state: \.todos, action: { .todo(id: $0, action: $1) })
 /// ) { todoStore in
 ///   TodoView(store: todoStore)
 /// }

--- a/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
@@ -9,7 +9,7 @@ import SwiftUI
 ///
 /// ```swift
 /// IfLetStore(
-///   store.scope(state: \.results, action: Search.Action.results)
+///   store.scope(state: \.results, action: { .results($0) })
 /// ) {
 ///   SearchResultsView(store: $0)
 /// } else: {

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -229,17 +229,17 @@ public struct WithViewStore<ViewState, ViewAction, Content: View>: View {
   ///
   ///   var body: some View {
   ///     WithViewStore(self.store, observe: \.selectedTab) { viewStore in
-  ///       TabView(selection: viewStore.binding(send: AppFeature.Action.tabSelected) {
+  ///       TabView(selection: viewStore.binding(send: { .tabSelected($0) }) {
   ///         ActivityView(
-  ///           store: self.store.scope(state: \.activity, action: AppFeature.Action.activity)
+  ///           store: self.store.scope(state: \.activity, action: { .activity($0) })
   ///         )
   ///         .tag(AppFeature.Tab.activity)
   ///         SearchView(
-  ///           store: self.store.scope(state: \.search, action: AppFeature.Action.search)
+  ///           store: self.store.scope(state: \.search, action: { .search($0) })
   ///         )
   ///         .tag(AppFeature.Tab.search)
   ///         ProfileView(
-  ///           store: self.store.scope(state: \.profile, action: AppFeature.Action.profile)
+  ///           store: self.store.scope(state: \.profile, action: { .profile($0) })
   ///         )
   ///         .tag(AppFeature.Tab.profile)
   ///       }
@@ -319,17 +319,17 @@ public struct WithViewStore<ViewState, ViewAction, Content: View>: View {
   ///
   ///   var body: some View {
   ///     WithViewStore(self.store, observe: \.selectedTab) { viewStore in
-  ///       TabView(selection: viewStore.binding(send: AppFeature.Action.tabSelected) {
+  ///       TabView(selection: viewStore.binding(send: { .tabSelected($0) }) {
   ///         ActivityView(
-  ///           store: self.store.scope(state: \.activity, action: AppFeature.Action.activity)
+  ///           store: self.store.scope(state: \.activity, action: { .activity($0) })
   ///         )
   ///         .tag(AppFeature.Tab.activity)
   ///         SearchView(
-  ///           store: self.store.scope(state: \.search, action: AppFeature.Action.search)
+  ///           store: self.store.scope(state: \.search, action: { .search($0) })
   ///         )
   ///         .tag(AppFeature.Tab.search)
   ///         ProfileView(
-  ///           store: self.store.scope(state: \.profile, action: AppFeature.Action.profile)
+  ///           store: self.store.scope(state: \.profile, action: { .profile($0) })
   ///         )
   ///         .tag(AppFeature.Tab.profile)
   ///       }
@@ -409,17 +409,17 @@ extension WithViewStore where ViewState: Equatable, Content: View {
   ///
   ///   var body: some View {
   ///     WithViewStore(self.store, observe: \.selectedTab) { viewStore in
-  ///       TabView(selection: viewStore.binding(send: AppFeature.Action.tabSelected) {
+  ///       TabView(selection: viewStore.binding(send: { .tabSelected($0) }) {
   ///         ActivityView(
-  ///           store: self.store.scope(state: \.activity, action: AppFeature.Action.activity)
+  ///           store: self.store.scope(state: \.activity, action: { .activity($0) })
   ///         )
   ///         .tag(AppFeature.Tab.activity)
   ///         SearchView(
-  ///           store: self.store.scope(state: \.search, action: AppFeature.Action.search)
+  ///           store: self.store.scope(state: \.search, action: { .search($0) })
   ///         )
   ///         .tag(AppFeature.Tab.search)
   ///         ProfileView(
-  ///           store: self.store.scope(state: \.profile, action: AppFeature.Action.profile)
+  ///           store: self.store.scope(state: \.profile, action: { .profile($0) })
   ///         )
   ///         .tag(AppFeature.Tab.profile)
   ///       }
@@ -498,17 +498,17 @@ extension WithViewStore where ViewState: Equatable, Content: View {
   ///
   ///   var body: some View {
   ///     WithViewStore(self.store, observe: \.selectedTab) { viewStore in
-  ///       TabView(selection: viewStore.binding(send: AppFeature.Action.tabSelected) {
+  ///       TabView(selection: viewStore.binding(send: { .tabSelected($0) }) {
   ///         ActivityView(
-  ///           store: self.store.scope(state: \.activity, action: AppFeature.Action.activity)
+  ///           store: self.store.scope(state: \.activity, action: { .activity($0) })
   ///         )
   ///         .tag(AppFeature.Tab.activity)
   ///         SearchView(
-  ///           store: self.store.scope(state: \.search, action: AppFeature.Action.search)
+  ///           store: self.store.scope(state: \.search, action: { .search($0) })
   ///         )
   ///         .tag(AppFeature.Tab.search)
   ///         ProfileView(
-  ///           store: self.store.scope(state: \.profile, action: AppFeature.Action.profile)
+  ///           store: self.store.scope(state: \.profile, action: { .profile($0) })
   ///         )
   ///         .tag(AppFeature.Tab.profile)
   ///       }

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -20,7 +20,7 @@ extension Store {
   ///   func viewDidLoad() {
   ///     // ...
   ///     self.store
-  ///       .scope(state: \.optionalChild, action: ParentAction.child)
+  ///       .scope(state: \.optionalChild, action: { .child($0) })
   ///       .ifLet(
   ///         then: { [weak self] childStore in
   ///           self?.navigationController?.pushViewController(

--- a/Sources/swift-composable-architecture-benchmark/StoreSuite.swift
+++ b/Sources/swift-composable-architecture-benchmark/StoreSuite.swift
@@ -44,7 +44,7 @@ private struct Feature: Reducer {
     case none
   }
   var body: some ReducerOf<Self> {
-    Reduce<State, Action> { state, action in
+    Reduce { state, action in
       switch action {
       case .child:
         return .none

--- a/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
@@ -2066,7 +2066,7 @@ final class PresentationReducerTests: BaseTCATestCase {
         }
 
         var body: some ReducerOf<Self> {
-          Reduce<State, Action> { state, action in
+          Reduce { state, action in
             switch action {
             case .destination(.presented(.alert(.showDialog))):
               state.destination = .dialog(


### PR DESCRIPTION
This PR just goes through our docs and examples and modernizes a few things, mainly:

  * Updating `action: MyFeature.Action.case` to `action: { .case($0) }`, which is often shorter and more symmetrical with `state: \.value`.
  * Removing unnecessary `<State, Action>` generic parameter list from `Reduce`.
  * General SwiftUI API modernization.