### PR TITLE
Add empty public init to ReducerMacro

### DIFF
--- a/Sources/ComposableArchitectureMacros/ReducerMacro.swift
+++ b/Sources/ComposableArchitectureMacros/ReducerMacro.swift
@@ -8,6 +8,20 @@ import SwiftSyntaxMacros
 public enum ReducerMacro {
 }
 
+extension ReducerMacro: MemberMacro {
+  public static func expansion<D: DeclGroupSyntax,C: MacroExpansionContext>(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: D,
+    in context: C
+  ) throws -> [DeclSyntax] {
+    guard
+      declaration.modifiers.map(\.name.tokenKind).contains(.keyword(.public)),
+      !declaration.memberBlock.members.contains(where: { $0.decl.as(InitializerDeclSyntax.self) != nil })
+    else { return [] }
+    return ["public init() {}"]
+  }
+}
+
 extension ReducerMacro: ExtensionMacro {
   public static func expansion<D: DeclGroupSyntax, T: TypeSyntaxProtocol, C: MacroExpansionContext>(
     of node: AttributeSyntax,

--- a/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
@@ -165,4 +165,77 @@ final class ReducerMacroTests: XCTestCase {
       """
     }
   }
+
+  func testPublicInit() {
+    assertMacro {
+      """
+      @Reducer
+      public struct Feature {
+        public struct State {
+        }
+        public enum Action {
+        }
+        public var body: some ReducerOf<Self> {
+          EmptyReducer()
+        }
+      }
+      """
+    } expansion: {
+      """
+      public struct Feature {
+        public struct State {
+        }
+        @CasePathable
+        public enum Action {
+        }
+        @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
+        public var body: some ReducerOf<Self> {
+          EmptyReducer()
+        }
+
+        public init() {
+        }
+      }
+
+      extension Feature: ComposableArchitecture.Reducer {
+      }
+      """
+    }
+  }
+
+  func testPublicInitAlreadyApplied() {
+    assertMacro {
+      """
+      @Reducer
+      public struct Feature {
+        public struct State {
+        }
+        public enum Action {
+        }
+        public init() {}
+        public var body: some ReducerOf<Self> {
+          EmptyReducer()
+        }
+      }
+      """
+    } expansion: {
+      """
+      public struct Feature {
+        public struct State {
+        }
+        @CasePathable
+        public enum Action {
+        }
+        public init() {}
+        @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
+        public var body: some ReducerOf<Self> {
+          EmptyReducer()
+        }
+      }
+
+      extension Feature: ComposableArchitecture.Reducer {
+      }
+      """
+    }
+  }
 }


### PR DESCRIPTION
This adds an empty public init `public init() {}` to the ReducerMacro. If the reducer struct is marked 'public', and an existing public initializer does not exist, it will add one.  