### PR TITLE
Annotate `ObservationStateRegistrar` with `Sendable`

### DIFF
--- a/Sources/ComposableArchitecture/Observation/ObservationStateRegistrar.swift
+++ b/Sources/ComposableArchitecture/Observation/ObservationStateRegistrar.swift
@@ -1,6 +1,6 @@
 import Perception
 
-public struct ObservationStateRegistrar {
+public struct ObservationStateRegistrar: Sendable {
   public let id = ObservableStateID()
   private let registrar = PerceptionRegistrar()
 


### PR DESCRIPTION
Since it's a struct, its two sole stored members are also `Sendable`, this should be trivially safe.