### PR TITLE
[Suggestion] Modify description to be clearer

### DIFF
--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -41,7 +41,7 @@
 /// }
 /// ```
 ///
-/// The `reduce` method's first responsibility is to mutate the feature's current state given an
+/// The `reduce` method's first responsibility is to mutate the feature's current state based on the given
 /// action. Its second responsibility is to return effects that will be executed asynchronously
 /// and feed their data back into the system. Currently `Feature` does not need to run any effects,
 /// and so ``Effect/none`` is returned.


### PR DESCRIPTION
I modified the description of `Reducer`: `"current state given an action"` -> `"current state based on the given action."`

However, because English is not my first language, so please consider this PR as a suggestion rather than a correction. Thanks

```
- The `reduce` method's first responsibility is to mutate the feature's current state given an action.
+ The `reduce` method's first responsibility is to mutate the feature's current state based on the given action.
```