### PR TITLE
Fix tutorial diffs

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-YourFirstPresentation.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-YourFirstPresentation.tutorial
@@ -25,21 +25,21 @@
         > Note: We conform `State` and `Action` to the `Equatable` protocol in order to test this 
         > feature later.
 
-        @Code(name: "ContactsFeature.swift", file: "02-01-01-code-0000")
+        @Code(name: "ContactsFeature.swift", file: 02-01-01-code-0000.swift)
       }
       
       @Step {
         Add a view that holds onto a ``ComposableArchitecture/Store`` of the `ContactsFeature`
         and observes the store in order to show a list of contacts and send actions.
         
-        @Code(name: "ContactsFeature.swift", file: "02-01-01-code-0001", reset: true)
+        @Code(name: "ContactsFeature.swift", file: 02-01-01-code-0001.swift, reset: true)
       }
       
       @Step {
         Add a preview with a few stubbed contacts already in the state so that we can see what
         the feature looks like.
         
-        @Code(name: "ContactsFeature.swift", file: "02-01-01-code-0002", reset: true) {
+        @Code(name: "ContactsFeature.swift", file: 02-01-01-code-0002.swift, reset: true) {
           @Image(source: "ch02-sub01-sec01-image-0001")
         }
       }
@@ -50,20 +50,20 @@
         button for dismissing, and a "Save" button that when tapped should dismiss the feature
         _and_ add the contact to the list of contacts in the parent.
         
-        @Code(name: "AddContactFeature.swift", file: "02-01-01-code-0003", reset: true)
+        @Code(name: "AddContactFeature.swift", file: 02-01-01-code-0003.swift, reset: true)
       }
       
       @Step {
         Add a view that holds onto a ``ComposableArchitecture/Store`` of the `AddContactFeature`
         and observes the state in order to show a text field for the contact name and send actions. 
         
-        @Code(name: "AddContactFeature.swift", file: "02-01-01-code-0004", reset: true)
+        @Code(name: "AddContactFeature.swift", file: 02-01-01-code-0004.swift, reset: true)
       }
       
       @Step {
         Add a preview so that we can see what the feature looks like. 
         
-        @Code(name: "AddContactFeature.swift", file: "02-01-01-code-0005", reset: true) {
+        @Code(name: "AddContactFeature.swift", file: 02-01-01-code-0005.swift, reset: true) {
           @Image(source: "ch02-sub01-sec01-image-0002")
         }
       }
@@ -87,7 +87,7 @@
         few steps. Go back to the ContactsFeature.swift file where we built the `ContactsFeature`
         reducer for handling the logic and behavior of the list of contacts.
         
-        @Code(name: "ContactsFeature.swift", file: "02-01-02-code-0000")
+        @Code(name: "ContactsFeature.swift", file: 02-01-02-code-0000.swift)
       }
        
       @Step {
@@ -98,7 +98,7 @@
         A `nil` value represents that the "Add Contacts" feature is not presented, and a non-`nil`
         value represents that it is presented.
         
-        @Code(name: "ContactsFeature.swift", file: "02-01-02-code-0001")
+        @Code(name: "ContactsFeature.swift", file: 02-01-02-code-0001.swift)
       }
        
       @Step {
@@ -107,7 +107,7 @@
         
         This allows the parent to observe every action sent from the child feature.
         
-        @Code(name: "ContactsFeature.swift", file: "02-01-02-code-0002")
+        @Code(name: "ContactsFeature.swift", file: 02-01-02-code-0002.swift)
       }
        
       @Step {
@@ -115,7 +115,7 @@
         reducer. For now we will do nothing for this case and return `.none`, but soon we will do
         more here.
         
-        @Code(name: "ContactsFeature.swift", file: "02-01-02-code-0003")
+        @Code(name: "ContactsFeature.swift", file: 02-01-02-code-0003.swift)
       }
        
       @Step {
@@ -128,7 +128,7 @@
         automatically handles effect cancellation when the child feature is dismissed, and a lot
         more. See the documentation for more information.
         
-        @Code(name: "ContactsFeature.swift", file: "02-01-02-code-0004")
+        @Code(name: "ContactsFeature.swift", file: 02-01-02-code-0004.swift)
       }
       
       That is all it takes to integrate the two features' domains together. Before moving onto the
