### PR TITLE
Add Documentation in TreeBasedNavigation.md

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
@@ -232,6 +232,23 @@ struct InventoryFeature: Reducer {
   // ...
 }
 ```
+And then we must make use of the ifLet(_:action:destination:fileID:line:) method to integrate the domain of the Destination with the domain of the parent feature:
+
+```swift
+struct InventoryFeature: Reducer {
+  // ...
+
+  var body: some ReducerOf<Self> {
+    Reduce { state, action in 
+      // Core logic for root feature
+    }
+    .ifLet(\.$destination, action: /Action.destination) { 
+      Destination()
+    }
+  }
+}
+```
+That completes the steps to integrate the child and parent features together.
 
 Now when we want to present a particular feature we can simply populate the `destination` state
 with a case of the enum:


### PR DESCRIPTION
Hi, I found the documentation lacking in TreeBasedNavigation.md .
The Stack-based Navigation one explained the integration from the child domain to the parent domain, but the Tree-based Navigation one did not.