### PR TITLE
fix: documentation error for the getting started example

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
@@ -124,7 +124,7 @@ struct Feature: Reducer {
           from: URL(string: "http://numbersapi.com/\(count)/trivia")!
         )
         await send(
-          .numberFactResponse(String(decoding: data, as: UTF8.self)
+          .numberFactResponse(String(decoding: data, as: UTF8.self))
         )
       }
 


### PR DESCRIPTION
I found a missing `)` in the documentation that'd be helpful to fix for others.