@@ -140,7 +140,7 @@
         When the "+" button is tapped in the contacts list feature we can now populate the 
         `addContact` state to represent that the feature should be presented.
         
-        @Code(name: "ContactsFeature.swift", file: "02-01-02-code-0005")
+        @Code(name: "ContactsFeature.swift", file: 02-01-02-code-0005.swift)
       }
       
       @Step {
@@ -152,7 +152,7 @@
         > ``ComposableArchitecture/PresentationAction/presented(_:)`` case in order to listen for 
         > actions inside the "Add Contact" feature.
         
-        @Code(name: "ContactsFeature.swift", file: "02-01-02-code-0006")
+        @Code(name: "ContactsFeature.swift", file: 02-01-02-code-0006.swift)
       }
       
       @Step {
@@ -160,7 +160,7 @@
         dismiss the feature, but we also want to add the new contact to the collection of contacts
         held in `ContactsFeature.State`.
         
-        @Code(name: "ContactsFeature.swift", file: "02-01-02-code-0007")
+        @Code(name: "ContactsFeature.swift", file: 02-01-02-code-0007.swift)
       }
       
       That is all it takes to implement communication between parent and child features. The parent
@@ -182,7 +182,7 @@
         and we have a navigation title and toolbar. We need to figure out how to present a sheet
         in this view whenever the `addContact` state flips to non-`nil`.
         
-        @Code(name: "ContactsFeature.swift", file: "02-01-02-code-0008", reset: true)        
+        @Code(name: "ContactsFeature.swift", file: 02-01-02-code-0008.swift, reset: true)        
       }
       
       The library comes with a variety of tools that mimic SwiftUI's native navigation tools (such
@@ -195,7 +195,7 @@
         store will be derived focused only on the `AddContactFeature` domain, which is what you can
         pass to the `AddContactView`.
         
-        @Code(name: "ContactsFeature.swift", file: "02-01-02-code-0009")        
+        @Code(name: "ContactsFeature.swift", file: 02-01-02-code-0009.swift)        
       }
       
       @Step {
@@ -225,14 +225,14 @@
         `AddContactFeature`. This enum will describe all the actions that the parent can listen for
         and interpret. It allows the child feature to directly tell the parent what it wants done.
         
-        @Code(name: "AddContactFeature.swift", file: 02-01-04-code-0000, previousFile: 02-01-04-code-0000-previous)
+        @Code(name: "AddContactFeature.swift", file: 02-01-04-code-0000.swift, previousFile: 02-01-04-code-0000-previous.swift)
       }
       
       @Step {
         Handle the new case in the reducer, but we should never actually perform any logic in this
         case. Only the parent should listen for `delegate` actions and respond accordingly.
         
-        @Code(name: "AddContactFeature.swift", file: 02-01-04-code-0001)
+        @Code(name: "AddContactFeature.swift", file: 02-01-04-code-0001.swift)
       }
       
       @Step {
@@ -240,14 +240,14 @@
         immediately and synchronously sends a delegate action. For example, when the "Save" button
         is tapped, we will send the `saveContact` action.
         
-        @Code(name: "AddContactFeature.swift", file: 02-01-04-code-0002)
+        @Code(name: "AddContactFeature.swift", file: 02-01-04-code-0002.swift)
       }
       
       @Step {
         Go back to ContactsFeature.swift and update the reducer to listen for delegate actions to
         figure out when it is time to dismiss or save the contact.
         
-        @Code(name: "ContactsFeature.swift", file: 02-01-04-code-0003, previousFile: 02-01-04-code-0003-previous)
+        @Code(name: "ContactsFeature.swift", file: 02-01-04-code-0003.swift, previousFile: 02-01-04-code-0003-previous.swift)
       }
       
       The application should work exactly as it did before the "delegate action" refactor, but now
