### PR TITLE
Add new view modifiers for observing alerts/dialogs

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -122,10 +122,8 @@ struct AlertAndConfirmationDialogView: View {
       Button("Confirmation Dialog") { store.send(.confirmationDialogButtonTapped) }
     }
     .navigationTitle("Alerts & Dialogs")
-    .alert(store: store.scope(state: \.$alert, action: \.alert))
-    .confirmationDialog(
-      store: store.scope(state: \.$confirmationDialog, action: \.confirmationDialog)
-    )
+    .alert($store.scope(state: \.alert, action: \.alert))
+    .confirmationDialog($store.scope(state: \.confirmationDialog, action: \.confirmationDialog))
   }
 }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -146,7 +146,7 @@ struct AnimationsView: View {
       Button("Reset") { store.send(.resetButtonTapped) }
         .padding([.horizontal, .bottom])
     }
-    .alert(store: store.scope(state: \.$alert, action: \.alert))
+    .alert($store.scope(state: \.alert, action: \.alert))
     .navigationBarTitleDisplayMode(.inline)
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
@@ -207,7 +207,7 @@ struct SharedStateView: View {
 }
 
 struct SharedStateCounterView: View {
-  let store: StoreOf<SharedState.Counter>
+  @Bindable var store: StoreOf<SharedState.Counter>
 
   var body: some View {
     VStack(spacing: 64) {
@@ -236,7 +236,7 @@ struct SharedStateCounterView: View {
     }
     .padding(.top)
     .navigationTitle("Shared State Demo")
-    .alert(store: store.scope(state: \.$alert, action: \.alert))
+    .alert($store.scope(state: \.alert, action: \.alert))
   }
 }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -198,7 +198,7 @@ struct WebSocketView: View {
         Text("Received messages")
       }
     }
-    .alert(store: store.scope(state: \.$alert, action: \.alert))
+    .alert($store.scope(state: \.alert, action: \.alert))
     .navigationTitle("Web Socket")
   }
 }

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
@@ -110,7 +110,7 @@ struct SpeechRecognition {
 }
 
 struct SpeechRecognitionView: View {
-  let store: StoreOf<SpeechRecognition>
+  @Bindable var store: StoreOf<SpeechRecognition>
 
   var body: some View {
     VStack {
@@ -148,7 +148,7 @@ struct SpeechRecognitionView: View {
       }
     }
     .padding()
-    .alert(store: store.scope(state: \.$alert, action: \.alert))
+    .alert($store.scope(state: \.alert, action: \.alert))
   }
 }
 

--- a/Examples/SyncUps/SyncUps/RecordMeeting.swift
+++ b/Examples/SyncUps/SyncUps/RecordMeeting.swift
@@ -200,7 +200,7 @@ struct RecordMeetingView: View {
       }
     }
     .navigationBarBackButtonHidden(true)
-    .alert(store: store.scope(state: \.$alert, action: \.alert))
+    .alert($store.scope(state: \.alert, action: \.alert))
     .task { await store.send(.onTask).finish() }
   }
 }

--- a/Examples/SyncUps/SyncUps/SyncUpDetail.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpDetail.swift
@@ -217,7 +217,7 @@ struct SyncUpDetailView: View {
         store.send(.editButtonTapped)
       }
     }
-    .alert(store: store.scope(state: \.$destination.alert, action: \.destination.alert))
+    .alert($store.scope(state: \.destination?.alert, action: \.destination.alert))
     .sheet(item: $store.scope(state: \.destination?.edit, action: \.destination.edit)) { store in
       NavigationStack {
         SyncUpFormView(store: store)

--- a/Examples/SyncUps/SyncUps/SyncUpsList.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpsList.swift
@@ -125,7 +125,7 @@ struct SyncUpsListView: View {
       }
     }
     .navigationTitle("Daily Sync-ups")
-    .alert(store: store.scope(state: \.$destination.alert, action: \.destination.alert))
+    .alert($store.scope(state: \.destination?.alert, action: \.destination.alert))
     .sheet(item: $store.scope(state: \.destination?.add, action: \.destination.add)) { store in
       NavigationStack {
         SyncUpFormView(store: store)

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -53,7 +53,7 @@ public struct LoginView: View {
       .disabled(store.isLoginButtonDisabled)
     }
     .disabled(store.isFormDisabled)
-    .alert(store: store.scope(state: \.$alert, action: \.alert))
+    .alert($store.scope(state: \.alert, action: \.alert))
     .navigationDestination(item: $store.scope(state: \.twoFactor, action: \.twoFactor)) { store in
       TwoFactorView(store: store)
     }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
@@ -39,7 +39,7 @@ public struct TwoFactorView: View {
         }
       }
     }
-    .alert(store: store.scope(state: \.$alert, action: \.alert))
+    .alert($store.scope(state: \.alert, action: \.alert))
     .disabled(store.isFormDisabled)
     .navigationTitle("Confirmation Code")
   }

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -162,7 +162,7 @@ struct VoiceMemosView: View {
         .frame(maxWidth: .infinity)
         .background(Color.init(white: 0.95))
       }
