### PR TITLE
Deprecate closure-based `store.scope` operations

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -44,22 +44,20 @@ struct CounterView: View {
   let store: StoreOf<Counter>
 
   var body: some View {
-    WithPerceptionTracking {
-      HStack {
-        Button {
-          store.send(.decrementButtonTapped)
-        } label: {
-          Image(systemName: "minus")
-        }
+    HStack {
+      Button {
+        store.send(.decrementButtonTapped)
+      } label: {
+        Image(systemName: "minus")
+      }
 
-        Text("\(store.count)")
-          .monospacedDigit()
+      Text("\(store.count)")
+        .monospacedDigit()
 
-        Button {
-          store.send(.incrementButtonTapped)
-        } label: {
-          Image(systemName: "plus")
-        }
+      Button {
+        store.send(.incrementButtonTapped)
+      } label: {
+        Image(systemName: "plus")
       }
     }
   }

--- a/Examples/SyncUps/SyncUps/AppFeature.swift
+++ b/Examples/SyncUps/SyncUps/AppFeature.swift
@@ -122,7 +122,7 @@ struct AppFeature {
 }
 
 struct AppView: View {
-  @BindableStore var store: StoreOf<AppFeature>
+  @Bindable var store: StoreOf<AppFeature>
 
   var body: some View {
     NavigationStack(path: $store.scope(state: \.path, action: \.path)) {

--- a/Examples/SyncUps/SyncUps/RecordMeeting.swift
+++ b/Examples/SyncUps/SyncUps/RecordMeeting.swift
@@ -163,7 +163,7 @@ struct RecordMeeting {
 }
 
 struct RecordMeetingView: View {
-  @BindableStore var store: StoreOf<RecordMeeting>
+  @Bindable var store: StoreOf<RecordMeeting>
 
   var body: some View {
     ZStack {

--- a/Examples/SyncUps/SyncUps/SyncUpDetail.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpDetail.swift
@@ -143,7 +143,7 @@ struct SyncUpDetail {
 }
 
 struct SyncUpDetailView: View {
-  @BindableStore var store: StoreOf<SyncUpDetail>
+  @Bindable var store: StoreOf<SyncUpDetail>
 
   var body: some View {
     List {

--- a/Examples/SyncUps/SyncUps/SyncUpForm.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpForm.swift
@@ -61,7 +61,7 @@ struct SyncUpForm {
 }
 
 struct SyncUpFormView: View {
-  @BindableStore var store: StoreOf<SyncUpForm>
+  @Bindable var store: StoreOf<SyncUpForm>
   @FocusState var focus: SyncUpForm.State.Field?
 
   var body: some View {

--- a/Examples/SyncUps/SyncUps/SyncUpsList.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpsList.swift
@@ -104,7 +104,7 @@ struct SyncUpsList {
 }
 
 struct SyncUpsListView: View {
-  @BindableStore var store: StoreOf<SyncUpsList>
+  @Bindable var store: StoreOf<SyncUpsList>
   
   var body: some View {
     List {

--- a/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
@@ -15,7 +15,18 @@ extension Store {
     state: KeyPath<State, IdentifiedArray<ElementID, ElementState>>,
     action: CaseKeyPath<Action, IdentifiedAction<ElementID, ElementAction>>
   ) -> some RandomAccessCollection<Store<ElementState, ElementAction>> {
-    _StoreCollection(self.scope(state: state, action: action))
+    #if DEBUG
+      if !self.canCacheChildren {
+        runtimeWarn(
+          """
+          Scoping from uncached \(self) is not compatible with observation. Ensure all store \
+          scoping operations in your application have been updated to take key paths and case key \
+          paths instead of transform functions, which have been deprecated.
+          """
+        )
+      }
+    #endif
+    return _StoreCollection(self.scope(state: state, action: action))
   }
 }
 

--- a/Sources/ComposableArchitecture/Observation/Store+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Store+Observation.swift
@@ -71,6 +71,17 @@ extension Store where State: ObservableState {
     state: KeyPath<State, ChildState?>,
     action: CaseKeyPath<Action, ChildAction>
   ) -> Store<ChildState, ChildAction>? {
+    #if DEBUG
+      if !self.canCacheChildren {
+        runtimeWarn(
+          """
+          Scoping from uncached \(self) is not compatible with observation. Ensure all store \
+          scoping operations in your application have been updated to take key paths and case key \
+          paths instead of transform functions, which have been deprecated.
+          """
+        )
+      }
+    #endif
     guard var childState = self.observableState[keyPath: state]
     else { return nil }
     return self.scope(

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -134,7 +134,7 @@ import SwiftUI
 @dynamicMemberLookup
 public final class Store<State, Action> {
   private var bufferedActions: [Action] = []
-  fileprivate var canCacheChildren = true
+  var canCacheChildren = true
   fileprivate var children: [AnyHashable: AnyObject] = [:]
   @_spi(Internals) public var effectCancellables: [UUID: AnyCancellable] = [:]
   var _isInvalidated = { false }
@@ -298,22 +298,7 @@ public final class Store<State, Action> {
   }
 
   @available(
-    iOS, deprecated: 9999,
-    message:
-      "Pass 'state' a key path to child state and 'action' a case key path to child action, instead. For more information see the following migration guide:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.5#Store-scoping-with-key-paths"
-  )
-  @available(
-    macOS, deprecated: 9999,
-    message:
-      "Pass 'state' a key path to child state and 'action' a case key path to child action, instead. For more information see the following migration guide:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.5#Store-scoping-with-key-paths"
-  )
-  @available(
-    tvOS, deprecated: 9999,
-    message:
-      "Pass 'state' a key path to child state and 'action' a case key path to child action, instead. For more information see the following migration guide:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.5#Store-scoping-with-key-paths"
-  )
-  @available(
-    watchOS, deprecated: 9999,
+    *, deprecated,
     message:
       "Pass 'state' a key path to child state and 'action' a case key path to child action, instead. For more information see the following migration guide:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.5#Store-scoping-with-key-paths"
   )
@@ -331,22 +316,7 @@ public final class Store<State, Action> {
   }
 
   @available(
-    iOS, deprecated: 9999,
-    message:
-      "Pass 'state' a key path to child state and 'action' a case key path to child action, instead. For more information see the following migration guide:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.5#Store-scoping-with-key-paths"
-  )
-  @available(
-    macOS, deprecated: 9999,
-    message:
-      "Pass 'state' a key path to child state and 'action' a case key path to child action, instead. For more information see the following migration guide:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.5#Store-scoping-with-key-paths"
-  )
-  @available(
-    tvOS, deprecated: 9999,
-    message:
-      "Pass 'state' a key path to child state and 'action' a case key path to child action, instead. For more information see the following migration guide:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.5#Store-scoping-with-key-paths"
-  )
-  @available(
-    watchOS, deprecated: 9999,
+    *, deprecated,
     message:
       "Pass 'state' a key path to child state and 'action' a case key path to child action, instead. For more information see the following migration guide:\n\nhttps://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.5#Store-scoping-with-key-paths"
   )

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -400,7 +400,13 @@ public struct BindingViewStore<State> {
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) where Action.State == State {
-    self.store = store.scope(state: { $0 }, action: Action.binding)
+    self.store = store.scope(
+      state: { $0 },
+      id: nil,
+      action: Action.binding,
+      isInvalid: nil,
+      removeDuplicates: nil
+    )
     #if DEBUG
       self.bindableActionType = type(of: Action.self)
       self.fileID = fileID
@@ -479,7 +485,17 @@ extension ViewStore {
     self.init(
       store,
       observe: { (_: State) in
-        toViewState(BindingViewStore(store: store.scope(state: { $0 }, action: fromViewAction)))
+        toViewState(
+          BindingViewStore(
+            store: store.scope(
+              state: { $0 },
+              id: nil,
+              action: fromViewAction,
+              isInvalid: nil,
+              removeDuplicates: nil
+            )
+          )
+        )
       },
       send: fromViewAction,
       removeDuplicates: isDuplicate
@@ -587,7 +603,17 @@ extension WithViewStore where Content: View {
     self.init(
       store,
       observe: { (_: State) in
-        toViewState(BindingViewStore(store: store.scope(state: { $0 }, action: fromViewAction)))
+        toViewState(
+          BindingViewStore(
+            store: store.scope(
+              state: { $0 },
+              id: nil,
+              action: fromViewAction,
+              isInvalid: nil,
+              removeDuplicates: nil
+            )
+          )
+        )
       },
       send: fromViewAction,
       removeDuplicates: isDuplicate,

--- a/Sources/ComposableArchitecture/SwiftUI/Deprecated/NavigationLinkStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Deprecated/NavigationLinkStore.swift
@@ -82,7 +82,10 @@ public struct NavigationLinkStore<
     self.viewStore = ViewStore(
       store.scope(
         state: { $0.wrappedValue.flatMap(toDestinationState) != nil },
-        action: { $0 }
+        id: nil,
+        action: { $0 },
+        isInvalid: nil,
+        removeDuplicates: nil
       ),
       observe: { $0 }
     )
@@ -132,7 +135,10 @@ public struct NavigationLinkStore<
     self.viewStore = ViewStore(
       store.scope(
         state: { $0.wrappedValue.flatMap(toDestinationState)?.id == id },
-        action: { $0 }
+        id: nil,
+        action: { $0 },
+        isInvalid: nil,
+        removeDuplicates: nil
       ),
       observe: { $0 }
     )
@@ -159,7 +165,10 @@ public struct NavigationLinkStore<
       IfLetStore(
         self.store.scope(
           state: returningLastNonNilValue { $0.wrappedValue.flatMap(self.toDestinationState) },
-          action: { .presented(self.fromDestinationAction($0)) }
+          id: nil,
+          action: { .presented(self.fromDestinationAction($0)) },
+          isInvalid: nil,
+          removeDuplicates: nil
         ),
         then: self.destination
       )

--- a/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
@@ -72,7 +72,10 @@ public struct IfLetStore<State, Action, Content: View>: View {
                 state = $0 ?? state
                 return state
               },
-              action: { $0 }
+              id: nil,
+              action: { $0 },
+              isInvalid: nil,
+              removeDuplicates: nil
             )
           )
         )
@@ -109,7 +112,10 @@ public struct IfLetStore<State, Action, Content: View>: View {
               state = $0 ?? state
               return state
             },
-            action: { $0 }
+            id: nil,
+            action: { $0 },
+            isInvalid: nil,
+            removeDuplicates: nil
           )
         )
       } else {
@@ -152,7 +158,7 @@ public struct IfLetStore<State, Action, Content: View>: View {
     @ViewBuilder else elseContent: @escaping () -> ElseContent
   ) where Content == _ConditionalContent<IfContent, ElseContent> {
     self.init(
-      store.scope(state: { $0.wrappedValue }, action: PresentationAction.presented),
+      store.scope(state: \.wrappedValue, action: \.presented),
       then: ifContent,
       else: elseContent
     )
@@ -190,7 +196,7 @@ public struct IfLetStore<State, Action, Content: View>: View {
     @ViewBuilder then ifContent: @escaping (_ store: Store<State, Action>) -> IfContent
   ) where Content == IfContent? {
     self.init(
-      store.scope(state: { $0.wrappedValue }, action: PresentationAction.presented),
+      store.scope(state: \.wrappedValue, action: \.presented),
       then: ifContent
     )
   }

--- a/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
@@ -239,7 +239,10 @@ public struct PresentationStore<
       DestinationContent(
         store: self.store.scope(
           state: { $0.wrappedValue.flatMap(self.toDestinationState) },
-          action: { .presented(fromDestinationAction($0)) }
+          id: nil,
+          action: { .presented(fromDestinationAction($0)) },
+          isInvalid: nil,
+          removeDuplicates: nil
         )
       )
     )
@@ -263,7 +266,14 @@ public struct DestinationContent<State, Action> {
     @ViewBuilder _ body: @escaping (_ store: Store<State, Action>) -> Content
   ) -> some View {
     IfLetStore(
-      self.store.scope(state: returningLastNonNilValue { $0 }, action: { $0 }), then: body
+      self.store.scope(
+        state: returningLastNonNilValue { $0 },
+        id: nil,
+        action: { $0 },
+        isInvalid: nil,
+        removeDuplicates: nil
+      ),
+      then: body
     )
   }
 }

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -153,7 +153,10 @@ public struct CaseLet<EnumState, EnumAction, CaseState, CaseAction, Content: Vie
     IfLetStore(
       self.store.wrappedValue.scope(
         state: self.toCaseState,
-        action: self.fromCaseAction
+        id: nil,
+        action: self.fromCaseAction,
+        isInvalid: nil,
+        removeDuplicates: nil
       ),
       then: self.content,
       else: {

--- a/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/WithViewStore.swift
@@ -296,7 +296,13 @@ public struct WithViewStore<ViewState, ViewAction, Content: View>: View {
     line: UInt = #line
   ) {
     self.init(
-      store: store.scope(state: toViewState, action: fromViewAction),
+      store: store.scope(
+        state: toViewState,
+        id: nil,
+        action: fromViewAction,
+        isInvalid: nil,
+        removeDuplicates: nil
+      ),
       removeDuplicates: isDuplicate,
       content: content,
       file: file,
@@ -385,7 +391,13 @@ public struct WithViewStore<ViewState, ViewAction, Content: View>: View {
     line: UInt = #line
   ) {
     self.init(
-      store: store.scope(state: toViewState, action: { $0 }),
+      store: store.scope(
+        state: toViewState,
+        id: nil,
+        action: { $0 },
+        isInvalid: nil,
+        removeDuplicates: nil
+      ),
       removeDuplicates: isDuplicate,
       content: content,
       file: file,
@@ -475,7 +487,13 @@ extension WithViewStore where ViewState: Equatable, Content: View {
     line: UInt = #line
   ) {
     self.init(
-      store: store.scope(state: toViewState, action: fromViewAction),
+      store: store.scope(
+        state: toViewState,
+        id: nil,
+        action: fromViewAction,
+        isInvalid: nil,
+        removeDuplicates: nil
+      ),
       removeDuplicates: ==,
       content: content,
       file: file,
@@ -561,7 +579,13 @@ extension WithViewStore where ViewState: Equatable, Content: View {
     line: UInt = #line
   ) {
     self.init(
-      store: store.scope(state: toViewState, action: { $0 }),
+      store: store.scope(
+        state: toViewState,
+        id: nil,
+        action: { $0 },
+        isInvalid: nil,
+        removeDuplicates: nil
+      ),
       removeDuplicates: ==,
       content: content,
       file: file,

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -2019,7 +2019,13 @@ extension TestStore {
       store: Store(initialState: self.state) {
         BindingReducer(action: toViewAction.extract(from:))
       }
-      .scope(state: { $0 }, action: toViewAction.embed)
+      .scope(
+        state: { $0 },
+        id: nil,
+        action: toViewAction.embed,
+        isInvalid: nil,
+        removeDuplicates: nil
+      )
     )
   }
 }

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -60,7 +60,10 @@ extension Store {
                 state = $0 ?? state
                 return state
               },
-              action: { $0 }
+              id: nil,
+              action: { $0 },
+              isInvalid: nil,
+              removeDuplicates: nil
             )
           )
         } else {


### PR DESCRIPTION
These uncached operations can be problematic, especially when working with observation, which often depends on the stable identity of stores.