@@ -262,7 +262,7 @@
         ``ComposableArchitecture/DismissEffect``. This is a value that allows child features to
         dismiss themselves without any direct contact with the parent feature.
         
-        @Code(name: "AddContactFeature.swift", file: 02-01-04-code-0004, previousFile: 02-01-04-code-0004-previous)
+        @Code(name: "AddContactFeature.swift", file: 02-01-04-code-0004.swift, previousFile: 02-01-04-code-0004-previous.swift)
       }
       
       @Step {
@@ -273,7 +273,7 @@
         > Note: The `dismiss` dependency is asynchronous which means it is only appropriate to 
         > invoke from an effect.
         
-        @Code(name: "AddContactFeature.swift", file: 02-01-04-code-0005)
+        @Code(name: "AddContactFeature.swift", file: 02-01-04-code-0005.swift)
       }
       
       @Step {
@@ -281,7 +281,7 @@
         not need to explicitly communicate to the parent that it should dismiss the child. That is
         all handled by the ``ComposableArchitecture/DismissEffect``.
         
-        @Code(name: "AddContactFeature.swift", file: 02-01-04-code-0006)
+        @Code(name: "AddContactFeature.swift", file: 02-01-04-code-0006.swift)
       }
       
       @Step {
@@ -289,7 +289,7 @@
         `ContactsFeature` reducer and it is no longer necessary to explicitly `nil` out the
         `addContact` state. That is already taken care of.
         
-        @Code(name: "ContactsFeature.swift", file: 02-01-04-code-0007, previousFile: 02-01-04-code-0007-previous)
+        @Code(name: "ContactsFeature.swift", file: 02-01-04-code-0007.swift, previousFile: 02-01-04-code-0007-previous.swift)
       }
     }
   }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-MultipleDestinations.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-MultipleDestinations.tutorial
@@ -19,7 +19,7 @@
         Go back to ContactsFeature.swift that we worked in from the last section. Add a new action
         that will be sent when the delete button is tapped on a row in the contacts list.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-01-code-0000, previousFile: 02-02-01-code-0000-previous)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-01-code-0000.swift, previousFile: 02-02-01-code-0000-previous.swift)
       }
       
       When the delete button is tapped we want to show an alert asking the user to confirm deletion
@@ -30,7 +30,7 @@
         `ContactsFeature` state. We will further use `AlertState` as it allows us to describe all
         of the details of the alert in a manner that is test friendly since it is `Equatable`.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-01-code-0001)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-01-code-0001.swift)
       }
       
       @Step {
@@ -40,7 +40,7 @@
         > Note: The only choices in the alert are to cancel or confirm deletion, but we do not need 
         to model the cancel action. That will be handled automatically for us.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-01-code-0002)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-01-code-0002.swift)
       }
       
       Now that we have new state modeled in our domain for the presentation of the alert, we can
@@ -50,21 +50,21 @@
         When the delete button is tapped we can populate the `alert` state in order to ask the user
         to confirm deletion of the contact.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-01-code-0003)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-01-code-0003.swift)
       }
       
       @Step {
         Integrate the alert's logic into the `ContactsFeature` by making another use of the 
         ``ComposableArchitecture/Reducer/ifLet(_:action:destination:fileID:line:)-4f2at`` operator.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-01-code-0004)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-01-code-0004.swift)
       }
       
       @Step {
         Listen for when the confirmation action is sent in the alert, and at that time we can
         actually remove the element from the array.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-01-code-0005)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-01-code-0005.swift)
       }
       
       That's all it takes to integrate the alert it the `ContactsFeature` and implement all of its 
