### PR TITLE
Allow existential reducers in builders

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
+++ b/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
@@ -47,6 +47,14 @@ public enum ReducerBuilder<State, Action> {
   }
 
   @inlinable
+  @_disfavoredOverload
+  public static func buildExpression(
+    _ expression: any Reducer<State, Action>
+  ) -> Reduce<State, Action> {
+    Reduce(expression)
+  }
+
+  @inlinable
   public static func buildFinalResult<R: Reducer>(_ reducer: R) -> R
   where R.State == State, R.Action == Action {
     reducer

--- a/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
@@ -19,6 +19,13 @@ private struct Test: Reducer {
   }
 }
 
+func testExistentialReducers() {
+  _ = CombineReducers {
+    Test()
+    Test() as any ReducerOf<Test>
+  }
+}
+
 func testLimitedAvailability() {
   _ = CombineReducers {
     Test()


### PR DESCRIPTION
Discovered this while troubleshooting a Swift bug, but seems like we should allow the builder to promote an existential to an erased `Reduce`.