### PR TITLE
Add stack action path element subscript to testing notes

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
@@ -487,6 +487,16 @@ await store.receive(\.path.popFrom) {
 }
 ```
 
+If you need to assert that a specific child action is received, you can construct a case key path 
+for a specific child element action by subscripting on the `\.path` case with the element ID. 
+
+For example, if the child feature performed an effect that sent an `.effectCompleted` action, you 
+can test that it is received:
+
+```swift
+await store.receive(\.path[id: 0].counter.effectCompleted)
+```
+
 This shows how we can write very nuanced tests on how parent and child features interact with each
 other in a navigation stack.
 


### PR DESCRIPTION
Updates the stack navigation documentation to include information on how to test that a specific element action is received using case key paths.

Wording could maybe be improved but its a starting point.