@@ -77,14 +77,14 @@
         Add the `alert(store:)` view modifier to the `ContactsView`, and hand it a store that is
         scoped to the alert domain.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-01-code-0006, previousFile: 02-02-01-code-0006-previous)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-01-code-0006.swift, previousFile: 02-02-01-code-0006-previous.swift)
       }
       
       @Step {
         Add a button to each row of the contacts list in order to send the `deleteButtonTapped`
         action to the view store.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-01-code-0007)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-01-code-0007.swift)
       }
       
       @Step {
@@ -121,14 +121,14 @@
         reducer will hold the domain and logic for every feature that can be navigated to from
         the contacts feature.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0000)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0000.swift)
       }
       
       @Step {
         Implement the `State` requirement as an enum because we want to express the fact that only
         one single destination can be active at a time, and enums are perfect for that.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0001)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0001.swift)
       }
       
       @Step {
@@ -136,26 +136,26 @@
         hold onto that feature's state. Right now this includes the `AddContactFeature` and the 
         alert.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0002)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0002.swift)
       }
       
       @Step {
         Implement the `Action` requirement as an enum. 
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0003)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0003.swift)
       }
       
       @Step {
         Add a case to the `Action` enum for each destination feature that can be navigated to, and
         hold onto that feature's action.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0004)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0004.swift)
       }
       
       @Step {
         Implement the ``ComposableArchitecture/Reducer/body-swift.property`` of the reducer.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0005)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0005.swift)
       }
       
       @Step {
@@ -164,21 +164,21 @@
         you will need one ``ComposableArchitecture/Scope`` reducer for each destination except for
         alerts and confirmation dialogs since they do not have a reducer of their own.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0006)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0006.swift)
       }
       
       @Step {
         Replace the two pieces of optional ``ComposableArchitecture/PresentationState`` with a 
         single option pointed at `Destination.State`.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0007, previousFile: 02-02-02-code-0007-previous)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0007.swift, previousFile: 02-02-02-code-0007-previous.swift)
       }
       
       @Step {
         Replace the two action cases that held onto ``ComposableArchitecture/PresentationAction``
         with a single case that holds onto `Destination.Action`.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0008)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0008.swift)
       }
       
       Now our model is more concisely defined, and we have compile time guarantees that only 
@@ -189,7 +189,7 @@
         Instead of populating a piece of `addContact` optional state in order to drive navigation
         to that feature, we will now mutate `destination` to point it to the `addContact` case.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0009)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0009.swift)
       }
       
       @Step {
@@ -197,34 +197,34 @@
         `.destination(.presented(_))` case, such as when the "Add Contact" feature tells us to 
         save the contact.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0010)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0010.swift)
       }
       
       @Step {
         And when the alert confirms deletion of the contact.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0011)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0011.swift)
       }
       
       @Step {
         We can handle all other destination actions by simply returning a `.none` effect to 
         represent there is no other work to perform.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0012)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0012.swift)
       }
       
       @Step {
         Update the state mutation for showing an alert to instead point the `destination` to the
         `alert` case.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0013)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0013.swift)
       }
       
       @Step {
         Replace the two `ifLet`s that were used at the bottom of the reducer with a single one that
         runs the `Destination` reducer whenever the `destination` state is non-`nil`.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0014)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0014.swift)
       }
       
       That's all it takes to convert two independent, imprecisely modeled optional values into a 
@@ -239,13 +239,13 @@
         the ``ComposableArchitecture/Reducer()`` macro applies the `@CasePathable` macro to each
         enum.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0015, previousFile: 02-02-02-code-0015-previous)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0015.swift, previousFile: 02-02-02-code-0015-previous.swift)
       }
 
       @Step {
         The same can be done for the `alert(store:)` view modifier.
         
-        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0016)
+        @Code(name: "ContactsFeatures.swift", file: 02-02-02-code-0016.swift)
       }
 
       That completes the refactor of the reducer and view to use a single piece of optional enum

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-TestingPresentation.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-TestingPresentation.tutorial
@@ -17,7 +17,7 @@
         Add a new file, ContactsFeatureTests.swift, to your test target and paste in some basic
         scaffolding for a test.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0000)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0000.swift)
       }
       
       @Step {
@@ -27,7 +27,7 @@
         > Note: See <doc:01-03-TestingYourFeature> for a tutorial on testing, as well as the article
         <doc:Testing> for more detailed information.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0001)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0001.swift)
       }
       
       @Step {
@@ -35,27 +35,27 @@
         trailing closure provided is where we will assert on how state changes after sending
         the action.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0002)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0002.swift)
       }
       
       @Step {
         The only mutation we expect to happen is that the `destination` field becomes populated
         with some data, in particular the `addContact` case of the destination enum.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0003)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0003.swift)
       }
       
       @Step {
         The `addContact` case will hold onto some data, which is `AddContactFeature.State`.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0004)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0004.swift)
       }
       
       @Step {
         To construct that state we need to construct a `Contact` value, and now we run into 
         trouble. What can we provide for the ID?
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0005)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0005.swift)
       }
       
       The `ContactsFeature` currently makes use of an uncontrolled dependency, making it very hard
