### PR TITLE
Revert "Fix Store leak when async effect is in flight (#2643)"

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -485,10 +485,6 @@ public final class Store<State, Action> {
     for id in self.children.keys {
       self.invalidateChild(id: id)
     }
-    self.effectCancellables.values.forEach { cancellable in
-      cancellable.cancel()
-    }
-    self.effectCancellables.removeAll()
   }
 
   fileprivate func invalidateChild(id: ScopeID<State, Action>) {
@@ -530,7 +526,6 @@ public final class Store<State, Action> {
       defer { index += 1 }
       let action = self.bufferedActions[index]
       let effect = self.reducer.reduce(into: &currentState, action: action)
-      let uuid = UUID()
 
       switch effect.operation {
       case .none:
@@ -538,6 +533,7 @@ public final class Store<State, Action> {
       case let .publisher(publisher):
         var didComplete = false
         let boxedTask = Box<Task<Void, Never>?>(wrappedValue: nil)
+        let uuid = UUID()
         let effectCancellable = withEscapedDependencies { continuation in
           publisher
             .handleEvents(
@@ -575,48 +571,45 @@ public final class Store<State, Action> {
         }
       case let .run(priority, operation):
         withEscapedDependencies { continuation in
-          let task = Task(priority: priority) { @MainActor [weak self] in
-            #if DEBUG
-              let isCompleted = LockIsolated(false)
-              defer { isCompleted.setValue(true) }
-            #endif
-            await operation(
-              Send { effectAction in
-                #if DEBUG
-                  if isCompleted.value {
-                    runtimeWarn(
-                      """
-                      An action was sent from a completed effect:
+          tasks.wrappedValue.append(
+            Task(priority: priority) { @MainActor in
+              #if DEBUG
+                let isCompleted = LockIsolated(false)
+                defer { isCompleted.setValue(true) }
+              #endif
+              await operation(
+                Send { effectAction in
+                  #if DEBUG
+                    if isCompleted.value {
+                      runtimeWarn(
+                        """
+                        An action was sent from a completed effect:
 
-                        Action:
-                          \(debugCaseOutput(effectAction))
+                          Action:
+                            \(debugCaseOutput(effectAction))
 
-                        Effect returned from:
-                          \(debugCaseOutput(action))
+                          Effect returned from:
+                            \(debugCaseOutput(action))
 
-                      Avoid sending actions using the 'send' argument from 'Effect.run' after \
-                      the effect has completed. This can happen if you escape the 'send' \
-                      argument in an unstructured context.
+                        Avoid sending actions using the 'send' argument from 'Effect.run' after \
+                        the effect has completed. This can happen if you escape the 'send' \
+                        argument in an unstructured context.
 
-                      To fix this, make sure that your 'run' closure does not return until \
-                      you're done calling 'send'.
-                      """
-                    )
+                        To fix this, make sure that your 'run' closure does not return until \
+                        you're done calling 'send'.
+                        """
+                      )
+                    }
+                  #endif
+                  if let task = continuation.yield({
+                    self.send(effectAction, originatingFrom: action)
+                  }) {
+                    tasks.wrappedValue.append(task)
                   }
-                #endif
-                if let task = continuation.yield({
-                  self?.send(effectAction, originatingFrom: action)
-                }) {
-                  tasks.wrappedValue.append(task)
                 }
-              }
-            )
-            self?.effectCancellables[uuid] = nil
-          }
-          tasks.wrappedValue.append(task)
-          self.effectCancellables[uuid] = AnyCancellable {
-            task.cancel()
-          }
+              )
+            }
+          )
         }
       }
     }

--- a/Tests/ComposableArchitectureTests/StoreLifetimeTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreLifetimeTests.swift
@@ -64,6 +64,9 @@ final class StoreLifetimeTests: BaseTCATestCase {
     }
 
     func testStoreDeinit_RunningEffect() async {
+      XCTTODO(
+        "We would like for this to pass, but it requires full deprecation of uncached child stores"
+      )
       Logger.shared.isEnabled = true
       let effectFinished = self.expectation(description: "Effect finished")
       do {
@@ -90,6 +93,9 @@ final class StoreLifetimeTests: BaseTCATestCase {
     }
 
     func testStoreDeinit_RunningCombineEffect() async {
+      XCTTODO(
+        "We would like for this to pass, but it requires full deprecation of uncached child stores"
+      )
       Logger.shared.isEnabled = true
       let effectFinished = self.expectation(description: "Effect finished")
       do {


### PR DESCRIPTION
This reverts commit b86012c82d6c75f29edd3b53d76a7f3910473412.

While we would like to adopt this change, it is incompatible with uncached stores, which are still the dominant kind of store these days.

We can revisit this in 2.0, when we have fully removed the old scoping operations and when stores have more defined lifecycles, cached in their parents.