### PR TITLE
Add `@Presents` macro for observable presentation

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -25,8 +25,8 @@ private let readMe = """
 struct AlertAndConfirmationDialog {
   @ObservableState
   struct State: Equatable {
-    @PresentationState var alert: AlertState<Action.Alert>?
-    @PresentationState var confirmationDialog: ConfirmationDialogState<Action.ConfirmationDialog>?
+    @Presents var alert: AlertState<Action.Alert>?
+    @Presents var confirmationDialog: ConfirmationDialogState<Action.ConfirmationDialog>?
     var count = 0
   }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -24,7 +24,7 @@ private let readMe = """
 struct Animations {
   @ObservableState
   struct State: Equatable {
-    @PresentationState var alert: AlertState<Action.Alert>?
+    @Presents var alert: AlertState<Action.Alert>?
     var circleCenter: CGPoint?
     var circleColor = Color.black
     var isCircleScaled = false

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
@@ -78,7 +78,7 @@ struct SharedState {
   struct Counter {
     @ObservableState
     struct State: Equatable {
-      @PresentationState var alert: AlertState<Action.Alert>?
+      @Presents var alert: AlertState<Action.Alert>?
       var count = 0
       var maxCount = 0
       var minCount = 0

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -16,7 +16,7 @@ private let readMe = """
 struct WebSocket {
   @ObservableState
   struct State: Equatable {
-    @PresentationState var alert: AlertState<Action.Alert>?
+    @Presents var alert: AlertState<Action.Alert>?
     var connectivityState = ConnectivityState.disconnected
     var messageToSend = ""
     var receivedMessages: [String] = []

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Multiple-Destinations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Multiple-Destinations.swift
@@ -10,6 +10,7 @@ private let readMe = """
 struct MultipleDestinations {
   @Reducer
   public struct Destination {
+    @ObservableState
     public enum State: Equatable {
       case drillDown(Counter.State)
       case popover(Counter.State)
@@ -37,7 +38,7 @@ struct MultipleDestinations {
 
   @ObservableState
   struct State: Equatable {
-    @PresentationState var destination: Destination.State?
+    @Presents var destination: Destination.State?
   }
 
   enum Action {

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -15,7 +15,7 @@ private let readMe = """
 struct LoadThenPresent {
   @ObservableState
   struct State: Equatable {
-    @PresentationState var counter: Counter.State?
+    @Presents var counter: Counter.State?
     var isActivityIndicatorVisible = false
   }
 

--- a/Examples/Integration/Integration/iOS 16+17/NewPresentsOldTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16+17/NewPresentsOldTestCase.swift
@@ -37,7 +37,7 @@ struct NewPresentsOldTestCase: View {
   struct Feature {
     @ObservableState
     struct State {
-      @PresentationState var child: BasicsView.Feature.State?
+      @Presents var child: BasicsView.Feature.State?
       var count = 0
       var isObservingChildCount = false
     }

--- a/Examples/Integration/Integration/iOS 17/ObservableBindingLocalTest.swift
+++ b/Examples/Integration/Integration/iOS 17/ObservableBindingLocalTest.swift
@@ -5,11 +5,11 @@ import SwiftUI
 private struct ObservableBindingLocalTestCase {
   @ObservableState
   struct State: Equatable {
-    @PresentationState var fullScreenCover: Child.State?
-    @PresentationState var navigationDestination: Child.State?
+    @Presents var fullScreenCover: Child.State?
+    @Presents var navigationDestination: Child.State?
     var path = StackState<Child.State>()
-    @PresentationState var popover: Child.State?
-    @PresentationState var sheet: Child.State?
+    @Presents var popover: Child.State?
+    @Presents var sheet: Child.State?
   }
   enum Action {
     case fullScreenCover(PresentationAction<Child.Action>)

--- a/Examples/Integration/Integration/iOS 17/ObservableEnumTestCase.swift
+++ b/Examples/Integration/Integration/iOS 17/ObservableEnumTestCase.swift
@@ -69,7 +69,7 @@ struct ObservableEnumView: View {
   struct Feature {
     @ObservableState
     struct State: Equatable {
-      @PresentationState var destination: Destination.State?
+      @Presents var destination: Destination.State?
     }
     enum Action {
       case destination(PresentationAction<Destination.Action>)

--- a/Examples/Integration/Integration/iOS 17/ObservableOptionalTestCase.swift
+++ b/Examples/Integration/Integration/iOS 17/ObservableOptionalTestCase.swift
@@ -39,7 +39,7 @@ struct ObservableOptionalView: View {
   struct Feature {
     @ObservableState
     struct State: Equatable {
-      @PresentationState var child: ObservableBasicsView.Feature.State?
+      @Presents var child: ObservableBasicsView.Feature.State?
       var isObservingCount = false
     }
     enum Action {

--- a/Examples/Integration/Integration/iOS 17/ObservablePresentationTestCase.swift
+++ b/Examples/Integration/Integration/iOS 17/ObservablePresentationTestCase.swift
@@ -98,8 +98,8 @@ struct ObservablePresentationView: View {
     @ObservableState
     struct State: Equatable {
       var isObservingChildCount = false
-      @PresentationState var destination: Destination.State?
-      @PresentationState var sheet: ObservableBasicsView.Feature.State?
+      @Presents var destination: Destination.State?
+      @Presents var sheet: ObservableBasicsView.Feature.State?
     }
     enum Action {
       case destination(PresentationAction<Destination.Action>)

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
@@ -12,7 +12,7 @@ private let readMe = """
 struct SpeechRecognition {
   @ObservableState
   struct State: Equatable {
-    @PresentationState var alert: AlertState<Action.Alert>?
+    @Presents var alert: AlertState<Action.Alert>?
     var isRecording = false
     var transcribedText = ""
   }

--- a/Examples/SyncUps/SyncUps/RecordMeeting.swift
+++ b/Examples/SyncUps/SyncUps/RecordMeeting.swift
@@ -6,7 +6,7 @@ import SwiftUI
 struct RecordMeeting {
   @ObservableState
   struct State: Equatable {
-    @PresentationState var alert: AlertState<Action.Alert>?
+    @Presents var alert: AlertState<Action.Alert>?
     var secondsElapsed = 0
     var speakerIndex = 0
     var syncUp: SyncUp

--- a/Examples/SyncUps/SyncUps/SyncUpDetail.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpDetail.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct SyncUpDetail {
   @ObservableState
   struct State: Equatable {
-    @PresentationState var destination: Destination.State?
+    @Presents var destination: Destination.State?
     var syncUp: SyncUp
 
     // TODO: Why is this needed?

--- a/Examples/SyncUps/SyncUps/SyncUpsList.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpsList.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct SyncUpsList {
   @ObservableState
   struct State: Equatable {
-    @PresentationState var destination: Destination.State?
+    @Presents var destination: Destination.State?
     var syncUps: IdentifiedArrayOf<SyncUp> = []
 
     init(

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginCore/LoginCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginCore/LoginCore.swift
@@ -7,12 +7,12 @@ import TwoFactorCore
 public struct Login: Sendable {
   @ObservableState
   public struct State: Equatable {
-    @PresentationState public var alert: AlertState<Action.Alert>?
+    @Presents public var alert: AlertState<Action.Alert>?
     public var email = ""
     public var isFormValid = false
     public var isLoginRequestInFlight = false
     public var password = ""
-    @PresentationState public var twoFactor: TwoFactor.State?
+    @Presents public var twoFactor: TwoFactor.State?
 
     public init() {}
   }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/NewGameCore/NewGameCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/NewGameCore/NewGameCore.swift
@@ -5,7 +5,7 @@ import GameCore
 public struct NewGame {
   @ObservableState
   public struct State: Equatable {
-    @PresentationState public var game: Game.State?
+    @Presents public var game: Game.State?
     public var oPlayerName = ""
     public var xPlayerName = ""
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
@@ -7,7 +7,7 @@ import Dispatch
 public struct TwoFactor: Sendable {
   @ObservableState
   public struct State: Equatable {
-    @PresentationState public var alert: AlertState<Action.Alert>?
+    @Presents public var alert: AlertState<Action.Alert>?
     public var code = ""
     public var isFormValid = false
     public var isTwoFactorRequestInFlight = false

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -6,9 +6,9 @@ import SwiftUI
 struct VoiceMemos {
   @ObservableState
   struct State: Equatable {
-    @PresentationState var alert: AlertState<Action.Alert>?
+    @Presents var alert: AlertState<Action.Alert>?
     var audioRecorderPermission = RecorderPermission.undetermined
-    @PresentationState var recordingMemo: RecordingMemo.State?
+    @Presents var recordingMemo: RecordingMemo.State?
     var voiceMemos: IdentifiedArrayOf<VoiceMemo.State> = []
 
     enum RecorderPermission {

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingTo1.6.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingTo1.6.md
@@ -131,6 +131,11 @@ apply all of the updates above, but with one additional simplification to the `b
 
 You no longer need the ``WithViewStore`` or `WithPerceptionTracking` at all.
 
+> When you apply the ``ObservableState()`` macro to state that presents child state via the
+> ``PresentationState`` property wrapper, you will encounter a diagnostic directing you to use the
+> ``Presents()`` macro instead, which will wrap the given field with ``PresentationState`` _and_
+> instrument it with observation.
+
 ## Replacing IfLetStore with 'if let'
 
 The ``IfLetStore`` view was a helper for transforming a ``Store`` of optional state into a store of
@@ -297,7 +302,7 @@ For example, if your feature's reducer looks roughly like this:
 struct Feature {
   @ObservableState
   struct State {
-    @PresentationState var child: Child.State?
+    @Presents var child: Child.State?
   }
   enum Action {
     case child(PresentationAction<Child.State>

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
@@ -38,7 +38,7 @@ form for adding a new item. We can integrate state and actions together by utili
 struct InventoryFeature {
   @ObservableState
   struct State: Equatable {
-    @PresentationState var addItem: ItemFormFeature.State?
+    @Presents var addItem: ItemFormFeature.State?
     var items: IdentifiedArrayOf<Item> = []
     // ...
   }
@@ -135,9 +135,9 @@ tempted to model that with multiple optional values:
 ```swift
 @ObservableState
 struct State {
-  @PresentationState var detailItem: DetailFeature.State?
-  @PresentationState var editItem: EditFeature.State?
-  @PresentationState var addItem: AddFeature.State?
+  @Presents var detailItem: DetailFeature.State?
+  @Presents var editItem: EditFeature.State?
+  @Presents var addItem: AddFeature.State?
   // ...
 }
 ```
@@ -222,7 +222,7 @@ With that done we can now hold onto a _single_ piece of optional state in our fe
 struct InventoryFeature {
   @ObservableState
   struct State { 
-    @PresentationState var destination: Destination.State?
+    @Presents var destination: Destination.State?
     // ...
   }
   enum Action {
@@ -526,7 +526,7 @@ And then let's embed that feature into a parent feature using ``PresentationStat
 struct Feature {
   @ObservableState
   struct State: Equatable {
-    @PresentationState var counter: CounterFeature.State?
+    @Presents var counter: CounterFeature.State?
   }
   enum Action {
     case counter(PresentationAction<CounterFeature.Action>)

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/WhatIsNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/WhatIsNavigation.md
@@ -64,13 +64,14 @@ of navigation are nested they form a tree-like structure.
 
 For example, suppose you have an inventory feature with a list of items such that tapping one of
 those items performs a drill-down navigation to a detail screen for the item. Then that can be
-modeled with the ``PresentationState`` property wrapper pointing to some optional state:
+modeled with the ``Presents()`` macro pointing to some optional state:
 
 ```swift
 @Reducer
 struct InventoryFeature {
+  @ObservableState
   struct State {
-    @PresentationState var detailItem: DetailItemFeature.State?
+    @Presents var detailItem: DetailItemFeature.State?
     // ...
   }
   // ...
@@ -78,13 +79,14 @@ struct InventoryFeature {
 ```
 
 Then, inside that detail screen there may be a button to edit the item in a sheet, and that too can
-be modeled with a ``PresentationState`` property wrapper pointing to a piece of optional state:
+be modeled with the ``Presents()`` macro pointing to a piece of optional state:
 
 ```swift
 @Reducer
 struct DetailItemFeature {
+  @ObservableState
   struct State {
-    @PresentationState var editItem: EditItemFeature.State?
+    @Presents var editItem: EditItemFeature.State?
     // ...
   }
   // ...
@@ -98,7 +100,7 @@ whether or not an alert is displayed:
 @Reducer
 struct EditItemFeature {
   struct State {
-    @PresentationState var alert: AlertState<AlertAction>?
+    @Presents var alert: AlertState<AlertAction>?
     // ...
   }
   // ...
@@ -198,8 +200,9 @@ be aware of their differences when modeling your domains.
     feature needs only to hold onto a piece of optional edit state:
 
     ```swift
+    @ObservableState
     struct State {
-      @PresentationState var editItem: EditItemFeature.State?
+      @Presents var editItem: EditItemFeature.State?
       // ...
     }
     ```

--- a/Sources/ComposableArchitecture/Macros.swift
+++ b/Sources/ComposableArchitecture/Macros.swift
@@ -173,14 +173,12 @@
   public macro ObservationStateIgnored() =
   #externalMacro(module: "ComposableArchitectureMacros", type: "ObservationStateIgnoredMacro")
 
-  //@attached(member, names: named(send))
-  //public macro WithViewStore<R: Reducer>(for: R.Type) = #externalMacro(
-  //  module: "ComposableArchitectureMacros", type: "WithViewStoreMacro"
-  //) where R.Action: ViewAction
-  //
-  //public protocol ViewAction<ViewAction> {
-  //  associatedtype ViewAction
-  //  static func view(_ action: ViewAction) -> Self
-  //  var view: ViewAction? { get }
-  //}
+  /// Wraps a property with ``PresentationState`` and observes it.
+  ///
+  /// Use this macro instead of ``PresentationState`` when you adopt the ``ObservableState()``
+  /// macro, which is incompatible with property wrappers like ``PresentationState``.
+  @attached(accessor, names: named(init), named(get), named(set))
+  @attached(peer, names: prefixed(`$`), prefixed(_))
+  public macro Presents() =
+  #externalMacro(module: "ComposableArchitectureMacros", type: "PresentsMacro")
 #endif

--- a/Sources/ComposableArchitecture/Observation/ObservableState.swift
+++ b/Sources/ComposableArchitecture/Observation/ObservableState.swift
@@ -43,6 +43,12 @@ public func _$isIdentityEqual<ID: Hashable, T: ObservableState>(
 }
 
 public func _$isIdentityEqual<T: ObservableState>(
+  _ lhs: PresentationState<T>, _ rhs: PresentationState<T>
+) -> Bool {
+  lhs.id == rhs.id
+}
+
+public func _$isIdentityEqual<T: ObservableState>(
   _ lhs: StackState<T>, _ rhs: StackState<T>
 ) -> Bool {
   areOrderedSetsDuplicates(lhs.ids, rhs.ids)

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -1,6 +1,5 @@
 @_spi(Reflection) import CasePaths
 import Combine
-import Perception
 
 /// A property wrapper for state that can be presented.
 ///
@@ -64,26 +63,12 @@ public struct PresentationState<State> {
   }
 
   public var wrappedValue: State? {
-    get {
-      self._$observationRegistrar.access(self, keyPath: \.wrappedValue)
-      return self.storage.state
-    }
+    get { self.storage.state }
     set {
-      func update() {
-        if !isKnownUniquelyReferenced(&self.storage) {
-          self.storage = Storage(state: newValue)
-        } else {
-          self.storage.state = newValue
-        }
-      }
-      if
-        !_$isIdentityEqual(self.storage.state, newValue)
-      {
-        self._$observationRegistrar.withMutation(of: self, keyPath: \.wrappedValue) {
-          update()
-        }
+      if !isKnownUniquelyReferenced(&self.storage) {
+        self.storage = Storage(state: newValue)
       } else {
-        update()
+        self.storage.state = newValue
       }
     }
   }
@@ -168,16 +153,7 @@ public struct PresentationState<State> {
   func sharesStorage(with other: Self) -> Bool {
     self.storage === other.storage
   }
-
-  private let _$observationRegistrar = ObservationRegistrarWrapper()
 }
-
-#if canImport(Observation)
-  @available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
-  extension PresentationState: Observable {}
-#endif
-
-extension PresentationState: Perceptible {}
 
 extension PresentationState: Equatable where State: Equatable {
   public static func == (lhs: Self, rhs: Self) -> Bool {

--- a/Sources/ComposableArchitectureMacros/Extensions.swift
+++ b/Sources/ComposableArchitectureMacros/Extensions.swift
@@ -84,7 +84,6 @@ extension VariableDeclSyntax {
     }
   }
 
-
   var isImmutable: Bool {
     return bindingSpecifier.tokenKind == .keyword(.let)
   }
@@ -112,6 +111,20 @@ extension VariableDeclSyntax {
       }
     }
     return false
+  }
+
+  func firstAttribute(for name: String) -> AttributeSyntax? {
+    for attribute in attributes {
+      switch attribute {
+      case .attribute(let attr):
+        if attr.attributeName.tokens(viewMode: .all).map({ $0.tokenKind }) == [.identifier(name)] {
+          return attr
+        }
+      default:
+        break
+      }
+    }
+    return nil
   }
 }
 

--- a/Sources/ComposableArchitectureMacros/Plugins.swift
+++ b/Sources/ComposableArchitectureMacros/Plugins.swift
@@ -7,8 +7,8 @@ struct MacrosPlugin: CompilerPlugin {
     ObservableStateMacro.self,
     ObservationStateTrackedMacro.self,
     ObservationStateIgnoredMacro.self,
-    // ObservationTrackedWhenMacro.self,
-    // WithViewStoreMacro.self,
+    PresentsMacro.self,
     ReducerMacro.self
+    // WithViewStoreMacro.self,
   ]
 }

--- a/Sources/ComposableArchitectureMacros/PresentsMacro.swift
+++ b/Sources/ComposableArchitectureMacros/PresentsMacro.swift
@@ -193,10 +193,21 @@ extension PatternBindingListSyntax {
           accessorBlock: AccessorBlockSyntax(
             accessors: .accessors([
               """
-              get { _\(identifier.identifier).projectedValue }
+              get {
+              access(keyPath: \\.\(identifier))
+              return _\(identifier.identifier).projectedValue
+              }
               """,
               """
-              set { _\(identifier.identifier).projectedValue = newValue }
+              set {
+              if _$isIdentityEqual(newValue, _\(identifier)) == true {
+              _\(identifier).projectedValue = newValue
+              } else {
+              withMutation(keyPath: \\.\(identifier)) {
+              _\(identifier).projectedValue = newValue
+              }
+              }
+              }
               """
             ])
           )

--- a/Sources/ComposableArchitectureMacros/PresentsMacro.swift
+++ b/Sources/ComposableArchitectureMacros/PresentsMacro.swift
@@ -1,0 +1,227 @@
+import SwiftDiagnostics
+import SwiftOperators
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
+
+public enum PresentsMacro {
+}
+
+extension PresentsMacro: AccessorMacro {
+  public static func expansion<D: DeclSyntaxProtocol, C: MacroExpansionContext>(
+    of node: AttributeSyntax,
+    providingAccessorsOf declaration: D,
+    in context: C
+  ) throws -> [AccessorDeclSyntax] {
+    guard
+      let property = declaration.as(VariableDeclSyntax.self),
+      property.isValidForPresentation,
+      let identifier = property.identifier?.trimmed
+    else {
+      return []
+    }
+
+    let initAccessor: AccessorDeclSyntax =
+      """
+      @storageRestrictions(initializes: _\(identifier))
+      init(initialValue) {
+      _\(identifier) = PresentationState(wrappedValue: initialValue)
+      }
+      """
+
+    let getAccessor: AccessorDeclSyntax =
+      """
+      get {
+      access(keyPath: \\.\(identifier))
+      return _\(identifier).wrappedValue
+      }
+      """
+
+    let setAccessor: AccessorDeclSyntax =
+      """
+      set {
+      if _$isIdentityEqual(newValue, _\(identifier).wrappedValue) == true {
+      _\(identifier).wrappedValue = newValue
+      } else {
+      withMutation(keyPath: \\.\(identifier)) {
+      _\(identifier).wrappedValue = newValue
+      }
+      }
+      }
+      """
+
+    return [initAccessor, getAccessor, setAccessor]
+  }
+}
+
+extension PresentsMacro: PeerMacro {
+  public static func expansion<D: DeclSyntaxProtocol, C: MacroExpansionContext>(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: D,
+    in context: C
+  ) throws -> [DeclSyntax] {
+    guard
+      let property = declaration.as(VariableDeclSyntax.self),
+      property.isValidForPresentation
+    else {
+      return []
+    }
+
+    let wrapped = DeclSyntax(
+      property.privateWrapped(addingAttribute: ObservableStateMacro.ignoredAttribute)
+    )
+    let projected = DeclSyntax(property.projected)
+    return [
+      projected,
+      wrapped,
+    ]
+  }
+}
+
+extension VariableDeclSyntax {
+  fileprivate func privateWrapped(
+    addingAttribute attribute: AttributeSyntax
+  ) -> VariableDeclSyntax {
+    var attributes = self.attributes
+    for index in attributes.indices.reversed() {
+      let attribute = attributes[index]
+      switch attribute {
+      case let .attribute(attribute):
+        if attribute.attributeName.tokens(viewMode: .all).map(\.tokenKind) == [
+          .identifier("Presents")
+        ] {
+          attributes.remove(at: index)
+        }
+      default:
+        break
+      }
+    }
+    let newAttributes = attributes + [.attribute(attribute)]
+    return VariableDeclSyntax(
+      leadingTrivia: leadingTrivia,
+      attributes: newAttributes,
+      modifiers: modifiers.privatePrefixed("_"),
+      bindingSpecifier: TokenSyntax(
+        bindingSpecifier.tokenKind, trailingTrivia: .space,
+        presence: .present
+      ),
+      bindings: bindings.privateWrapped,
+      trailingTrivia: trailingTrivia
+    )
+  }
+
+  fileprivate var projected: VariableDeclSyntax {
+    VariableDeclSyntax(
+      leadingTrivia: leadingTrivia,
+      modifiers: modifiers,
+      bindingSpecifier: TokenSyntax(
+        bindingSpecifier.tokenKind, trailingTrivia: .space,
+        presence: .present
+      ),
+      bindings: bindings.projected,
+      trailingTrivia: trailingTrivia
+    )
+  }
+
+  fileprivate var isValidForPresentation: Bool {
+    !isComputed && isInstance && !isImmutable && identifier != nil
+  }
+}
+
+extension PatternBindingListSyntax {
+  var privateWrapped: PatternBindingListSyntax {
+    var bindings = self
+    for index in bindings.indices {
+      var binding = bindings[index]
+      if let optionalType = binding.typeAnnotation?.type.as(OptionalTypeSyntax.self) {
+        binding.typeAnnotation = nil
+        binding.initializer = InitializerClauseSyntax(
+          value: FunctionCallExprSyntax(
+            calledExpression: optionalType.wrappedType.presentationWrapped,
+            leftParen: .leftParenToken(),
+            arguments: [
+              LabeledExprSyntax(
+                label: "wrappedValue",
+                expression: binding.initializer?.value ?? ExprSyntax(NilLiteralExprSyntax())
+              )
+            ],
+            rightParen: .rightParenToken()
+          )
+        )
+      }
+      if let identifier = binding.pattern.as(IdentifierPatternSyntax.self) {
+        bindings[index] = PatternBindingSyntax(
+          leadingTrivia: binding.leadingTrivia,
+          pattern: IdentifierPatternSyntax(
+            leadingTrivia: identifier.leadingTrivia,
+            identifier: identifier.identifier.privatePrefixed("_"),
+            trailingTrivia: identifier.trailingTrivia
+          ),
+          typeAnnotation: binding.typeAnnotation,
+          initializer: binding.initializer,
+          accessorBlock: binding.accessorBlock,
+          trailingComma: binding.trailingComma,
+          trailingTrivia: binding.trailingTrivia
+        )
+      }
+    }
+
+    return bindings
+  }
+
+  var projected: PatternBindingListSyntax {
+    var bindings = self
+    for index in bindings.indices {
+      var binding = bindings[index]
+      if let optionalType = binding.typeAnnotation?.type.as(OptionalTypeSyntax.self) {
+        binding.typeAnnotation?.type = TypeSyntax(
+          IdentifierTypeSyntax(
+            name: .identifier(optionalType.wrappedType.presentationWrapped.trimmedDescription)
+          )
+        )
+      }
+      if let identifier = binding.pattern.as(IdentifierPatternSyntax.self) {
+        bindings[index] = PatternBindingSyntax(
+          leadingTrivia: binding.leadingTrivia,
+          pattern: IdentifierPatternSyntax(
+            leadingTrivia: identifier.leadingTrivia,
+            identifier: identifier.identifier.privatePrefixed("$"),
+            trailingTrivia: identifier.trailingTrivia
+          ),
+          typeAnnotation: binding.typeAnnotation,
+          accessorBlock: AccessorBlockSyntax(
+            accessors: .accessors([
+              """
+              get { _\(identifier.identifier).projectedValue }
+              """,
+              """
+              set { _\(identifier.identifier).projectedValue = newValue }
+              """
+            ])
+          )
+        )
+      }
+    }
+
+    return bindings
+  }
+}
+
+extension TypeSyntax {
+  fileprivate var presentationWrapped: GenericSpecializationExprSyntax {
+    GenericSpecializationExprSyntax(
+      expression: MemberAccessExprSyntax(
+        base: DeclReferenceExprSyntax(baseName: "ComposableArchitecture"),
+        name: "PresentationState"
+      ),
+      genericArgumentClause: GenericArgumentClauseSyntax(
+        arguments: [
+          GenericArgumentSyntax(
+            argument: self
+          )
+        ]
+      )
+    )
+  }
+}

--- a/Tests/ComposableArchitectureMacrosTests/MacroBaseTestCase.swift
+++ b/Tests/ComposableArchitectureMacrosTests/MacroBaseTestCase.swift
@@ -12,6 +12,7 @@ class MacroBaseTestCase: XCTestCase {
         ObservableStateMacro.self,
         ObservationStateTrackedMacro.self,
         ObservationStateIgnoredMacro.self,
+        PresentsMacro.self,
         // WithViewStoreMacro.self,
       ]
     ) {

--- a/Tests/ComposableArchitectureMacrosTests/PresentsMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/PresentsMacroTests.swift
@@ -1,0 +1,163 @@
+import ComposableArchitectureMacros
+import MacroTesting
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+final class PresentsMacroTests: XCTestCase {
+  override func invokeTest() {
+    withMacroTesting(
+      isRecording: true,
+      macros: [PresentsMacro.self]
+    ) {
+      super.invokeTest()
+    }
+  }
+
+  func testBasics() {
+    assertMacro {
+      """
+      struct State {
+        @Presents var destination: Destination.State?
+      }
+      """
+    } expansion: {
+      #"""
+      struct State {
+        var destination: Destination.State? {
+          @storageRestrictions(initializes: _destination)
+          init(initialValue) {
+            _destination = PresentationState(wrappedValue: initialValue)
+          }
+          get {
+            access(keyPath: \.destination)
+            return _destination.wrappedValue
+          }
+          set {
+            if _$isIdentityEqual(newValue, _destination.wrappedValue) == true {
+              _destination.wrappedValue = newValue
+            } else {
+              withMutation(keyPath: \.destination) {
+                _destination.wrappedValue = newValue
+              }
+            }
+          }
+        }
+
+        var $destination: ComposableArchitecture.PresentationState<Destination.State> {
+          get {
+            _destination.projectedValue
+          }
+          set {
+            _destination.projectedValue = newValue
+          }
+        }
+
+        @ObservationStateIgnored private var _destination = ComposableArchitecture.PresentationState<Destination.State>(wrappedValue: nil)
+      }
+      """#
+    }
+  }
+
+  func testPublicAccess() {
+    assertMacro {
+      """
+      public struct State {
+        @Presents public var destination: Destination.State?
+      }
+      """
+    } expansion: {
+      #"""
+      public struct State {
+        public var destination: Destination.State? {
+          @storageRestrictions(initializes: _destination)
+          init(initialValue) {
+            _destination = PresentationState(wrappedValue: initialValue)
+          }
+          get {
+            access(keyPath: \.destination)
+            return _destination.wrappedValue
+          }
+          set {
+            if _$isIdentityEqual(newValue, _destination.wrappedValue) == true {
+              _destination.wrappedValue = newValue
+            } else {
+              withMutation(keyPath: \.destination) {
+                _destination.wrappedValue = newValue
+              }
+            }
+          }
+        }
+
+        public var $destination: ComposableArchitecture.PresentationState<Destination.State> {
+          get {
+            _destination.projectedValue
+          }
+          set {
+            _destination.projectedValue = newValue
+          }
+        }
+
+        @ObservationStateIgnored private var _destination = ComposableArchitecture.PresentationState<Destination.State>(wrappedValue: nil)
+      }
+      """#
+    }
+  }
+
+  func testObservableStateDiagnostic() {
+    assertMacro([
+      ObservableStateMacro.self,
+      ObservationStateIgnoredMacro.self,
+      ObservationStateTrackedMacro.self,
+      PresentsMacro.self,
+    ]) {
+      """
+      @ObservableState
+      struct State: Equatable {
+        @PresentationState var destination: Destination.State?
+      }
+      """
+    } diagnostics: {
+      """
+      @ObservableState
+      struct State: Equatable {
+        @PresentationState var destination: Destination.State?
+        ┬─────────────────
+        ╰─ 🛑 '@PresentationState' property wrapper cannot be used directly in '@ObservableState'
+           ✏️ Use '@Presents' instead
+      }
+      """
+    } fixes: {
+      """
+      @ObservableState
+      struct State: Equatable {
+        @Presents
+      }
+      """
+    } expansion: {
+      """
+      struct State: Equatable {
+
+        private let _$observationRegistrar = ComposableArchitecture.ObservationStateRegistrar()
+
+        internal nonisolated func access<Member>(
+          keyPath: KeyPath<State, Member>
+        ) {
+          _$observationRegistrar.access(self, keyPath: keyPath)
+        }
+
+        internal nonisolated func withMutation<Member, MutationResult>(
+          keyPath: KeyPath<State, Member>,
+          _ mutation: () throws -> MutationResult
+        ) rethrows -> MutationResult {
+          try _$observationRegistrar.withMutation(of: self, keyPath: keyPath, mutation)
+        }
+
+        var _$id: ComposableArchitecture.ObservableStateID {
+          self._$observationRegistrar.id
+        }
+      }
+      """
+    }
+  }
+}

--- a/Tests/ComposableArchitectureMacrosTests/PresentsMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/PresentsMacroTests.swift
@@ -7,7 +7,7 @@ import XCTest
 final class PresentsMacroTests: XCTestCase {
   override func invokeTest() {
     withMacroTesting(
-      isRecording: true,
+      // isRecording: true,
       macros: [PresentsMacro.self]
     ) {
       super.invokeTest()
@@ -46,10 +46,17 @@ final class PresentsMacroTests: XCTestCase {
 
         var $destination: ComposableArchitecture.PresentationState<Destination.State> {
           get {
-            _destination.projectedValue
+            access(keyPath: \.destination)
+            return _destination.projectedValue
           }
           set {
-            _destination.projectedValue = newValue
+            if _$isIdentityEqual(newValue, _destination) == true {
+              _destination.projectedValue = newValue
+            } else {
+              withMutation(keyPath: \.destination) {
+                _destination.projectedValue = newValue
+              }
+            }
           }
         }
 
@@ -91,10 +98,17 @@ final class PresentsMacroTests: XCTestCase {
 
         public var $destination: ComposableArchitecture.PresentationState<Destination.State> {
           get {
-            _destination.projectedValue
+            access(keyPath: \.destination)
+            return _destination.projectedValue
           }
           set {
-            _destination.projectedValue = newValue
+            if _$isIdentityEqual(newValue, _destination) == true {
+              _destination.projectedValue = newValue
+            } else {
+              withMutation(keyPath: \.destination) {
+                _destination.projectedValue = newValue
+              }
+            }
           }
         }
 


### PR DESCRIPTION
While it would be nice for the `@PresentationState` property wrapper to "just work" with TCA's upcoming observable tools, sadly that does not seem to be the case. Adding observation directly to `@PresentationState`, as we have done with the beta so far, can break existing projects due to the additional observation. This primarily manifests itself in projects that present navigation stacks, where the `@PresentationState` observation can cause the navigation hierarchy to recompute and trigger SwiftUI bugs.

The best we've come up with so far is introducing a brand new macro that automatically wraps a property with `@PresentationState` _and_ instruments it with observation.

We're open to other ideas, and we do have future plans to eliminate the need for a property wrapper or macro at all, but till then this offers a non-breaking upgrade path!