### PR TITLE
Use `StoreTask.cancel()` instead of `task.rawValue?.cancel()`

### DIFF
--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -315,7 +315,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
     await withTaskCancellationHandler {
       await self.yield(while: predicate)
     } onCancel: {
-      task.rawValue?.cancel()
+      task.cancel()
     }
   }
 
@@ -338,7 +338,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
     await withTaskCancellationHandler {
       await self.yield(while: predicate)
     } onCancel: {
-      task.rawValue?.cancel()
+      task.cancel()
     }
   }
 


### PR DESCRIPTION
Rewrote `task.rawValue?.cancel()` instead of `task.rawValue?.cancel()` because `ViewStoreTask.cancel()` cancels the underlying task and also waits for the task to finish.
However, since the current `StoreTask.cancel()` only cancels the task, it is no longer necessary to write `task.rawValue?.cancel()`.
So, I changed the writing style to use `StoreTask.cancel()`.