### PR TITLE
Add effect delay

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Delay.swift
+++ b/Sources/ComposableArchitecture/Effects/Delay.swift
@@ -17,6 +17,10 @@ extension Effect {
   ///     canceled before starting this new one.
   /// - Returns: An effect that publishes events  after a specified time.
   ///
+  @available(macOS, deprecated: 13.0, message: "use delay with a clock and tolereance parameters insted (`.delay(id:for:tolerance:clock:cancelInFlight)`).")
+  @available(iOS, deprecated: 16.0, message: "use delay with a clock and tolereance parameters insted (`.delay(id:for:tolerance:clock:cancelInFlight)`).")
+  @available(watchOS, deprecated: 9.0, message: "use delay with a clock and tolereance parameters insted (`.delay(id:for:tolerance:clock:cancelInFlight)`).")
+  @available(tvOS, deprecated: 16.0, message: "use delay with a clock and tolereance parameters insted (`.delay(id:for:tolerance:clock:cancelInFlight)`).")
   public func delay<ID: Hashable, S: Scheduler>(
     id: ID,
     for dueTime: S.SchedulerTimeType.Stride,
@@ -41,6 +45,51 @@ extension Effect {
     case .run:
       return .publisher { _EffectPublisher(self) }
         .delay(id: id, for: dueTime, scheduler: scheduler, options: options)
+    }
+  }
+
+  /// Delay an effect. using async.
+  ///
+  /// - Parameters:
+  ///   - id: The effect's identifier.
+  ///   - duration: The duration you want to debounce for.
+  ///   - tolerance: The tolarence you want accept.
+  ///   - clock: Th clock you want to use for delaying/
+  ///   - cancelInFlight: Determines if any in-flight effect with the same identifier should be
+  ///     canceled before starting this new one.
+  /// - Returns: An effect that publishes events  after a specified time.
+  ///
+  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+  public func delay<ID: Hashable, C: Clock<Duration>>(
+    id: ID,
+    for duration: C.Instant.Duration,
+    tolerance: C.Instant.Duration? = nil,
+    clock: C,
+    cancelInFlight: Bool = false
+  ) -> Self {
+    switch self.operation {
+    case .none:
+      return .none
+
+    case let .publisher(publisher):
+      return Self(
+        operation: .run { send in
+          for await action in publisher.values {
+            _ = try? await clock.sleep(for: duration, tolerance: tolerance)
+            await send(action)
+          }
+        }
+      )
+      .cancellable(id: id, cancelInFlight: cancelInFlight)
+
+    case let .run(priority, operation):
+      return Self(
+        operation: .run(priority) { send in
+          _ = try? await clock.sleep(for: duration, tolerance: tolerance)
+          await operation(send)
+        }
+      )
+      .cancellable(id: id, cancelInFlight: cancelInFlight)
     }
   }
 }

--- a/Sources/ComposableArchitecture/Effects/Delay.swift
+++ b/Sources/ComposableArchitecture/Effects/Delay.swift
@@ -1,0 +1,46 @@
+import Combine
+
+extension Effect {
+  /// Delay an effect.
+  ///
+  /// To delay an effect you must provide an identifier, which is used to
+  /// determine which in-flight effect should be canceled in order to start a new effect. Any
+  /// hashable value can be used for the identifier, such as a string, but you can add a bit of
+  /// protection against typos by defining a new type that conforms to `Hashable`, such as an enum:
+  ///
+  /// - Parameters:
+  ///   - id: The effect's identifier.
+  ///   - dueTime: The duration you want to debounce for.
+  ///   - scheduler: The scheduler you want to deliver the debounced output to.
+  ///   - options: Scheduler options that customize the effect's delivery of elements.
+  ///   - cancelInFlight: Determines if any in-flight effect with the same identifier should be
+  ///     canceled before starting this new one.
+  /// - Returns: An effect that publishes events  after a specified time.
+  ///
+  public func delay<ID: Hashable, S: Scheduler>(
+    id: ID,
+    for dueTime: S.SchedulerTimeType.Stride,
+    scheduler: S,
+    options: S.SchedulerOptions? = nil,
+    cancelInFlight: Bool = false
+  ) -> Self {
+    switch self.operation {
+    case .none:
+      return .none
+
+    case let .publisher(publisher):
+      return Self(
+        operation: .publisher(
+          publisher
+            .delay(for: dueTime, scheduler: scheduler, options: options)
+            .eraseToAnyPublisher()
+        )
+      )
+      .cancellable(id: id, cancelInFlight: cancelInFlight)
+
+    case .run:
+      return .publisher { _EffectPublisher(self) }
+        .delay(id: id, for: dueTime, scheduler: scheduler, options: options)
+    }
+  }
+}

