### PR TITLE
Use `Text.init(verbatim:)` to avoid localization warnings

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/Internal/TemplateText.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/Internal/TemplateText.swift
@@ -44,7 +44,7 @@ extension Text {
     }
     flushSegment()
 
-    self = segments.reduce(Text(""), +)
+    self = segments.reduce(Text(verbatim: ""), +)
   }
 }
 

--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -33,7 +33,7 @@ extension View {
     ) { `self`, $isPresented, destination in
       let alertState = store.withState { $0.wrappedValue.flatMap(toDestinationState) }
       self.alert(
-        (alertState?.title).map(Text.init) ?? Text(""),
+        (alertState?.title).map(Text.init) ?? Text(verbatim: ""),
         isPresented: $isPresented,
         presenting: alertState,
         actions: { alertState in
@@ -55,7 +55,7 @@ extension View {
           }
         },
         message: {
-          $0.message.map(Text.init) ?? Text("")
+          $0.message.map(Text.init)
         }
       )
     }

--- a/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
@@ -36,7 +36,7 @@ extension View {
     ) { `self`, $isPresented, destination in
       let confirmationDialogState = store.withState { $0.wrappedValue.flatMap(toDestinationState) }
       self.confirmationDialog(
-        (confirmationDialogState?.title).map(Text.init) ?? Text(""),
+        (confirmationDialogState?.title).map(Text.init) ?? Text(verbatim: ""),
         isPresented: $isPresented,
         titleVisibility: (confirmationDialogState?.titleVisibility).map(Visibility.init)
           ?? .automatic,


### PR DESCRIPTION
Fixes #2502.