### PR TITLE
Fix ownership between parent and child stores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
           - release
     steps:
       - uses: actions/checkout@v4
-      - name: Select Xcode 15
-        run: sudo xcode-select -s /Applications/Xcode_15.0.1.app
+      - name: Select Xcode 15.1
+        run: sudo xcode-select -s /Applications/Xcode_15.1.app
       - name: Run ${{ matrix.config }} tests
         run: make CONFIG=${{ matrix.config }} test-library
 
@@ -34,8 +34,8 @@ jobs:
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
-      - name: Select Xcode 15
-        run: sudo xcode-select -s /Applications/Xcode_15.0.1.app
+      - name: Select Xcode 15.1
+        run: sudo xcode-select -s /Applications/Xcode_15.1.app
       - name: Build for library evolution
         run: make build-for-library-evolution
 
@@ -44,8 +44,8 @@ jobs:
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
-      - name: Select Xcode 15
-        run: sudo xcode-select -s /Applications/Xcode_15.0.1.app
+      - name: Select Xcode 15.1
+        run: sudo xcode-select -s /Applications/Xcode_15.1.app
       - name: Run benchmark
         run: make benchmark
 
@@ -54,7 +54,7 @@ jobs:
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
-      - name: Select Xcode 15
-        run: sudo xcode-select -s /Applications/Xcode_15.0.1.app
+      - name: Select Xcode 15.1
+        run: sudo xcode-select -s /Applications/Xcode_15.1.app
       - name: Run tests
         run: make test-examples

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,8 +19,8 @@ jobs:
   build:
     runs-on: macos-13
     steps:
-      - name: Select Xcode 15.0.1
-        run: sudo xcode-select -s /Applications/Xcode_15.0.1.app
+      - name: Select Xcode 15.1
+        run: sudo xcode-select -s /Applications/Xcode_15.1.app
 
       - name: Checkout Package
         uses: actions/checkout@v4

--- a/.github/workflows/scheduled-ci.yml
+++ b/.github/workflows/scheduled-ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
-      - name: Select Xcode 15
-        run: sudo xcode-select -s /Applications/Xcode_15.0.1.app
+      - name: Select Xcode 15.1
+        run: sudo xcode-select -s /Applications/Xcode_15.1.app
       - name: Run tests
         run: make test-integration

