### PR TITLE
correcting readme.md syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,11 +515,13 @@ This means the entry point to the application no longer needs to construct depen
 @main
 struct MyApp: App {
   var body: some Scene {
-    FeatureView(
-      store: Store(initialState: Feature.State()) {
-        Feature()
-      }
-    )
+    WindowGroup {
+      FeatureView(
+        store: Store(initialState: Feature.State()) {
+          Feature()
+        }
+      )
+    }
   }
 }
 ```


### PR DESCRIPTION
Hi~!   
I corrected the README document because there was a part that could cause a syntax error.
Since `FeatureView` is not `Scene`, I wrapped it in `WindowGroup`.

Please check it out! 😊