### PR TITLE
Improve `TestStore.receive(\.action, payload)` failures

### DIFF
--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -551,9 +551,12 @@ final class TestStoreTests: BaseTCATestCase {
         $0.compactDescription == """
           Received unexpected action: …
 
-            Action.delegate(
-              .success(42)
-            )
+              Action.delegate(
+            −   .success(43)
+            +   .success(42)
+              )
+
+          (Expected: −, Actual: +)
           """
       }
       await store.send(.tap)


### PR DESCRIPTION
This commit improves the failure messaging for the new `TestStore.receive` method by rendering a diff of the value when the payload doesn't match up.