### PR TITLE
Implement memoization for perception checks

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -81,6 +81,7 @@ let package = Package(
       name: "Perception",
       dependencies: [
         "PerceptionMacros",
+        .product(name: "OrderedCollections", package: "swift-collections"),
         .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ]
     ),

--- a/Sources/Perception/Internal/Locking.swift
+++ b/Sources/Perception/Internal/Locking.swift
@@ -49,3 +49,12 @@ extension _ManagedCriticalState: Identifiable {
     ObjectIdentifier(buffer)
   }
 }
+
+extension NSLock {
+  @inlinable @discardableResult
+  @_spi(Internals) public func sync<R>(work: () -> R) -> R {
+    self.lock()
+    defer { self.unlock() }
+    return work()
+  }
+}

--- a/Sources/Perception/Internal/Memoization.swift
+++ b/Sources/Perception/Internal/Memoization.swift
@@ -50,14 +50,12 @@ final class MemoizedCache<Key: Hashable, Value>: @unchecked Sendable {
 
 func memoize<Input: Hashable, Result>(
   maxCapacity: Int = 500,
-  _ apply: @escaping (_ key: Input) -> Result
+  _ apply: @escaping (Input) -> Result
 ) -> (Input) -> Result {
   let cache = MemoizedCache<Input, Result>(maxCapacity: maxCapacity)
   
   return { input in
-    //    defer {
-    //       cache.printStats()
-    //    }
+//    defer { cache.printStats() }
     if let memoizedResult = cache[input] {
       return memoizedResult
     }

--- a/Sources/Perception/Internal/Memoization.swift
+++ b/Sources/Perception/Internal/Memoization.swift
@@ -1,0 +1,70 @@
+import Foundation
+import OrderedCollections
+
+final class MemoizedCache<Key: Hashable, Value>: @unchecked Sendable {
+  private var dictionary = OrderedDictionary<Key, Value>()
+  private var lock = NSLock()
+  private let maxCapacity: Int
+  
+  // TODO possibly remove these stats later
+  private var totalEvictions = 0
+  private var totalCalls = 0
+  private var totalHits = 0
+  
+  init(maxCapacity: Int = 500) {
+    self.maxCapacity = maxCapacity
+  }
+  
+  func printStats() {
+    lock.sync {
+      let hitRate = (Float(totalHits) / Float(totalCalls)) * 100
+      let evictionRate = (Float(totalEvictions) / Float(totalCalls)) * 100
+      print("size = \(dictionary.count), totalCalls = \(totalCalls), hitRate = \(hitRate)%, evictionRate = \(evictionRate)%")
+    }
+  }
+  
+  subscript(key: Key) -> Value? {
+    get {
+      lock.sync {
+        totalCalls += 1
+        if let value = dictionary[key] {
+          totalHits += 1
+          return value
+        }
+        return nil
+      }
+    }
+    set {
+      lock.sync {
+        dictionary[key] = newValue
+        if dictionary.count > maxCapacity {
+          // evict first (oldest) element
+          dictionary.removeFirst()
+          totalEvictions += 1
+        }
+      }
+    }
+  }
+  
+}
+
+func memoize<Input: Hashable, Result>(
+  maxCapacity: Int = 500,
+  _ apply: @escaping (_ key: Input) -> Result
+) -> (Input) -> Result {
+  let cache = MemoizedCache<Input, Result>(maxCapacity: maxCapacity)
+  
+  return { input in
+    //    defer {
+    //       cache.printStats()
+    //    }
+    if let memoizedResult = cache[input] {
+      return memoizedResult
+    }
+    
+    let result = apply(input)
+    cache[input] = result
+    return result
+  }
+  
+}

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -209,11 +209,9 @@ extension PerceptionRegistrar: Hashable {
     determineIfInSwiftUIBodyMemoized(Thread.callStackReturnAddresses)
   }
 
-  let determineIfInSwiftUIBodyMemoized = memoize(
-    { (_ : [NSNumber]) in
+  let determineIfInSwiftUIBodyMemoized = memoize({ (_ : [NSNumber]) in
       determineIfInSwiftUIBody
-    }
-  )
+  })
 
   var determineIfInSwiftUIBody: Bool {
     for callStackSymbol in Thread.callStackSymbols {

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -206,6 +206,16 @@ extension PerceptionRegistrar: Hashable {
   }
 
   var isInSwiftUIBody: Bool {
+    determineIfInSwiftUIBodyMemoized(Thread.callStackReturnAddresses)
+  }
+
+  let determineIfInSwiftUIBodyMemoized = memoize(
+    { (_ : [NSNumber]) in
+      determineIfInSwiftUIBody
+    }
+  )
+
+  var determineIfInSwiftUIBody: Bool {
     for callStackSymbol in Thread.callStackSymbols {
       let mangledSymbol = callStackSymbol.utf8
         .drop(while: { $0 != .init(ascii: "$") })


### PR DESCRIPTION
This PR adds memoization to the calculation of `isInSwiftUIBody` during perception checks as originally discussed [here](https://github.com/pointfreeco/swift-composable-architecture/discussions/2620#discussioncomment-7768616).

This substantially increases performance while exercising an app in a simulator running iOS 16 (or older). In my standard test case of text input in a back-ported SyncUps app, typing a single character now only takes 0.0005 secs when the memoization cache has been pre-warmed.  It was previously taking approximately 0.15 secs after the fixes in #2622.

The memoization cache is built on top of an `OrderedDictionary` and caps the capacity to a fixed number of entries. As new entries are added, the oldest entry is evicted. In my experiments with SyncUps, fully exercising the app results in about 500 unique stack backtraces across the various views. When the cache is fully primed, the app performance on iOS 16 is indistinguishable from iOS 17 from a user interaction perspective.

Based on my experiments with SyncUps I have set the default cache max size to 500, which seems to be large enough to hold the working set of a moderately complex app under development/test. A typical stack backtrace has about 80-90 frames (for math purposes, we will round up to 100).  So the rough memory cost of this cache is ~400k (500 entries * 100 frames per entry * 8 bytes per frame). This seems like a reasonable tradeoff for most apps under development/test.

Note, I have left some instrumentation code in the memoization cache. It should probably be removed at some point, but it was useful in testing this feature so I left it there for now.