### PR TITLE
Fix typo in MigratingTo1.6.md

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingTo1.6.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingTo1.6.md
@@ -300,7 +300,7 @@ struct Feature {
     @PresentationState var child: Child.State?
   }
   enum Action {
-    case child(PresentationAction<Child.State>
+    case child(PresentationAction<Child.Action>)
   }
   var body: some ReducerOf<Self> { /* ... */ }
 }


### PR DESCRIPTION
There is a typo in section `## Replacing navigation view modifiers with SwiftUI modifiers`
