### PR TITLE
Don't show perception warnings in action closures.

### DIFF
--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -222,9 +222,15 @@ extension PerceptionRegistrar: Hashable {
       else {
         continue
       }
+      let demangledParts = demangled.split(separator: " ")
       guard
         demangled.hasPrefix("protocol witness for SwiftUI.View.body.getter : ")
-          || demangled.contains(" SwiftUI.") && demangled.contains("body.getter : some")
+          || demangled.contains(" SwiftUI.")
+          && demangled.contains("body.getter : some")
+          && !(
+            demangledParts.first == "closure"
+            && demangledParts.dropFirst(2).prefix(3).joined(separator: " ") == "() -> ()"
+          )
       else {
         continue
       }


### PR DESCRIPTION
I'm sure there is better ways to do this, but it seems to work. Unfortunately it's not possible to test without an integration test.