--- a/Tests/ComposableArchitectureTests/EffectDelayTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectDelayTests.swift
@@ -1,0 +1,269 @@
+import Combine
+@_spi(Internals) import ComposableArchitecture
+import XCTest
+
+@MainActor
+final class EffectDelayTests: BaseTCATestCase {
+  func testDeprecatedDelay() async {
+    let mainQueue = DispatchQueue.test
+    var currentValue: Int?
+
+    @discardableResult
+    func runDelayedEffect(value: Int) -> Task<Void, Never> {
+      Task {
+        struct CancelToken: Hashable {}
+
+        let effect = Effect.send(value)
+          .delay(id: CancelToken(), for: 1, scheduler: mainQueue)
+
+        for await action in effect.actions {
+          currentValue = action
+        }
+      }
+    }
+
+    runDelayedEffect(value: 1)
+    await mainQueue.advance()
+    // Nothing emits right away.
+    XCTAssertNil(currentValue)
+
+    // Waiting for the delayed time
+    await mainQueue.advance(by: .seconds(1))
+    XCTAssertEqual(currentValue, 1)
+  }
+
+  func testDeprecatedDelayMultiple() async {
+    let mainQueue = DispatchQueue.test
+    var currentValue: Int?
+
+    @discardableResult
+    func runDelayedEffect(value: Int) -> Task<Void, Never> {
+      Task {
+        struct CancelToken: Hashable {}
+
+        let effect = Effect.send(value)
+          .delay(id: CancelToken(), for: 1, scheduler: mainQueue)
+
+        for await action in effect.actions {
+          currentValue = action
+        }
+      }
+    }
+
+    runDelayedEffect(value: 1)
+    await mainQueue.advance()
+    // Nothing emits right away.
+    XCTAssertNil(currentValue)
+
+    // 0.5 s
+    await mainQueue.advance(by: .seconds(0.5))
+    // Nothing emits right away.
+    XCTAssertNil(currentValue)
+
+    runDelayedEffect(value: 2)
+    // Nothing emits right away.
+    XCTAssertNil(currentValue)
+
+    // 1.0 s
+    // Waiting for the second value.
+    await mainQueue.advance(by: .seconds(0.5))
+    XCTAssertEqual(currentValue, 1)
+
+    runDelayedEffect(value: 3)
+
+    // 1.5 s
+    // Waiting for the second value.
+    await mainQueue.advance(by: .seconds(0.5))
+    XCTAssertEqual(currentValue, 2)
+
+    // 2.0 s
+    // Waiting for the third value.
+    await mainQueue.advance(by: .seconds(0.5))
+    XCTAssertEqual(currentValue, 3)
+  }
+
+  func testDeprecatedDelayCanceledInFlight() async {
+    let mainQueue = DispatchQueue.test
+    var currentValue: Int?
+
+    @discardableResult
+    func runDelayedEffect(value: Int) -> Task<Void, Never> {
+      Task {
+        struct CancelToken: Hashable {}
+
+        let effect = Effect.send(value)
+          .delay(id: CancelToken(), for: 1, scheduler: mainQueue, cancelInFlight: true)
+
+        for await action in effect.actions {
+          currentValue = action
+        }
+      }
+    }
+
+    runDelayedEffect(value: 1)
+    await mainQueue.advance()
+    // Nothing emits right away.
+    XCTAssertNil(currentValue)
+
+    // 0.5 s
+    await mainQueue.advance(by: .seconds(0.5))
+    // Nothing emits right away.
+    XCTAssertNil(currentValue)
+
+    runDelayedEffect(value: 2)
+    // Nothing emits right away.
+    XCTAssertNil(currentValue)
+
+    // 1.0 s
+    // Waiting for the second value
+    await mainQueue.advance(by: .seconds(0.5))
+    // Nothing emits right away because the previos call was canceled
+    XCTAssertNil(currentValue)
+
+    runDelayedEffect(value: 3)
+
+    // 1.5 s
+    // Waiting for the second value
+    await mainQueue.advance(by: .seconds(0.5))
+    // Nothing emits right away because the previos call was canceled
+    XCTAssertNil(currentValue)
+
+    // 2.0 s
+    // Waiting for the third value
+    await mainQueue.advance(by: .seconds(0.5))
+    // Checking the last call
+    XCTAssertEqual(currentValue, 3)
+  }
+
+  @available(iOS 16, *)
+  func testDelay() async {
+    let clock = TestClock()
+    var currentValue: Int?
+
+    @discardableResult
+    func runDelayedEffect(value: Int) -> Task<Void, Never> {
+      Task {
+        struct CancelToken: Hashable {}
+
+        let effect = Effect.send(value)
+          .delay(id: CancelToken(), for: .seconds(1), clock: clock)
+
+        for await action in effect.actions {
+          currentValue = action
+        }
+      }
+    }
+
+    runDelayedEffect(value: 1)
+    await clock.advance()
+    // Nothing emits right away.
+    XCTAssertNil(currentValue)
+
+    // Waiting for the delayed time
+    await clock.advance(by: .seconds(1))
+    XCTAssertEqual(currentValue, 1)
+  }
+
+  @available(iOS 16, *)
+  func testDelayMultiple() async {
+    let clock = TestClock()
+    var currentValue: Int?
+
+    @discardableResult
+    func runDelayedEffect(value: Int) -> Task<Void, Never> {
+      Task {
+        struct CancelToken: Hashable {}
+
+        let effect = Effect.send(value)
+          .delay(id: CancelToken(), for: .seconds(1), clock: clock)
+
+        for await action in effect.actions {
+          currentValue = action
+        }
+      }
+    }
+
+    runDelayedEffect(value: 1)
+    await clock.advance()
+    // Nothing emits right away.
+    XCTAssertNil(currentValue)
+
+    // 0.5 s
+    await clock.advance(by: .seconds(0.5))
+    // Nothing emits right away.
+    XCTAssertNil(currentValue)
+
+    runDelayedEffect(value: 2)
+    // Nothing emits right away.
+    XCTAssertNil(currentValue)
+
+    // 1.0 s
+    // Waiting for the second value.
+    await clock.advance(by: .seconds(0.5))
+    XCTAssertEqual(currentValue, 1)
+
+    runDelayedEffect(value: 3)
+
+    // 1.5 s
+    // Waiting for the second value.
+    await clock.advance(by: .seconds(0.5))
+    XCTAssertEqual(currentValue, 2)
+
+    // 2.0 s
+    // Waiting for the third value.
+    await clock.advance(by: .seconds(0.5))
+    XCTAssertEqual(currentValue, 3)
+  }
+
+  @available(iOS 16, *)
+  func testDelayCanceledInFlight() async {
+    let clock = TestClock()
+    var currentValue: Int?
+
+    @discardableResult
+    func runDelayedEffect(value: Int) -> Task<Void, Never> {
+      Task {
+        struct CancelToken: Hashable {}
+
+        let effect = Effect.send(value)
+          .delay(id: CancelToken(), for: .seconds(1), clock: clock, cancelInFlight: true)
+
+        for await action in effect.actions {
+          currentValue = action
+        }
+      }
+    }
+
+    runDelayedEffect(value: 1)
+    await clock.advance()
+    // Nothing emits right away.
+    XCTAssertNil(currentValue)
+
+    // 0.5 s
+    await clock.advance(by: .seconds(0.5))
+    // Nothing emits right away.
+    XCTAssertNil(currentValue)
+
+    runDelayedEffect(value: 2)
+    // Nothing emits right away.
+    XCTAssertNil(currentValue)
+
+    // 1.0 s
+    await clock.advance(by: .seconds(0.5))
+    // Nothing emits right away because the previos call was canceled
+    XCTAssertNil(currentValue)
+
+    runDelayedEffect(value: 3)
+
+    // 1.5 s
+    await clock.advance(by: .seconds(0.5))
+    // Nothing emits right away because the previos call was canceled
+    XCTAssertNil(currentValue)
+
+    // 2.0 s
+    // Waiting for the third value
+    await clock.advance(by: .seconds(0.5))
+    // Checking the last call
+    XCTAssertEqual(currentValue, 3)
+  }
+}


### PR DESCRIPTION
Add a delay effect next to the debounce and throttle functions because we need to delay emitted values without debouncing them. There are two options for this function: one is deprecated and uses the combine operator, and the other uses an asynchronous clock from async&await.