### PR TITLE
Remove unnecessary Reducer conformance and @CasePathable macro in CaseStudies

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -11,7 +11,7 @@ private let readMe = """
 // MARK: - Feature domain
 
 @Reducer
-struct Nested: Reducer {
+struct Nested {
   struct State: Equatable, Identifiable {
     let id: UUID
     var name: String = ""

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -18,7 +18,6 @@ struct Nested {
     var rows: IdentifiedArrayOf<State> = []
   }
 
-  @CasePathable
   enum Action {
     case addRowButtonTapped
     case nameTextFieldChanged(String)


### PR DESCRIPTION
HI loving the new macros in introduced in 1.4.0!

After studying how to use the new @Reducer macro with the CaseStudies example code, there seemed to be some unnecessary code left

As stated in the [docs](https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/reducer()#overview), when a @Reducer macro is used, it applies the @CasePathable macro to the enum Action. 

however there seemed to be a unnecessary @CasePathable in one of the case studies so i removed it

Also, the docs says that when a @Reducer macro is used you no longer have to explicitly confrom to the Reducer protocol so i also removed it too. 
(not sure if this was intentional for making the compiler happy but every other example didnt explicilty conform Reducer)