### PR TITLE
Update migration guide 1.5

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingTo1.5.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingTo1.5.md
@@ -144,8 +144,9 @@ ChildView(
 
 Another common case you may encounter is when dealing with collections. It is common in the 
 Composable Architecture to use an `IdentifiedArray` in your feature's state and an
-``IdentifiedAction`` in your feature's actions. If you needed to scope your store down to one 
-specific row of the identified domain, previously you would have done so like this:
+``IdentifiedAction`` in your feature's actions (see <doc:MigratingTo1.4#Identified-actions> for more
+info on ``IdentifiedAction``). If you needed to scope your store down to one specific row of the
+identified domain, previously you would have done so like this:
 
 ```swift
 store.scope(

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingTo1.5.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingTo1.5.md
@@ -142,6 +142,27 @@ ChildView(
 )
 ```
 
+Another common case you may encounter is when dealing with collections. It is common in the 
+Composable Architecture to use an `IdentifiedArray` in your feature's state and an
+``IdentifiedAction`` in your feature's actions. If you needed to scope your store down to one 
+specific row of the identified domain, previously you would have done so like this:
+
+```swift
+store.scope(
+  state: \.rows[id: id],
+  action: { .rows(.element(id: id, action: $0)) }
+)
+```
+
+With case key paths it can be done simply like this:
+
+```swift
+store.scope(
+  state: \.rows[id: id],
+  action: \.rows[id: id]
+)
+```
+
 These tricks should be enough for you to rewrite all of your store scopes using key paths, but if
 you have any problems feel free to open a
 [discussion](http://github.com/pointfreeco/swift-composable-architecture/discussions) on the repo.

--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -42,6 +42,19 @@ extension IdentifiedAction: Sendable where ID: Sendable, Action: Sendable {}
 extension IdentifiedAction: Decodable where ID: Decodable, Action: Decodable {}
 extension IdentifiedAction: Encodable where ID: Encodable, Action: Encodable {}
 
+/// A convenience type alias for referring to an identified action of a given reducer's domain.
+///
+/// Instead of specifying the action like this:
+///
+/// ```swift
+/// case rows(IdentifiedAction<ChildFeature.State.ID, ChildFeature.Action>)
+/// ```
+///
+/// You can specify the reducer:
+///
+/// ```swift
+/// case rows(IdentifiedActionOf<ChildFeature>)
+/// ```
 public typealias IdentifiedActionOf<R: Reducer> = IdentifiedAction<R.State.ID, R.Action>
 where R.State: Identifiable
 


### PR DESCRIPTION
We mentioned how to subscript into identified actions in the testing section of the migration guide, but not the main section.