### PR TITLE
Move binding warning suppression to dynamic member lookup

### DIFF
--- a/Sources/ComposableArchitecture/Observation/Binding+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Binding+Observation.swift
@@ -100,7 +100,11 @@
       dynamicMember keyPath: WritableKeyPath<State, Value>
     ) -> Value {
       get { self.state[keyPath: keyPath] }
-      set { self.send(.binding(.set(keyPath, newValue))) }
+      set {
+        BindingLocal.$isActive.withValue(true) {
+          self.send(.binding(.set(keyPath, newValue)))
+        }
+      }
     }
   }
 
@@ -114,7 +118,11 @@
     @_disfavoredOverload
     public var state: State {
       get { self.state }
-      set { self.send(.binding(.set(\.self, newValue))) }
+      set {
+        BindingLocal.$isActive.withValue(true) {
+          self.send(.binding(.set(\.self, newValue)))
+        }
+      }
     }
   }
 
@@ -130,7 +138,11 @@
       dynamicMember keyPath: WritableKeyPath<State, Value>
     ) -> Value {
       get { self.state[keyPath: keyPath] }
-      set { self.send(.view(.binding(.set(keyPath, newValue)))) }
+      set {
+        BindingLocal.$isActive.withValue(true) {
+          self.send(.view(.binding(.set(keyPath, newValue))))
+        }
+      }
     }
   }
 
@@ -145,129 +157,11 @@
     @_disfavoredOverload
     public var state: State {
       get { self.state }
-      set { self.send(.view(.binding(.set(\.self, newValue)))) }
+      set {
+        BindingLocal.$isActive.withValue(true) {
+          self.send(.view(.binding(.set(\.self, newValue))))
+        }
+      }
     }
   }
-
-  // NB: These overloads ensure runtime warnings aren't emitted for errant SwiftUI bindings.
-  #if DEBUG
-    extension Binding {
-      public subscript<State: ObservableState, Action: BindableAction, Member: Equatable>(
-        dynamicMember keyPath: WritableKeyPath<State, Member>
-      ) -> Binding<Member>
-      where Value == Store<State, Action>, Action.State == State {
-        Binding<Member>(
-          get: { self.wrappedValue.state[keyPath: keyPath] },
-          set: { newValue, transaction in
-            BindingLocal.$isActive.withValue(true) {
-              _ = self.wrappedValue.send(
-                .binding(.set(keyPath, newValue)), transaction: transaction
-              )
-            }
-          }
-        )
-      }
-
-      public subscript<State: ObservableState, Action: ViewAction, Member: Equatable>(
-        dynamicMember keyPath: WritableKeyPath<State, Member>
-      ) -> Binding<Member>
-      where
-        Value == Store<State, Action>,
-        Action.ViewAction: BindableAction,
-        Action.ViewAction.State == State
-      {
-        Binding<Member>(
-          get: { self.wrappedValue.state[keyPath: keyPath] },
-          set: { newValue, transaction in
-            BindingLocal.$isActive.withValue(true) {
-              _ = self.wrappedValue.send(
-                .view(.binding(.set(keyPath, newValue))), transaction: transaction
-              )
-            }
-          }
-        )
-      }
-    }
-
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    extension SwiftUI.Bindable {
-      public subscript<State: ObservableState, Action: BindableAction, Member: Equatable>(
-        dynamicMember keyPath: WritableKeyPath<State, Member>
-      ) -> Binding<Member>
-      where Value == Store<State, Action>, Action.State == State {
-        Binding<Member>(
-          get: { self.wrappedValue.state[keyPath: keyPath] },
-          set: { newValue, transaction in
-            BindingLocal.$isActive.withValue(true) {
-              _ = self.wrappedValue.send(
-                .binding(.set(keyPath, newValue)), transaction: transaction
-              )
-            }
-          }
-        )
-      }
-
-      public subscript<State: ObservableState, Action: ViewAction, Member: Equatable>(
-        dynamicMember keyPath: WritableKeyPath<State, Member>
-      ) -> Binding<Member>
-      where
-        Value == Store<State, Action>,
-        Action.ViewAction: BindableAction,
-        Action.ViewAction.State == State
-      {
-        Binding<Member>(
-          get: { self.wrappedValue.state[keyPath: keyPath] },
-          set: { newValue, transaction in
-            BindingLocal.$isActive.withValue(true) {
-              _ = self.wrappedValue.send(
-                .view(.binding(.set(keyPath, newValue))), transaction: transaction
-              )
-            }
-          }
-        )
-      }
-    }
-
-    @available(iOS, introduced: 13, obsoleted: 17)
-    @available(macOS, introduced: 10.15, obsoleted: 14)
-    @available(tvOS, introduced: 13, obsoleted: 17)
-    @available(watchOS, introduced: 6, obsoleted: 10)
-    extension Perception.Bindable {
-      public subscript<State: ObservableState, Action: BindableAction, Member: Equatable>(
-        dynamicMember keyPath: WritableKeyPath<State, Member>
-      ) -> Binding<Member>
-      where Value == Store<State, Action>, Action.State == State {
-        Binding<Member>(
-          get: { self.wrappedValue.state[keyPath: keyPath] },
-          set: { newValue, transaction in
-            BindingLocal.$isActive.withValue(true) {
-              _ = self.wrappedValue.send(
-                .binding(.set(keyPath, newValue)), transaction: transaction
-              )
-            }
-          }
-        )
-      }
-
-      public subscript<State: ObservableState, Action: ViewAction, Member: Equatable>(
-        dynamicMember keyPath: WritableKeyPath<State, Member>
-      ) -> Binding<Member>
-      where
-        Value == Store<State, Action>,
-        Action.ViewAction: BindableAction,
-        Action.ViewAction.State == State
-      {
-        Binding<Member>(
-          get: { self.wrappedValue.state[keyPath: keyPath] },
-          set: { newValue, transaction in
-            BindingLocal.$isActive.withValue(true) {
-              _ = self.wrappedValue.send(
-                .view(.binding(.set(keyPath, newValue))), transaction: transaction
-              )
-            }
-          }
-        )
-      }
-    }
-  #endif
 #endif


### PR DESCRIPTION
In TCA it is considered a bug to send an action to a child feature when it is dismissed.

In SwiftUI, a focused text field binding will write to itself when the view it is presented in is dismissed.

So if you derive a TCA binding to a text field in a dismissable child feature, dismissing said feature will write to the text field and cause a warning to be emitted.

To work around this, we set a task local, and are currently setting it in debug-only methods that construct a binding from scratch. Creating bindings from scratch unfortunately leads to issues with animations, so we should avoid doing so.

Instead, we can leverage properties on store that bindings are derived from and suppress the warnings from there.