--- a/Examples/CaseStudies/SwiftUICaseStudies/CaseStudiesApp.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/CaseStudiesApp.swift
@@ -1,9 +1,10 @@
-import ComposableArchitecture
+@_spi(Logging) import ComposableArchitecture
 import SwiftUI
 
 @main
 struct CaseStudiesApp: App {
   var body: some Scene {
+    let _ = Logger.shared.isEnabled = true
     WindowGroup {
       RootView()
     }

--- a/Examples/CaseStudies/SwiftUICaseStudies/CaseStudiesApp.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/CaseStudiesApp.swift
@@ -1,10 +1,9 @@
-@_spi(Logging) import ComposableArchitecture
+import ComposableArchitecture
 import SwiftUI
 
 @main
 struct CaseStudiesApp: App {
   var body: some Scene {
-    let _ = Logger.shared.isEnabled = true
     WindowGroup {
       RootView()
     }

--- a/Examples/Integration/IntegrationUITests/EnumTests.swift
+++ b/Examples/Integration/IntegrationUITests/EnumTests.swift
@@ -141,46 +141,14 @@ final class EnumTests: BaseIntegrationTests {
       """
       BasicsView.body
       EnumView.body
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.init
-      StoreOf<BasicsView.Feature>.init
-      StoreOf<BasicsView.Feature>.init
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.init
-      StoreOf<BasicsView.Feature?>.init
-      StoreOf<BasicsView.Feature?>.init
-      StoreOf<BasicsView.Feature?>.init
-      StoreOf<EnumView.Feature.Destination>.deinit
-      StoreOf<EnumView.Feature.Destination>.deinit
-      StoreOf<EnumView.Feature.Destination>.deinit
-      StoreOf<EnumView.Feature.Destination>.init
-      StoreOf<EnumView.Feature.Destination>.init
-      StoreOf<EnumView.Feature.Destination>.init
       ViewStore<EnumView.ViewState, EnumView.Feature.Action>.deinit
       ViewStore<EnumView.ViewState, EnumView.Feature.Action>.init
       ViewStoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature>.deinit
       ViewStoreOf<BasicsView.Feature>.init
-      ViewStoreOf<BasicsView.Feature>.init
-      ViewStoreOf<BasicsView.Feature?>.deinit
-      ViewStoreOf<BasicsView.Feature?>.deinit
-      ViewStoreOf<BasicsView.Feature?>.init
-      ViewStoreOf<BasicsView.Feature?>.init
-      ViewStoreOf<EnumView.Feature.Destination>.deinit
-      ViewStoreOf<EnumView.Feature.Destination>.deinit
-      ViewStoreOf<EnumView.Feature.Destination>.init
-      ViewStoreOf<EnumView.Feature.Destination>.init
       ViewStoreOf<EnumView.Feature.Destination?>.deinit
       ViewStoreOf<EnumView.Feature.Destination?>.init
       WithViewStore<EnumView.ViewState, EnumView.Feature.Action>.body
       WithViewStoreOf<BasicsView.Feature>.body
-      WithViewStoreOf<BasicsView.Feature?>.body
-      WithViewStoreOf<EnumView.Feature.Destination>.body
       WithViewStoreOf<EnumView.Feature.Destination?>.body
       """
     }

--- a/Examples/Integration/IntegrationUITests/EnumTests.swift
+++ b/Examples/Integration/IntegrationUITests/EnumTests.swift
@@ -141,14 +141,46 @@ final class EnumTests: BaseIntegrationTests {
       """
       BasicsView.body
       EnumView.body
+      StoreOf<BasicsView.Feature>.deinit
+      StoreOf<BasicsView.Feature>.deinit
+      StoreOf<BasicsView.Feature>.deinit
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature?>.deinit
+      StoreOf<BasicsView.Feature?>.deinit
+      StoreOf<BasicsView.Feature?>.deinit
+      StoreOf<BasicsView.Feature?>.deinit
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<EnumView.Feature.Destination>.deinit
+      StoreOf<EnumView.Feature.Destination>.deinit
+      StoreOf<EnumView.Feature.Destination>.deinit
+      StoreOf<EnumView.Feature.Destination>.init
+      StoreOf<EnumView.Feature.Destination>.init
+      StoreOf<EnumView.Feature.Destination>.init
       ViewStore<EnumView.ViewState, EnumView.Feature.Action>.deinit
       ViewStore<EnumView.ViewState, EnumView.Feature.Action>.init
       ViewStoreOf<BasicsView.Feature>.deinit
+      ViewStoreOf<BasicsView.Feature>.deinit
       ViewStoreOf<BasicsView.Feature>.init
+      ViewStoreOf<BasicsView.Feature>.init
+      ViewStoreOf<BasicsView.Feature?>.deinit
+      ViewStoreOf<BasicsView.Feature?>.deinit
+      ViewStoreOf<BasicsView.Feature?>.init
+      ViewStoreOf<BasicsView.Feature?>.init
+      ViewStoreOf<EnumView.Feature.Destination>.deinit
+      ViewStoreOf<EnumView.Feature.Destination>.deinit
+      ViewStoreOf<EnumView.Feature.Destination>.init
+      ViewStoreOf<EnumView.Feature.Destination>.init
       ViewStoreOf<EnumView.Feature.Destination?>.deinit
       ViewStoreOf<EnumView.Feature.Destination?>.init
       WithViewStore<EnumView.ViewState, EnumView.Feature.Action>.body
       WithViewStoreOf<BasicsView.Feature>.body
+      WithViewStoreOf<BasicsView.Feature?>.body
+      WithViewStoreOf<EnumView.Feature.Destination>.body
       WithViewStoreOf<EnumView.Feature.Destination?>.body
       """
     }

--- a/Examples/Integration/IntegrationUITests/EnumTests.swift
+++ b/Examples/Integration/IntegrationUITests/EnumTests.swift
@@ -19,6 +19,16 @@ final class EnumTests: BaseIntegrationTests {
       """
       BasicsView.body
       EnumView.body
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<EnumView.Feature.Destination>.init
+      StoreOf<EnumView.Feature.Destination>.init
+      StoreOf<EnumView.Feature.Destination>.init
       ViewStore<EnumView.ViewState, EnumView.Feature.Action>.deinit
       ViewStore<EnumView.ViewState, EnumView.Feature.Action>.init
       ViewStoreOf<BasicsView.Feature>.deinit
@@ -80,8 +90,19 @@ final class EnumTests: BaseIntegrationTests {
       """
       BasicsView.body
       EnumView.body
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature>.init
       StoreOf<BasicsView.Feature?>.deinit
       StoreOf<BasicsView.Feature?>.deinit
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<BasicsView.Feature?>.init
       ViewStore<EnumView.ViewState, EnumView.Feature.Action>.deinit
       ViewStore<EnumView.ViewState, EnumView.Feature.Action>.init
       ViewStoreOf<BasicsView.Feature>.deinit

--- a/Examples/Integration/IntegrationUITests/IdentifiedListTests.swift
+++ b/Examples/Integration/IntegrationUITests/IdentifiedListTests.swift
@@ -22,9 +22,19 @@ final class IdentifiedListTests: BaseIntegrationTests {
       IdentifiedListView.body.ForEachStore
       IdentifiedStoreOf<BasicsView.Feature>.deinit
       IdentifiedStoreOf<BasicsView.Feature>.deinit
+      IdentifiedStoreOf<BasicsView.Feature>.init
+      IdentifiedStoreOf<BasicsView.Feature>.init
       Store<UUID, Action>
       Store<UUID, BasicsView.Feature.Action>.deinit
       Store<UUID, BasicsView.Feature.Action>.deinit
+      Store<UUID, BasicsView.Feature.Action>.init
+      Store<UUID, BasicsView.Feature.Action>.init
+      Store<UUID, BasicsView.Feature.Action>.init
+      Store<UUID, BasicsView.Feature.Action>.init
+      Store<UUID, BasicsView.Feature.Action>.init
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature>.init
       ViewIdentifiedStoreOf<BasicsView.Feature>.deinit
       ViewIdentifiedStoreOf<BasicsView.Feature>.deinit
       ViewIdentifiedStoreOf<BasicsView.Feature>.init
@@ -60,12 +70,18 @@ final class IdentifiedListTests: BaseIntegrationTests {
       IdentifiedListView.body.ForEachStore
       IdentifiedStoreOf<BasicsView.Feature>.deinit
       IdentifiedStoreOf<BasicsView.Feature>.deinit
+      IdentifiedStoreOf<BasicsView.Feature>.init
+      IdentifiedStoreOf<BasicsView.Feature>.init
       Store<UUID, Action>
       Store<UUID, Action>
       Store<UUID, BasicsView.Feature.Action>.deinit
       Store<UUID, BasicsView.Feature.Action>.deinit
       Store<UUID, BasicsView.Feature.Action>.deinit
       Store<UUID, BasicsView.Feature.Action>.deinit
+      Store<UUID, BasicsView.Feature.Action>.init
+      Store<UUID, BasicsView.Feature.Action>.init
+      Store<UUID, BasicsView.Feature.Action>.init
+      Store<UUID, BasicsView.Feature.Action>.init
       ViewIdentifiedStoreOf<BasicsView.Feature>.deinit
       ViewIdentifiedStoreOf<BasicsView.Feature>.deinit
       ViewIdentifiedStoreOf<BasicsView.Feature>.init

--- a/Examples/Integration/IntegrationUITests/NavigationTests.swift
+++ b/Examples/Integration/IntegrationUITests/NavigationTests.swift
@@ -17,6 +17,9 @@ final class NavigationTests: BaseIntegrationTests {
     self.assertLogs {
       """
       BasicsView.body
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature>.init
       ViewStoreOf<BasicsView.Feature>.deinit
       ViewStoreOf<BasicsView.Feature>.init
       ViewStoreOf<BasicsView.Feature>.init

--- a/Examples/Integration/IntegrationUITests/OptionalTests.swift
+++ b/Examples/Integration/IntegrationUITests/OptionalTests.swift
@@ -18,6 +18,9 @@ final class OptionalTests: BaseIntegrationTests {
       """
       BasicsView.body
       OptionalView.body
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature>.init
       ViewStore<OptionalView.ViewState, OptionalView.Feature.Action>.deinit
       ViewStore<OptionalView.ViewState, OptionalView.Feature.Action>.init
       ViewStoreOf<BasicsView.Feature>.deinit

--- a/Examples/Integration/IntegrationUITests/PresentationTests.swift
+++ b/Examples/Integration/IntegrationUITests/PresentationTests.swift
@@ -19,6 +19,13 @@ final class PresentationTests: BaseIntegrationTests {
     self.assertLogs {
       """
       BasicsView.body
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<BasicsView.Feature?>.init
       ViewStoreOf<BasicsView.Feature>.deinit
       ViewStoreOf<BasicsView.Feature>.init
       ViewStoreOf<BasicsView.Feature>.init
@@ -59,6 +66,13 @@ final class PresentationTests: BaseIntegrationTests {
     self.assertLogs {
       """
       BasicsView.body
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature>.init
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<BasicsView.Feature?>.init
+      StoreOf<BasicsView.Feature?>.init
       ViewStoreOf<BasicsView.Feature>.deinit
       ViewStoreOf<BasicsView.Feature>.init
       ViewStoreOf<BasicsView.Feature>.init

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -454,7 +454,7 @@ public final class Store<State, Action> {
     let childStore = Store<ChildState, ChildAction>(
       rootStore: self.rootStore,
       toState: self.toState.appending(state.base),
-      fromAction: { self.fromAction(fromChildAction($0)) }
+      fromAction: { [fromAction] in fromAction(fromChildAction($0)) }
     )
     childStore._isInvalidated = isInvalid
     childStore.canCacheChildren = self.canCacheChildren && id != nil

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -135,7 +135,6 @@ public final class Store<State, Action> {
   private var canCacheChildren = true
   private var children: [ScopeID<State, Action>: AnyObject] = [:]
   var _isInvalidated = { false }
-  private var parentCancellable: AnyCancellable?
 
   @_spi(Internals) public let rootStore: RootStore
   private let toState: PartialToState<State>
@@ -459,15 +458,6 @@ public final class Store<State, Action> {
     childStore.canCacheChildren = self.canCacheChildren && id != nil
     if let id = id, self.canCacheChildren {
       self.children[id] = childStore
-      if let isInvalid = isInvalid {
-        childStore.parentCancellable = self.rootStore.didSet
-          .filter { [weak self] in
-            guard let self else { return true }
-            return isInvalid(self.currentState)
-          }
-          .prefix(1)
-          .sink { [weak self] in self?.invalidateChild(id: id) }
-      }
     }
     return childStore
   }

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -445,11 +445,11 @@ public final class Store<State, Action> {
     let isInvalid =
       id == nil || !self.canCacheChildren
       ? {
-        self._isInvalidated() || isInvalid?(self.currentState) == true
+        isInvalid?(self.currentState) == true || self._isInvalidated()
       }
       : { [weak self] in
         guard let self = self else { return true }
-        return self._isInvalidated() || isInvalid?(self.currentState) == true
+        return isInvalid?(self.currentState) == true || self._isInvalidated()
       }
     let childStore = Store<ChildState, ChildAction>(
       rootStore: self.rootStore,

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -463,8 +463,6 @@ public final class Store<State, Action> {
   }
 
   fileprivate func invalidateChild(id: ScopeID<State, Action>) {
-    guard self.children.keys.contains(id)
-    else { return }
     self.children[id] = nil
   }
 

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -445,10 +445,10 @@ public final class Store<State, Action> {
     }
     let isInvalid =
       id == nil || !self.canCacheChildren
-      ? { isInvalid?(self.currentState) == true }
+    ? { isInvalid?(self.currentState) == true || self._isInvalidated() }
       : { [weak self] in
         guard let self = self else { return true }
-        return isInvalid?(self.currentState) == true
+        return isInvalid?(self.currentState) == true || self._isInvalidated()
       }
     let childStore = Store<ChildState, ChildAction>(
       rootStore: self.rootStore,

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -170,7 +170,6 @@ public final class Store<State, Action> {
   }
 
   deinit {
-    self.invalidate()
     Logger.shared.log("\(storeTypeName(of: self)).deinit")
   }
 
@@ -473,15 +472,9 @@ public final class Store<State, Action> {
     return childStore
   }
 
-  fileprivate func invalidate() {
-    for id in self.children.keys {
-      self.invalidateChild(id: id)
-    }
-  }
-
   fileprivate func invalidateChild(id: ScopeID<State, Action>) {
-    guard self.children.keys.contains(id) else { return }
-    (self.children[id] as? any AnyStore)?.invalidate()
+    guard self.children.keys.contains(id)
+    else { return }
     self.children[id] = nil
   }
 
@@ -650,10 +643,6 @@ public struct StoreTask: Hashable, Sendable {
   public var isCancelled: Bool {
     self.rawValue?.isCancelled ?? true
   }
-}
-
-private protocol AnyStore {
-  func invalidate()
 }
 
 private protocol _OptionalProtocol {}

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -152,7 +152,6 @@ public final class Store<State, Action> {
     @ReducerBuilder<State, Action> reducer: () -> R,
     withDependencies prepareDependencies: ((inout DependencyValues) -> Void)? = nil
   ) where R.State == State, R.Action == Action {
-    defer { Logger.shared.log("\(storeTypeName(of: self)).init") }
     if let prepareDependencies = prepareDependencies {
       let (initialState, reducer) = withDependencies(prepareDependencies) {
         (initialState(), reducer())
@@ -495,12 +494,13 @@ public final class Store<State, Action> {
     toState: PartialToState<State>,
     fromAction: @escaping (Action) -> Any
   ) {
+    defer { Logger.shared.log("\(storeTypeName(of: self)).init") }
     self.rootStore = rootStore
     self.toState = toState
     self.fromAction = fromAction
   }
 
-  init<R: Reducer>(
+  convenience init<R: Reducer>(
     initialState: R.State,
     reducer: R
   )
@@ -508,9 +508,11 @@ public final class Store<State, Action> {
     R.State == State,
     R.Action == Action
   {
-    self.rootStore = RootStore(initialState: initialState, reducer: reducer)
-    self.toState = PartialToState.keyPath(\State.self)
-    self.fromAction = { $0 }
+    self.init(
+      rootStore: RootStore(initialState: initialState, reducer: reducer),
+      toState: .keyPath(\State.self),
+      fromAction: { $0 }
+    )
   }
 
   /// A publisher that emits when state changes.

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -462,10 +462,6 @@ public final class Store<State, Action> {
     return childStore
   }
 
-  fileprivate func invalidateChild(id: ScopeID<State, Action>) {
-    self.children[id] = nil
-  }
-
   @_spi(Internals)
   public func send(
     _ action: Action,


### PR DESCRIPTION
This is a continuation of our work in #2664.

This PR cleans up a few of the internals of the revamped store scoping, including:

- It avoids a retain cycle between parent and child store. This retain cycle does not generally matter, as cached stores live as long as the lifetime of the app at this time, but in the future when we more proactively prune invalidated stores, it could prevent stores from being reinitialized.
- It brackets some debug codes to debug builds only.
- It cleans up some unused code.