### PR TITLE
Fix archiving problem since 1.4.0

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
@@ -70,6 +70,8 @@ where State == ViewAction.State {
 
   @inlinable
   public func reduce(into state: inout State, action: Action) -> Effect<Action> {
+    // NB: Using a closure and not a `\.binding` key path literal to avoid a bug with archives:
+    //     https://github.com/pointfreeco/swift-composable-architecture/pull/2641
     guard let bindingAction = self.toViewAction(action).flatMap({ $0.binding })
     else { return .none }
 

--- a/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
@@ -70,7 +70,7 @@ where State == ViewAction.State {
 
   @inlinable
   public func reduce(into state: inout State, action: Action) -> Effect<Action> {
-    guard let bindingAction = self.toViewAction(action).flatMap(\.binding)
+    guard let bindingAction = self.toViewAction(action).flatMap({ $0.binding })
     else { return .none }
 
     bindingAction.set(&state)


### PR DESCRIPTION
After discussion with Jon Shier (@jshier) on the Slack, he suggested making this change.
It appears to fix the key path getter error that was appearing when trying to archive a project using the `BindingReducer`.
 I've tested a project which compiled but failed to archive on TCA 1.4 onwards, when macros were introduced, and this change allows it to compile and archive successfully.

For context, the Slack discussion is here: https://pointfreecommunity.slack.com/archives/C04KQQ7NXHV/p1702313629767679

This fix is entirely thanks to @jshier's suggestions! I take no credit for this!