### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -3,15 +3,10 @@ builder:
   configs:
   - platform: ios
     scheme: ComposableArchitecture
-    swift_version: 5.9
   - platform: macos-xcodebuild
     scheme: ComposableArchitecture
-    swift_version: 5.9
   - platform: tvos
     scheme: ComposableArchitecture
-    swift_version: 5.9
   - platform: watchos
     scheme: ComposableArchitecture
-    swift_version: 5.9
   - documentation_targets: [ComposableArchitecture]
-    swift_version: 5.9


### PR DESCRIPTION
Not sure what the intent was for these changes but I believe they're what made the 5.7...5.8 builds being flagged as incompatible on SPI.

https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2798#issuecomment-1867634649