### PR TITLE
Fix syntax error in Migrate To 1.4.

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingTo1.4.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingTo1.4.md
@@ -207,7 +207,7 @@ case:
 ```swift
 enum Action {
   // ...
-  rows(IdentifiedActionOf<Nested>)
+  case rows(IdentifiedActionOf<Nested>)
 }
 ```
 


### PR DESCRIPTION
I found and fixed an error in the syntax of enum.