### PR TITLE
Fix perception bindings

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/xcschemes/ComposableArchitecture.xcscheme
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/xcschemes/ComposableArchitecture.xcscheme
@@ -49,6 +49,26 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "PerceptionMacrosTests"
+               BuildableName = "PerceptionMacrosTests"
+               BlueprintName = "PerceptionMacrosTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "PerceptionTests"
+               BuildableName = "PerceptionTests"
+               BlueprintName = "PerceptionTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
@@ -11,7 +11,7 @@ extension Binding {
     let isInViewBody = PerceptionLocals.isInPerceptionTracking
     return Binding<Store<StackState<ElementState>, StackAction<ElementState, ElementAction>>>(
       get: {
-        // TODO: Is this right? Should we just be more forgiving in bindings?
+        // TODO: Can this be localized to the `Perception` framework?
         PerceptionLocals.$isInPerceptionTracking.withValue(isInViewBody) {
           self.wrappedValue.scope(state: state, action: action)
         }
@@ -29,14 +29,8 @@ extension Bindable {
     action: CaseKeyPath<Action, StackAction<ElementState, ElementAction>>
   ) -> Binding<Store<StackState<ElementState>, StackAction<ElementState, ElementAction>>>
   where Value == Store<State, Action> {
-    let isInViewBody = PerceptionLocals.isInPerceptionTracking
-    return Binding<Store<StackState<ElementState>, StackAction<ElementState, ElementAction>>>(
-      get: {
-        // TODO: Is this right? Should we just be more forgiving in bindings?
-        PerceptionLocals.$isInPerceptionTracking.withValue(isInViewBody) {
-          self.wrappedValue.scope(state: state, action: action)
-        }
-      },
+    Binding<Store<StackState<ElementState>, StackAction<ElementState, ElementAction>>>(
+      get: { self.wrappedValue.scope(state: state, action: action) },
       set: { _ in }
     )
   }

--- a/Sources/ComposableArchitecture/Observation/Store+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Store+Observation.swift
@@ -103,19 +103,14 @@ extension Binding {
     let isInViewBody = PerceptionLocals.isInPerceptionTracking
     return Binding<Store<ChildState, ChildAction>?>(
       get: {
-        // TODO: Is this right? Should we just be more forgiving in bindings?
+        // TODO: Can this be localized to the `Perception` framework?
         PerceptionLocals.$isInPerceptionTracking.withValue(isInViewBody) {
-          self.wrappedValue.scope(
-            state: state,
-            action: action.appending(path: \.presented)
-          )
+          self.wrappedValue.scope(state: state, action: action.appending(path: \.presented))
         }
       },
       set: {
         if $0 == nil, self.wrappedValue.stateSubject.value[keyPath: state] != nil {
-          // TODO: Is `transaction($1)` needed and does it do what we want?
-          // TODO: Should it be `send(action(.dismiss), transaction: $1)`, instead?
-          self.transaction($1).wrappedValue.send(action(.dismiss))
+          self.wrappedValue.send(action(.dismiss), transaction: $1)
         }
       }
     )
@@ -137,17 +132,8 @@ extension Bindable {
     action: CaseKeyPath<Action, PresentationAction<ChildAction>>
   ) -> Binding<Store<ChildState, ChildAction>?>
   where Value == Store<State, Action> {
-    let isInViewBody = PerceptionLocals.isInPerceptionTracking
-    return Binding<Store<ChildState, ChildAction>?>(
-      get: {
-        // TODO: Is this right? Should we just be more forgiving in bindings?
-        PerceptionLocals.$isInPerceptionTracking.withValue(isInViewBody) {
-          self.wrappedValue.scope(
-            state: state,
-            action: action.appending(path: \.presented)
-          )
-        }
-      },
+    Binding<Store<ChildState, ChildAction>?>(
+      get: { self.wrappedValue.scope(state: state, action: action.appending(path: \.presented)) },
       set: {
         if $0 == nil, self.wrappedValue.stateSubject.value[keyPath: state] != nil {
           self.wrappedValue.send(action(.dismiss))

--- a/Sources/Perception/Macros.swift
+++ b/Sources/Perception/Macros.swift
@@ -13,6 +13,9 @@
 import Observation
 
 @available(iOS, deprecated: 17, message: "TODO")
+@available(macOS, deprecated: 14, message: "TODO")
+@available(tvOS, deprecated: 17, message: "TODO")
+@available(watchOS, deprecated: 10, message: "TODO")
 @attached(member, names: named(_$id), named(_$perceptionRegistrar), named(access), named(withMutation))
 @attached(memberAttribute)
 @attached(extension, conformances: Observable, Perceptible)
@@ -20,12 +23,18 @@ public macro Perceptible() =
 #externalMacro(module: "PerceptionMacros", type: "PerceptibleMacro")
 
 @available(iOS, deprecated: 17, message: "TODO")
+@available(macOS, deprecated: 14, message: "TODO")
+@available(tvOS, deprecated: 17, message: "TODO")
+@available(watchOS, deprecated: 10, message: "TODO")
 @attached(accessor, names: named(init), named(get), named(set))
 @attached(peer, names: prefixed(_))
 public macro PerceptionTracked() =
 #externalMacro(module: "PerceptionMacros", type: "PerceptionTrackedMacro")
 
 @available(iOS, deprecated: 17, message: "TODO")
+@available(macOS, deprecated: 14, message: "TODO")
+@available(tvOS, deprecated: 17, message: "TODO")
+@available(watchOS, deprecated: 10, message: "TODO")
 @attached(accessor, names: named(willSet))
 public macro PerceptionIgnored() =
 #externalMacro(module: "PerceptionMacros", type: "PerceptionIgnoredMacro")

--- a/Sources/Perception/Perceptible.swift
+++ b/Sources/Perception/Perceptible.swift
@@ -17,6 +17,9 @@
 /// the ``Perception/Perceptible()`` macro when adding observation
 /// support to a type.
 @available(iOS, deprecated: 17, message: "TODO")
+@available(macOS, deprecated: 14, message: "TODO")
+@available(tvOS, deprecated: 17, message: "TODO")
+@available(watchOS, deprecated: 10, message: "TODO")
 public protocol Perceptible { }
 
 // TODO: Rename to Perceptive?

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -134,13 +134,11 @@ extension PerceptionRegistrar: Hashable {
   }
 }
 
-@_transparent
-@inline(__always)
-private func perceptionCheck() {
-  #if DEBUG
+#if DEBUG
+  private func perceptionCheck() {
     if #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10),
       !PerceptionLocals.isInPerceptionTracking,
-      isInSwiftUIStack
+      isInSwiftUIBody
     {
       runtimeWarn(
         """
@@ -149,47 +147,51 @@ private func perceptionCheck() {
         """
       )
     }
-  #endif
-}
-
-var isInSwiftUIStack: Bool {
-  for callStackSymbol in Thread.callStackSymbols {
-    guard
-      let symbol = callStackSymbol.split(separator: " ").dropFirst(3).first,
-      symbol.utf8.first == .init(ascii: "$"),
-      let demangled = String(symbol).demangled,
-      demangled.hasPrefix("protocol witness for SwiftUI.View.body.getter : ")
-    else { continue }
-    return true
   }
-  return false
-}
 
-extension String {
-  fileprivate var demangled: String? {
-    return self.utf8CString.withUnsafeBufferPointer { mangledNameUTF8CStr in
-      let demangledNamePtr = swift_demangle(
-        mangledName: mangledNameUTF8CStr.baseAddress,
-        mangledNameLength: UInt(mangledNameUTF8CStr.count - 1),
-        outputBuffer: nil,
-        outputBufferSize: nil,
-        flags: 0
-      )
-      if let demangledNamePtr = demangledNamePtr {
-        let demangledName = String(cString: demangledNamePtr)
-        free(demangledNamePtr)
-        return demangledName
+  var isInSwiftUIBody: Bool {
+    for callStackSymbol in Thread.callStackSymbols {
+      guard
+        let symbol = callStackSymbol.split(separator: " ").dropFirst(3).first,
+        symbol.utf8.first == .init(ascii: "$"),
+        let demangled = String(symbol).demangled,
+        demangled.hasPrefix("protocol witness for SwiftUI.View.body.getter : ")
+      else { continue }
+      return true
+    }
+    return false
+  }
+
+  extension String {
+    fileprivate var demangled: String? {
+      return self.utf8CString.withUnsafeBufferPointer { mangledNameUTF8CStr in
+        let demangledNamePtr = swift_demangle(
+          mangledName: mangledNameUTF8CStr.baseAddress,
+          mangledNameLength: UInt(mangledNameUTF8CStr.count - 1),
+          outputBuffer: nil,
+          outputBufferSize: nil,
+          flags: 0
+        )
+        if let demangledNamePtr = demangledNamePtr {
+          let demangledName = String(cString: demangledNamePtr)
+          free(demangledNamePtr)
+          return demangledName
+        }
+        return nil
       }
-      return nil
     }
   }
-}
 
-@_silgen_name("swift_demangle")
-private func swift_demangle(
+  @_silgen_name("swift_demangle")
+  private func swift_demangle(
     mangledName: UnsafePointer<CChar>?,
     mangledNameLength: UInt,
     outputBuffer: UnsafeMutablePointer<CChar>?,
     outputBufferSize: UnsafeMutablePointer<UInt>?,
     flags: UInt32
-) -> UnsafeMutablePointer<CChar>?
+  ) -> UnsafeMutablePointer<CChar>?
+#else
+  @_transparent
+  @inline(__always)
+  private func perceptionCheck() {}
+#endif

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -131,8 +131,8 @@ extension PerceptionRegistrar: Hashable {
   }
 }
 
-//@_transparent
-//@inline(__always)
+@_transparent
+@inline(__always)
 private func perceptionCheck() {
   #if DEBUG
     if #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10),

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -156,8 +156,9 @@ var isInSwiftUIStack: Bool {
   for callStackSymbol in Thread.callStackSymbols {
     guard
       let symbol = callStackSymbol.split(separator: " ").dropFirst(3).first,
-      symbol.hasPrefix("$"),
-      String(symbol).demangled.hasPrefix("protocol witness for SwiftUI.View.body.getter : ")
+      symbol.utf8.first == .init(ascii: "$"),
+      let demangled = String(symbol).demangled,
+      demangled.hasPrefix("protocol witness for SwiftUI.View.body.getter : ")
     else { continue }
     return true
   }
@@ -165,7 +166,7 @@ var isInSwiftUIStack: Bool {
 }
 
 extension String {
-  fileprivate var demangled: String {
+  fileprivate var demangled: String? {
     return self.utf8CString.withUnsafeBufferPointer { mangledNameUTF8CStr in
       let demangledNamePtr = swift_demangle(
         mangledName: mangledNameUTF8CStr.baseAddress,
@@ -179,7 +180,7 @@ extension String {
         free(demangledNamePtr)
         return demangledName
       }
-      return self
+      return nil
     }
   }
 }

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -9,6 +9,9 @@ import Foundation
 /// You don't need to create an instance of `PerceptionRegistrar` when using
 /// the ``Perception/Perceptible()`` macro to indicate observability of a type.
 @available(iOS, deprecated: 17, message: "TODO")
+@available(macOS, deprecated: 14, message: "TODO")
+@available(tvOS, deprecated: 17, message: "TODO")
+@available(watchOS, deprecated: 10, message: "TODO")
 public struct PerceptionRegistrar: Sendable {
   private let _rawValue: AnySendable
 

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -141,7 +141,7 @@ private func perceptionCheck() {
     if #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10),
       !PerceptionLocals.isInPerceptionTracking,
       isInSwiftUIStack,
-      !isInSwiftUIBindingGetter
+      !isInKeyPathAccess
     {
       runtimeWarn(
         """
@@ -158,10 +158,7 @@ var isInSwiftUIStack: Bool {
     .contains { $0.contains(" AttributeGraph ") }
 }
 
-var isInSwiftUIBindingGetter: Bool {
-  zip(Thread.callStackSymbols, Thread.callStackSymbols.dropFirst())
-    .contains { previousSymbol, symbol in
-      symbol.contains("SwiftUI7Binding")
-        && previousSymbol.contains("swift_readAtKeyPath")
-    }
+var isInKeyPathAccess: Bool {
+  Thread.callStackSymbols
+    .contains { $0.contains("swift_getAtKeyPath") }
 }

--- a/Sources/Perception/PerceptionTracking.swift
+++ b/Sources/Perception/PerceptionTracking.swift
@@ -11,6 +11,9 @@
 
 @_spi(SwiftUI)
 @available(iOS, deprecated: 17, message: "TODO")
+@available(macOS, deprecated: 14, message: "TODO")
+@available(tvOS, deprecated: 17, message: "TODO")
+@available(watchOS, deprecated: 10, message: "TODO")
 public struct PerceptionTracking: Sendable {
   enum Id {
     case willSet(Int)
@@ -51,6 +54,9 @@ public struct PerceptionTracking: Sendable {
 
   @_spi(SwiftUI)
   @available(iOS, deprecated: 17, message: "TODO")
+  @available(macOS, deprecated: 14, message: "TODO")
+  @available(tvOS, deprecated: 17, message: "TODO")
+  @available(watchOS, deprecated: 10, message: "TODO")
   public struct _AccessList: Sendable {
     internal var entries = [ObjectIdentifier : Entry]()
 
@@ -72,6 +78,9 @@ public struct PerceptionTracking: Sendable {
 
   @_spi(SwiftUI)
   @available(iOS, deprecated: 17, message: "TODO")
+  @available(macOS, deprecated: 14, message: "TODO")
+  @available(tvOS, deprecated: 17, message: "TODO")
+  @available(watchOS, deprecated: 10, message: "TODO")
   public static func _installTracking(
     _ tracking: PerceptionTracking,
     willSet: (@Sendable (PerceptionTracking) -> Void)? = nil,
@@ -201,6 +210,9 @@ fileprivate func generateAccessList<T>(_ apply: () -> T) -> (T, PerceptionTracki
 /// - Returns: The value that the `apply` closure returns if it has a return
 /// value; otherwise, there is no return value.
 @available(iOS, deprecated: 17, message: "TODO")
+@available(macOS, deprecated: 14, message: "TODO")
+@available(tvOS, deprecated: 17, message: "TODO")
+@available(watchOS, deprecated: 10, message: "TODO")
 public func withPerceptionTracking<T>(
   _ apply: () -> T,
   onChange: @autoclosure () -> @Sendable () -> Void
@@ -214,6 +226,9 @@ public func withPerceptionTracking<T>(
 
 @_spi(SwiftUI)
 @available(iOS, deprecated: 17, message: "TODO")
+@available(macOS, deprecated: 14, message: "TODO")
+@available(tvOS, deprecated: 17, message: "TODO")
+@available(watchOS, deprecated: 10, message: "TODO")
 public func withPerceptionTracking<T>(
   _ apply: () -> T,
   willSet: @escaping @Sendable (PerceptionTracking) -> Void,
@@ -226,6 +241,9 @@ public func withPerceptionTracking<T>(
 
 @_spi(SwiftUI)
 @available(iOS, deprecated: 17, message: "TODO")
+@available(macOS, deprecated: 14, message: "TODO")
+@available(tvOS, deprecated: 17, message: "TODO")
+@available(watchOS, deprecated: 10, message: "TODO")
 public func withPerceptionTracking<T>(
   _ apply: () -> T,
   willSet: @escaping @Sendable (PerceptionTracking) -> Void
@@ -237,6 +255,9 @@ public func withPerceptionTracking<T>(
 
 @_spi(SwiftUI)
 @available(iOS, deprecated: 17, message: "TODO")
+@available(macOS, deprecated: 14, message: "TODO")
+@available(tvOS, deprecated: 17, message: "TODO")
+@available(watchOS, deprecated: 10, message: "TODO")
 public func withPerceptionTracking<T>(
   _ apply: () -> T,
   didSet: @escaping @Sendable (PerceptionTracking) -> Void

--- a/Sources/Perception/WithPerceptionTracking.swift
+++ b/Sources/Perception/WithPerceptionTracking.swift
@@ -1,11 +1,17 @@
 import SwiftUI
 
 @available(iOS, deprecated: 17, message: "TODO")
+@available(macOS, deprecated: 14, message: "TODO")
+@available(tvOS, deprecated: 17, message: "TODO")
+@available(watchOS, deprecated: 10, message: "TODO")
 public enum PerceptionLocals {
   @TaskLocal public static var isInPerceptionTracking = false
 }
 
 @available(iOS, deprecated: 17, message: "TODO")
+@available(macOS, deprecated: 14, message: "TODO")
+@available(tvOS, deprecated: 17, message: "TODO")
+@available(watchOS, deprecated: 10, message: "TODO")
 @MainActor
 public struct WithPerceptionTracking<Content: View>: View {
   @State var id = 0
@@ -14,7 +20,7 @@ public struct WithPerceptionTracking<Content: View>: View {
     self.content = content
   }
   public var body: Content {
-    if #available(iOS 17, *) {  // TODO: other platforms
+    if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {  // TODO: other platforms
       return self.content()
     } else {
       let _ = self.id

--- a/Tests/ComposableArchitectureMacrosTests/MacroBaseTestCase.swift
+++ b/Tests/ComposableArchitectureMacrosTests/MacroBaseTestCase.swift
@@ -1,21 +1,23 @@
-import ComposableArchitectureMacros
-import MacroTesting
-import SwiftSyntaxMacros
-import SwiftSyntaxMacrosTestSupport
-import XCTest
+#if canImport(ComposableArchitectureMacros)
+  import ComposableArchitectureMacros
+  import MacroTesting
+  import SwiftSyntaxMacros
+  import SwiftSyntaxMacrosTestSupport
+  import XCTest
 
-class MacroBaseTestCase: XCTestCase {
-  override func invokeTest() {
-    MacroTesting.withMacroTesting(
-      // isRecording: true,
-      macros: [
-        ObservableStateMacro.self,
-        ObservationStateTrackedMacro.self,
-        ObservationStateIgnoredMacro.self,
-        // WithViewStoreMacro.self,
-      ]
-    ) {
-      super.invokeTest()
+  class MacroBaseTestCase: XCTestCase {
+    override func invokeTest() {
+      MacroTesting.withMacroTesting(
+        // isRecording: true,
+        macros: [
+          ObservableStateMacro.self,
+          ObservationStateTrackedMacro.self,
+          ObservationStateIgnoredMacro.self,
+          // WithViewStoreMacro.self,
+        ]
+      ) {
+        super.invokeTest()
+      }
     }
   }
-}
+#endif

--- a/Tests/ComposableArchitectureMacrosTests/ObservableStateTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ObservableStateTests.swift
@@ -1,242 +1,244 @@
-import ComposableArchitectureMacros
-import MacroTesting
-import SwiftSyntaxMacros
-import SwiftSyntaxMacrosTestSupport
-import XCTest
+#if canImport(ComposableArchitectureMacros)
+  import ComposableArchitectureMacros
+  import MacroTesting
+  import SwiftSyntaxMacros
+  import SwiftSyntaxMacrosTestSupport
+  import XCTest
 
-final class ObservableStateMacroTests: MacroBaseTestCase {
-  override func invokeTest() {
-    withMacroTesting(
-      // isRecording: true
-    ) {
-      super.invokeTest()
-    }
-  }
-
-  func testAvailability() {
-    assertMacro {
-      """
-      @ObservableState
-      @available(iOS 18, *)
-      struct State {
-        var count = 0
+  final class ObservableStateMacroTests: MacroBaseTestCase {
+    override func invokeTest() {
+      withMacroTesting(
+        // isRecording: true
+      ) {
+        super.invokeTest()
       }
-      """
-    } expansion: {
-      #"""
-      @available(iOS 18, *)
-      struct State {
-        var count = 0 {
-          @storageRestrictions(initializes: _count)
-          init(initialValue) {
-            _count = initialValue
-          }
-          get {
-            access(keyPath: \.count)
-            return _count
-          }
-          set {
-            if _$isIdentityEqual(newValue, _count) == true {
-              _count = newValue
-            } else {
-              withMutation(keyPath: \.count) {
+    }
+
+    func testAvailability() {
+      assertMacro {
+        """
+        @ObservableState
+        @available(iOS 18, *)
+        struct State {
+          var count = 0
+        }
+        """
+      } expansion: {
+        #"""
+        @available(iOS 18, *)
+        struct State {
+          var count = 0 {
+            @storageRestrictions(initializes: _count)
+            init(initialValue) {
+              _count = initialValue
+            }
+            get {
+              access(keyPath: \.count)
+              return _count
+            }
+            set {
+              if _$isIdentityEqual(newValue, _count) == true {
                 _count = newValue
+              } else {
+                withMutation(keyPath: \.count) {
+                  _count = newValue
+                }
               }
             }
           }
-        }
 
-        private let _$observationRegistrar = ComposableArchitecture.ObservationStateRegistrar()
+          private let _$observationRegistrar = ComposableArchitecture.ObservationStateRegistrar()
 
-        internal nonisolated func access<Member>(
-          keyPath: KeyPath<State, Member>
-        ) {
-          _$observationRegistrar.access(self, keyPath: keyPath)
-        }
+          internal nonisolated func access<Member>(
+            keyPath: KeyPath<State, Member>
+          ) {
+            _$observationRegistrar.access(self, keyPath: keyPath)
+          }
 
-        internal nonisolated func withMutation<Member, MutationResult>(
-          keyPath: KeyPath<State, Member>,
-          _ mutation: () throws -> MutationResult
-        ) rethrows -> MutationResult {
-          try _$observationRegistrar.withMutation(of: self, keyPath: keyPath, mutation)
-        }
+          internal nonisolated func withMutation<Member, MutationResult>(
+            keyPath: KeyPath<State, Member>,
+            _ mutation: () throws -> MutationResult
+          ) rethrows -> MutationResult {
+            try _$observationRegistrar.withMutation(of: self, keyPath: keyPath, mutation)
+          }
 
-        var _$id: ComposableArchitecture.ObservableStateID {
-          self._$observationRegistrar.id
+          var _$id: ComposableArchitecture.ObservableStateID {
+            self._$observationRegistrar.id
+          }
         }
+        """#
       }
-      """#
     }
-  }
 
-  func testObservableState() throws {
-    assertMacro {
-      #"""
-      @ObservableState
-      struct State {
-        var count = 0
-      }
-      """#
-    } expansion: {
-      #"""
-      struct State {
-        var count = 0 {
-          @storageRestrictions(initializes: _count)
-          init(initialValue) {
-            _count = initialValue
-          }
-          get {
-            access(keyPath: \.count)
-            return _count
-          }
-          set {
-            if _$isIdentityEqual(newValue, _count) == true {
-              _count = newValue
-            } else {
-              withMutation(keyPath: \.count) {
+    func testObservableState() throws {
+      assertMacro {
+        #"""
+        @ObservableState
+        struct State {
+          var count = 0
+        }
+        """#
+      } expansion: {
+        #"""
+        struct State {
+          var count = 0 {
+            @storageRestrictions(initializes: _count)
+            init(initialValue) {
+              _count = initialValue
+            }
+            get {
+              access(keyPath: \.count)
+              return _count
+            }
+            set {
+              if _$isIdentityEqual(newValue, _count) == true {
                 _count = newValue
+              } else {
+                withMutation(keyPath: \.count) {
+                  _count = newValue
+                }
               }
             }
           }
-        }
 
-        private let _$observationRegistrar = ComposableArchitecture.ObservationStateRegistrar()
+          private let _$observationRegistrar = ComposableArchitecture.ObservationStateRegistrar()
 
-        internal nonisolated func access<Member>(
-          keyPath: KeyPath<State, Member>
-        ) {
-          _$observationRegistrar.access(self, keyPath: keyPath)
-        }
+          internal nonisolated func access<Member>(
+            keyPath: KeyPath<State, Member>
+          ) {
+            _$observationRegistrar.access(self, keyPath: keyPath)
+          }
 
-        internal nonisolated func withMutation<Member, MutationResult>(
-          keyPath: KeyPath<State, Member>,
-          _ mutation: () throws -> MutationResult
-        ) rethrows -> MutationResult {
-          try _$observationRegistrar.withMutation(of: self, keyPath: keyPath, mutation)
-        }
+          internal nonisolated func withMutation<Member, MutationResult>(
+            keyPath: KeyPath<State, Member>,
+            _ mutation: () throws -> MutationResult
+          ) rethrows -> MutationResult {
+            try _$observationRegistrar.withMutation(of: self, keyPath: keyPath, mutation)
+          }
 
-        var _$id: ComposableArchitecture.ObservableStateID {
-          self._$observationRegistrar.id
-        }
-      }
-      """#
-    }
-  }
-
-  func testObservableStateIgnored() throws {
-    assertMacro {
-      #"""
-      @ObservableState
-      struct State {
-        @ObservationStateIgnored
-        var count = 0
-      }
-      """#
-    } expansion: {
-      """
-      struct State {
-        var count = 0
-
-        private let _$observationRegistrar = ComposableArchitecture.ObservationStateRegistrar()
-
-        internal nonisolated func access<Member>(
-          keyPath: KeyPath<State, Member>
-        ) {
-          _$observationRegistrar.access(self, keyPath: keyPath)
-        }
-
-        internal nonisolated func withMutation<Member, MutationResult>(
-          keyPath: KeyPath<State, Member>,
-          _ mutation: () throws -> MutationResult
-        ) rethrows -> MutationResult {
-          try _$observationRegistrar.withMutation(of: self, keyPath: keyPath, mutation)
-        }
-
-        var _$id: ComposableArchitecture.ObservableStateID {
-          self._$observationRegistrar.id
-        }
-      }
-      """
-    }
-  }
-
-  func testObservableState_Enum() {
-    assertMacro {
-      """
-      @ObservableState
-      enum Path {
-        case feature1(Feature1.State)
-        case feature2(Feature2.State)
-      }
-      """
-    } expansion: {
-      """
-      enum Path {
-        case feature1(Feature1.State)
-        case feature2(Feature2.State)
-
-        var _$id: ComposableArchitecture.ObservableStateID {
-          switch self {
-          case let .feature1(state):
-            return ._$id(for: state)._$tag(0)
-          case let .feature2(state):
-            return ._$id(for: state)._$tag(1)
+          var _$id: ComposableArchitecture.ObservableStateID {
+            self._$observationRegistrar.id
           }
         }
+        """#
       }
-      """
     }
-  }
 
-  func testObservableState_Enum_AccessControl() {
-    assertMacro {
-      """
-      @ObservableState
-      public enum Path {
-        case feature1(Feature1.State)
-        case feature2(Feature2.State)
-      }
-      """
-    } expansion: {
-      """
-      public enum Path {
-        case feature1(Feature1.State)
-        case feature2(Feature2.State)
+    func testObservableStateIgnored() throws {
+      assertMacro {
+        #"""
+        @ObservableState
+        struct State {
+          @ObservationStateIgnored
+          var count = 0
+        }
+        """#
+      } expansion: {
+        """
+        struct State {
+          var count = 0
 
-        public var _$id: ComposableArchitecture.ObservableStateID {
-          switch self {
-          case let .feature1(state):
-            return ._$id(for: state)._$tag(0)
-          case let .feature2(state):
-            return ._$id(for: state)._$tag(1)
+          private let _$observationRegistrar = ComposableArchitecture.ObservationStateRegistrar()
+
+          internal nonisolated func access<Member>(
+            keyPath: KeyPath<State, Member>
+          ) {
+            _$observationRegistrar.access(self, keyPath: keyPath)
+          }
+
+          internal nonisolated func withMutation<Member, MutationResult>(
+            keyPath: KeyPath<State, Member>,
+            _ mutation: () throws -> MutationResult
+          ) rethrows -> MutationResult {
+            try _$observationRegistrar.withMutation(of: self, keyPath: keyPath, mutation)
+          }
+
+          var _$id: ComposableArchitecture.ObservableStateID {
+            self._$observationRegistrar.id
           }
         }
+        """
       }
-      """
     }
-  }
 
-  func testObservableState_Enum_MultipleAssociatedValues() {
-    assertMacro {
-      """
-      @ObservableState
-      public enum Path {
-        case foo(Int, String)
-      }
-      """
-    } expansion: {
-      """
-      public enum Path {
-        case foo(Int, String)
+    func testObservableState_Enum() {
+      assertMacro {
+        """
+        @ObservableState
+        enum Path {
+          case feature1(Feature1.State)
+          case feature2(Feature2.State)
+        }
+        """
+      } expansion: {
+        """
+        enum Path {
+          case feature1(Feature1.State)
+          case feature2(Feature2.State)
 
-        public var _$id: ComposableArchitecture.ObservableStateID {
-          switch self {
-          case .foo:
-            return ._$inert._$tag(0)
+          var _$id: ComposableArchitecture.ObservableStateID {
+            switch self {
+            case let .feature1(state):
+              return ._$id(for: state)._$tag(0)
+            case let .feature2(state):
+              return ._$id(for: state)._$tag(1)
+            }
           }
         }
+        """
       }
-      """
+    }
+
+    func testObservableState_Enum_AccessControl() {
+      assertMacro {
+        """
+        @ObservableState
+        public enum Path {
+          case feature1(Feature1.State)
+          case feature2(Feature2.State)
+        }
+        """
+      } expansion: {
+        """
+        public enum Path {
+          case feature1(Feature1.State)
+          case feature2(Feature2.State)
+
+          public var _$id: ComposableArchitecture.ObservableStateID {
+            switch self {
+            case let .feature1(state):
+              return ._$id(for: state)._$tag(0)
+            case let .feature2(state):
+              return ._$id(for: state)._$tag(1)
+            }
+          }
+        }
+        """
+      }
+    }
+
+    func testObservableState_Enum_MultipleAssociatedValues() {
+      assertMacro {
+        """
+        @ObservableState
+        public enum Path {
+          case foo(Int, String)
+        }
+        """
+      } expansion: {
+        """
+        public enum Path {
+          case foo(Int, String)
+
+          public var _$id: ComposableArchitecture.ObservableStateID {
+            switch self {
+            case .foo:
+              return ._$inert._$tag(0)
+            }
+          }
+        }
+        """
+      }
     }
   }
-}
+#endif

--- a/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
@@ -1,168 +1,170 @@
-import ComposableArchitectureMacros
-import MacroTesting
-import XCTest
+#if canImport(ComposableArchitectureMacros)
+  import ComposableArchitectureMacros
+  import MacroTesting
+  import XCTest
 
-final class ReducerMacroTests: XCTestCase {
-  override func invokeTest() {
-    withMacroTesting(
-      // isRecording: true,
-      macros: [ReducerMacro.self]
-    ) {
-      super.invokeTest()
+  final class ReducerMacroTests: XCTestCase {
+    override func invokeTest() {
+      withMacroTesting(
+        // isRecording: true,
+        macros: [ReducerMacro.self]
+      ) {
+        super.invokeTest()
+      }
+    }
+
+    func testBasics() {
+      assertMacro {
+        """
+        @Reducer
+        struct Feature {
+          struct State {
+          }
+          enum Action {
+          }
+          var body: some ReducerOf<Self> {
+            EmptyReducer()
+          }
+        }
+        """
+      } expansion: {
+        """
+        struct Feature {
+          struct State {
+          }
+          @CasePathable
+          enum Action {
+          }
+          @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
+          var body: some ReducerOf<Self> {
+            EmptyReducer()
+          }
+        }
+
+        extension Feature: ComposableArchitecture.Reducer {
+        }
+        """
+      }
+    }
+
+    func testEnumState() {
+      assertMacro {
+        """
+        @Reducer
+        struct Feature {
+          enum State {
+          }
+          enum Action {
+          }
+          var body: some ReducerOf<Self> {
+            EmptyReducer()
+          }
+        }
+        """
+      } expansion: {
+        """
+        struct Feature {
+          @CasePathable @dynamicMemberLookup
+          enum State {
+          }
+          @CasePathable
+          enum Action {
+          }
+          @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
+          var body: some ReducerOf<Self> {
+            EmptyReducer()
+          }
+        }
+
+        extension Feature: ComposableArchitecture.Reducer {
+        }
+        """
+      }
+    }
+
+    func testAlreadyApplied() {
+      assertMacro {
+        """
+        @Reducer
+        struct Feature: Reducer, Sendable {
+          @CasePathable
+          @dynamicMemberLookup
+          enum State {
+          }
+          @CasePathable
+          enum Action {
+          }
+          @ReducerBuilder<State, Action>
+          var body: some ReducerOf<Self> {
+            EmptyReducer()
+          }
+        }
+        """
+      } expansion: {
+        """
+        struct Feature: Reducer, Sendable {
+          @CasePathable
+          @dynamicMemberLookup
+          enum State {
+          }
+          @CasePathable
+          enum Action {
+          }
+          @ReducerBuilder<State, Action>
+          var body: some ReducerOf<Self> {
+            EmptyReducer()
+          }
+        }
+        """
+      }
+    }
+
+    func testReduceMethodDiagnostic() {
+      assertMacro {
+        """
+        @Reducer
+        struct Feature {
+          struct State {
+          }
+          enum Action {
+          }
+          func reduce(into state: inout State, action: Action) -> EffectOf<Self> {
+            .none
+          }
+          var body: some ReducerOf<Self> {
+            Reduce(reduce)
+            Reduce(reduce(into:action:))
+            Reduce(self.reduce)
+            Reduce(self.reduce(into:action:))
+            Reduce(AnotherReducer().reduce)
+            Reduce(AnotherReducer().reduce(into:action:))
+          }
+        }
+        """
+      } diagnostics: {
+        """
+        @Reducer
+        struct Feature {
+          struct State {
+          }
+          enum Action {
+          }
+          func reduce(into state: inout State, action: Action) -> EffectOf<Self> {
+               ┬─────
+               ╰─ 🛑 A 'reduce' method should not be defined in a reducer with a 'body'; it takes precedence and 'body' will never be invoked
+            .none
+          }
+          var body: some ReducerOf<Self> {
+            Reduce(reduce)
+            Reduce(reduce(into:action:))
+            Reduce(self.reduce)
+            Reduce(self.reduce(into:action:))
+            Reduce(AnotherReducer().reduce)
+            Reduce(AnotherReducer().reduce(into:action:))
+          }
+        }
+        """
+      }
     }
   }
-
-  func testBasics() {
-    assertMacro {
-      """
-      @Reducer
-      struct Feature {
-        struct State {
-        }
-        enum Action {
-        }
-        var body: some ReducerOf<Self> {
-          EmptyReducer()
-        }
-      }
-      """
-    } expansion: {
-      """
-      struct Feature {
-        struct State {
-        }
-        @CasePathable
-        enum Action {
-        }
-        @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
-        var body: some ReducerOf<Self> {
-          EmptyReducer()
-        }
-      }
-
-      extension Feature: ComposableArchitecture.Reducer {
-      }
-      """
-    }
-  }
-
-  func testEnumState() {
-    assertMacro {
-      """
-      @Reducer
-      struct Feature {
-        enum State {
-        }
-        enum Action {
-        }
-        var body: some ReducerOf<Self> {
-          EmptyReducer()
-        }
-      }
-      """
-    } expansion: {
-      """
-      struct Feature {
-        @CasePathable @dynamicMemberLookup
-        enum State {
-        }
-        @CasePathable
-        enum Action {
-        }
-        @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
-        var body: some ReducerOf<Self> {
-          EmptyReducer()
-        }
-      }
-
-      extension Feature: ComposableArchitecture.Reducer {
-      }
-      """
-    }
-  }
-
-  func testAlreadyApplied() {
-    assertMacro {
-      """
-      @Reducer
-      struct Feature: Reducer, Sendable {
-        @CasePathable
-        @dynamicMemberLookup
-        enum State {
-        }
-        @CasePathable
-        enum Action {
-        }
-        @ReducerBuilder<State, Action>
-        var body: some ReducerOf<Self> {
-          EmptyReducer()
-        }
-      }
-      """
-    } expansion: {
-      """
-      struct Feature: Reducer, Sendable {
-        @CasePathable
-        @dynamicMemberLookup
-        enum State {
-        }
-        @CasePathable
-        enum Action {
-        }
-        @ReducerBuilder<State, Action>
-        var body: some ReducerOf<Self> {
-          EmptyReducer()
-        }
-      }
-      """
-    }
-  }
-
-  func testReduceMethodDiagnostic() {
-    assertMacro {
-      """
-      @Reducer
-      struct Feature {
-        struct State {
-        }
-        enum Action {
-        }
-        func reduce(into state: inout State, action: Action) -> EffectOf<Self> {
-          .none
-        }
-        var body: some ReducerOf<Self> {
-          Reduce(reduce)
-          Reduce(reduce(into:action:))
-          Reduce(self.reduce)
-          Reduce(self.reduce(into:action:))
-          Reduce(AnotherReducer().reduce)
-          Reduce(AnotherReducer().reduce(into:action:))
-        }
-      }
-      """
-    } diagnostics: {
-      """
-      @Reducer
-      struct Feature {
-        struct State {
-        }
-        enum Action {
-        }
-        func reduce(into state: inout State, action: Action) -> EffectOf<Self> {
-             ┬─────
-             ╰─ 🛑 A 'reduce' method should not be defined in a reducer with a 'body'; it takes precedence and 'body' will never be invoked
-          .none
-        }
-        var body: some ReducerOf<Self> {
-          Reduce(reduce)
-          Reduce(reduce(into:action:))
-          Reduce(self.reduce)
-          Reduce(self.reduce(into:action:))
-          Reduce(AnotherReducer().reduce)
-          Reduce(AnotherReducer().reduce(into:action:))
-        }
-      }
-      """
-    }
-  }
-}
+#endif

--- a/Tests/PerceptionMacrosTests/PerceptionMacrosTests.swift
+++ b/Tests/PerceptionMacrosTests/PerceptionMacrosTests.swift
@@ -1,64 +1,66 @@
-import MacroTesting
-import PerceptionMacros
-import XCTest
+#if canImport(PerceptionMacros)
+  import MacroTesting
+  import PerceptionMacros
+  import XCTest
 
-class PerceptionMacroTests: XCTestCase {
-  override func invokeTest() {
-    withMacroTesting(
-      //isRecording: true,
-      macros: [
-        PerceptibleMacro.self,
-        PerceptionTrackedMacro.self,
-        PerceptionIgnoredMacro.self,
-      ]
-    ) {
-      super.invokeTest()
-    }
-  }
-
-  func testPerceptible() {
-    assertMacro {
-      """
-      @Perceptible
-      class Feature {
-        var count = 0
+  class PerceptionMacroTests: XCTestCase {
+    override func invokeTest() {
+      withMacroTesting(
+        //isRecording: true,
+        macros: [
+          PerceptibleMacro.self,
+          PerceptionTrackedMacro.self,
+          PerceptionIgnoredMacro.self,
+        ]
+      ) {
+        super.invokeTest()
       }
-      """
-    } expansion: {
-      #"""
-      class Feature {
-        var count = 0 {
-          @storageRestrictions(initializes: _count )
-          init(initialValue) {
-            _count  = initialValue
-          }
-          get {
-            access(keyPath: \.count )
-            return _count
-          }
-          set {
-            withMutation(keyPath: \.count ) {
-              _count  = newValue
+    }
+
+    func testPerceptible() {
+      assertMacro {
+        """
+        @Perceptible
+        class Feature {
+          var count = 0
+        }
+        """
+      } expansion: {
+        #"""
+        class Feature {
+          var count = 0 {
+            @storageRestrictions(initializes: _count )
+            init(initialValue) {
+              _count  = initialValue
+            }
+            get {
+              access(keyPath: \.count )
+              return _count
+            }
+            set {
+              withMutation(keyPath: \.count ) {
+                _count  = newValue
+              }
             }
           }
-        }
 
-        private let _$perceptionRegistrar = Perception.PerceptionRegistrar()
+          private let _$perceptionRegistrar = Perception.PerceptionRegistrar()
 
-        internal nonisolated func access<Member>(
-            keyPath: KeyPath<Feature , Member>
-        ) {
-          _$perceptionRegistrar.access(self, keyPath: keyPath)
-        }
+          internal nonisolated func access<Member>(
+              keyPath: KeyPath<Feature , Member>
+          ) {
+            _$perceptionRegistrar.access(self, keyPath: keyPath)
+          }
 
-        internal nonisolated func withMutation<Member, MutationResult>(
-          keyPath: KeyPath<Feature , Member>,
-          _ mutation: () throws -> MutationResult
-        ) rethrows -> MutationResult {
-          try _$perceptionRegistrar.withMutation(of: self, keyPath: keyPath, mutation)
+          internal nonisolated func withMutation<Member, MutationResult>(
+            keyPath: KeyPath<Feature , Member>,
+            _ mutation: () throws -> MutationResult
+          ) rethrows -> MutationResult {
+            try _$perceptionRegistrar.withMutation(of: self, keyPath: keyPath, mutation)
+          }
         }
+        """#
       }
-      """#
     }
   }
-}
+#endif

--- a/Tests/PerceptionTests/PerceptionTests.swift
+++ b/Tests/PerceptionTests/PerceptionTests.swift
@@ -43,7 +43,8 @@ final class PerceptionTests: XCTestCase {
   }
 
   func testRuntimeWarning_NotInPerceptionBody_SwiftUIBinding() {
-    // NB: Ideally this should emit a runtime warning, but it does not.
+    self.expectFailure()
+
     struct FeatureView: View {
       @State var model = Model()
       var body: some View {

--- a/Tests/PerceptionTests/PerceptionTests.swift
+++ b/Tests/PerceptionTests/PerceptionTests.swift
@@ -2,7 +2,7 @@ import Perception
 import SwiftUI
 import XCTest
 
-@available(iOS 16.0, *)
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
 @MainActor
 final class PerceptionTests: XCTestCase {
   func testRuntimeWarning_NotInPerceptionBody() {
@@ -49,14 +49,8 @@ final class PerceptionTests: XCTestCase {
   }
 
   func testRuntimeWarning_NotInPerceptionBody_SwiftUIBinding() async {
-    if #unavailable(iOS 17) {
-      XCTExpectFailure {
-        $0.compactDescription == """
-          Perceptible state was accessed but is not being tracked. Track changes to state by \
-          wrapping your view in a 'WithPerceptionTracking' view.
-          """
-      }
-    }
+    self.expectFailure()
+
     struct FeatureView: View {
       @State var model = Model()
       var body: some View {
@@ -67,14 +61,8 @@ final class PerceptionTests: XCTestCase {
   }
 
   func testRuntimeWarning_InPerceptionBody_SwiftUIBinding() async {
-    if #unavailable(iOS 17) {
-      XCTExpectFailure {
-        $0.compactDescription == """
-          Perceptible state was accessed but is not being tracked. Track changes to state by \
-          wrapping your view in a 'WithPerceptionTracking' view.
-          """
-      }
-    }
+    self.expectFailure()
+
     struct FeatureView: View {
       @State var model = Model()
       var body: some View {
@@ -84,6 +72,17 @@ final class PerceptionTests: XCTestCase {
       }
     }
     _ = ImageRenderer(content: FeatureView()).uiImage
+  }
+
+  private func expectFailure() {
+    if #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10) {
+      XCTExpectFailure {
+        $0.compactDescription == """
+          Perceptible state was accessed but is not being tracked. Track changes to state by \
+          wrapping your view in a 'WithPerceptionTracking' view.
+          """
+      }
+    }
   }
 }
 

--- a/Tests/PerceptionTests/PerceptionTests.swift
+++ b/Tests/PerceptionTests/PerceptionTests.swift
@@ -19,21 +19,15 @@ final class PerceptionTests: XCTestCase {
   }
 
   func testRuntimeWarning_NotInPerceptionBody_InSwiftUIBody() {
-    if #unavailable(iOS 17) {
-      XCTExpectFailure {
-        $0.compactDescription == """
-          Perceptible state was accessed but is not being tracked. Track changes to state by \
-          wrapping your view in a 'WithPerceptionTracking' view.
-          """
-      }
-    }
+    self.expectFailure()
+
     struct FeatureView: View {
       let model = Model()
       var body: some View {
         Text(self.model.count.description)
       }
     }
-    _ = ImageRenderer(content: FeatureView()).uiImage
+    self.render(FeatureView())
   }
 
   func testRuntimeWarning_InPerceptionBody_InSwiftUIBody() {
@@ -45,7 +39,7 @@ final class PerceptionTests: XCTestCase {
         }
       }
     }
-    _ = ImageRenderer(content: FeatureView()).uiImage
+    self.render(FeatureView())
   }
 
   func testRuntimeWarning_NotInPerceptionBody_SwiftUIBinding() {
@@ -57,7 +51,7 @@ final class PerceptionTests: XCTestCase {
         TextField("", text: self.$model.text)
       }
     }
-    _ = ImageRenderer(content: FeatureView()).uiImage
+    self.render(FeatureView())
   }
 
   func testRuntimeWarning_InPerceptionBody_SwiftUIBinding() {
@@ -71,7 +65,7 @@ final class PerceptionTests: XCTestCase {
         }
       }
     }
-    _ = ImageRenderer(content: FeatureView()).uiImage
+    self.render(FeatureView())
   }
 
   private func expectFailure() {
@@ -83,6 +77,10 @@ final class PerceptionTests: XCTestCase {
           """
       }
     }
+  }
+
+  private func render(_ view: some View) {
+    _ = ImageRenderer(content: view).cgImage
   }
 }
 

--- a/Tests/PerceptionTests/PerceptionTests.swift
+++ b/Tests/PerceptionTests/PerceptionTests.swift
@@ -18,7 +18,7 @@ final class PerceptionTests: XCTestCase {
     }
   }
 
-  func testRuntimeWarning_NotInPerceptionBody_InSwiftUIBody() async {
+  func testRuntimeWarning_NotInPerceptionBody_InSwiftUIBody() {
     if #unavailable(iOS 17) {
       XCTExpectFailure {
         $0.compactDescription == """
@@ -36,7 +36,7 @@ final class PerceptionTests: XCTestCase {
     _ = ImageRenderer(content: FeatureView()).uiImage
   }
 
-  func testRuntimeWarning_InPerceptionBody_InSwiftUIBody() async {
+  func testRuntimeWarning_InPerceptionBody_InSwiftUIBody() {
     struct FeatureView: View {
       let model = Model()
       var body: some View {
@@ -48,7 +48,7 @@ final class PerceptionTests: XCTestCase {
     _ = ImageRenderer(content: FeatureView()).uiImage
   }
 
-  func testRuntimeWarning_NotInPerceptionBody_SwiftUIBinding() async {
+  func testRuntimeWarning_NotInPerceptionBody_SwiftUIBinding() {
     self.expectFailure()
 
     struct FeatureView: View {
@@ -60,7 +60,7 @@ final class PerceptionTests: XCTestCase {
     _ = ImageRenderer(content: FeatureView()).uiImage
   }
 
-  func testRuntimeWarning_InPerceptionBody_SwiftUIBinding() async {
+  func testRuntimeWarning_InPerceptionBody_SwiftUIBinding() {
     self.expectFailure()
 
     struct FeatureView: View {

--- a/Tests/PerceptionTests/PerceptionTests.swift
+++ b/Tests/PerceptionTests/PerceptionTests.swift
@@ -43,20 +43,19 @@ final class PerceptionTests: XCTestCase {
   }
 
   func testRuntimeWarning_NotInPerceptionBody_SwiftUIBinding() {
-    self.expectFailure()
-
+    // NB: Ideally this should emit a runtime warning, but it does not.
     struct FeatureView: View {
       @State var model = Model()
       var body: some View {
-        TextField("", text: self.$model.text)
+        VStack {
+          TextField("", text: self.$model.text)
+        }
       }
     }
     self.render(FeatureView())
   }
 
   func testRuntimeWarning_InPerceptionBody_SwiftUIBinding() {
-    self.expectFailure()
-
     struct FeatureView: View {
       @State var model = Model()
       var body: some View {

--- a/Tests/PerceptionTests/PerceptionTests.swift
+++ b/Tests/PerceptionTests/PerceptionTests.swift
@@ -1,0 +1,94 @@
+import Perception
+import SwiftUI
+import XCTest
+
+@available(iOS 16.0, *)
+@MainActor
+final class PerceptionTests: XCTestCase {
+  func testRuntimeWarning_NotInPerceptionBody() {
+    let model = Model()
+    model.count += 1
+    XCTAssertEqual(model.count, 1)
+  }
+
+  func testRuntimeWarning_InPerceptionBody_NotInSwiftUIBody() {
+    let model = Model()
+    PerceptionLocals.$isInPerceptionTracking.withValue(true) {
+      _ = model.count
+    }
+  }
+
+  func testRuntimeWarning_NotInPerceptionBody_InSwiftUIBody() async {
+    if #unavailable(iOS 17) {
+      XCTExpectFailure {
+        $0.compactDescription == """
+          Perceptible state was accessed but is not being tracked. Track changes to state by \
+          wrapping your view in a 'WithPerceptionTracking' view.
+          """
+      }
+    }
+    struct FeatureView: View {
+      let model = Model()
+      var body: some View {
+        Text(self.model.count.description)
+      }
+    }
+    _ = ImageRenderer(content: FeatureView()).uiImage
+  }
+
+  func testRuntimeWarning_InPerceptionBody_InSwiftUIBody() async {
+    struct FeatureView: View {
+      let model = Model()
+      var body: some View {
+        WithPerceptionTracking {
+          Text(self.model.count.description)
+        }
+      }
+    }
+    _ = ImageRenderer(content: FeatureView()).uiImage
+  }
+
+  func testRuntimeWarning_NotInPerceptionBody_SwiftUIBinding() async {
+    if #unavailable(iOS 17) {
+      XCTExpectFailure {
+        $0.compactDescription == """
+          Perceptible state was accessed but is not being tracked. Track changes to state by \
+          wrapping your view in a 'WithPerceptionTracking' view.
+          """
+      }
+    }
+    struct FeatureView: View {
+      @State var model = Model()
+      var body: some View {
+        TextField("", text: self.$model.text)
+      }
+    }
+    _ = ImageRenderer(content: FeatureView()).uiImage
+  }
+
+  func testRuntimeWarning_InPerceptionBody_SwiftUIBinding() async {
+    if #unavailable(iOS 17) {
+      XCTExpectFailure {
+        $0.compactDescription == """
+          Perceptible state was accessed but is not being tracked. Track changes to state by \
+          wrapping your view in a 'WithPerceptionTracking' view.
+          """
+      }
+    }
+    struct FeatureView: View {
+      @State var model = Model()
+      var body: some View {
+        WithPerceptionTracking {
+          TextField("", text: self.$model.text)
+        }
+      }
+    }
+    _ = ImageRenderer(content: FeatureView()).uiImage
+  }
+}
+
+@Perceptible
+private class Model {
+  var count = 0
+  var text = ""
+}

--- a/Tests/PerceptionTests/Tests.swift
+++ b/Tests/PerceptionTests/Tests.swift
@@ -1,7 +1,0 @@
-import Perception
-import XCTest
-
-final class PerceptionTests: XCTestCase {
-  func testExample() throws {
-  }
-}


### PR DESCRIPTION
Fixes the issue brought up [here](https://github.com/pointfreeco/swift-composable-architecture/discussions/2594?sort=new#discussioncomment-7734054).

Essentially when a binding's getter is accessed in SwiftUI, it does not happen in the call stack of the `AttributeGraph`. So, we will separately detect bindings and allow them to go by without a runtime warning. I was also able to get some test coverage on this which was nice.