### PR TITLE
Prevent unnecessary diffs in the tutorials

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-01-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-01-code-0006.swift
@@ -17,7 +17,7 @@ struct CounterFeature {
       case .decrementButtonTapped:
         state.count -= 1
         return .none
-        
+
       case .incrementButtonTapped:
         state.count += 1
         return .none

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-01-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-01-code-0003.swift
@@ -17,7 +17,7 @@ struct CounterFeature {
       case .decrementButtonTapped:
         state.count -= 1
         return .none
-        
+
       case .incrementButtonTapped:
         state.count += 1
         return .none

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-01-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-01-code-0005.swift
@@ -21,21 +21,21 @@ struct CounterFeature {
         state.count -= 1
         state.fact = nil
         return .none
-        
+
       case .factButtonTapped:
         state.fact = nil
         state.isLoading = true
-        
+
         let (data, _) = try await URLSession.shared
           .data(from: URL(string: "http://numbersapi.com/\(state.count)")!)
         // 🛑 'async' call in a function that does not support concurrency
         // 🛑 Errors thrown from here are not handled
-        
+
         state.fact = String(decoding: data, as: UTF8.self)
         state.isLoading = false
-        
+
         return .none
-        
+
       case .incrementButtonTapped:
         state.count += 1
         state.fact = nil

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0001.swift
@@ -21,14 +21,14 @@ struct CounterFeature {
         state.count -= 1
         state.fact = nil
         return .none
-        
+
       case .factButtonTapped:
         state.fact = nil
         state.isLoading = true
         return .run { send in
           // ✅ Do async work in here, and send actions back into the system.
         }
-        
+
       case .incrementButtonTapped:
         state.count += 1
         state.fact = nil

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0002.swift
@@ -7,13 +7,13 @@ struct CounterFeature {
     var fact: String?
     var isLoading = false
   }
-  
+
   enum Action {
     case decrementButtonTapped
     case factButtonTapped
     case incrementButtonTapped
   }
-  
+
   var body: some ReducerOf<Self> {
     Reduce { state, action in
       switch action {
@@ -21,7 +21,7 @@ struct CounterFeature {
         state.count -= 1
         state.fact = nil
         return .none
-        
+
       case .factButtonTapped:
         state.fact = nil
         state.isLoading = true
@@ -30,7 +30,7 @@ struct CounterFeature {
             .data(from: URL(string: "http://numbersapi.com/\(count)")!)
           let fact = String(decoding: data, as: UTF8.self)
         }
-        
+
       case .incrementButtonTapped:
         state.count += 1
         state.fact = nil

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0003.swift
@@ -21,7 +21,7 @@ struct CounterFeature {
         state.count -= 1
         state.fact = nil
         return .none
-        
+
       case .factButtonTapped:
         state.fact = nil
         state.isLoading = true
@@ -33,7 +33,7 @@ struct CounterFeature {
           // 🛑 Mutable capture of 'inout' parameter 'state' is not allowed in
           //    concurrently-executing code
         }
-        
+
       case .incrementButtonTapped:
         state.count += 1
         state.fact = nil

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0004.swift
@@ -22,7 +22,7 @@ struct CounterFeature {
         state.count -= 1
         state.fact = nil
         return .none
-        
+
       case .factButtonTapped:
         state.fact = nil
         state.isLoading = true
@@ -32,12 +32,12 @@ struct CounterFeature {
           let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }
-        
+
       case let .factResponse(fact):
         state.fact = fact
         state.isLoading = false
         return .none
-        
+
       case .incrementButtonTapped:
         state.count += 1
         state.fact = nil

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0005.swift
@@ -22,7 +22,7 @@ struct CounterFeature {
         state.count -= 1
         state.fact = nil
         return .none
-        
+
       case .factButtonTapped:
         state.fact = nil
         state.isLoading = true
@@ -32,12 +32,12 @@ struct CounterFeature {
           let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }
-        
+
       case let .factResponse(fact):
         state.fact = fact
         state.isLoading = false
         return .none
-        
+
       case .incrementButtonTapped:
         state.count += 1
         state.fact = nil

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0002.swift
@@ -24,7 +24,7 @@ struct CounterFeature {
         state.count -= 1
         state.fact = nil
         return .none
-        
+
       case .factButtonTapped:
         state.fact = nil
         state.isLoading = true
@@ -34,17 +34,17 @@ struct CounterFeature {
           let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }
-        
+
       case let .factResponse(fact):
         state.fact = fact
         state.isLoading = false
         return .none
-        
+
       case .incrementButtonTapped:
         state.count += 1
         state.fact = nil
         return .none
-        
+
       case .toggleTimerButtonTapped:
         state.isTimerRunning.toggle()
         return .run { send in

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0003.swift
@@ -24,7 +24,7 @@ struct CounterFeature {
         state.count -= 1
         state.fact = nil
         return .none
-        
+
       case .factButtonTapped:
         state.fact = nil
         state.isLoading = true
@@ -34,17 +34,17 @@ struct CounterFeature {
           let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }
-        
+
       case let .factResponse(fact):
         state.fact = fact
         state.isLoading = false
         return .none
-        
+
       case .incrementButtonTapped:
         state.count += 1
         state.fact = nil
         return .none
-        
+
       case .toggleTimerButtonTapped:
         state.isTimerRunning.toggle()
         return .run { send in

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0004.swift
@@ -25,7 +25,7 @@ struct CounterFeature {
         state.count -= 1
         state.fact = nil
         return .none
-        
+
       case .factButtonTapped:
         state.fact = nil
         state.isLoading = true
@@ -35,22 +35,22 @@ struct CounterFeature {
           let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }
-        
+
       case let .factResponse(fact):
         state.fact = fact
         state.isLoading = false
         return .none
-        
+
       case .incrementButtonTapped:
         state.count += 1
         state.fact = nil
         return .none
-        
+
       case .timerTick:
         state.count += 1
         state.fact = nil
         return .none
-        
+
       case .toggleTimerButtonTapped:
         state.isTimerRunning.toggle()
         return .run { send in

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0005.swift
@@ -27,7 +27,7 @@ struct CounterFeature {
         state.count -= 1
         state.fact = nil
         return .none
-        
+
       case .factButtonTapped:
         state.fact = nil
         state.isLoading = true
@@ -37,22 +37,22 @@ struct CounterFeature {
           let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }
-        
+
       case let .factResponse(fact):
         state.fact = fact
         state.isLoading = false
         return .none
-        
+
       case .incrementButtonTapped:
         state.count += 1
         state.fact = nil
         return .none
-        
+
       case .timerTick:
         state.count += 1
         state.fact = nil
         return .none
-        
+
       case .toggleTimerButtonTapped:
         state.isTimerRunning.toggle()
         if state.isTimerRunning {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0006.swift
@@ -27,7 +27,7 @@ struct CounterFeature {
         state.count -= 1
         state.fact = nil
         return .none
-        
+
       case .factButtonTapped:
         state.fact = nil
         state.isLoading = true
@@ -37,22 +37,22 @@ struct CounterFeature {
           let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }
-        
+
       case let .factResponse(fact):
         state.fact = fact
         state.isLoading = false
         return .none
-        
+
       case .incrementButtonTapped:
         state.count += 1
         state.fact = nil
         return .none
-        
+
       case .timerTick:
         state.count += 1
         state.fact = nil
         return .none
-        
+
       case .toggleTimerButtonTapped:
         state.isTimerRunning.toggle()
         if state.isTimerRunning {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-02-code-0008.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-02-code-0008.swift
@@ -29,7 +29,7 @@ struct CounterFeature {
         state.count -= 1
         state.fact = nil
         return .none
-        
+
       case .factButtonTapped:
         state.fact = nil
         state.isLoading = true
@@ -39,22 +39,22 @@ struct CounterFeature {
           let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }
-        
+
       case let .factResponse(fact):
         state.fact = fact
         state.isLoading = false
         return .none
-        
+
       case .incrementButtonTapped:
         state.count += 1
         state.fact = nil
         return .none
-        
+
       case .timerTick:
         state.count += 1
         state.fact = nil
         return .none
-        
+
       case .toggleTimerButtonTapped:
         state.isTimerRunning.toggle()
         if state.isTimerRunning {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-04-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-04-code-0005.swift
@@ -30,29 +30,29 @@ struct CounterFeature {
         state.count -= 1
         state.fact = nil
         return .none
-        
+
       case .factButtonTapped:
         state.fact = nil
         state.isLoading = true
         return .run { [count = state.count] send in
           try await send(.factResponse(self.numberFact.fetch(count)))
         }
-        
+
       case let .factResponse(fact):
         state.fact = fact
         state.isLoading = false
         return .none
-        
+
       case .incrementButtonTapped:
         state.count += 1
         state.fact = nil
         return .none
-        
+
       case .timerTick:
         state.count += 1
         state.fact = nil
         return .none
-        
+
       case .toggleTimerButtonTapped:
         state.isTimerRunning.toggle()
         if state.isTimerRunning {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-01-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-01-code-0001.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct AppView: View {
   var body: some View {
     TabView {
-    
+
     }
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0001.swift
@@ -2,5 +2,5 @@ import ComposableArchitecture
 
 @Reducer
 struct AppFeature {
-  
+
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0003.swift
@@ -11,7 +11,7 @@ struct AppFeature {
     case tab2(CounterFeature.Action)
   }
   var body: some ReducerOf<Self> {
-    Reduce { state, action in 
+    Reduce { state, action in
       // Core logic of the app feature
       return .none
     }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0004.swift
@@ -17,7 +17,7 @@ struct AppFeature {
     Scope(state: \.tab2, action: \.tab2) {
       CounterFeature()
     }
-    Reduce { state, action in 
+    Reduce { state, action in
       // Core logic of the app feature
       return .none
     }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0005.swift
@@ -3,6 +3,6 @@ import XCTest
 
 class AppFeatureTests: XCTestCase {
   func testIncrementInFirstTab() {
-  
+
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-01-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-01-code-0003.swift
@@ -15,10 +15,10 @@ struct AddContactFeature {
       switch action {
       case .cancelButtonTapped:
         return .none
-        
+
       case .saveButtonTapped:
         return .none
-        
+
       case let .setName(name):
         state.contact.name = name
         return .none

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0000-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0000-previous.swift
@@ -15,10 +15,10 @@ struct AddContactFeature {
       switch action {
       case .cancelButtonTapped:
         return .none
-        
+
       case .saveButtonTapped:
         return .none
-        
+
       case let .setName(name):
         state.contact.name = name
         return .none

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0000.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0000.swift
@@ -20,10 +20,10 @@ struct AddContactFeature {
       switch action {
       case .cancelButtonTapped:
         return .none
-        
+
       case .saveButtonTapped:
         return .none
-        
+
       case let .setName(name):
         state.contact.name = name
         return .none

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0001.swift
@@ -20,13 +20,13 @@ struct AddContactFeature {
       switch action {
       case .cancelButtonTapped:
         return .none
-        
+
       case .delegate:
         return .none
-        
+
       case .saveButtonTapped:
         return .none
-        
+
       case let .setName(name):
         state.contact.name = name
         return .none

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0002.swift
@@ -20,13 +20,13 @@ struct AddContactFeature {
       switch action {
       case .cancelButtonTapped:
         return .send(.delegate(.cancel))
-        
+
       case .delegate:
         return .none
-        
+
       case .saveButtonTapped:
         return .send(.delegate(.saveContact(state.contact)))
-        
+
       case let .setName(name):
         state.contact.name = name
         return .none

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0004-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0004-previous.swift
@@ -20,13 +20,13 @@ struct AddContactFeature {
       switch action {
       case .cancelButtonTapped:
         return .send(.delegate(.cancel))
-        
+
       case .delegate:
         return .none
-        
+
       case .saveButtonTapped:
         return .send(.delegate(.saveContact(state.contact)))
-        
+
       case let .setName(name):
         state.contact.name = name
         return .none

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0004.swift
@@ -21,13 +21,13 @@ struct AddContactFeature {
       switch action {
       case .cancelButtonTapped:
         return .send(.delegate(.cancel))
-        
+
       case .delegate:
         return .none
-        
+
       case .saveButtonTapped:
         return .send(.delegate(.saveContact(state.contact)))
-        
+
       case let .setName(name):
         state.contact.name = name
         return .none

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0005.swift
@@ -21,16 +21,16 @@ struct AddContactFeature {
       switch action {
       case .cancelButtonTapped:
         return .run { _ in await self.dismiss() }
-        
+
       case .delegate:
         return .none
-        
+
       case .saveButtonTapped:
         return .run { [contact = state.contact] send in
           await send(.delegate(.saveContact(contact)))
           await self.dismiss()
         }
-        
+
       case let .setName(name):
         state.contact.name = name
         return .none

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-04-code-0006.swift
@@ -21,16 +21,16 @@ struct AddContactFeature {
       switch action {
       case .cancelButtonTapped:
         return .run { _ in await self.dismiss() }
-        
+
       case .delegate:
         return .none
-        
+
       case .saveButtonTapped:
         return .run { [contact = state.contact] send in
           await send(.delegate(.saveContact(contact)))
           await self.dismiss()
         }
-        
+
       case let .setName(name):
         state.contact.name = name
         return .none


### PR DESCRIPTION
Just removing all trailing whitespaces 😄 

### Before:
![before](https://github.com/pointfreeco/swift-composable-architecture/assets/266357/c09136dd-4416-450b-89b0-19d06bb687a8)

### After:
![after](https://github.com/pointfreeco/swift-composable-architecture/assets/266357/ba7d253e-2f08-4d72-8f5c-47edb3647b5d)
