### PR TITLE
Short-circuit the store cache from uncached stores

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -133,6 +133,7 @@ import SwiftUI
 /// of the store are also checked to make sure that work is performed on the main thread.
 public final class Store<State, Action> {
   private var bufferedActions: [Action] = []
+  fileprivate var canCacheChildren = true
   fileprivate var children: [AnyHashable: AnyObject] = [:]
   @_spi(Internals) public var effectCancellables: [UUID: AnyCancellable] = [:]
   var _isInvalidated = { false }
@@ -1033,14 +1034,16 @@ extension ScopedStoreReducer: AnyScopedStoreReducer {
     removeDuplicates isDuplicate: ((ChildState, ChildState) -> Bool)?
   ) -> Store<ChildState, ChildAction> {
     let id = id?(store.stateSubject.value)
-    if let id = id,
+    if
+      store.canCacheChildren,
+      let id = id,
       let childStore = store.children[id] as? Store<ChildState, ChildAction>
     {
       return childStore
     }
     let fromAction = self.fromAction as! (A) -> RootAction?
     let isInvalid =
-      id == nil
+      id == nil || !store.canCacheChildren
       ? {
         store._isInvalidated() || isInvalid?(store.stateSubject.value) == true
       }
@@ -1067,6 +1070,7 @@ extension ScopedStoreReducer: AnyScopedStoreReducer {
       reducer
     }
     childStore._isInvalidated = isInvalid
+    childStore.canCacheChildren = store.canCacheChildren && id != nil
     childStore.parentCancellable = store.stateSubject
       .dropFirst()
       .sink { [weak store, weak childStore] state in
@@ -1092,7 +1096,11 @@ extension ScopedStoreReducer: AnyScopedStoreReducer {
         Logger.shared.log("\(storeTypeName(of: store)).scope")
       }
     if let id = id {
-      store.children[id] = childStore
+      if store.canCacheChildren {
+        store.children[id] = childStore
+      } else {
+        // runtimeWarn("Can't cache child store at '\(id)' in an uncached store")
+      }
     }
     return childStore
   }

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -139,7 +139,7 @@ public final class Store<State, Action> {
   private var isSending = false
   var parentCancellable: AnyCancellable?
   private let reducer: any Reducer<State, Action>
-  @_spi(Internals) public var stateSubject: CurrentValueSubject<State, Never>!
+  @_spi(Internals) public var stateSubject: CurrentValueSubject<State, Never>
   #if DEBUG
     private let mainThreadChecksEnabled: Bool
   #endif
@@ -173,14 +173,6 @@ public final class Store<State, Action> {
         mainThreadChecksEnabled: true
       )
     }
-  }
-
-  fileprivate init() {
-    self._isInvalidated = { true }
-    self.reducer = EmptyReducer()
-    #if DEBUG
-      self.mainThreadChecksEnabled = true
-    #endif
   }
 
   deinit {
@@ -1002,15 +994,12 @@ private final class ScopedStoreReducer<RootState, RootAction, State, Action>: Re
 
   @inlinable
   func reduce(into state: inout State, action: Action) -> Effect<Action> {
-    let isInvalid = self.isInvalid()
-    if isInvalid {
+    if self.isInvalid() {
       self.onInvalidate()
     }
     self.isSending = true
     defer {
-      if !isInvalid || state is _OptionalProtocol {
-        state = self.toState(self.rootStore.stateSubject.value)
-      }
+      state = self.toState(self.rootStore.stateSubject.value)
       self.isSending = false
     }
     if let action = self.fromAction(action),
@@ -1043,10 +1032,6 @@ extension ScopedStoreReducer: AnyScopedStoreReducer {
     isInvalid: ((S) -> Bool)?,
     removeDuplicates isDuplicate: ((ChildState, ChildState) -> Bool)?
   ) -> Store<ChildState, ChildAction> {
-    guard isInvalid.map({ $0(store.stateSubject.value) == false }) ?? true
-    else {
-      return Store()
-    }
     let id = id?(store.stateSubject.value)
     if let id = id,
       let childStore = store.children[id] as? Store<ChildState, ChildAction>
@@ -1068,7 +1053,7 @@ extension ScopedStoreReducer: AnyScopedStoreReducer {
     }
     let reducer = ScopedStoreReducer<RootState, RootAction, ChildState, ChildAction>(
       rootStore: self.rootStore,
-      state: { [stateSubject = store.stateSubject!] _ in toChildState(stateSubject.value) },
+      state: { [stateSubject = store.stateSubject] _ in toChildState(stateSubject.value) },
       action: { fromChildAction($0).flatMap(fromAction) },
       isInvalid: isInvalid,
       onInvalidate: { [weak store] in

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -1098,8 +1098,6 @@ extension ScopedStoreReducer: AnyScopedStoreReducer {
     if let id = id {
       if store.canCacheChildren {
         store.children[id] = childStore
-      } else {
-        // runtimeWarn("Can't cache child store at '\(id)' in an uncached store")
       }
     }
     return childStore


### PR DESCRIPTION
1.5 introduced the store tree, which works well when the entire tree is cached, but can produce invalid stores when an uncached store caches a child store and is then reinitialized. While folks upgrading to 1.5 should be in a good state, adopting the new `scope` operator can introduce this problem. To mitigate, we should only cache from the root to nodes as far as the cache resolves.

This is a temporary limitation to avoid breaking existing apps. We should be able to remove this workaround when uncached scopes are fully deprecated and removed from the library.