### PR TITLE
Deprecate `Reducer.onChange(of:removeDuplicates:)`

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/ReducerDeprecations.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/ReducerDeprecations.md
@@ -18,3 +18,4 @@ instead.
 - ``Reducer/ifCaseLet(_:action:then:fileID:line:)-36dz4``
 - ``Reducer/forEach(_:action:element:fileID:line:)-65nr1``
 - ``Reducer/forEach(_:action:destination:fileID:line:)-51zt9``
+- ``Reducer/onChange(of:removeDuplicates:_:)``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerOnChange.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerOnChange.md
@@ -1,7 +1,0 @@
-# ``ComposableArchitecture/Reducer/onChange(of:_:)``
-
-## Topics
-
-### Deduping changes
-
-- ``Reducer/onChange(of:removeDuplicates:_:)``

--- a/Sources/ComposableArchitecture/Reducer/Reducers/OnChange.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/OnChange.swift
@@ -50,6 +50,7 @@ extension Reducer {
   ///   - oldValue: The old value that failed the comparison check.
   ///   - newValue: The new value that failed the comparison check.
   /// - Returns: A reducer that performs the logic when the state changes.
+  @available(*, deprecated, message: "Use 'onChange(of:)' with and equatable value, instead.")
   @inlinable
   public func onChange<V, R: Reducer>(
     of toValue: @escaping (State) -> V,


### PR DESCRIPTION
The `removeDuplicates` overload is just too tough on the compiler to resolve, so we don't think it's worth shipping in the library in the long run. SwiftUI's `View.onChange` doesn't have such an option, and adding such a signature results in the same compiler issues. Let's stick with the interface that most closely matches SwiftUI's and avoid interfaces that are problematic for the compiler.