### PR TITLE
Fix search example debounce duration

### DIFF
--- a/Examples/Search/Search/SearchView.swift
+++ b/Examples/Search/Search/SearchView.swift
@@ -165,7 +165,7 @@ struct SearchView: View {
       }
       .task(id: viewStore.searchQuery) {
         do {
-          try await Task.sleep(for: .seconds(3))
+          try await Task.sleep(for: .milliseconds(300))
           await viewStore.send(.searchQueryChangeDebounced).finish()
         } catch {}
       }


### PR DESCRIPTION
The docs and code comments suggest that the debounce duration is 300ms, not 3 seconds. This small patch ensures the example works as described.