### PR TITLE
Internal: rename `Store.{state,stateSubject}`

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -133,7 +133,7 @@ public final class Store<State, Action> {
   private var isSending = false
   var parentCancellable: AnyCancellable?
   private let reducer: any Reducer<State, Action>
-  @_spi(Internals) public var state: CurrentValueSubject<State, Never>
+  @_spi(Internals) public var stateSubject: CurrentValueSubject<State, Never>
   #if DEBUG
     private let mainThreadChecksEnabled: Bool
   #endif
@@ -186,7 +186,7 @@ public final class Store<State, Action> {
   ///   you want to observe store state in a view, use a ``ViewStore`` instead.
   /// - Returns: The return value, if any, of the `body` closure.
   public func withState<R>(_ body: (_ state: State) -> R) -> R {
-    body(self.state.value)
+    body(self.stateSubject.value)
   }
 
   /// Sends an action to the store.
@@ -425,7 +425,7 @@ public final class Store<State, Action> {
       action: { state, action in isInvalid(state) && BindingLocal.isActive ? nil : action },
       removeDuplicates: { isInvalid($0) && isInvalid($1) }
     )
-    store._isInvalidated = { self._isInvalidated() || isInvalid(self.state.value) }
+    store._isInvalidated = { self._isInvalidated() || isInvalid(self.stateSubject.value) }
     return store
   }
 
@@ -440,13 +440,13 @@ public final class Store<State, Action> {
     guard !self.isSending else { return nil }
 
     self.isSending = true
-    var currentState = self.state.value
+    var currentState = self.stateSubject.value
     let tasks = Box<[Task<Void, Never>]>(wrappedValue: [])
     defer {
       withExtendedLifetime(self.bufferedActions) {
         self.bufferedActions.removeAll()
       }
-      self.state.value = currentState
+      self.stateSubject.value = currentState
       self.isSending = false
       if !self.bufferedActions.isEmpty {
         if let task = self.send(
@@ -660,7 +660,7 @@ public final class Store<State, Action> {
     reducer: R,
     mainThreadChecksEnabled: Bool
   ) where R.State == State, R.Action == Action {
-    self.state = CurrentValueSubject(initialState)
+    self.stateSubject = CurrentValueSubject(initialState)
     self.reducer = reducer
     #if DEBUG
       self.mainThreadChecksEnabled = mainThreadChecksEnabled
@@ -678,7 +678,7 @@ public final class Store<State, Action> {
   ///   .sink { ... }
   /// ```
   public var publisher: StorePublisher<State> {
-    StorePublisher(store: self, upstream: self.state)
+    StorePublisher(store: self, upstream: self.stateSubject)
   }
 }
 
@@ -746,7 +746,7 @@ private final class ScopedReducer<RootState, RootAction, State, Action>: Reducer
   func reduce(into state: inout State, action: Action) -> Effect<Action> {
     self.isSending = true
     defer {
-      state = self.toScopedState(self.rootStore.state.value)
+      state = self.toScopedState(self.rootStore.stateSubject.value)
       self.isSending = false
     }
     if let action = self.fromScopedAction(state, action),
@@ -779,17 +779,17 @@ extension ScopedReducer: AnyScopedReducer {
     let fromScopedAction = self.fromScopedAction as! (ScopedState, ScopedAction) -> RootAction?
     let reducer = ScopedReducer<RootState, RootAction, RescopedState, RescopedAction>(
       rootStore: self.rootStore,
-      state: { _ in toRescopedState(store.state.value) },
-      action: { fromRescopedAction($0, $1).flatMap { fromScopedAction(store.state.value, $0) } },
+      state: { _ in toRescopedState(store.stateSubject.value) },
+      action: { fromRescopedAction($0, $1).flatMap { fromScopedAction(store.stateSubject.value, $0) } },
       parentStores: self.parentStores + [store]
     )
     let childStore = Store<RescopedState, RescopedAction>(
-      initialState: toRescopedState(store.state.value)
+      initialState: toRescopedState(store.stateSubject.value)
     ) {
       reducer
     }
     childStore._isInvalidated = store._isInvalidated
-    childStore.parentCancellable = store.state
+    childStore.parentCancellable = store.stateSubject
       .dropFirst()
       .sink { [weak childStore] newValue in
         guard
@@ -797,10 +797,10 @@ extension ScopedReducer: AnyScopedReducer {
           let childStore = childStore
         else { return }
         let newValue = toRescopedState(newValue)
-        guard isDuplicate.map({ !$0(childStore.state.value, newValue) }) ?? true else {
+        guard isDuplicate.map({ !$0(childStore.stateSubject.value, newValue) }) ?? true else {
           return
         }
-        childStore.state.value = newValue
+        childStore.stateSubject.value = newValue
         Logger.shared.log("\(typeName(of: store)).scope")
       }
     return childStore

--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -31,7 +31,7 @@ extension View {
     self.presentation(
       store: store, state: toDestinationState, action: fromDestinationAction
     ) { `self`, $isPresented, destination in
-      let alertState = store.state.value.wrappedValue.flatMap(toDestinationState)
+      let alertState = store.withState { $0.wrappedValue.flatMap(toDestinationState) }
       self.alert(
         (alertState?.title).map(Text.init) ?? Text(""),
         isPresented: $isPresented,

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -379,7 +379,7 @@ public struct BindingViewStore<State> {
   }
 
   public var wrappedValue: State {
-    self.store.state.value
+    self.store.withState { $0 }
   }
 
   public var projectedValue: Self {

--- a/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
@@ -34,7 +34,7 @@ extension View {
     self.presentation(
       store: store, state: toDestinationState, action: fromDestinationAction
     ) { `self`, $isPresented, destination in
-      let confirmationDialogState = store.state.value.wrappedValue.flatMap(toDestinationState)
+      let confirmationDialogState = store.withState { $0.wrappedValue.flatMap(toDestinationState) }
       self.confirmationDialog(
         (confirmationDialogState?.title).map(Text.init) ?? Text(""),
         isPresented: $isPresented,

--- a/Sources/ComposableArchitecture/SwiftUI/Deprecated/ActionSheet.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Deprecated/ActionSheet.swift
@@ -73,7 +73,7 @@ extension View {
     self.presentation(
       store: store, state: toDestinationState, action: fromDestinationAction
     ) { `self`, $item, _ in
-      let actionSheetState = store.state.value.wrappedValue.flatMap(toDestinationState)
+      let actionSheetState = store.withState { $0.wrappedValue.flatMap(toDestinationState) }
       self.actionSheet(item: $item) { _ in
         ActionSheet(actionSheetState!) { action in
           if let action = action {

--- a/Sources/ComposableArchitecture/SwiftUI/Deprecated/LegacyAlert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Deprecated/LegacyAlert.swift
@@ -62,7 +62,7 @@ extension View {
     self.presentation(
       store: store, state: toDestinationState, action: fromDestinationAction
     ) { `self`, $item, _ in
-      let alertState = store.state.value.wrappedValue.flatMap(toDestinationState)
+      let alertState = store.withState { $0.wrappedValue.flatMap(toDestinationState) }
       self.alert(item: $item) { _ in
         Alert(alertState!) { action in
           if let action = action {

--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -104,7 +104,7 @@ public struct ForEachStore<
       ForEach<IdentifiedArray<ID, EachState>, ID, EachContent>
     >
   {
-    self.data = store.state.value
+    self.data = store.withState { $0 }
     self.content = WithViewStore(
       store,
       observe: { $0 },

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -157,7 +157,7 @@ public struct _CaseLetMismatchView<State, Action>: View {
         Warning: A "CaseLet" at "\(self.fileID):\(self.line)" was encountered when state was set \
         to another case:
 
-            \(debugCaseOutput(self.store.wrappedValue.state.value))
+            \(debugCaseOutput(self.store.wrappedValue.withState { $0 }))
 
         This usually happens when there is a mismatch between the case being switched on and the \
         "CaseLet" view being rendered.

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -49,7 +49,7 @@ extension Store {
     then unwrap: @escaping (_ store: Store<Wrapped, Action>) -> Void,
     else: @escaping () -> Void = {}
   ) -> Cancellable where State == Wrapped? {
-    return self.state
+    self.stateSubject
       .removeDuplicates(by: { ($0 != nil) == ($1 != nil) })
       .sink { state in
         if var state = state {

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -92,9 +92,9 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
     removeDuplicates isDuplicate: @escaping (_ lhs: ViewState, _ rhs: ViewState) -> Bool
   ) {
     self._send = { store.send($0, originatingFrom: nil) }
-    self._state = CurrentValueRelay(toViewState(store.state.value))
+    self._state = CurrentValueRelay(toViewState(store.stateSubject.value))
     self._isInvalidated = store._isInvalidated
-    self.viewCancellable = store.state
+    self.viewCancellable = store.stateSubject
       .map(toViewState)
       .removeDuplicates(by: isDuplicate)
       .sink { [weak objectWillChange = self.objectWillChange, weak _state = self._state] in
@@ -126,9 +126,9 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
     removeDuplicates isDuplicate: @escaping (_ lhs: ViewState, _ rhs: ViewState) -> Bool
   ) {
     self._send = { store.send(fromViewAction($0), originatingFrom: nil) }
-    self._state = CurrentValueRelay(toViewState(store.state.value))
+    self._state = CurrentValueRelay(toViewState(store.stateSubject.value))
     self._isInvalidated = store._isInvalidated
-    self.viewCancellable = store.state
+    self.viewCancellable = store.stateSubject
       .map(toViewState)
       .removeDuplicates(by: isDuplicate)
       .sink { [weak objectWillChange = self.objectWillChange, weak _state = self._state] in

--- a/Sources/swift-composable-architecture-benchmark/StoreSuite.swift
+++ b/Sources/swift-composable-architecture-benchmark/StoreSuite.swift
@@ -15,7 +15,7 @@ let storeSuite = BenchmarkSuite(name: "Store") {
         Feature()
       }
     } tearDown: {
-      precondition(count(of: store.state.value, level: level) == 1)
+      precondition(count(of: store.withState { $0 }, level: level) == 1)
       _cancellationCancellables.removeAll()
     }
   }
@@ -27,7 +27,7 @@ let storeSuite = BenchmarkSuite(name: "Store") {
         Feature()
       }
     } tearDown: {
-      precondition(count(of: store.state.value, level: level) == 0)
+      precondition(count(of: store.withState { $0 }, level: level) == 0)
       _cancellationCancellables.removeAll()
     }
   }

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -633,7 +633,7 @@ final class StoreTests: BaseTCATestCase {
       Feature()
     }
     await store.send(.tap, originatingFrom: nil)?.value
-    XCTAssertEqual(store.state.value.count, testStore.state.count)
+    XCTAssertEqual(store.withState(\.count), testStore.state.count)
   }
 
   func testStoreVsTestStore_Publisher() async {
@@ -691,7 +691,7 @@ final class StoreTests: BaseTCATestCase {
       Feature()
     }
     await store.send(.tap, originatingFrom: nil)?.value
-    XCTAssertEqual(store.state.value.count, testStore.state.count)
+    XCTAssertEqual(store.withState(\.count), testStore.state.count)
   }
 
   func testChildParentEffectCancellation() async throws {
@@ -785,7 +785,7 @@ final class StoreTests: BaseTCATestCase {
       $0.date = .constant(Date(timeIntervalSinceReferenceDate: 1_234_567_890))
     }
 
-    XCTAssertEqual(store.state.value.date, Date(timeIntervalSinceReferenceDate: 1_234_567_890))
+    XCTAssertEqual(store.withState(\.date), Date(timeIntervalSinceReferenceDate: 1_234_567_890))
   }
 
   func testInit_ReducerBuilder_WithDependencies() async {
@@ -807,7 +807,7 @@ final class StoreTests: BaseTCATestCase {
     }
 
     store.send(.tap)
-    XCTAssertEqual(store.state.value.date, Date(timeIntervalSinceReferenceDate: 1_234_567_890))
+    XCTAssertEqual(store.withState(\.date), Date(timeIntervalSinceReferenceDate: 1_234_567_890))
   }
 
   func testPresentationScope() async {
@@ -865,7 +865,7 @@ final class StoreTests: BaseTCATestCase {
     childViewStore1.objectWillChange
       .sink { _ in viewStoreCount1 += 1 }
       .store(in: &self.cancellables)
-    childStore1.state
+    childStore1.stateSubject
       .sink { _ in storeStateCount1 += 1 }
       .store(in: &self.cancellables)
     let childStore2 = store.scope(
@@ -886,7 +886,7 @@ final class StoreTests: BaseTCATestCase {
     childViewStore2.objectWillChange
       .sink { _ in viewStoreCount2 += 1 }
       .store(in: &self.cancellables)
-    childStore2.state
+    childStore2.stateSubject
       .sink { _ in storeStateCount2 += 1 }
       .store(in: &self.cancellables)
 


### PR DESCRIPTION
Both an internal readability win and will make it easier to provide a public `state` property in the future.