@@ -66,14 +66,14 @@
       @Step {
         Go back to ContactsFeature.swift, and add a dependency on the UUID generator.
         
-        @Code(name: "ContactsFeature.swift", file: 02-03-01-code-0006, previousFile: 02-03-01-code-0006-previous)
+        @Code(name: "ContactsFeature.swift", file: 02-03-01-code-0006.swift, previousFile: 02-03-01-code-0006-previous.swift)
       }
       
       @Step {
         Use the newly added UUID dependency for creating UUIDs rather than reaching out to the
         global, uncontrollable initializer.
         
-        @Code(name: "ContactsFeature.swift", file: 02-03-01-code-0007)
+        @Code(name: "ContactsFeature.swift", file: 02-03-01-code-0007.swift)
       }
       
       @Step {
@@ -81,7 +81,7 @@
         that it uses a controlled UUID generator. In particular, we will use the "incrementing"
         generator, which generates sequential, increasing IDs starting at 0.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0008, previousFile: 02-03-01-code-0008-previous)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0008.swift, previousFile: 02-03-01-code-0008-previous.swift)
       }
       
       @Step {
@@ -93,7 +93,7 @@
         
         [swift-dependencies]: http://github.com/pointfreeco/swift-dependencies
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0009)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0009.swift)
       }
       
       This test passes! So this proves that when the "+" button is tapped, that a sheet will fly
@@ -103,7 +103,7 @@
         Emulate the user typing into the name text field of the contact. The trailing closure is
         where we can assert on how state changed after sending the action.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0010)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0010.swift)
       }
       
       @Step {
@@ -117,7 +117,7 @@
         > Tip: See ``ComposableArchitecture/PresentationState/subscript(case:)-2sweb`` for 
         > documentation on this subscript.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0011)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0011.swift)
       }
       
       @Step {
@@ -125,21 +125,21 @@
         expect the state to change immediately when sending this action, and so we do not need
         to provide a trailing closure.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0012)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0012.swift)
       }
       
       @Step {
         Emulate the delegate action `saveContact` being received by the test store. This action is
         sent from the `AddContactFeature` when the "Save" button is tapped.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0013)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0013.swift)
       }
       
       @Step {
         Assert that when the `saveContact` delegate action is received that state mutates by adding
         a contact to the array.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0014)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0014.swift)
       }
       
       @Step {
@@ -147,7 +147,7 @@
         ``ComposableArchitecture/PresentationAction/dismiss`` action, which causes the "Add Contact"
         feature to be dismissed.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0015)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0015.swift)
       }
       
       This is a fully passing test, and proves the end-to-end lifecycle of presenting a child
