### PR TITLE
Fix `TestStore.assert` docs

### DIFF
--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -933,13 +933,15 @@ extension TestStore where State: Equatable {
   /// <doc:Testing#Non-exhaustive-testing>), which allow you to assert on a subset of the things
   /// happening inside your features. For example, you can send an action in a child feature
   /// without asserting on how many changes in the system, and then tell the test store to
-  /// ``finish(timeout:file:line:)-53gi5`` by executing all of its effects and receiving all
-  /// actions. After that is done you can assert on the final state of the store:
+  /// ``finish(timeout:file:line:)-53gi5`` by executing all of its effects, and finally to
+  /// ``skipReceivedActions(strict:file:line:)-a4ri`` to receive all actions. After that is done you
+  /// can assert on the final state of the store:
   ///
   /// ```swift
   /// store.exhaustivity = .off
   /// await store.send(.child(.closeButtonTapped))
   /// await store.finish()
+  /// await store.skipReceivedActions()
   /// store.assert {
   ///   $0.child = nil
   /// }


### PR DESCRIPTION
If you want to skip received actions before calling `assert`, you must do so explicitly.