### PR TITLE
Performance Improvement: Skip perception checks when calling reducers.

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -396,7 +396,9 @@ public final class Store<State, Action> {
     while index < self.bufferedActions.endIndex {
       defer { index += 1 }
       let action = self.bufferedActions[index]
-      let effect = self.reducer.reduce(into: &currentState, action: action)
+      let effect = withoutPerceptionChecking {
+        self.reducer.reduce(into: &currentState, action: action)
+      }
 
       switch effect.operation {
       case .none:

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -194,6 +194,7 @@ extension PerceptionRegistrar: Hashable {
   private func perceptionCheck() {
     if #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10),
       !PerceptionLocals.isInPerceptionTracking,
+      !PerceptionLocals.isInWithoutPerceptionChecking,
       isInSwiftUIBody
     {
       runtimeWarn(
@@ -265,4 +266,28 @@ extension PerceptionRegistrar: Hashable {
   @_transparent
   @inline(__always)
   private func perceptionCheck() {}
+#endif
+
+#if DEBUG
+@available(iOS, deprecated: 17, message: "TODO")
+@available(macOS, deprecated: 14, message: "TODO")
+@available(tvOS, deprecated: 17, message: "TODO")
+@available(watchOS, deprecated: 10, message: "TODO")
+public func withoutPerceptionChecking<T>(
+  _ apply: () -> T
+) -> T {
+    return PerceptionLocals.$isInWithoutPerceptionChecking.withValue(true) {
+      apply()
+    }
+}
+#else
+@available(iOS, deprecated: 17, message: "TODO")
+@available(macOS, deprecated: 14, message: "TODO")
+@available(tvOS, deprecated: 17, message: "TODO")
+@available(watchOS, deprecated: 10, message: "TODO")
+public func withoutPerceptionChecking<T>(
+  _ apply: () -> T
+) -> T {
+    apply()
+}
 #endif

--- a/Sources/Perception/WithPerceptionTracking.swift
+++ b/Sources/Perception/WithPerceptionTracking.swift
@@ -6,6 +6,7 @@ import SwiftUI
 @available(watchOS, deprecated: 10, message: "TODO")
 public enum PerceptionLocals {
   @TaskLocal public static var isInPerceptionTracking = false
+  @TaskLocal public static var isInWithoutPerceptionChecking = false
 }
 
 @available(iOS, deprecated: 17, message: "TODO")


### PR DESCRIPTION
This PR attempts to improve the performance of `perceptionCheck()` when using perception in iOS 16 or older as discussed [here](https://github.com/pointfreeco/swift-composable-architecture/discussions/2620#discussioncomment-7768601).

It introduces a new function `withoutPerceptionChecking` which may be used to wrap any calls that should be excluded from perception checking backtrace analysis. This function is only relevant for DEBUG builds and is a no-op in RELEASE builds.

Store is modified to wrap calls to `reduce` with `withoutPerceptionChecking` to eliminate checks of reducer access to observable state in `perceptionCheck()`.

Below are the performance improvement results using the the test case mentioned in the discussion linked above.

|Test Case|`.isInPerceptionTracking` true|`.isInWithoutPerceptionChecking` true|`.isInSwiftUIBody` called from Reducer call stack|`.isInSwiftUIBody` called from non-Reducer call stack|Total calls to `perceptionCheck()`|Total Time spent in `perceptionCheck()` (secs)|
|----------|-----|-----------------------|----------------|--------------------|----------|-----|
|No use of `WithPerceptionTracking` in`body` (before fix)|0|0|34|10|44|0.73|
|`WithPerceptionTracking` used in `body` (before fix)|7|0|34|18|59|0.75|
|No use of `WithPerceptionTracking` in`body` (with fix)|0|32|0|10|44|0.1|
|`WithPerceptionTracking` used in `body` (with fix)|7|34|0|18|59|0.15|

As can be seen, this change results in a significant improvement of app performance when using perception tracking in iOS 16 by eliminating the expensive backtrace analysis when observable state is accessed from a reducer. Reducing about 0.6 seconds of backtrace computation per keystroke of text field input in this example.

There is still room for improvement, including possible memoization of the stack back traces, but this is hopefully a step in the right direction and provides a tool that could possibly be used elsewhere.

A final note, it may be possible to combine `PerceptionLocals.isInWithoutPerceptionChecking` with `PerceptionLocals.InPerceptionTracking` as they mostly serve the same purpose. However, I did notice there is a use of `PerceptionLocals.InPerceptionTracking` in some binding code, and don't know the full context so keep them separate for now.