@@ -176,13 +176,13 @@
         Start a new test case to test the same "Add Contact" user flow as above, but this time
         we will do it in the non-exhaustive style.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-02-code-0000)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-02-code-0000.swift)
       }
       
       @Step {
         Set the test store's ``ComposableArchitecture/TestStore/exhaustivity`` to `.off`.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-02-code-0001)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-02-code-0001.swift)
       }
       
       @Step {
@@ -190,20 +190,20 @@
         closure. In non-exhaustive test stores there is no need to assert on state changes if you
         do not want to.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-02-code-0002)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-02-code-0002.swift)
       } 
       
       @Step {
         Emulate the user typing into the name text field of the contact, but again do not assert
         on any state changes in the child feature.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-02-code-0003)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-02-code-0003.swift)
       }
       
       @Step {
         Emulate the user tapping the "Save" button in the child feature.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-02-code-0004)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-02-code-0004.swift)
       }
       
       @Step {
@@ -212,14 +212,14 @@
         on that until all the actions have been received, and so we can do that by using
         ``ComposableArchitecture/TestStore/skipReceivedActions(strict:file:line:)``.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-02-code-0005)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-02-code-0005.swift)
       }
       
       @Step {
         Assert that the final state of the feature has a new contact added to the array and the
         `destination` state is `nil`'d out.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-02-code-0006)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-02-code-0006.swift)
       }
       
       That's all it takes to write a very high level test covering the full user flow of adding
@@ -240,7 +240,7 @@
       @Step {
         Start a new test method to test the delete flow.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-03-code-0000)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-03-code-0000.swift)
       }
       
       @Step {
@@ -248,35 +248,35 @@
         This time we do not need to override any dependencies because we do not expect any to be
         used
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-03-code-0001)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-03-code-0001.swift)
       }
       
       @Step {
         Start the initial state of the feature with some contacts already added to the array. This
         will make it easier to test the deletion behavior.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-03-code-0002)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-03-code-0002.swift)
       }
       
       @Step {
         Emulate the user tapping on the delete button by sending the `deleteButtonTapped` action.
         We will test deleting the second contact, which has an ID of `UUID(1)`.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-03-code-0003)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-03-code-0003.swift)
       }
       
       @Step {
         We expect that the state's `destination` field will be populated with the `alert` case 
         since an alert should appear.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-03-code-0004)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-03-code-0004.swift)
       }
       
       @Step {
         Technically we can simply repeat exactly what we did in the reducer for constructing the
         alert. It's verbose, but it does get the test passing.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-03-code-0005)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-03-code-0005.swift)
       }
       
       However, that is a bit of a pain to repeat all of that work. There is a better way.
@@ -286,14 +286,14 @@
         with its `Action` generic constrained to `ContactsFeature.Action`. Add a static function
         that constructs the alert, which allows us to reuse this logic in multiple places.
         
-        @Code(name: "ContactsFeature.swift", file: 02-03-03-code-0006)
+        @Code(name: "ContactsFeature.swift", file: 02-03-03-code-0006.swift)
       }
       
       @Step {
         Make use of the new `deleteConfirmation` static alert function in the `CounterFeature` 
         reducer, rather than building `AlertState` from scratch.
         
-        @Code(name: "ContactsFeature.swift", file: 02-03-03-code-0007, previousFile: 02-03-03-code-0007-previous)
+        @Code(name: "ContactsFeature.swift", file: 02-03-03-code-0007.swift, previousFile: 02-03-03-code-0007-previous.swift)
       }
       
       @Step {
@@ -303,21 +303,21 @@
         Run the test to see this passes. This proves that when the delete button is tapped, an
         alert is shown to the user.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-03-code-0008, previousFile: 02-03-03-code-0008-previous)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-03-code-0008.swift, previousFile: 02-03-03-code-0008-previous.swift)
       }
       
       @Step {
         Emulate the user confirming to delete contact by sending the `confirmDeletion` action 
         in the alert.
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-03-code-0009)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-03-code-0009.swift)
       }
       
       @Step {
         Assert that the alert was dismissed and that the contact corresponding to the ID of 
         `UUID(1)` was removed. 
         
-        @Code(name: "ContactsFeatureTests.swift", file: 02-03-03-code-0010)
+        @Code(name: "ContactsFeatureTests.swift", file: 02-03-03-code-0010.swift)
       }
       
       That is all it takes to test the deletion flow. Run the test suite to see everything passes,

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-NavigationStacks.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-NavigationStacks.tutorial
@@ -15,7 +15,7 @@
         Create a new file called ContactDetailFeature.swift, import the Composable Architecture, and 
         start a stub of a reducer by using the ``ComposableArchitecture/Reducer()`` macro.
         
