### PR TITLE
Return "invalid" stores from scoping

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -175,7 +175,7 @@ public final class Store<State, Action> {
     }
   }
 
-  init() {
+  fileprivate init() {
     self._isInvalidated = { true }
     self.reducer = EmptyReducer()
     #if DEBUG
@@ -1047,7 +1047,6 @@ extension ScopedStoreReducer: AnyScopedStoreReducer {
     else {
       return Store()
     }
-
     let id = id?(store.stateSubject.value)
     if let id = id,
       let childStore = store.children[id] as? Store<ChildState, ChildAction>


### PR DESCRIPTION
Scoping can sometimes be invalid, _e.g._ SwiftUI may scope through an index of a collection that no longer exists while diffing in a `ForEach`, which can cause a crash when the child state is eagerly evaluated. This commit introduces the idea of an invalid store that will only crash if the store's state is interacted with, avoiding crashes that could happen deeper in SwiftUI.