### PR TITLE
Fix `swift-case-paths` being pinned to 1.1.0 the wrong way

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.0"),
-    .package(url: "https://github.com/pointfreeco/swift-case-paths", branch: "1.1.0"),
+    .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.1.0"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.1.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.0.0"),


### PR DESCRIPTION
I think that `Package.swift` and `Package@swift-5.9.swift` should be the same and we should not pin `swift-case-paths` to given release by `branch:`.

Also it kinda breaks SPM in my project so that's how we were able to spot this issue.