### PR TITLE
Fix SwiftUI warning

### DIFF
--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -131,6 +131,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
     self.viewCancellable = self.store.rootStore.didSet
       .compactMap { [weak self] in self?.store.currentState }
       .removeDuplicates(by: isDuplicate)
+      .dropFirst()
       .sink { [weak self] in
         self?.objectWillChange.send()
         self?._state.value = $0


### PR DESCRIPTION
I noticed this when taking SyncUps for a spin on `main`. When I was editing an attendee and added a new one while the current attendee autocompleted, I'd get a warning in the `ViewStore`'s `sink` where `objectWillChange` was getting pinged during a render.

I'm pretty sure we should be dropping the first value from the `sink` to prevent `objectWillChange` from being pinged when the `ViewStore` is being initialized in the view.