### PR TITLE
[FIX] Updated Swift compiler version to 5.7.1 to follow Apple's policy

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.7.1
 
 import PackageDescription
 

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -4,7 +4,5 @@ public typealias EffectTask = Effect
 @available(*, unavailable, renamed: "Reducer")
 public typealias ReducerProtocol = Reducer
 
-#if swift(>=5.7.1)
-  @available(*, unavailable, renamed: "ReducerOf")
-  public typealias ReducerProtocolOf<R: Reducer> = Reducer<R.State, R.Action>
-#endif
+@available(*, unavailable, renamed: "ReducerOf")
+public typealias ReducerProtocolOf<R: Reducer> = Reducer<R.State, R.Action>

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -247,25 +247,21 @@ extension Reducer where Body: Reducer, Body.State == State, Body.Action == Actio
   }
 }
 
-// NB: This is available starting from Swift 5.7.1 due to the following bug:
-//     https://github.com/apple/swift/issues/60550
-#if swift(>=5.7.1)
-  /// A convenience for constraining a ``Reducer`` conformance.
-  ///
-  /// This allows you to specify the `body` of a ``Reducer`` conformance like so:
-  ///
-  /// ```swift
-  /// var body: some ReducerOf<Self> {
-  ///   // ...
-  /// }
-  /// ```
-  ///
-  /// …instead of the more verbose:
-  ///
-  /// ```swift
-  /// var body: some Reducer<State, Action> {
-  ///   // ...
-  /// }
-  /// ```
-  public typealias ReducerOf<R: Reducer> = Reducer<R.State, R.Action>
-#endif
+/// A convenience for constraining a ``Reducer`` conformance.
+///
+/// This allows you to specify the `body` of a ``Reducer`` conformance like so:
+///
+/// ```swift
+/// var body: some ReducerOf<Self> {
+///   // ...
+/// }
+/// ```
+///
+/// …instead of the more verbose:
+///
+/// ```swift
+/// var body: some Reducer<State, Action> {
+///   // ...
+/// }
+/// ```
+public typealias ReducerOf<R: Reducer> = Reducer<R.State, R.Action>


### PR DESCRIPTION
Since April, the apps and SDKs must be built in Xcode 14.1 + to submit to the AppStore. To support Xcode 14.1+, I modified the swift version to **5.7.1** from 5.7

> Reference: [developer.apple.com/news](https://developer.apple.com/news/?id=jd9wcyov)


After this changes, it no longer needs to worry about the apple-side bug that caused `ReducerOf` to specify support for versions 5.7.1+ : https://github.com/apple/swift/issues/60550

```swift
- #if swift(>=5.7.1)
public typealias ReducerOf<R: Reducer> = Reducer<R.State, R.Action>
- #endif
```
---
In addition, since April 2024, the apps and SDKs must be built in Xcode 15+ to submit to the AppStore.  Therefore, versions under 5.9 will no longer be needed to be supported after that date

> Reference: [developer.apple.com/ios/submit](https://developer.apple.com/ios/submit/#:~:text=Please%20note%20that,iOS%2017%20SDK.)