### PR TITLE
Re-adds `Reducer.forEach` method removed in 1.4

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -146,50 +146,6 @@ extension Reducer {
   @warn_unqualified_access
   public func forEach<ElementState, ElementAction, ID: Hashable, Element: Reducer>(
     _ toElementsState: WritableKeyPath<State, IdentifiedArray<ID, ElementState>>,
-    action toElementAction: CaseKeyPath<Action, (id: ID, action: ElementAction)>,
-    @ReducerBuilder<ElementState, ElementAction> element: () -> Element,
-    fileID: StaticString = #fileID,
-    line: UInt = #line
-  ) -> _ForEachReducer<Self, ID, Element>
-  where ElementState == Element.State, ElementAction == Element.Action {
-    _ForEachReducer(
-      parent: self,
-      toElementsState: toElementsState,
-      toElementAction: AnyCasePath(toElementAction),
-      element: element(),
-      fileID: fileID,
-      line: line
-    )
-  }
-
-  @available(
-    iOS,
-    deprecated: 9999,
-    message:
-      "Use an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/Migratingto14#Identified-actions"
-  )
-  @available(
-    macOS,
-    deprecated: 9999,
-    message:
-      "Use an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/Migratingto14#Identified-actions"
-  )
-  @available(
-    tvOS,
-    deprecated: 9999,
-    message:
-      "Use an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/Migratingto14#Identified-actions"
-  )
-  @available(
-    watchOS,
-    deprecated: 9999,
-    message:
-      "Use an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/Migratingto14#Identified-actions"
-  )
-  @inlinable
-  @warn_unqualified_access
-  public func forEach<ElementState, ElementAction, ID: Hashable, Element: Reducer>(
-    _ toElementsState: WritableKeyPath<State, IdentifiedArray<ID, ElementState>>,
     action toElementAction: AnyCasePath<Action, (ID, ElementAction)>,
     @ReducerBuilder<ElementState, ElementAction> element: () -> Element,
     fileID: StaticString = #fileID,
@@ -203,50 +159,6 @@ extension Reducer {
         embed: toElementAction.embed,
         extract: toElementAction.extract
       ),
-      element: element(),
-      fileID: fileID,
-      line: line
-    )
-  }
-
-  @available(
-    iOS,
-    deprecated: 9999,
-    message:
-      "Use an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/Migratingto14#Identified-actions"
-  )
-  @available(
-    macOS,
-    deprecated: 9999,
-    message:
-      "Use an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/Migratingto14#Identified-actions"
-  )
-  @available(
-    tvOS,
-    deprecated: 9999,
-    message:
-      "Use an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/Migratingto14#Identified-actions"
-  )
-  @available(
-    watchOS,
-    deprecated: 9999,
-    message:
-      "Use an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/Migratingto14#Identified-actions"
-  )
-  @inlinable
-  @warn_unqualified_access
-  public func forEach<ElementState, ElementAction, ID: Hashable, Element: Reducer>(
-    _ toElementsState: WritableKeyPath<State, IdentifiedArray<ID, ElementState>>,
-    action toElementAction: AnyCasePath<Action, (id: ID, action: ElementAction)>,
-    @ReducerBuilder<ElementState, ElementAction> element: () -> Element,
-    fileID: StaticString = #fileID,
-    line: UInt = #line
-  ) -> _ForEachReducer<Self, ID, Element>
-  where ElementState == Element.State, ElementAction == Element.Action {
-    _ForEachReducer(
-      parent: self,
-      toElementsState: toElementsState,
-      toElementAction: toElementAction,
       element: element(),
       fileID: fileID,
       line: line

--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -122,25 +122,25 @@ extension Reducer {
     iOS,
     deprecated: 9999,
     message:
-      "Use an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/Migratingto14#Identified-actions"
+      "Use a case key path to an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4"
   )
   @available(
     macOS,
     deprecated: 9999,
     message:
-      "Use an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/Migratingto14#Identified-actions"
+      "Use a case key path to an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4"
   )
   @available(
     tvOS,
     deprecated: 9999,
     message:
-      "Use an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/Migratingto14#Identified-actions"
+      "Use a case key path to an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4"
   )
   @available(
     watchOS,
     deprecated: 9999,
     message:
-      "Use an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/Migratingto14#Identified-actions"
+      "Use a case key path to an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4"
   )
   @inlinable
   @warn_unqualified_access

--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -190,6 +190,53 @@ extension Reducer {
   @warn_unqualified_access
   public func forEach<ElementState, ElementAction, ID: Hashable, Element: Reducer>(
     _ toElementsState: WritableKeyPath<State, IdentifiedArray<ID, ElementState>>,
+    action toElementAction: AnyCasePath<Action, (ID, ElementAction)>,
+    @ReducerBuilder<ElementState, ElementAction> element: () -> Element,
+    fileID: StaticString = #fileID,
+    line: UInt = #line
+  ) -> _ForEachReducer<Self, ID, Element>
+  where ElementState == Element.State, ElementAction == Element.Action {
+    _ForEachReducer(
+      parent: self,
+      toElementsState: toElementsState,
+      toElementAction: .init(
+        embed: toElementAction.embed,
+        extract: toElementAction.extract
+      ),
+      element: element(),
+      fileID: fileID,
+      line: line
+    )
+  }
+
+  @available(
+    iOS,
+    deprecated: 9999,
+    message:
+      "Use an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/Migratingto14#Identified-actions"
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message:
+      "Use an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/Migratingto14#Identified-actions"
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message:
+      "Use an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/Migratingto14#Identified-actions"
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message:
+      "Use an 'IdentifiedAction', instead. See the following migration guide for more information:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/Migratingto14#Identified-actions"
+  )
+  @inlinable
+  @warn_unqualified_access
+  public func forEach<ElementState, ElementAction, ID: Hashable, Element: Reducer>(
+    _ toElementsState: WritableKeyPath<State, IdentifiedArray<ID, ElementState>>,
     action toElementAction: AnyCasePath<Action, (id: ID, action: ElementAction)>,
     @ReducerBuilder<ElementState, ElementAction> element: () -> Element,
     fileID: StaticString = #fileID,


### PR DESCRIPTION
TCA 1.4 perhaps unintentionally removed the `Reducer.forEach` code which allowed creating a `ForEachReducer` with a `AnyCasePath<Action, (ID, ElementAction)>` as the `action` parameter.
Unfortunately, it seems that:

`AnyCasePath<Action, (ID, ElementAction)>`, and 
`AnyCasePath<Action, (id: ID, action: ElementAction)>`

are not (always) considered equivalent by the Swift compiler.

The helper library, [TCACoordinators](https://github.com/johnpatrickmorgan/TCACoordinators), relies on the previous behaviour by passing an `AnyCasePath<Action, (ID, ElementAction)>`. I have tried updating TCACoordinators to use `AnyCasePath<Action, (id: ID, action: ElementAction)>`, but this has the effect of breaking TCACoordinators when used with TCA 1.3. Without re-adding this particular method, TCACoordinators cannot compile in a way that works with both TCA 1.3 and TCA 1.4. With this small change, TCACoordinators compiles and works just fine!