### PR TITLE
Perception caching updates

### DIFF
--- a/Sources/Perception/Internal/Memoization.swift
+++ b/Sources/Perception/Internal/Memoization.swift
@@ -1,43 +1,45 @@
-import Foundation
-import OrderedCollections
+#if DEBUG
+  import Foundation
+  import OrderedCollections
 
-func memoize<Result>(
-  maxCapacity: Int = 500,
-  _ apply: @escaping () -> Result
-) -> () -> Result {
-  let cache = Cache<[NSNumber], Result>(maxCapacity: maxCapacity)
-  return {
-    let callStack = Thread.callStackReturnAddresses
-    guard let memoizedResult = cache[callStack]
-    else {
-      let result = apply()
-      defer { cache[callStack] = result }
-      return result
-    }
-    return memoizedResult
-  }
-}
-
-private final class Cache<Key: Hashable, Value>: @unchecked Sendable {
-  var dictionary = OrderedDictionary<Key, Value>()
-  var lock = NSLock()
-  let maxCapacity: Int
-  init(maxCapacity: Int = 500) {
-    self.maxCapacity = maxCapacity
-  }
-  subscript(key: Key) -> Value? {
-    get {
-      self.lock.sync {
-        self.dictionary[key]
+  func memoize<Result>(
+    maxCapacity: Int = 500,
+    _ apply: @escaping () -> Result
+  ) -> () -> Result {
+    let cache = Cache<[NSNumber], Result>(maxCapacity: maxCapacity)
+    return {
+      let callStack = Thread.callStackReturnAddresses
+      guard let memoizedResult = cache[callStack]
+      else {
+        let result = apply()
+        defer { cache[callStack] = result }
+        return result
       }
+      return memoizedResult
     }
-    set {
-      self.lock.sync {
-        self.dictionary[key] = newValue
-        if self.dictionary.count > self.maxCapacity {
-          self.dictionary.removeFirst()
+  }
+
+  private final class Cache<Key: Hashable, Value>: @unchecked Sendable {
+    var dictionary = OrderedDictionary<Key, Value>()
+    var lock = NSLock()
+    let maxCapacity: Int
+    init(maxCapacity: Int = 500) {
+      self.maxCapacity = maxCapacity
+    }
+    subscript(key: Key) -> Value? {
+      get {
+        self.lock.sync {
+          self.dictionary[key]
+        }
+      }
+      set {
+        self.lock.sync {
+          self.dictionary[key] = newValue
+          if self.dictionary.count > self.maxCapacity {
+            self.dictionary.removeFirst()
+          }
         }
       }
     }
   }
-}
+#endif

--- a/Sources/Perception/Internal/Memoization.swift
+++ b/Sources/Perception/Internal/Memoization.swift
@@ -6,8 +6,8 @@ func memoize<Result>(
   _ apply: @escaping () -> Result
 ) -> () -> Result {
   let cache = Cache<[NSNumber], Result>(maxCapacity: maxCapacity)
-  let callStack = Thread.callStackReturnAddresses
   return {
+    let callStack = Thread.callStackReturnAddresses
     guard let memoizedResult = cache[callStack]
     else {
       let result = apply()
@@ -27,7 +27,7 @@ private final class Cache<Key: Hashable, Value>: @unchecked Sendable {
   }
   subscript(key: Key) -> Value? {
     get {
-      return self.lock.sync {
+      self.lock.sync {
         self.dictionary[key]
       }
     }

--- a/Sources/Perception/Internal/Memoization.swift
+++ b/Sources/Perception/Internal/Memoization.swift
@@ -1,68 +1,43 @@
 import Foundation
 import OrderedCollections
 
-final class MemoizedCache<Key: Hashable, Value>: @unchecked Sendable {
-  private var dictionary = OrderedDictionary<Key, Value>()
-  private var lock = NSLock()
-  private let maxCapacity: Int
-  
-  // TODO possibly remove these stats later
-  private var totalEvictions = 0
-  private var totalCalls = 0
-  private var totalHits = 0
-  
+func memoize<Result>(
+  maxCapacity: Int = 500,
+  _ apply: @escaping () -> Result
+) -> () -> Result {
+  let cache = Cache<[NSNumber], Result>(maxCapacity: maxCapacity)
+  let callStack = Thread.callStackReturnAddresses
+  return {
+    guard let memoizedResult = cache[callStack]
+    else {
+      let result = apply()
+      defer { cache[callStack] = result }
+      return result
+    }
+    return memoizedResult
+  }
+}
+
+private final class Cache<Key: Hashable, Value>: @unchecked Sendable {
+  var dictionary = OrderedDictionary<Key, Value>()
+  var lock = NSLock()
+  let maxCapacity: Int
   init(maxCapacity: Int = 500) {
     self.maxCapacity = maxCapacity
   }
-  
-  func printStats() {
-    lock.sync {
-      let hitRate = (Float(totalHits) / Float(totalCalls)) * 100
-      let evictionRate = (Float(totalEvictions) / Float(totalCalls)) * 100
-      print("size = \(dictionary.count), totalCalls = \(totalCalls), hitRate = \(hitRate)%, evictionRate = \(evictionRate)%")
-    }
-  }
-  
   subscript(key: Key) -> Value? {
     get {
-      lock.sync {
-        totalCalls += 1
-        if let value = dictionary[key] {
-          totalHits += 1
-          return value
-        }
-        return nil
+      return self.lock.sync {
+        self.dictionary[key]
       }
     }
     set {
-      lock.sync {
-        dictionary[key] = newValue
-        if dictionary.count > maxCapacity {
-          // evict first (oldest) element
-          dictionary.removeFirst()
-          totalEvictions += 1
+      self.lock.sync {
+        self.dictionary[key] = newValue
+        if self.dictionary.count > self.maxCapacity {
+          self.dictionary.removeFirst()
         }
       }
     }
   }
-  
-}
-
-func memoize<Input: Hashable, Result>(
-  maxCapacity: Int = 500,
-  _ apply: @escaping (Input) -> Result
-) -> (Input) -> Result {
-  let cache = MemoizedCache<Input, Result>(maxCapacity: maxCapacity)
-  
-  return { input in
-//    defer { cache.printStats() }
-    if let memoizedResult = cache[input] {
-      return memoizedResult
-    }
-    
-    let result = apply(input)
-    cache[input] = result
-    return result
-  }
-  
 }

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -191,10 +191,11 @@ extension PerceptionRegistrar: Hashable {
 
 #if DEBUG
   private func perceptionCheck() {
-    if #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10),
+    if
+      #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10),
       !PerceptionLocals.isInPerceptionTracking,
       !PerceptionLocals.isInWithoutPerceptionChecking,
-      isInSwiftUIBody
+      isInSwiftUIBody()
     {
       runtimeWarn(
         """
@@ -205,15 +206,7 @@ extension PerceptionRegistrar: Hashable {
     }
   }
 
-  var isInSwiftUIBody: Bool {
-    determineIfInSwiftUIBodyMemoized(Thread.callStackReturnAddresses)
-  }
-
-  let determineIfInSwiftUIBodyMemoized = memoize({ (_ : [NSNumber]) in
-      determineIfInSwiftUIBody
-  })
-
-  var determineIfInSwiftUIBody: Bool {
+  private let isInSwiftUIBody: () -> Bool = memoize {
     for callStackSymbol in Thread.callStackSymbols {
       let mangledSymbol = callStackSymbol.utf8
         .drop(while: { $0 != .init(ascii: "$") })


### PR DESCRIPTION
Just a few small updates to @scogeo's work on caching in the perception checks (see #2630). I've mainly just removed the stats and moved things around. I considered removing the `maxCapacity` entirely to keep things simple, but I do think it's necessary. The cache does get quite big over time.