### PR TITLE
 Fix Composing features tutorial; Modify Make the State conform to Equatable to pass the test.

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0002.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 
 @Reducer
 struct AppFeature {
-  struct State {
+  struct State: Equatable {
     var tab1 = CounterFeature.State()
     var tab2 = CounterFeature.State()
   }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0003.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 
 @Reducer
 struct AppFeature {
-  struct State {
+  struct State: Equatable {
     var tab1 = CounterFeature.State()
     var tab2 = CounterFeature.State()
   }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0004.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 
 @Reducer
 struct AppFeature {
-  struct State {
+  struct State: Equatable {
     var tab1 = CounterFeature.State()
     var tab2 = CounterFeature.State()
   }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-ComposingFeatures.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-ComposingFeatures.tutorial
@@ -85,6 +85,9 @@
         and actions for each tab, each of which are just the `CounterFeature`.
         
         @Code(name: "AppFeature.swift", file: 01-04-02-code-0002.swift)
+        
+        > Note: We are proactively conforming `State` to `Equatable` in order to be able to write
+        tests on this feature later.
       }
       
       @Step {


### PR DESCRIPTION
In Composing features of Tutorial Chapter 1, `AppFeatureTests` will not pass unless `State` is not conform to `Equatable`. So, I made `State` conform to `Equatable`.

https://pointfreeco.github.io/swift-composable-architecture/main/tutorials/composablearchitecture/01-04-composingfeatures/
