### PR TITLE
Optimization: Key path subscript presentation scopes

### DIFF
--- a/Sources/ComposableArchitecture/Internal/SubscriptDefault.swift
+++ b/Sources/ComposableArchitecture/Internal/SubscriptDefault.swift
@@ -1,0 +1,22 @@
+final class SubscriptDefault<Value> {
+  var wrappedValue: Value
+
+  init(_ wrappedValue: Value) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+extension SubscriptDefault: Hashable {
+  static func == (lhs: SubscriptDefault<Value>, rhs: SubscriptDefault<Value>) -> Bool {
+    true
+  }
+
+  func hash(into hasher: inout Hasher) {}
+}
+
+extension Optional {
+  subscript(default default: SubscriptDefault<Wrapped>) -> Wrapped {
+    `default`.wrappedValue = self ?? `default`.wrappedValue
+    return `default`.wrappedValue
+  }
+}

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -379,8 +379,8 @@ public final class Store<State, Action> {
     action: CaseKeyPath<Action, ChildAction>
   ) -> Store<ChildState, ChildAction> {
     self.scope(
-      state: ToState(state),
       id: self.id(state: state, action: action),
+      state: ToState(state),
       action: { action($0) },
       isInvalid: nil
     )
@@ -411,8 +411,8 @@ public final class Store<State, Action> {
     action fromChildAction: @escaping (_ childAction: ChildAction) -> Action
   ) -> Store<ChildState, ChildAction> {
     self.scope(
-      state: ToState(toChildState),
       id: nil,
+      state: ToState(toChildState),
       action: fromChildAction,
       isInvalid: nil
     )
@@ -427,8 +427,8 @@ public final class Store<State, Action> {
   @_spi(Internals)
   public
     func scope<ChildState, ChildAction>(
-      state: ToState<State, ChildState>,
       id: ScopeID<State, Action>?,
+      state: ToState<State, ChildState>,
       action fromChildAction: @escaping (ChildAction) -> Action,
       isInvalid: ((State) -> Bool)?
     ) -> Store<ChildState, ChildAction>

--- a/Sources/ComposableArchitecture/SwiftUI/Deprecated/NavigationLinkStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Deprecated/NavigationLinkStore.swift
@@ -72,8 +72,8 @@ public struct NavigationLinkStore<
     @ViewBuilder label: () -> Label
   ) {
     let store = store.scope(
-      state: ToState(\.self),
       id: nil,
+      state: ToState(\.self),
       action: { $0 },
       isInvalid: { $0.wrappedValue.flatMap(toDestinationState) == nil }
     )
@@ -121,8 +121,8 @@ public struct NavigationLinkStore<
     @ViewBuilder label: () -> Label
   ) where DestinationState: Identifiable {
     let store = store.scope(
-      state: ToState(\.self),
       id: nil,
+      state: ToState(\.self),
       action: { $0 },
       isInvalid: { $0.wrappedValue.flatMap(toDestinationState)?.id != id }
     )

--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -114,14 +114,10 @@ public struct ForEachStore<
     ) { viewStore in
       ForEach(viewStore.state, id: viewStore.state.id) { element in
         let id = element[keyPath: viewStore.state.id]
-        var element = element
         content(
           store.scope(
-            state: ToState {
-              element = $0[id: id] ?? element
-              return element
-            },
             id: store.id(state: \.[id:id]!, action: \.[id:id]),
+            state: ToState(\.[id: id, default: SubscriptDefault(element)]),
             action: { .element(id: id, action: $0) },
             isInvalid: { !$0.ids.contains(id) }
           )
@@ -173,14 +169,10 @@ public struct ForEachStore<
     ) { viewStore in
       ForEach(viewStore.state, id: viewStore.state.id) { element in
         let id = element[keyPath: viewStore.state.id]
-        var element = element
         content(
           store.scope(
-            state: ToState {
-              element = $0[id: id] ?? element
-              return element
-            },
             id: store.id(state: \.[id:id]!, action: \.[id:id]),
+            state: ToState(\.[id: id, default: SubscriptDefault(element)]),
             action: { (id, $0) },
             isInvalid: { !$0.ids.contains(id) }
           )
@@ -191,6 +183,13 @@ public struct ForEachStore<
 
   public var body: some View {
     self.content
+  }
+}
+
+extension IdentifiedArray {
+  fileprivate subscript(id id: ID, default default: SubscriptDefault<Element>) -> Element {
+    `default`.wrappedValue = self[id: id] ?? `default`.wrappedValue
+    return `default`.wrappedValue
   }
 }
 

--- a/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/IfLetStore.swift
@@ -35,23 +35,20 @@ public struct IfLetStore<State, Action, Content: View>: View {
     @ViewBuilder else elseContent: () -> ElseContent
   ) where Content == _ConditionalContent<IfContent, ElseContent> {
     let store = store.scope(
-      state: ToState(\.self),
       id: store.id(state: \.self, action: \.self),
+      state: ToState(\.self),
       action: { $0 },
       isInvalid: { $0 == nil }
     )
     self.store = store
     let elseContent = elseContent()
     self.content = { viewStore in
-      if var state = viewStore.state {
+      if let state = viewStore.state {
         return ViewBuilder.buildEither(
           first: ifContent(
             store.scope(
-              state: ToState {
-                state = $0 ?? state
-                return state
-              },
               id: store.id(state: \.!, action: \.self),
+              state: ToState(\.[default: SubscriptDefault(state)]),
               action: { $0 },
               isInvalid: { $0 == nil }
             )
@@ -75,21 +72,18 @@ public struct IfLetStore<State, Action, Content: View>: View {
     @ViewBuilder then ifContent: @escaping (_ store: Store<State, Action>) -> IfContent
   ) where Content == IfContent? {
     let store = store.scope(
-      state: ToState(\.self),
       id: store.id(state: \.self, action: \.self),
+      state: ToState(\.self),
       action: { $0 },
       isInvalid: { $0 == nil }
     )
     self.store = store
     self.content = { viewStore in
-      if var state = viewStore.state {
+      if let state = viewStore.state {
         return ifContent(
           store.scope(
-            state: ToState {
-              state = $0 ?? state
-              return state
-            },
             id: store.id(state: \.!, action: \.self),
+            state: ToState(\.[default: SubscriptDefault(state)]),
             action: { $0 },
             isInvalid: { $0 == nil }
           )

--- a/Sources/ComposableArchitecture/SwiftUI/NavigationStackStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/NavigationStackStore.swift
@@ -29,15 +29,11 @@ public struct NavigationStackStore<State, Action, Root: View, Destination: View>
   ) {
     self.root = root()
     self.destination = { component in
-      var element = component.element
-      return destination(
+      destination(
         store
           .scope(
-            state: ToState {
-              element = $0[id: component.id] ?? element
-              return element
-            },
             id: store.id(state: \.[id:component.id]!, action: \.[id:component.id]),
+            state: ToState(\.[id: component.id, default: SubscriptDefault(component.element)]),
             action: { .element(id: component.id, action: $0) },
             isInvalid: { !$0.ids.contains(component.id) }
           )
@@ -68,15 +64,11 @@ public struct NavigationStackStore<State, Action, Root: View, Destination: View>
   ) where Destination == SwitchStore<State, Action, D> {
     self.root = root()
     self.destination = { component in
-      var element = component.element
-      return SwitchStore(
+      SwitchStore(
         store
           .scope(
-            state: ToState {
-              element = $0[id: component.id] ?? component.element
-              return element
-            },
             id: store.id(state: \.[id:component.id]!, action: \.[id:component.id]),
+            state: ToState(\.[id: component.id, default: SubscriptDefault(component.element)]),
             action: { .element(id: component.id, action: $0) },
             isInvalid: { !$0.ids.contains(component.id) }
           )
@@ -253,6 +245,13 @@ extension StackState {
       self = path.base
     }
     set { self = newValue.base }
+  }
+
+  fileprivate subscript(
+    id id: StackElementID, default default: SubscriptDefault<Element>
+  ) -> Element {
+    `default`.wrappedValue = self[id: id] ?? `default`.wrappedValue
+    return `default`.wrappedValue
   }
 
   fileprivate struct PathView: MutableCollection, RandomAccessCollection,

--- a/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
@@ -215,8 +215,8 @@ public struct PresentationStore<
     ) -> Content
   ) where State == DestinationState, Action == DestinationAction {
     let store = store.scope(
-      state: ToState(\.self),
       id: nil,
+      state: ToState(\.self),
       action: { $0 },
       isInvalid: { $0.wrappedValue == nil }
     )
@@ -231,8 +231,8 @@ public struct PresentationStore<
     self.toID = toID
     self.fromDestinationAction = { $0 }
     self.destinationStore = store.scope(
-      state: ToState(\.wrappedValue),
       id: store.id(state: \.wrappedValue, action: \.presented),
+      state: ToState(\.wrappedValue),
       action: { .presented($0) },
       isInvalid: nil
     )
@@ -251,8 +251,8 @@ public struct PresentationStore<
     ) -> Content
   ) {
     let store = store.scope(
-      state: ToState(\.self),
       id: nil,
+      state: ToState(\.self),
       action: { $0 },
       isInvalid: { $0.wrappedValue.flatMap(toDestinationState) == nil }
     )
@@ -317,8 +317,8 @@ public struct DestinationContent<State, Action> {
   ) -> some View {
     IfLetStore(
       self.store.scope(
-        state: ToState(returningLastNonNilValue { $0 }),
         id: self.store.id(state: \.self, action: \.self),
+        state: ToState(returningLastNonNilValue { $0 }),
         action: { $0 },
         isInvalid: nil
       ),

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -53,14 +53,11 @@ extension Store {
       .map { self.currentState }
       .removeDuplicates(by: { ($0 != nil) == ($1 != nil) })
       .sink { state in
-        if var state = state {
+        if let state = state {
           unwrap(
             self.scope(
-              state: ToState {
-                state = $0 ?? state
-                return state
-              },
               id: self.id(state: \.!, action: \.self),
+              state: ToState(\.[default: state]),
               action: { $0 },
               isInvalid: { $0 == nil }
             )

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -57,7 +57,7 @@ extension Store {
           unwrap(
             self.scope(
               id: self.id(state: \.!, action: \.self),
-              state: ToState(\.[default: state]),
+              state: ToState(\.[default: SubscriptDefault(state)]),
               action: { $0 },
               isInvalid: { $0 == nil }
             )

--- a/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
+++ b/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
@@ -3,8 +3,9 @@
   import ComposableArchitecture
   import XCTest
 
+  @MainActor
   final class RuntimeWarningTests: BaseTCATestCase {
-    func testStoreCreationMainThread() {
+    func testStoreCreationMainThread() async {
       uncheckedUseMainSerialExecutor = false
       XCTExpectFailure {
         $0.compactDescription == """
@@ -15,13 +16,13 @@
           """
       }
 
-      Task {
+      _ = await Task {
         _ = Store<Int, Void>(initialState: 0) {}
       }
-      _ = XCTWaiter.wait(for: [.init()], timeout: 0.5)
+      .value
     }
 
-    func testEffectFinishedMainThread() throws {
+    func testEffectFinishedMainThread() async throws {
       XCTExpectFailure {
         $0.compactDescription == """
           An effect completed on a non-main thread. …
@@ -51,11 +52,11 @@
           }
         }
       }
-      store.send(.tap)
-      _ = XCTWaiter.wait(for: [.init()], timeout: 5)
+      await store.send(.tap).finish()
     }
 
-    func testStoreScopeMainThread() {
+    @MainActor
+    func testStoreScopeMainThread() async {
       uncheckedUseMainSerialExecutor = false
       XCTExpectFailure {
         [
@@ -76,13 +77,14 @@
       }
 
       let store = Store<Int, Void>(initialState: 0) {}
-      Task {
+      await Task.detached {
         _ = store.scope(state: { $0 }, action: { $0 })
       }
-      _ = XCTWaiter.wait(for: [.init()], timeout: 0.5)
+      .value
     }
 
-    func testViewStoreSendMainThread() {
+    @MainActor
+    func testViewStoreSendMainThread() async {
       uncheckedUseMainSerialExecutor = false
       XCTExpectFailure {
         [
@@ -93,26 +95,14 @@
           "Store" (including all of its scopes and derived view stores) must be done on the main \
           thread.
           """,
-          """
-          An effect completed on a non-main thread. …
-
-            Effect returned from:
-              ()
-
-          Make sure to use ".receive(on:)" on any effects that execute on background threads to \
-          receive their output on the main thread.
-
-          The "Store" class is not thread-safe, and so all interactions with an instance of "Store" \
-          (including all of its scopes and derived view stores) must be done on the main thread.
-          """,
         ].contains($0.compactDescription)
       }
 
       let store = Store<Int, Void>(initialState: 0) {}
-      Task {
-        store.send(())
+      await Task.detached {
+        _ = store.send(())
       }
-      _ = XCTWaiter.wait(for: [.init()], timeout: 0.5)
+      .value
     }
 
     #if os(macOS)

--- a/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
+++ b/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
@@ -16,7 +16,7 @@
           """
       }
 
-      _ = await Task {
+      _ = await Task.detached {
         _ = Store<Int, Void>(initialState: 0) {}
       }
       .value
@@ -106,7 +106,6 @@
     }
 
     #if os(macOS)
-      @MainActor
       func testEffectEmitMainThread() async throws {
         try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] != nil)
         XCTExpectFailure {
@@ -179,7 +178,6 @@
       }
     #endif
 
-    @MainActor
     func testBindingUnhandledAction() {
       let line = #line + 2
       struct State: Equatable {
@@ -205,7 +203,6 @@
       }
     }
 
-    @MainActor
     func testBindingUnhandledAction_BindingState() {
       struct State: Equatable {
         @BindingState var value = 0

--- a/Tests/ComposableArchitectureTests/ScopeCacheTests.swift
+++ b/Tests/ComposableArchitectureTests/ScopeCacheTests.swift
@@ -8,8 +8,8 @@ class ScopeCacheTests: XCTestCase {
     }
     let childStore = store.scope(state: \.child, action: \.child)
     let unwrappedChildStore = childStore.scope(
-      state: ToState { $0! },
       id: childStore.id(state: \.!, action: \.self),
+      state: ToState { $0! },
       action: { $0 },
       isInvalid: { $0 == nil }
     )

--- a/Tests/ComposableArchitectureTests/StoreFilterTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreFilterTests.swift
@@ -9,8 +9,8 @@ final class StoreInvalidationTests: BaseTCATestCase {
   func testInvalidation() {
     let store = Store<Int?, Void>(initialState: nil) {}
       .scope(
-        state: ToState { $0 },
         id: nil,
+        state: ToState { $0 },
         action: { $0 },
         isInvalid: { $0 != nil }
       )


### PR DESCRIPTION
When scoping a store over a "presentation" boundary (optional, stack element, list element), we maintain a local, memoized value so that during dismissal, views still have access to the last element should SwiftUI render.

This PR introduces private subscripts so that these scopes can be done via key path.