### PR TITLE
Updates @Reducer to no longer apply @CasePathable macro to enums with explicit conformance.

### DIFF
--- a/Sources/ComposableArchitectureMacros/ReducerMacro.swift
+++ b/Sources/ComposableArchitectureMacros/ReducerMacro.swift
@@ -50,6 +50,14 @@ extension ReducerMacro: MemberAttributeMacro {
       default:
         break
       }
+      if let inheritanceClause = enumDecl.inheritanceClause,
+        inheritanceClause.inheritedTypes.contains(
+          where: {
+            ["CasePathable"].withCasePathsQualified.contains($0.type.trimmedDescription)
+          }
+        ) {
+        attributes.removeAll(where: { $0 == "CasePathable" })
+      }
       for attribute in enumDecl.attributes {
         guard
           case let .attribute(attribute) = attribute,
@@ -129,6 +137,10 @@ extension ReducerMacro: MemberAttributeMacro {
 }
 
 extension Array where Element == String {
+  var withCasePathsQualified: Self {
+    self.flatMap { [$0, "CasePaths.\($0)"] }
+  }
+
   var withQualified: Self {
     self.flatMap { [$0, "ComposableArchitecture.\($0)"] }
   }

--- a/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
@@ -119,6 +119,49 @@
       }
     }
 
+    func testExistingCasePathableConformance() {
+      assertMacro {
+        """
+        @Reducer
+        struct Feature {
+          enum State: CasePathable {
+            struct AllCasePaths {}
+            static var allCasePaths: AllCasePaths { AllCasePaths() }
+          }
+          enum Action: CasePathable {
+            struct AllCasePaths {}
+            static var allCasePaths: AllCasePaths { AllCasePaths() }
+          }
+          @ReducerBuilder<State, Action>
+          var body: some ReducerOf<Self> {
+            EmptyReducer()
+          }
+        }
+        """
+      } expansion: {
+        """
+        struct Feature {
+          @dynamicMemberLookup
+          enum State: CasePathable {
+            struct AllCasePaths {}
+            static var allCasePaths: AllCasePaths { AllCasePaths() }
+          }
+          enum Action: CasePathable {
+            struct AllCasePaths {}
+            static var allCasePaths: AllCasePaths { AllCasePaths() }
+          }
+          @ReducerBuilder<State, Action>
+          var body: some ReducerOf<Self> {
+            EmptyReducer()
+          }
+        }
+
+        extension Feature: ComposableArchitecture.Reducer {
+        }
+        """
+      }
+    }
+
     func testReduceMethodDiagnostic() {
       assertMacro {
         """


### PR DESCRIPTION
I have a macro library that I'm developing for TCA that helps generate members of `Action` and `State`. This also requires that I manage the `AllCasePaths` struct when implementing `CasePathable` conformance.  The current `@Reducer` macro automatically applies the `@CasePathable` macro to the `Action` and `State` enums, even though my implementation has explicitly conformed to `CasePathable`.

For example the following code produces multiple compiler errors due to the application of `@CasePathable` to `Action` by the `@Reducer` macro, resulting in duplicate declarations of `AllCasePaths` and `allCasePaths`.

```swift
@Reducer
struct Feature {
  // ...

  enum Action: CasePathable {
    struct AllCasePaths {}
    static var allCasePaths: AllCasePaths { AllCasePaths() }
  }

  // ...
}
```

This PR changes the behavior of `@Reducer` to check if either `State` or `Action` enums provide explicit conformance to `CasePathable`, and if so, the `@CasePathable` macro is not applied.
