### PR TITLE
Add async throwing closure initializer for Result

### DIFF
--- a/Sources/ComposableArchitecture/Effects/TaskResult.swift
+++ b/Sources/ComposableArchitecture/Effects/TaskResult.swift
@@ -332,3 +332,20 @@ extension TaskResult {
     try self.value
   }
 }
+
+public extension Result where Failure == any Error {
+  /// Creates a new task result by evaluating an async throwing closure, capturing the returned
+  /// value as a success, or any thrown error as a failure.
+  ///
+  /// This initializer is most often used in an async effect being returned from a reducer.
+  ///
+  /// - Parameter body: An async, throwing closure.
+  @inlinable
+  init(catching body: @Sendable () async throws -> Success) async {
+    do {
+      self = try .success(await body())
+    } catch {
+      self = .failure(error)
+    }
+  }
+}


### PR DESCRIPTION
The CasePathable macro eliminates the need to make the Action conform to Equatable, and the TaskResult is now deprecated.
However, the current TCA does not provide a complete replacement for TaskResult, and an extension to the Result must be created in each individual project.
I believe that this initializer should be added to TCA since it is most often used in an async effect being returned from a reducer.