-        @Code(name: "ContactDetailFeature.swift", file: 02-04-01-code-0000)
+        @Code(name: "ContactDetailFeature.swift", file: 02-04-01-code-0000.swift)
       }
       
       @Step {
@@ -23,7 +23,7 @@
         ``ComposableArchitecture/Reducer`` protocol. The only state we currently need is the
         contact, and it can be `let` since we do not plan on mutating it from this screen.
         
-        @Code(name: "ContactDetailFeature.swift", file: 02-04-01-code-0001)
+        @Code(name: "ContactDetailFeature.swift", file: 02-04-01-code-0001.swift)
       }
       
       @Step {
@@ -31,7 +31,7 @@
         ``ComposableArchitecture/Reducer`` protocol. There are not currently any actions that can
         be performed in this feature, so we will leave it empty.
         
-        @Code(name: "ContactDetailFeature.swift", file: 02-04-01-code-0002)
+        @Code(name: "ContactDetailFeature.swift", file: 02-04-01-code-0002.swift)
       }
       
       @Step {
@@ -39,13 +39,13 @@
         requirement of ``ComposableArchitecture/Reducer`` protocol. Since there are no actions in 
         this feature there is nothing we can do in the reducer. More will be added to this later.
         
-        @Code(name: "ContactDetailFeature.swift", file: 02-04-01-code-0003)
+        @Code(name: "ContactDetailFeature.swift", file: 02-04-01-code-0003.swift)
       }
       
       @Step {
         Create a stub for a `ContactDetailView`.
         
-        @Code(name: "ContactDetailFeature.swift", file: 02-04-01-code-0004, reset: true)
+        @Code(name: "ContactDetailFeature.swift", file: 02-04-01-code-0004.swift, reset: true)
       }
       
       @Step {
@@ -53,7 +53,7 @@
         `ContactDetailFeature` domain, allowing it to observe the feature's state changes and 
         send actions.
         
-        @Code(name: "ContactDetailFeature.swift", file: 02-04-01-code-0005)
+        @Code(name: "ContactDetailFeature.swift", file: 02-04-01-code-0005.swift)
       }
       
       @Step {
@@ -61,13 +61,13 @@
         ``ComposableArchitecture/WithViewStore``. There is no real information to show in this 
         view now other than the contact's name, but more will be added later.
         
-        @Code(name: "ContactDetailFeature.swift", file: 02-04-01-code-0006)
+        @Code(name: "ContactDetailFeature.swift", file: 02-04-01-code-0006.swift)
       }
       
       @Step {
         Add a preview so that we can see what the view looks like.
         
-        @Code(name: "ContactDetailFeature.swift", file: 02-04-01-code-0007) {
+        @Code(name: "ContactDetailFeature.swift", file: 02-04-01-code-0007.swift) {
           @Image(source: ch02-sub04-sec01-image-0000)
         }
       }
@@ -94,7 +94,7 @@
         Composable Architecture, and makes it easy and ergonomic to integrate stack navigation
         into your applications.
         
-        @Code(name: "ContactsFeature.swift", file: 02-04-02-code-0000, previousFile: 02-04-02-code-0000-previous) 
+        @Code(name: "ContactsFeature.swift", file: 02-04-02-code-0000.swift, previousFile: 02-04-02-code-0000-previous.swift) 
       }
       
       @Step {
@@ -106,7 +106,7 @@
         We will also handle the `.path` case in the reducer and return 
         ``ComposableArchitecture/Effect/none`` for now.
         
-        @Code(name: "ContactsFeature.swift", file: 02-04-02-code-0001) 
+        @Code(name: "ContactsFeature.swift", file: 02-04-02-code-0001.swift) 
       }
       
       @Step {
@@ -117,7 +117,7 @@
         > Tip: Scroll down to the bottom of the code snippet to see the application of the
         > `forEach` operator.
         
-        @Code(name: "ContactsFeature.swift", file: 02-04-02-code-0002) 
+        @Code(name: "ContactsFeature.swift", file: 02-04-02-code-0002.swift) 
       }
       
       @Step {
@@ -127,7 +127,7 @@
         You hand it a store that is scoped down to ``ComposableArchitecture/StackState`` and
         ``ComposableArchitecture/StackAction``, and it handles the rest.
         
-        @Code(name: "ContactsFeature.swift", file: 02-04-02-code-0003, previousFile: 02-04-02-code-0003-previous) 
+        @Code(name: "ContactsFeature.swift", file: 02-04-02-code-0003.swift, previousFile: 02-04-02-code-0003-previous.swift) 
       }
       
       @Step {
@@ -136,7 +136,7 @@
         destinations that can be navigated to. It is handled a store that is focused on the domain
         of just a single element in the stack.
         
-        @Code(name: "ContactsFeature.swift", file: 02-04-02-code-0004) 
+        @Code(name: "ContactsFeature.swift", file: 02-04-02-code-0004.swift) 
       }
       
       @Step {
@@ -147,7 +147,7 @@
         > Warning: It is necessary to use the `init(state)` initializer on `NavigationLink`, 
         > instead of the `init(value:)` that comes with SwiftUI.
         
-        @Code(name: "ContactsFeature.swift", file: 02-04-02-code-0005, previousFile: 02-04-02-code-0005-previous) 
+        @Code(name: "ContactsFeature.swift", file: 02-04-02-code-0005.swift, previousFile: 02-04-02-code-0005-previous.swift) 
       }
       
       @Step {
@@ -172,7 +172,7 @@
         will start by adding some optional ``ComposableArchitecture/PresentationState`` to represent
         show the alert.
         
-        @Code(name: "ContactDetailFeature.swift", file: 02-04-03-code-0000, previousFile: 02-04-03-code-0000-previous) 
+        @Code(name: "ContactDetailFeature.swift", file: 02-04-03-code-0000.swift, previousFile: 02-04-03-code-0000-previous.swift) 
       }
       
       @Step {
@@ -183,7 +183,7 @@
         > Note: The alert and delegate actions do not need an ID like was needed before. You will
         > see why soon.
         
-        @Code(name: "ContactDetailFeature.swift", file: 02-04-03-code-0001) 
+        @Code(name: "ContactDetailFeature.swift", file: 02-04-03-code-0001.swift) 
       }
       
       @Step {
@@ -193,14 +193,14 @@
         dependency, and we have extracted the alert state to its own helper to make it easier to 
         test later.
         
-        @Code(name: "ContactDetailFeature.swift", file: 02-04-03-code-0002) 
+        @Code(name: "ContactDetailFeature.swift", file: 02-04-03-code-0002.swift) 
       }
       
       @Step {
         Go to the `ContactDetailView` struct and add a button for deleting the contact, as well as
         use the `alert(store:)` modifier to show an alert with the `alert` state becomes non-`nil`.
         
-        @Code(name: "ContactDetailFeature.swift", file: 02-04-03-code-0003, previousFile: 02-04-03-code-0003-previous) 
+        @Code(name: "ContactDetailFeature.swift", file: 02-04-03-code-0003.swift, previousFile: 02-04-03-code-0003-previous.swift) 
       }
       
       @Step {
@@ -209,7 +209,7 @@
         `.delegate(.confirmDeletion)` action is sent, and in that case remove the contact from the
         array.
         
-        @Code(name: "ContactsFeature.swift", file: 02-04-03-code-0004, previousFile: 02-04-03-code-0004-previous) 
+        @Code(name: "ContactsFeature.swift", file: 02-04-03-code-0004.swift, previousFile: 02-04-03-code-0004-previous.swift) 
       }
       
       @Step {


### PR DESCRIPTION
While tutorials appear to compile just fine when files are referenced as strings and omitting the file suffix, it mysteriously breaks the diffing between each step. This PR fixes things.