### PR TITLE
Add missing `var` keyword to Migrating to 1.7 doc

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.7.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.7.md
@@ -612,7 +612,7 @@ your feature's state with ``ObservableState()`` and removing all instances of <d
 +@ObservableState
  struct State {
 -  @BindingState var text = ""
--  @BindingState isOn = false
+-  @BindingState var isOn = false
 +  var text = ""
 +  var isOn = false
  }


### PR DESCRIPTION
I noticed that there is no `var` keyword on the line where `isOn` is declared 🙂