-      .alert(store: store.scope(state: \.$alert, action: \.alert))
+      .alert($store.scope(state: \.alert, action: \.alert))
       .navigationTitle("Voice memos")
     }
   }

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingTo1.6.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingTo1.6.md
@@ -325,7 +325,7 @@ struct Feature {
 }
 ```
 
-Then previously you would drive a sheet presentation from this feature like so:
+Then previously you would drive a sheet presentation from the feature's view like so:
 
 ```swift
 .sheet(store: store.scope(state: \.$child, action: \.child)) { store in
@@ -389,6 +389,42 @@ This can now be changed to this:
 
 Note that the state key path is simply `state: \.destination?.editForm`, and not 
 `state: \.$destination.editForm`.
+
+## Replacing alert(store:) and confirmationDialog(store:)
+
+The ``SwiftUI/View/alert(store:)`` and ``SwiftUI/View/confirmationDialog(store:)`` modifiers have
+been used to drive alerts and dialogs from stores, but new modifiers are now available that can
+drive alerts and dialogs from the same store binding scope operation that can power vanilla SwiftUI
+presentation, like `sheet(item:)`.
+
+For example, if your feature's reducer presents an alert:
+
+```swift
+@Reducer
+struct Feature {
+  @ObservableState
+  struct State {
+    @Presents var alert: AlertState<Action.Alert>?
+  }
+  enum Action {
+    case alert(PresentationAction<Alert>)
+    enum Alert { /* ... */ }
+  }
+  var body: some ReducerOf<Self> { /* ... */ }
+}
+```
+
+Then previously you would drive an alert from the feature's view like so:
+
+```swift
+.alert(store: store.scope(state: \.$alert, action: \.alert))
+```
+
+You can now replace `alert(store:)` with a new modifier, ``SwiftUI/View/alert(_:)``:
+
+```swift
+.alert($store.scope(state: \.alert, action: \.alert))
+```
 
 ## Replacing NavigationStackStore with NavigationStack
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003-previous.swift
@@ -35,6 +35,6 @@ struct ContactsView: View {
         AddContactView(store: addContactStore)
       }
     }
-    .alert(store: store.scope(state: \.$destination.alert, action: \.destination.alert))
+    .alert($store.scope(state: \.destination?.alert, action: \.destination.alert))
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003.swift
@@ -35,6 +35,6 @@ struct ContactsView: View {
         AddContactView(store: addContactStore)
       }
     }
-    .alert(store: store.scope(state: \.$destination.alert, action: \.destination.alert))
+    .alert($store.scope(state: \.destination?.alert, action: \.destination.alert))
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0004.swift
@@ -37,6 +37,6 @@ struct ContactsView: View {
         AddContactView(store: addContactStore)
       }
     }
-    .alert(store: store.scope(state: \.$destination.alert, action: \.destination.alert))
+    .alert($store.scope(state: \.destination?.alert, action: \.destination.alert))
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0005-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0005-previous.swift
@@ -37,6 +37,6 @@ struct ContactsView: View {
         AddContactView(store: addContactStore)
       }
     }
-    .alert(store: store.scope(state: \.$destination.alert, action: \.destination.alert))
+    .alert($store.scope(state: \.destination?.alert, action: \.destination.alert))
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0005.swift
@@ -40,6 +40,6 @@ struct ContactsView: View {
         AddContactView(store: addContactStore)
       }
     }
-    .alert(store: store.scope(state: \.$destination.alert, action: \.destination.alert))
+    .alert($store.scope(state: \.destination?.alert, action: \.destination.alert))
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-03-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-03-code-0003.swift
@@ -10,7 +10,7 @@ struct ContactDetailView: View {
       }
     }
     .navigationBarTitle(Text(store.contact.name))
-    .alert(store: store.scope(state: \.$alert, action: \.alert))
+    .alert($store.scope(state: \.alert, action: \.alert))
   }
 }
 

--- a/Sources/ComposableArchitecture/Observation/Alert+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Alert+Observation.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+@available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+extension View {
+  public func alert<Action>(_ item: Binding<Store<AlertState<Action>, Action>?>) -> some View{
+    let store = item.wrappedValue
+    let alertState = store?.withState { $0 }
+    return self.alert(
+      (alertState?.title).map(Text.init) ?? Text(verbatim: ""),
+      isPresented: item.isPresent(),
+      presenting: alertState,
+      actions: { alertState in
+        ForEach(alertState.buttons) { button in
+          Button(role: button.role.map(ButtonRole.init)) {
+            switch button.action.type {
+            case let .send(action):
+              if let action = action {
+                store?.send(action)
+              }
+            case let .animatedSend(action, animation):
+              if let action = action {
+                store?.send(action, animation: animation)
+              }
+            }
+          } label: {
+            Text(button.label)
+          }
+        }
+      },
+      message: {
+        $0.message.map(Text.init)
+      }
+    )
+  }
+}
+
+@available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+extension View {
+  public func confirmationDialog<Action>(
+    _ item: Binding<Store<ConfirmationDialogState<Action>, Action>?>
+  ) -> some View {
+    let store = item.wrappedValue
+    let confirmationDialogState = store?.withState { $0 }
+    return self.confirmationDialog(
+      (confirmationDialogState?.title).map(Text.init) ?? Text(verbatim: ""),
+      isPresented: item.isPresent(),
+      titleVisibility: (confirmationDialogState?.titleVisibility).map(Visibility.init)
+      ?? .automatic,
+      presenting: confirmationDialogState,
+      actions: { confirmationDialogState in
+        ForEach(confirmationDialogState.buttons) { button in
+          Button(role: button.role.map(ButtonRole.init)) {
+            switch button.action.type {
+            case let .send(action):
+              if let action = action {
+                store?.send(action)
+              }
+            case let .animatedSend(action, animation):
+              if let action = action {
+                store?.send(action, animation: animation)
+              }
+            }
+          } label: {
+            Text(button.label)
+          }
+        }
+      },
+      message: {
+        $0.message.map(Text.init)
+      }
+    )
+  }
+}


### PR DESCRIPTION
Instead of:

```swift
.alert(store: store.scope(state: \.$alert, action: \.alert))
```

You can now do:

```swift
.alert($store.scope(state: \.alert, action: \.alert))
```

This new modifier is powered by the same store binding scope operation that can power `sheet(item:)`, etc., and is much lighter weight than the previous view modifier, which spun up view stores and `WithViewStore` views.