### PR TITLE
Observation beta perception foreach fix

### DIFF
--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -152,11 +152,26 @@ extension PerceptionRegistrar: Hashable {
   var isInSwiftUIBody: Bool {
     for callStackSymbol in Thread.callStackSymbols {
       guard
-        let symbol = callStackSymbol.split(separator: " ").dropFirst(3).first,
-        symbol.utf8.first == .init(ascii: "$"),
-        let demangled = String(symbol).demangled,
+        let symbol = callStackSymbol.split(separator: " ").dropFirst(3).first
+      else {
+        continue
+      }
+      guard
+        symbol.utf8.first == .init(ascii: "$")
+      else {
+        continue
+      }
+      guard
+        let demangled = String(symbol).demangled
+      else {
+        continue
+      }
+      guard
         demangled.hasPrefix("protocol witness for SwiftUI.View.body.getter : ")
-      else { continue }
+          || demangled.contains("SwiftUI.ForEach") && demangled.contains("body.getter : some")
+      else {
+        continue
+      }
       return true
     }
     return false

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -168,7 +168,7 @@ extension PerceptionRegistrar: Hashable {
       }
       guard
         demangled.hasPrefix("protocol witness for SwiftUI.View.body.getter : ")
-          || demangled.contains("SwiftUI.ForEach") && demangled.contains("body.getter : some")
+          || demangled.contains(" SwiftUI.") && demangled.contains("body.getter : some")
       else {
         continue
       }


### PR DESCRIPTION
@oliverfoggin Pointed out that `WithPerceptionTracking` warnings were missing when accessing state in a `ForEach`. This PR addresses the issue by relaxing the demangled symbol check a bit with something that more correctly identifies views and modifiers that have escaping view builders.