### PR TITLE
Support `package` access modifier for Observation architecture

### DIFF
--- a/Sources/ComposableArchitectureMacros/ObservableStateMacro.swift
+++ b/Sources/ComposableArchitectureMacros/ObservableStateMacro.swift
@@ -134,7 +134,7 @@ extension DeclModifierListSyntax {
         switch $0.name.tokenKind {
         case .keyword(let keyword):
           switch keyword {
-          case .fileprivate, .private, .internal, .public:
+          case .fileprivate, .private, .internal, .public, .package:
             return false
           default:
             return true
@@ -248,7 +248,7 @@ extension ObservableStateMacro: MemberMacro {
 
     var declarations = [DeclSyntax]()
 
-    let access = declaration.modifiers.first { $0.name.tokenKind == .keyword(.public) }
+    let access = declaration.modifiers.first { $0.name.tokenKind == .keyword(.public) || $0.name.tokenKind == .keyword(.package) }
     declaration.addIfNeeded(
       ObservableStateMacro.registrarVariable(observableType), to: &declarations)
     declaration.addIfNeeded(ObservableStateMacro.idVariable(access), to: &declarations)
@@ -267,7 +267,7 @@ extension ObservableStateMacro {
     providingMembersOf declaration: Declaration,
     in context: Context
   ) throws -> [DeclSyntax] {
-    let access = declaration.modifiers.first { $0.name.tokenKind == .keyword(.public) }
+    let access = declaration.modifiers.first { $0.name.tokenKind == .keyword(.public) || $0.name.tokenKind == .keyword(.package) }
 
     let enumCaseDecls = declaration.memberBlock.members
       .flatMap { $0.decl.as(EnumCaseDeclSyntax.self)?.elements ?? [] }

--- a/Sources/ComposableArchitectureMacros/ViewActionMacro.swift
+++ b/Sources/ComposableArchitectureMacros/ViewActionMacro.swift
@@ -26,10 +26,7 @@ public struct ViewActionMacro: ExtensionMacro {
           leadingTrivia: declarationWithStoreVariable.memberBlock.members.first?.leadingTrivia
             ?? "\n    ",
           decl: VariableDeclSyntax(
-            bindingSpecifier: declaration.modifiers
-              .contains(where: { $0.name.tokenKind == .keyword(.public) })
-              ? "public let"
-              : "let",
+            bindingSpecifier: declaration.modifiers.bindingSpecifier(),
             bindings: [
               PatternBindingSyntax(
                 pattern: " store" as PatternSyntax,
@@ -157,6 +154,15 @@ extension DeclGroupSyntax {
     default:
       return nil
     }
+  }
+}
+
+extension DeclModifierListSyntax {
+  fileprivate func bindingSpecifier() -> TokenSyntax {
+    guard
+      let modifier = first(where: { $0.name.tokenKind == .keyword(.public) || $0.name.tokenKind == .keyword(.package) })
+    else { return "let" }
+    return "\(raw: modifier.name.text) let"
   }
 }
 

--- a/Tests/ComposableArchitectureMacrosTests/ViewActionMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ViewActionMacroTests.swift
@@ -217,6 +217,54 @@
       }
     }
 
+    func testNoStore_Package() {
+      assertMacro {
+        """
+        @ViewAction(for: Feature.self)
+        package struct FeatureView: View {
+          package var body: some View {
+            EmptyView()
+          }
+        }
+        """
+      } diagnostics: {
+        """
+        @ViewAction(for: Feature.self)
+        ╰─ 🛑 '@ViewAction' requires 'FeatureView' to have a 'store' property of type 'Store'.
+           ✏️ Add 'store'
+        package struct FeatureView: View {
+          package var body: some View {
+            EmptyView()
+          }
+        }
+        """
+      } fixes: {
+        """
+        @ViewAction(for: Feature.self)
+        package struct FeatureView: View {
+          package let store: StoreOf<Feature>
+
+          package var body: some View {
+            EmptyView()
+          }
+        }
+        """
+      } expansion: {
+        """
+        package struct FeatureView: View {
+          package let store: StoreOf<Feature>
+
+          package var body: some View {
+            EmptyView()
+          }
+        }
+
+        extension FeatureView: ComposableArchitecture.ViewActionSending {
+        }
+        """
+      }
+    }
+
     func testWarning_StoreSend() {
       assertMacro {
         """


### PR DESCRIPTION
`@ObservableState` macro was not support `package` access modifier.

<img width="600" alt="error" src="https://github.com/pointfreeco/swift-composable-architecture/assets/9856514/bff2a2f7-044c-457b-9aac-05cf7425fb63">

| Before | After |
| :----: | :----: |
| ![before](https://github.com/pointfreeco/swift-composable-architecture/assets/9856514/3af133ad-0ced-4c4a-8957-b4b253ae4416) | ![after](https://github.com/pointfreeco/swift-composable-architecture/assets/9856514/02f7f4fa-0240-430f-9361-341ddd0da375) |