### PR TITLE
Bring back _printChanges queue.

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
@@ -1,3 +1,5 @@
+import Dispatch
+
 extension Reducer {
   #if swift(>=5.8)
     /// Enhances a reducer with debug logging of received actions and state mutations for the given
@@ -26,13 +28,19 @@ extension Reducer {
   #endif
 }
 
+private let printQueue = DispatchQueue(label: "co.pointfree.swift-composable-architecture.printer")
+
 public struct _ReducerPrinter<State, Action> {
   private let _printChange: (_ receivedAction: Action, _ oldState: State, _ newState: State) -> Void
+  @usableFromInline
+  let queue: DispatchQueue
 
   public init(
-    printChange: @escaping (_ receivedAction: Action, _ oldState: State, _ newState: State) -> Void
+    printChange: @escaping (_ receivedAction: Action, _ oldState: State, _ newState: State) -> Void,
+    queue: DispatchQueue? = nil
   ) {
     self._printChange = printChange
+    self.queue = queue ?? printQueue
   }
 
   public func printChange(receivedAction: Action, oldState: State, newState: State) {
@@ -81,8 +89,10 @@ public struct _PrintChangesReducer<Base: Reducer>: Reducer {
         let oldState = state
         let effects = self.base.reduce(into: &state, action: action)
         return effects.merge(
-          with: .run { [newState = state] _ in
-            printer.printChange(receivedAction: action, oldState: oldState, newState: newState)
+          with: .run { [newState = state, queue = printer.queue] _ in
+            queue.async {
+              printer.printChange(receivedAction: action, oldState: oldState, newState: newState)
+            }
           }
         )
       }

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -133,7 +133,7 @@
         typealias Action = Bool
         func reduce(into state: inout Int, action: Bool) -> Effect<Bool> {
           state += action ? 1 : -1
-          return .none
+          return .run { _ in await Task.yield() }
         }
       }
 


### PR DESCRIPTION
Prior to the `ReducerProtocol` we would queue print changes in the debug operator on reducers:

https://github.com/pointfreeco/swift-composable-architecture/blob/54c384581cd0ed395d4f314dfdaca14dc70acf4c/Sources/ComposableArchitecture/Debugging/ReducerDebugging.swift#L118

We lost that in #1283, but we still used `fireAndForget` which had a sync overload, and so queuing just naturally happened on the main thread.

But, with 1.0 we got rid of `fireAndForget` and so instead used `run`, but then that introduced asynchrony and possible ordering issues with logs. So, currently it is possible for `actionA` to be sent before `actionB`, yet the logs for `actionB` will appear in the console before `actionA`.

This PR brings back the queue. Alternatively we could `@MainActor` the `run` effect. Each approach has their pros and cons. With the queue we run the risk of the logs starting to lag if too much is logged at once, and with `@MainActor` we risk slowing down the app if too much is logged (only in debug). I went with the queue for now, but open to switch to `@MainActor` too.