### PR TITLE
Use `ScopeID` for all cached child stores

### DIFF
--- a/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
@@ -51,10 +51,7 @@ public struct _StoreCollection<ID: Hashable, State, Action>: RandomAccessCollect
     let id = self.ids[position]
     return self.store.scope(
       state: { $0[id: id]! },
-      id: ScopeID(
-        state: \IdentifiedArray<ID, State>.[id: id],
-        action: \IdentifiedAction<ID, Action>.Cases[id: id]
-      ),
+      id: store.id(state: \.[id: id]!, action: \.[id: id]),
       action: { .element(id: id, action: $0) },
       isInvalid: { !$0.ids.contains(id) },
       removeDuplicates: nil

--- a/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
@@ -106,19 +106,12 @@ public struct _NavigationDestinationViewModifier<
     content
       .environment(\.navigationDestinationType, State.self)
       .navigationDestination(for: StackState<State>.Component.self) { component in
-        var state = component.element
         WithPerceptionTracking {
           self
             .destination(
               self.store.scope(
-                state: {
-                  state = $0[id: component.id] ?? state
-                  return state
-                },
-                id: ScopeID(
-                  state: \StackState<State>.[id: component.id],
-                  action: \StackAction<State, Action>.Cases[id: component.id]
-                ),
+                state: { $0[id: component.id]! },
+                id: store.id(state: \.[id: component.id]!, action: \.[id: component.id]),
                 action: { .element(id: component.id, action: $0) },
                 isInvalid: { !$0.ids.contains(component.id) },
                 removeDuplicates: nil

--- a/Sources/ComposableArchitecture/Observation/Store+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Store+Observation.swift
@@ -82,14 +82,11 @@ extension Store where State: ObservableState {
         )
       }
     #endif
-    guard var childState = self.observableState[keyPath: state]
+    guard self.observableState[keyPath: state] != nil
     else { return nil }
     return self.scope(
-      state: {
-        childState = $0[keyPath: state] ?? childState
-        return childState
-      },
-      id: ScopeID(state: state, action: action),
+      state: { $0[keyPath: state]! },
+      id: self.id(state: state.appending(path: \.!), action: action),
       action: { action($0) },
       isInvalid: { $0[keyPath: state] == nil },
       removeDuplicates: nil

--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -133,18 +133,11 @@ public struct ForEachStore<
       removeDuplicates: { areOrderedSetsDuplicates($0.ids, $1.ids) }
     ) { viewStore in
       ForEach(viewStore.state, id: viewStore.state.id) { element in
-        var element = element
         let id = element[keyPath: viewStore.state.id]
         content(
           store.scope(
-            state: {
-              element = $0[id: id] ?? element
-              return element
-            },
-            id: ScopeID(
-              state: \IdentifiedArray<ID, EachState>.[id: id],
-              action: \IdentifiedAction<ID, EachAction>.Cases[id: id]
-            ),
+            state: { $0[id: id]! },
+            id: store.id(state: \.[id: id]!, action: \.[id: id]),
             action: { .element(id: id, action: $0) },
             isInvalid: { !$0.ids.contains(id) },
             removeDuplicates: nil
@@ -204,7 +197,7 @@ public struct ForEachStore<
               element = $0[id: id] ?? element
               return element
             },
-            id: id,
+            id: nil,
             action: { (id, $0) },
             isInvalid: { !$0.ids.contains(id) },
             removeDuplicates: nil

--- a/Sources/ComposableArchitecture/SwiftUI/NavigationStackStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/NavigationStackStore.swift
@@ -49,18 +49,11 @@ public struct NavigationStackStore<State, Action, Root: View, Destination: View>
   ) {
     self.root = root()
     self.destination = { component in
-      var state = component.element
-      return destination(
+      destination(
         store
           .scope(
-            state: {
-              state = $0[id: component.id] ?? state
-              return state
-            },
-            id: ScopeID(
-              state: \StackState<State>.[id: component.id],
-              action: \StackAction<State, Action>.Cases.[id: component.id]
-            ),
+            state: { $0[id: component.id]! },
+            id: store.id(state: \.[id: component.id]!, action: \.[id: component.id]),
             action: { .element(id: component.id, action: $0) },
             isInvalid: { !$0.ids.contains(component.id) },
             removeDuplicates: nil
@@ -92,18 +85,11 @@ public struct NavigationStackStore<State, Action, Root: View, Destination: View>
   ) where Destination == SwitchStore<State, Action, D> {
     self.root = root()
     self.destination = { component in
-      var state = component.element
-      return SwitchStore(
+      SwitchStore(
         store
           .scope(
-            state: {
-              state = $0[id: component.id] ?? state
-              return state
-            },
-            id: ScopeID(
-              state: \StackState<State>.[id: component.id],
-              action: \StackAction<State, Action>.Cases.[id: component.id]
-            ),
+            state: { $0[id: component.id]! },
+            id: store.id(state: \.[id: component.id]!, action: \.[id: component.id]),
             action: { .element(id: component.id, action: $0) },
             isInvalid: { !$0.ids.contains(component.id) },
             removeDuplicates: nil


### PR DESCRIPTION
This PR forces child stores to be cached more strictly with actual scope ids.