### PR TITLE
Fix Tree-based Navigation Bug

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
@@ -213,7 +213,6 @@ public struct PresentationStore<
   }
 
   public var body: some View {
-    let id = self.toID(self.viewStore.state)
     self.content(
       self.viewStore.binding(
         get: {
@@ -224,8 +223,7 @@ public struct PresentationStore<
         compactSend: {
           guard
             $0 == nil,
-            self.viewStore.wrappedValue != nil,
-            id == nil || self.toID(self.viewStore.state) == id
+            self.viewStore.wrappedValue != nil
           else { return nil }
           return .dismiss
         }


### PR DESCRIPTION
I have encountered a bug where the PresentationState does not turn nil when a View is popped.
This happened during a push transition using Tree-based Navigation like this.

```Swift
.navigationDestination(
    store: store.scope(state: \.$destination, action: { .destination($0) }),
    state: /MyReducer.Destination.State.screenA,
    action: MyReducer.Destination.Action.screenA
) { store in
    ScreenA(store: store)
}
.navigationDestination(
    store: store.scope(state: \.$destination, action: { .destination($0) }),
    state: /MyReducer.Destination.State.screenB,
    action: MyReducer.Destination.Action.screenB
) { store in
    ScreenB(store: store)
}
```
Currently, the following code is executed when a View is popped.
```Swift
self.viewStore.binding(
  get: {
    $0.wrappedValue.flatMap(toDestinationState) != nil
      ? toID($0).map { AnyIdentifiable(Identified($0) { $0 }) }
      : nil
  },
  compactSend: {
    guard
      $0 == nil,
      self.viewStore.wrappedValue != nil,
      id == nil || self.toID(self.viewStore.state) == id
    else { return nil }
    return .dismiss
  }
),
```
However, when I debugged it, the id was not nil.
So I erased the evaluation of `id == nil` and it works fine.
Why is it currently evaluating `id == nil || self.toID(self.viewStore.state) == id`? It seems to me that it should simply return `.dismiss` when $0 is nil.