### PR TITLE
Clean up examples

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -145,15 +145,6 @@
       }
     },
     {
-      "identity" : "swift-tagged",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-tagged.git",
-      "state" : {
-        "revision" : "3907a9438f5b57d317001dc99f3f11b46882272b",
-        "version" : "0.10.0"
-      }
-    },
-    {
       "identity" : "swiftui-navigation",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation.git",

--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -145,6 +145,15 @@
       }
     },
     {
+      "identity" : "swift-tagged",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-tagged.git",
+      "state" : {
+        "revision" : "3907a9438f5b57d317001dc99f3f11b46882272b",
+        "version" : "0.10.0"
+      }
+    },
+    {
       "identity" : "swiftui-navigation",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation.git",

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -110,10 +110,6 @@ struct RootView: View {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct RootView_Previews: PreviewProvider {
-  static var previews: some View {
-    RootView()
-  }
+#Preview {
+  RootView()
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -177,18 +177,18 @@ struct RootView: View {
 /// This wrapper provides an "entry" point into an individual demo that can own a store.
 struct Demo<State, Action, Content: View>: View {
   @SwiftUI.State var store: Store<State, Action>
-  let content: Content
+  let content: (Store<State, Action>) -> Content
 
   init(
     store: Store<State, Action>,
-    @ViewBuilder content: (Store<State, Action>) -> Content
+    @ViewBuilder content: @escaping (Store<State, Action>) -> Content
   ) {
     self.store = store
-    self.content = content(store)
+    self.content = content
   }
 
   var body: some View {
-    self.content
+    self.content(self.store)
   }
 }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -9,31 +9,67 @@ struct RootView: View {
       Form {
         Section {
           NavigationLink("Basics") {
-            CounterDemoView()
+            CounterDemoView(
+              store: Store(initialState: Counter.State()) {
+                Counter()
+              }
+            )
           }
           NavigationLink("Combining reducers") {
-            TwoCountersView()
+            TwoCountersView(
+              store: Store(initialState: TwoCounters.State()) {
+                TwoCounters()
+              }
+            )
           }
           NavigationLink("Bindings") {
-            BindingBasicsView()
+            BindingBasicsView(
+              store: Store(initialState: BindingBasics.State()) {
+                BindingBasics()
+              }
+            )
           }
           NavigationLink("Form bindings") {
-            BindingFormView()
+            BindingFormView(
+              store: Store(initialState: BindingForm.State()) {
+                BindingForm()
+              }
+            )
           }
           NavigationLink("Optional state") {
-            OptionalBasicsView()
+            OptionalBasicsView(
+              store: Store(initialState: OptionalBasics.State()) {
+                OptionalBasics()
+              }
+            )
           }
           NavigationLink("Shared state") {
-            SharedStateView()
+            SharedStateView(
+              store: Store(initialState: SharedState.State()) {
+                SharedState()
+              }
+            )
           }
           NavigationLink("Alerts and Confirmation Dialogs") {
-            AlertAndConfirmationDialogView()
+            AlertAndConfirmationDialogView(
+              store: Store(initialState: AlertAndConfirmationDialog.State()) {
+                AlertAndConfirmationDialog()
+              }
+            )
           }
           NavigationLink("Focus State") {
-            FocusDemoView()
+            FocusDemoView(
+              store: Store(initialState: FocusDemo.State()) {
+                FocusDemo()
+              }
+            )
           }
           NavigationLink("Animations") {
-            AnimationsView()
+            AnimationsView(
+              store: Store(initialState: Animations.State()) {
+                Animations()
+              }
+            )
           }
         } header: {
           Text("Getting started")
@@ -41,22 +77,46 @@ struct RootView: View {
 
         Section {
           NavigationLink("Basics") {
-            EffectsBasicsView()
+            EffectsBasicsView(
+              store: Store(initialState: EffectsBasics.State()) {
+                EffectsBasics()
+              }
+            )
           }
           NavigationLink("Cancellation") {
-            EffectsCancellationView()
+            EffectsCancellationView(
+              store: Store(initialState: EffectsCancellation.State()) {
+                EffectsCancellation()
+              }
+            )
           }
           NavigationLink("Long-living effects") {
-            LongLivingEffectsView()
+            LongLivingEffectsView(
+              store: Store(initialState: LongLivingEffects.State()) {
+                LongLivingEffects()
+              }
+            )
           }
           NavigationLink("Refreshable") {
-            RefreshableView()
+            RefreshableView(
+              store: Store(initialState: Refreshable.State()) {
+                Refreshable()
+              }
+            )
           }
           NavigationLink("Timers") {
-            TimersView()
+            TimersView(
+              store: Store(initialState: Timers.State()) {
+                Timers()
+              }
+            )
           }
           NavigationLink("Web socket") {
-            WebSocketView()
+            WebSocketView(
+              store: Store(initialState: WebSocket.State()) {
+                WebSocket()
+              }
+            )
           }
         } header: {
           Text("Effects")
@@ -69,20 +129,40 @@ struct RootView: View {
           .buttonStyle(.plain)
 
           NavigationLink("Navigate and load data") {
-            NavigateAndLoadView()
+            NavigateAndLoadView(
+              store: Store(initialState: NavigateAndLoad.State()) {
+                NavigateAndLoad()
+              }
+            )
           }
 
           NavigationLink("Lists: Navigate and load data") {
-            NavigateAndLoadListView()
+            NavigateAndLoadListView(
+              store: Store(initialState: NavigateAndLoadList.State()) {
+                NavigateAndLoadList()
+              }
+            )
           }
           NavigationLink("Sheets: Present and load data") {
-            PresentAndLoadView()
+            PresentAndLoadView(
+              store: Store(initialState: PresentAndLoad.State()) {
+                PresentAndLoad()
+              }
+            )
           }
           NavigationLink("Sheets: Load data then present") {
-            LoadThenPresentView()
+            LoadThenPresentView(
+              store: Store(initialState: LoadThenPresent.State()) {
+                LoadThenPresent()
+              }
+            )
           }
           NavigationLink("Multiple destinations") {
-            MultipleDestinationsView()
+            MultipleDestinationsView(
+              store: Store(initialState: MultipleDestinations.State()) {
+                MultipleDestinations()
+              }
+            )
           }
         } header: {
           Text("Navigation")
@@ -90,13 +170,25 @@ struct RootView: View {
 
         Section {
           NavigationLink("Reusable favoriting component") {
-            EpisodesView()
+            EpisodesView(
+              store: Store(initialState: Episodes.State()) {
+                Episodes()
+              }
+            )
           }
           NavigationLink("Reusable offline download component") {
-            CitiesView()
+            CitiesView(
+              store: Store(initialState: MapApp.State()) {
+                MapApp()
+              }
+            )
           }
           NavigationLink("Recursive state and actions") {
-            NestedView()
+            NestedView(
+              store: Store(initialState: Nested.State()) {
+                Nested()
+              }
+            )
           }
         } header: {
           Text("Higher-order reducers")
@@ -104,7 +196,11 @@ struct RootView: View {
       }
       .navigationTitle("Case Studies")
       .sheet(isPresented: self.$isNavigationStackCaseStudyPresented) {
-        NavigationDemoView()
+        NavigationDemoView(
+          store: Store(initialState: NavigationDemo.State()) {
+            NavigationDemo()
+          }
+        )
       }
     }
   }

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -9,67 +9,53 @@ struct RootView: View {
       Form {
         Section {
           NavigationLink("Basics") {
-            CounterDemoView(
-              store: Store(initialState: Counter.State()) {
-                Counter()
-              }
-            )
+            Demo(store: Store(initialState: Counter.State()) { Counter() }) { store in
+              CounterDemoView(store: store)
+            }
           }
           NavigationLink("Combining reducers") {
-            TwoCountersView(
-              store: Store(initialState: TwoCounters.State()) {
-                TwoCounters()
-              }
-            )
+            Demo(store: Store(initialState: TwoCounters.State()) { TwoCounters() }) { store in
+              TwoCountersView(store: store)
+            }
           }
           NavigationLink("Bindings") {
-            BindingBasicsView(
-              store: Store(initialState: BindingBasics.State()) {
-                BindingBasics()
-              }
-            )
+            Demo(store: Store(initialState: BindingBasics.State()) { BindingBasics() }) { store in
+              BindingBasicsView(store: store)
+            }
           }
           NavigationLink("Form bindings") {
-            BindingFormView(
-              store: Store(initialState: BindingForm.State()) {
-                BindingForm()
-              }
-            )
+            Demo(store: Store(initialState: BindingForm.State()) { BindingForm() }) { store in
+              BindingFormView(store: store)
+            }
           }
           NavigationLink("Optional state") {
-            OptionalBasicsView(
-              store: Store(initialState: OptionalBasics.State()) {
-                OptionalBasics()
-              }
-            )
+            Demo(store: Store(initialState: OptionalBasics.State()) { OptionalBasics() }) { store in
+              OptionalBasicsView(store: store)
+            }
           }
           NavigationLink("Shared state") {
-            SharedStateView(
-              store: Store(initialState: SharedState.State()) {
-                SharedState()
-              }
-            )
+            Demo(store: Store(initialState: SharedState.State()) { SharedState() }) { store in
+              SharedStateView(store: store)
+            }
           }
           NavigationLink("Alerts and Confirmation Dialogs") {
-            AlertAndConfirmationDialogView(
+            Demo(
               store: Store(initialState: AlertAndConfirmationDialog.State()) {
                 AlertAndConfirmationDialog()
               }
-            )
+            ) { store in
+              AlertAndConfirmationDialogView(store: store)
+            }
           }
           NavigationLink("Focus State") {
-            FocusDemoView(
-              store: Store(initialState: FocusDemo.State()) {
-                FocusDemo()
-              }
-            )
+            Demo(store: Store(initialState: FocusDemo.State()) { FocusDemo() }) { store in
+              FocusDemoView(store: store)
+            }
           }
           NavigationLink("Animations") {
-            AnimationsView(
-              store: Store(initialState: Animations.State()) {
-                Animations()
-              }
-            )
+            Demo(store: Store(initialState: Animations.State()) { Animations() }) { store in
+              AnimationsView(store: store)
+            }
           }
         } header: {
           Text("Getting started")
@@ -77,46 +63,38 @@ struct RootView: View {
 
         Section {
           NavigationLink("Basics") {
-            EffectsBasicsView(
-              store: Store(initialState: EffectsBasics.State()) {
-                EffectsBasics()
-              }
-            )
+            Demo(store: Store(initialState: EffectsBasics.State()) { EffectsBasics() }) { store in
+              EffectsBasicsView(store: store)
+            }
           }
           NavigationLink("Cancellation") {
-            EffectsCancellationView(
-              store: Store(initialState: EffectsCancellation.State()) {
-                EffectsCancellation()
-              }
-            )
+            Demo(
+              store: Store(initialState: EffectsCancellation.State()) { EffectsCancellation() }
+            ) { store in
+              EffectsCancellationView(store: store)
+            }
           }
           NavigationLink("Long-living effects") {
-            LongLivingEffectsView(
-              store: Store(initialState: LongLivingEffects.State()) {
-                LongLivingEffects()
-              }
-            )
+            Demo(
+              store: Store(initialState: LongLivingEffects.State()) { LongLivingEffects() }
+            ) { store in
+              LongLivingEffectsView(store: store)
+            }
           }
           NavigationLink("Refreshable") {
-            RefreshableView(
-              store: Store(initialState: Refreshable.State()) {
-                Refreshable()
-              }
-            )
+            Demo(store: Store(initialState: Refreshable.State()) { Refreshable() }) { store in
+              RefreshableView(store: store)
+            }
           }
           NavigationLink("Timers") {
-            TimersView(
-              store: Store(initialState: Timers.State()) {
-                Timers()
-              }
-            )
+            Demo(store: Store(initialState: Timers.State()) { Timers() }) { store in
+              TimersView(store: store)
+            }
           }
           NavigationLink("Web socket") {
-            WebSocketView(
-              store: Store(initialState: WebSocket.State()) {
-                WebSocket()
-              }
-            )
+            Demo(store: Store(initialState: WebSocket.State()) { WebSocket() }) { store in
+              WebSocketView(store: store)
+            }
           }
         } header: {
           Text("Effects")
@@ -129,40 +107,38 @@ struct RootView: View {
           .buttonStyle(.plain)
 
           NavigationLink("Navigate and load data") {
-            NavigateAndLoadView(
-              store: Store(initialState: NavigateAndLoad.State()) {
-                NavigateAndLoad()
-              }
-            )
+            Demo(
+              store: Store(initialState: NavigateAndLoad.State()) { NavigateAndLoad() }
+            ) { store in
+              NavigateAndLoadView(store: store)
+            }
           }
 
           NavigationLink("Lists: Navigate and load data") {
-            NavigateAndLoadListView(
-              store: Store(initialState: NavigateAndLoadList.State()) {
-                NavigateAndLoadList()
-              }
-            )
+            Demo(
+              store: Store(initialState: NavigateAndLoadList.State()) { NavigateAndLoadList() }
+            ) { store in
+              NavigateAndLoadListView(store: store)
+            }
           }
           NavigationLink("Sheets: Present and load data") {
-            PresentAndLoadView(
-              store: Store(initialState: PresentAndLoad.State()) {
-                PresentAndLoad()
-              }
-            )
+            Demo(store: Store(initialState: PresentAndLoad.State()) { PresentAndLoad() }) { store in
+              PresentAndLoadView(store: store)
+            }
           }
           NavigationLink("Sheets: Load data then present") {
-            LoadThenPresentView(
-              store: Store(initialState: LoadThenPresent.State()) {
-                LoadThenPresent()
-              }
-            )
+            Demo(
+              store: Store(initialState: LoadThenPresent.State()) { LoadThenPresent() }
+            ) { store in
+              LoadThenPresentView(store: store)
+            }
           }
           NavigationLink("Multiple destinations") {
-            MultipleDestinationsView(
-              store: Store(initialState: MultipleDestinations.State()) {
-                MultipleDestinations()
-              }
-            )
+            Demo(
+              store: Store(initialState: MultipleDestinations.State()) { MultipleDestinations() }
+            ) { store in
+              MultipleDestinationsView(store: store)
+            }
           }
         } header: {
           Text("Navigation")
@@ -170,25 +146,19 @@ struct RootView: View {
 
         Section {
           NavigationLink("Reusable favoriting component") {
-            EpisodesView(
-              store: Store(initialState: Episodes.State()) {
-                Episodes()
-              }
-            )
+            Demo(store: Store(initialState: Episodes.State()) { Episodes() }) { store in
+              EpisodesView(store: store)
+            }
           }
           NavigationLink("Reusable offline download component") {
-            CitiesView(
-              store: Store(initialState: MapApp.State()) {
-                MapApp()
-              }
-            )
+            Demo(store: Store(initialState: MapApp.State()) { MapApp() }) { store in
+              CitiesView(store: store)
+            }
           }
           NavigationLink("Recursive state and actions") {
-            NestedView(
-              store: Store(initialState: Nested.State()) {
-                Nested()
-              }
-            )
+            Demo(store: Store(initialState: Nested.State()) { Nested() }) { store in
+              NestedView(store: store)
+            }
           }
         } header: {
           Text("Higher-order reducers")
@@ -196,13 +166,29 @@ struct RootView: View {
       }
       .navigationTitle("Case Studies")
       .sheet(isPresented: self.$isNavigationStackCaseStudyPresented) {
-        NavigationDemoView(
-          store: Store(initialState: NavigationDemo.State()) {
-            NavigationDemo()
-          }
-        )
+        Demo(store: Store(initialState: NavigationDemo.State()) { NavigationDemo() }) { store in
+          NavigationDemoView(store: store)
+        }
       }
     }
+  }
+}
+
+/// This wrapper provides an "entry" point into an individual demo that can own a store.
+struct Demo<State, Action, Content: View>: View {
+  @SwiftUI.State var store: Store<State, Action>
+  let content: Content
+
+  init(
+    store: Store<State, Action>,
+    @ViewBuilder content: (Store<State, Action>) -> Content
+  ) {
+    self.store = store
+    self.content = content(store)
+  }
+
+  var body: some View {
+    self.content
   }
 }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -5,18 +5,15 @@ private let readMe = """
   This demonstrates how to best handle alerts and confirmation dialogs in the Composable \
   Architecture.
 
-  Because the library demands that all data flow through the application in a single direction, we \
-  cannot leverage SwiftUI's two-way bindings because they can make changes to state without going \
-  through a reducer. This means we can't directly use the standard API to display alerts and sheets.
+  The library comes with two types, `AlertState` and `ConfirmationDialogState`, which are data \
+  descriptions of the state and actions of an alert or dialog. These types can be constructed in \
+  reducers to control whether or not an alert or confirmation dialog is displayed, and \
+  corresponding view modifiers, `alert(_:)` and `confirmationDialog(_:)`, can be handed bindings \
+  to a store focused on an alert or dialog domain so that the alert or dialog can be displayed in \
+  the view.
 
-  However, the library comes with two types, `AlertState` and `ConfirmationDialogState`, which can \
-  be constructed from reducers and control whether or not an alert or confirmation dialog is \
-  displayed. Further, it automatically handles sending actions when you tap their buttons, which \
-  allows you to properly handle their functionality in the reducer rather than in two-way bindings \
-  and action closures.
-
-  The benefit of doing this is that you can get full test coverage on how a user interacts with \
-  alerts and dialogs in your application
+  The benefit of using these types is that you can get full test coverage on how a user interacts \
+  with alerts and dialogs in your application
   """
 
 @Reducer

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -103,9 +103,7 @@ struct AlertAndConfirmationDialog {
 }
 
 struct AlertAndConfirmationDialogView: View {
-  @Bindable var store = Store(initialState: AlertAndConfirmationDialog.State()) {
-    AlertAndConfirmationDialog()
-  }
+  @Bindable var store: StoreOf<AlertAndConfirmationDialog>
 
   var body: some View {
     Form {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -19,8 +19,6 @@ private let readMe = """
   alerts and dialogs in your application
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct AlertAndConfirmationDialog {
   @ObservableState
@@ -104,8 +102,6 @@ struct AlertAndConfirmationDialog {
   }
 }
 
-// MARK: - Feature view
-
 struct AlertAndConfirmationDialogView: View {
   @Bindable var store = Store(initialState: AlertAndConfirmationDialog.State()) {
     AlertAndConfirmationDialog()
@@ -127,16 +123,12 @@ struct AlertAndConfirmationDialogView: View {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct AlertAndConfirmationDialog_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationView {
-      AlertAndConfirmationDialogView(
-        store: Store(initialState: AlertAndConfirmationDialog.State()) {
-          AlertAndConfirmationDialog()
-        }
-      )
-    }
+#Preview {
+  NavigationStack {
+    AlertAndConfirmationDialogView(
+      store: Store(initialState: AlertAndConfirmationDialog.State()) {
+        AlertAndConfirmationDialog()
+      }
+    )
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -3,19 +3,20 @@ import SwiftUI
 
 private let readMe = """
   This screen demonstrates how changes to application state can drive animations. Because the \
-  `Store` processes actions sent to it synchronously you can typically perform animations \
-  in the Composable Architecture just as you would in regular SwiftUI.
+  `Store` processes actions sent to it synchronously you can typically perform animations in the \
+  Composable Architecture just as you would in regular SwiftUI.
 
-  To animate the changes made to state when an action is sent to the store you can pass along an \
-  explicit animation, as well, or you can call `viewStore.send` in a `withAnimation` block.
+  To animate the changes made to state when an action is sent to the store, you can also pass \
+  along an explicit animation, or you can call `store.send` in a `withAnimation` block.
 
-  To animate changes made to state through a binding, use the `.animation` method on `Binding`.
+  To animate changes made to state through a binding, you can call the `animation` method on \
+  `Binding`.
 
-  To animate asynchronous changes made to state via effects, use `Effect.run` style of effects \
-  which allows you to send actions with animations.
+  To animate asynchronous changes made to state via effects, use the `Effect.run` style of \
+  effects, which allows you to send actions with animations.
 
-  Try it out by tapping or dragging anywhere on the screen to move the dot, and by flipping the \
-  toggle at the bottom of the screen.
+  Try out the demo by tapping or dragging anywhere on the screen to move the dot, and by flipping \
+  the toggle at the bottom of the screen.
   """
 
 @Reducer

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -18,8 +18,6 @@ private let readMe = """
   toggle at the bottom of the screen.
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct Animations {
   @ObservableState
@@ -99,8 +97,6 @@ struct Animations {
   }
 }
 
-// MARK: - Feature view
-
 struct AnimationsView: View {
   @Bindable var store = Store(initialState: Animations.State()) {
     Animations()
@@ -151,27 +147,23 @@ struct AnimationsView: View {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct AnimationsView_Previews: PreviewProvider {
-  static var previews: some View {
-    Group {
-      NavigationView {
-        AnimationsView(
-          store: Store(initialState: Animations.State()) {
-            Animations()
-          }
-        )
+#Preview {
+  NavigationStack {
+    AnimationsView(
+      store: Store(initialState: Animations.State()) {
+        Animations()
       }
-
-      NavigationView {
-        AnimationsView(
-          store: Store(initialState: Animations.State()) {
-            Animations()
-          }
-        )
-      }
-      .environment(\.colorScheme, .dark)
-    }
+    )
   }
+}
+
+#Preview("Dark mode") {
+  NavigationStack {
+    AnimationsView(
+      store: Store(initialState: Animations.State()) {
+        Animations()
+      }
+    )
+  }
+  .environment(\.colorScheme, .dark)
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -98,9 +98,7 @@ struct Animations {
 }
 
 struct AnimationsView: View {
-  @Bindable var store = Store(initialState: Animations.State()) {
-    Animations()
-  }
+  @Bindable var store: StoreOf<Animations>
 
   var body: some View {
     VStack(alignment: .leading) {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -18,8 +18,6 @@ private let readMe = """
   component changes, which means you can keep using a unidirectional style for your feature.
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct BindingBasics {
   @ObservableState
@@ -60,8 +58,6 @@ struct BindingBasics {
     }
   }
 }
-
-// MARK: - Feature view
 
 struct BindingBasicsView: View {
   @Bindable var store = Store(initialState: BindingBasics.State()) {
@@ -120,16 +116,12 @@ private func alternate(_ string: String) -> String {
     .joined()
 }
 
-// MARK: - SwiftUI previews
-
-struct BindingBasicsView_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationView {
-      BindingBasicsView(
-        store: Store(initialState: BindingBasics.State()) {
-          BindingBasics()
-        }
-      )
-    }
+#Preview {
+  NavigationStack {
+    BindingBasicsView(
+      store: Store(initialState: BindingBasics.State()) {
+        BindingBasics()
+      }
+    )
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -60,9 +60,7 @@ struct BindingBasics {
 }
 
 struct BindingBasicsView: View {
-  @Bindable var store = Store(initialState: BindingBasics.State()) {
-    BindingBasics()
-  }
+  @Bindable var store: StoreOf<BindingBasics>
 
   var body: some View {
     Form {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -12,10 +12,11 @@ private let readMe = """
   actions to the store, and this means there is only ever one place to see how the state of our \
   feature evolves, which is the reducer.
 
-  Any SwiftUI component that requires a Binding to do its job can be used in the Composable \
-  Architecture. You can derive a Binding from your ViewStore by using the `binding` method. This \
-  will allow you to specify what state renders the component, and what action to send when the \
-  component changes, which means you can keep using a unidirectional style for your feature.
+  Any SwiftUI component that requires a binding to do its job can be used in the Composable \
+  Architecture. You can derive a binding from a store by taking a bindable store, chaining into a \
+  property of state that renders the component, and calling the `sending` method with a key path \
+  to an action to send when the component changes, which means you can keep using a unidirectional \
+  style for your feature.
   """
 
 @Reducer

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -13,8 +13,6 @@ private let readMe = """
   It is instructive to compare this case study to the "Binding Basics" case study.
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct BindingForm {
   @ObservableState
@@ -48,8 +46,6 @@ struct BindingForm {
     }
   }
 }
-
-// MARK: - Feature view
 
 struct BindingFormView: View {
   @Bindable var store = Store(initialState: BindingForm.State()) {
@@ -108,16 +104,12 @@ private func alternate(_ string: String) -> String {
     .joined()
 }
 
-// MARK: - SwiftUI previews
-
-struct BindingFormView_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationView {
-      BindingFormView(
-        store: Store(initialState: BindingForm.State()) {
-          BindingForm()
-        }
-      )
-    }
+#Preview {
+  NavigationStack {
+    BindingFormView(
+      store: Store(initialState: BindingForm.State()) {
+        BindingForm()
+      }
+    )
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -3,12 +3,11 @@ import SwiftUI
 
 private let readMe = """
   This file demonstrates how to handle two-way bindings in the Composable Architecture using \
-  binding state and actions.
+  bindable actions and binding reducers.
 
-  Binding state and actions allow you to safely eliminate the boilerplate caused by needing to \
-  have a unique action for every UI control. Instead, all UI bindings can be consolidated into a \
-  single `binding` action that holds onto a `BindingAction` value, and all binding state can be \
-  safeguarded with the `BindingState` property wrapper.
+  Bindable actions allow you to safely eliminate the boilerplate caused by needing to have a \
+  unique action for every UI control. Instead, all UI bindings can be consolidated into a single \
+  `binding` action, which the `BindingReducer` can automatically apply to state.
 
   It is instructive to compare this case study to the "Binding Basics" case study.
   """

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -48,9 +48,7 @@ struct BindingForm {
 }
 
 struct BindingFormView: View {
-  @Bindable var store = Store(initialState: BindingForm.State()) {
-    BindingForm()
-  }
+  @Bindable var store: StoreOf<BindingForm>
 
   var body: some View {
     Form {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -31,9 +31,7 @@ struct TwoCounters {
 }
 
 struct TwoCountersView: View {
-  var store = Store(initialState: TwoCounters.State()) {
-    TwoCounters()
-  }
+  let store: StoreOf<TwoCounters>
 
   var body: some View {
     Form {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -2,7 +2,8 @@ import ComposableArchitecture
 import SwiftUI
 
 private let readMe = """
-  This screen demonstrates how to take small features and compose them into bigger ones using reducer builders and the `Scope` reducer, as well as the `scope` operator on stores.
+  This screen demonstrates how to take small features and compose them into bigger ones using \
+  reducer builders and the `Scope` reducer, as well as the `scope` operator on stores.
 
   It reuses the domain of the counter screen and embeds it, twice, in a larger domain.
   """

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -7,8 +7,6 @@ private let readMe = """
   It reuses the domain of the counter screen and embeds it, twice, in a larger domain.
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct TwoCounters {
   @ObservableState
@@ -31,8 +29,6 @@ struct TwoCounters {
     }
   }
 }
-
-// MARK: - Feature view
 
 struct TwoCountersView: View {
   var store = Store(initialState: TwoCounters.State()) {
@@ -62,16 +58,12 @@ struct TwoCountersView: View {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct TwoCountersView_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationView {
-      TwoCountersView(
-        store: Store(initialState: TwoCounters.State()) {
-          TwoCounters()
-        }
-      )
-    }
+#Preview {
+  NavigationStack {
+    TwoCountersView(
+      store: Store(initialState: TwoCounters.State()) {
+        TwoCounters()
+      }
+    )
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -9,8 +9,6 @@ private let readMe = """
   state of the application and any actions that can affect that state or the outside world.
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct Counter {
   @ObservableState
@@ -36,8 +34,6 @@ struct Counter {
     }
   }
 }
-
-// MARK: - Feature view
 
 struct CounterView: View {
   let store: StoreOf<Counter>
@@ -83,16 +79,12 @@ struct CounterDemoView: View {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct CounterView_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationView {
-      CounterDemoView(
-        store: Store(initialState: Counter.State()) {
-          Counter()
-        }
-      )
-    }
+#Preview {
+  NavigationStack {
+    CounterDemoView(
+      store: Store(initialState: Counter.State()) {
+        Counter()
+      }
+    )
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -59,9 +59,7 @@ struct CounterView: View {
 }
 
 struct CounterDemoView: View {
-  var store = Store(initialState: Counter.State()) {
-    Counter()
-  }
+  let store: StoreOf<Counter>
 
   var body: some View {
     Form {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -4,7 +4,7 @@ import SwiftUI
 private let readMe = """
   This demonstrates how to make use of SwiftUI's `@FocusState` in the Composable Architecture with \
   the library's `bind` view modifier. If you tap the "Sign in" button while a field is empty, the \
-  focus will be changed to that field.
+  focus will be changed to the first empty field.
   """
 
 @Reducer

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -45,9 +45,7 @@ struct FocusDemo {
 }
 
 struct FocusDemoView: View {
-  @Bindable var store = Store(initialState: FocusDemo.State()) {
-    FocusDemo()
-  }
+  @Bindable var store: StoreOf<FocusDemo>
   @FocusState var focusedField: FocusDemo.State.Field?
 
   var body: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -7,8 +7,6 @@ private let readMe = """
   focus will be changed to that field.
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct FocusDemo {
   @ObservableState
@@ -46,8 +44,6 @@ struct FocusDemo {
   }
 }
 
-// MARK: - Feature view
-
 struct FocusDemoView: View {
   @Bindable var store = Store(initialState: FocusDemo.State()) {
     FocusDemo()
@@ -76,16 +72,12 @@ struct FocusDemoView: View {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct FocusDemo_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationView {
-      FocusDemoView(
-        store: Store(initialState: FocusDemo.State()) {
-          FocusDemo()
-        }
-      )
-    }
+#Preview {
+  NavigationStack {
+    FocusDemoView(
+      store: Store(initialState: FocusDemo.State()) {
+        FocusDemo()
+      }
+    )
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -12,8 +12,6 @@ private let readMe = """
   Tapping "Toggle counter state" will flip between the `nil` and non-`nil` counter states.
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct OptionalBasics {
   @ObservableState
@@ -45,8 +43,6 @@ struct OptionalBasics {
   }
 }
 
-// MARK: - Feature view
-
 struct OptionalBasicsView: View {
   var store = Store(initialState: OptionalBasics.State()) {
     OptionalBasics()
@@ -75,28 +71,28 @@ struct OptionalBasicsView: View {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct OptionalBasicsView_Previews: PreviewProvider {
-  static var previews: some View {
-    Group {
-      NavigationView {
-        OptionalBasicsView(
-          store: Store(initialState: OptionalBasics.State()) {
-            OptionalBasics()
-          }
-        )
+#Preview {
+  NavigationStack {
+    OptionalBasicsView(
+      store: Store(initialState: OptionalBasics.State()) {
+        OptionalBasics()
       }
+    )
+  }
+}
 
-      NavigationView {
-        OptionalBasicsView(
-          store: Store(
-            initialState: OptionalBasics.State(optionalCounter: Counter.State(count: 42))
-          ) {
-            OptionalBasics()
-          }
+#Preview("Deep-linked") {
+  NavigationStack {
+    OptionalBasicsView(
+      store: Store(
+        initialState: OptionalBasics.State(
+          optionalCounter: Counter.State(
+            count: 42
+          )
         )
+      ) {
+        OptionalBasics()
       }
-    }
+    )
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -5,9 +5,9 @@ private let readMe = """
   This screen demonstrates how to show and hide views based on the presence of some optional child \
   state.
 
-  The parent state holds a `Counter.State?` value. When it is `nil` we will default to a plain text \
-  view. But when it is non-`nil` we will show a view fragment for a counter that operates on the \
-  non-optional counter state.
+  The parent state holds a `Counter.State?` value. When it is `nil` we will default to a plain \
+  text view. But when it is non-`nil` we will show a view fragment for a counter that operates on \
+  the non-optional counter state.
 
   Tapping "Toggle counter state" will flip between the `nil` and non-`nil` counter states.
   """

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -44,9 +44,7 @@ struct OptionalBasics {
 }
 
 struct OptionalBasicsView: View {
-  var store = Store(initialState: OptionalBasics.State()) {
-    OptionalBasics()
-  }
+  let store: StoreOf<OptionalBasics>
 
   var body: some View {
     Form {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
@@ -14,8 +14,6 @@ private let readMe = """
   can be reset from the other tab.
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct CounterTab {
   @ObservableState
@@ -244,16 +242,6 @@ struct Stats: Equatable {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct SharedState_Previews: PreviewProvider {
-  static var previews: some View {
-    SharedStateView()
-  }
-}
-
-// MARK: - Private helpers
-
 /// Checks if a number is prime or not.
 private func isPrime(_ p: Int) -> Bool {
   if p <= 1 { return false }
@@ -262,4 +250,8 @@ private func isPrime(_ p: Int) -> Bool {
     if p % i == 0 { return false }
   }
   return true
+}
+
+#Preview {
+  SharedStateView()
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
@@ -197,9 +197,7 @@ struct SharedState {
 }
 
 struct SharedStateView: View {
-  @State var store = Store(initialState: SharedState.State()) {
-    SharedState()
-  }
+  @Bindable var store: StoreOf<SharedState>
 
   var body: some View {
     TabView(selection: $store.currentTab.sending(\.selectTab)) {
@@ -253,5 +251,9 @@ private func isPrime(_ p: Int) -> Bool {
 }
 
 #Preview {
-  SharedStateView()
+  SharedStateView(
+    store: Store(initialState: SharedState.State()) {
+      SharedState()
+    }
+  )
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -91,9 +91,7 @@ struct EffectsBasics {
 }
 
 struct EffectsBasicsView: View {
-  var store = Store(initialState: EffectsBasics.State()) {
-    EffectsBasics()
-  }
+  let store: StoreOf<EffectsBasics>
   @Environment(\.openURL) var openURL
 
   var body: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -18,8 +18,6 @@ private let readMe = """
   suite is written to confirm that the effect behaves in the way we expect.
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct EffectsBasics {
   @ObservableState
@@ -92,8 +90,6 @@ struct EffectsBasics {
   }
 }
 
-// MARK: - Feature view
-
 struct EffectsBasicsView: View {
   var store = Store(initialState: EffectsBasics.State()) {
     EffectsBasics()
@@ -154,16 +150,12 @@ struct EffectsBasicsView: View {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct EffectsBasicsView_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationView {
-      EffectsBasicsView(
-        store: Store(initialState: EffectsBasics.State()) {
-          EffectsBasics()
-        }
-      )
-    }
+#Preview {
+  NavigationStack {
+    EffectsBasicsView(
+      store: Store(initialState: EffectsBasics.State()) {
+        EffectsBasics()
+      }
+    )
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -11,7 +11,7 @@ private let readMe = """
 
   Many things we do in our applications involve side effects, such as timers, database requests, \
   file access, socket connections, and anytime a clock is involved (such as debouncing, \
-  throttling and delaying), and they are typically difficult to test.
+  throttling, and delaying), and they are typically difficult to test.
 
   This application has a simple side effect: tapping "Number fact" will trigger an API request to \
   load a piece of trivia about that number. This effect is handled by the reducer, and a full test \

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -12,8 +12,6 @@ private let readMe = """
   request is in-flight will also cancel it.
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct EffectsCancellation {
   @ObservableState
@@ -68,8 +66,6 @@ struct EffectsCancellation {
   }
 }
 
-// MARK: - Feature view
-
 struct EffectsCancellationView: View {
   @Bindable var store = Store(initialState: EffectsCancellation.State()) {
     EffectsCancellation()
@@ -117,16 +113,12 @@ struct EffectsCancellationView: View {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct EffectsCancellation_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationView {
-      EffectsCancellationView(
-        store: Store(initialState: EffectsCancellation.State()) {
-          EffectsCancellation()
-        }
-      )
-    }
+#Preview {
+  NavigationStack {
+    EffectsCancellationView(
+      store: Store(initialState: EffectsCancellation.State()) {
+        EffectsCancellation()
+      }
+    )
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -67,9 +67,7 @@ struct EffectsCancellation {
 }
 
 struct EffectsCancellationView: View {
-  @Bindable var store = Store(initialState: EffectsCancellation.State()) {
-    EffectsCancellation()
-  }
+  @Bindable var store: StoreOf<EffectsCancellation>
   @Environment(\.openURL) var openURL
 
   var body: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -14,8 +14,6 @@ private let readMe = """
   the screen, and restarted when entering the screen.
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct LongLivingEffects {
   @ObservableState
@@ -66,8 +64,6 @@ private enum ScreenshotsKey: DependencyKey {
   }
 }
 
-// MARK: - Feature view
-
 struct LongLivingEffectsView: View {
   var store = Store(initialState: LongLivingEffects.State()) {
     LongLivingEffects()
@@ -106,19 +102,12 @@ struct LongLivingEffectsView: View {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct EffectsLongLiving_Previews: PreviewProvider {
-  static var previews: some View {
-    let appView = LongLivingEffectsView(
+#Preview {
+  NavigationStack {
+    LongLivingEffectsView(
       store: Store(initialState: LongLivingEffects.State()) {
         LongLivingEffects()
       }
     )
-
-    return Group {
-      NavigationView { appView }
-      NavigationView { appView.detailView }
-    }
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -65,9 +65,7 @@ private enum ScreenshotsKey: DependencyKey {
 }
 
 struct LongLivingEffectsView: View {
-  var store = Store(initialState: LongLivingEffects.State()) {
-    LongLivingEffects()
-  }
+  let store: StoreOf<LongLivingEffects>
 
   var body: some View {
     Form {

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -67,9 +67,7 @@ struct Refreshable {
 }
 
 struct RefreshableView: View {
-  var store = Store(initialState: Refreshable.State()) {
-    Refreshable()
-  }
+  let store: StoreOf<Refreshable>
   @State var isLoading = false
 
   var body: some View {

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -1,14 +1,15 @@
 import ComposableArchitecture
-@preconcurrency import SwiftUI
+import SwiftUI
 
 private let readMe = """
   This application demonstrates how to make use of SwiftUI's `refreshable` API in the Composable \
   Architecture. Use the "-" and "+" buttons to count up and down, and then pull down to request \
   a fact about that number.
 
-  There is an overload of the `.send` method that allows you to suspend and await while a piece \
-  of state is true. You can use this method to communicate to SwiftUI that you are \
-  currently fetching data so that it knows to continue showing the loading indicator.
+  There is a discardable task that is returned from the store's `.send` method representing any \
+  effects kicked off by the reducer. You can `await` this task using its `.finish` method, which \
+  will suspend while the effects remain in flight. This suspension communicates to SwiftUI that \
+  you are currently fetching data so that it knows to continue showing the loading indicator.
   """
 
 @Reducer

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -11,8 +11,6 @@ private let readMe = """
   currently fetching data so that it knows to continue showing the loading indicator.
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct Refreshable {
   @ObservableState
@@ -68,8 +66,6 @@ struct Refreshable {
   }
 }
 
-// MARK: - Feature view
-
 struct RefreshableView: View {
   var store = Store(initialState: Refreshable.State()) {
     Refreshable()
@@ -119,14 +115,10 @@ struct RefreshableView: View {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct Refreshable_Previews: PreviewProvider {
-  static var previews: some View {
-    RefreshableView(
-      store: Store(initialState: Refreshable.State()) {
-        Refreshable()
-      }
-    )
-  }
+#Preview {
+  RefreshableView(
+    store: Store(initialState: Refreshable.State()) {
+      Refreshable()
+    }
+  )
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -51,9 +51,7 @@ struct Timers {
 }
 
 struct TimersView: View {
-  var store = Store(initialState: Timers.State()) {
-    Timers()
-  }
+  var store: StoreOf<Timers>
 
   var body: some View {
     Form {

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -9,8 +9,6 @@ private let readMe = """
   dealing with times in asynchronous code.
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct Timers {
   @ObservableState
@@ -51,8 +49,6 @@ struct Timers {
     }
   }
 }
-
-// MARK: - Feature view
 
 struct TimersView: View {
   var store = Store(initialState: Timers.State()) {
@@ -118,16 +114,12 @@ struct TimersView: View {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct TimersView_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationView {
-      TimersView(
-        store: Store(initialState: Timers.State()) {
-          Timers()
-        }
-      )
-    }
+#Preview {
+  NavigationStack {
+    TimersView(
+      store: Store(initialState: Timers.State()) {
+        Timers()
+      }
+    )
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -137,9 +137,7 @@ struct WebSocket {
 }
 
 struct WebSocketView: View {
-  @Bindable var store = Store(initialState: WebSocket.State()) {
-    WebSocket()
-  }
+  @Bindable var store: StoreOf<WebSocket>
 
   var body: some View {
     Form {

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -9,8 +9,6 @@ private let readMe = """
   message. The socket server should immediately reply with the exact message you sent in.
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct WebSocket {
   @ObservableState
@@ -138,8 +136,6 @@ struct WebSocket {
   }
 }
 
-// MARK: - Feature view
-
 struct WebSocketView: View {
   @Bindable var store = Store(initialState: WebSocket.State()) {
     WebSocket()
@@ -192,8 +188,6 @@ struct WebSocketView: View {
     .navigationTitle("Web Socket")
   }
 }
-
-// MARK: - WebSocketClient
 
 @DependencyClient
 struct WebSocketClient {
@@ -357,16 +351,12 @@ extension DependencyValues {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct WebSocketView_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationView {
-      WebSocketView(
-        store: Store(initialState: WebSocket.State(receivedMessages: ["Hi"])) {
-          WebSocket()
-        }
-      )
-    }
+#Preview {
+  NavigationStack {
+    WebSocketView(
+      store: Store(initialState: WebSocket.State(receivedMessages: ["Hi"])) {
+        WebSocket()
+      }
+    )
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -8,8 +8,6 @@ private let readMe = """
   and fires off an effect that will load this state a second later.
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct NavigateAndLoadList {
   struct State: Equatable {
@@ -71,8 +69,6 @@ struct NavigateAndLoadList {
   }
 }
 
-// MARK: - Feature view
-
 struct NavigateAndLoadListView: View {
   @Bindable var store = Store(initialState: NavigateAndLoadList.State()) {
     NavigateAndLoadList()
@@ -106,25 +102,21 @@ struct NavigateAndLoadListView: View {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct NavigateAndLoadListView_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationView {
-      NavigateAndLoadListView(
-        store: Store(
-          initialState: NavigateAndLoadList.State(
-            rows: [
-              NavigateAndLoadList.State.Row(count: 1, id: UUID()),
-              NavigateAndLoadList.State.Row(count: 42, id: UUID()),
-              NavigateAndLoadList.State.Row(count: 100, id: UUID()),
-            ]
-          )
-        ) {
-          NavigateAndLoadList()
-        }
-      )
-    }
-    .navigationViewStyle(.stack)
+#Preview {
+  NavigationView {
+    NavigateAndLoadListView(
+      store: Store(
+        initialState: NavigateAndLoadList.State(
+          rows: [
+            NavigateAndLoadList.State.Row(count: 1, id: UUID()),
+            NavigateAndLoadList.State.Row(count: 42, id: UUID()),
+            NavigateAndLoadList.State.Row(count: 100, id: UUID()),
+          ]
+        )
+      ) {
+        NavigateAndLoadList()
+      }
+    )
   }
+  .navigationViewStyle(.stack)
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -70,9 +70,7 @@ struct NavigateAndLoadList {
 }
 
 struct NavigateAndLoadListView: View {
-  @Bindable var store = Store(initialState: NavigateAndLoadList.State()) {
-    NavigateAndLoadList()
-  }
+  @Bindable var store: StoreOf<NavigateAndLoadList>
 
   var body: some View {
     WithViewStore(self.store, observe: { $0 }) { viewStore in

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Multiple-Destinations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Multiple-Destinations.swift
@@ -71,9 +71,7 @@ struct MultipleDestinations {
 }
 
 struct MultipleDestinationsView: View {
-  @Bindable var store = Store(initialState: MultipleDestinations.State()) {
-    MultipleDestinations()
-  }
+  @Bindable var store: StoreOf<MultipleDestinations>
 
   var body: some View {
     Form {

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -8,8 +8,6 @@ private let readMe = """
   counter state and fires off an effect that will load this state a second later.
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct NavigateAndLoad {
   @ObservableState
@@ -57,8 +55,6 @@ struct NavigateAndLoad {
   }
 }
 
-// MARK: - Feature view
-
 struct NavigateAndLoadView: View {
   @Bindable var store = Store(initialState: NavigateAndLoad.State()) {
     NavigateAndLoad()
@@ -84,17 +80,13 @@ struct NavigateAndLoadView: View {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct NavigateAndLoadView_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationView {
-      NavigateAndLoadView(
-        store: Store(initialState: NavigateAndLoad.State()) {
-          NavigateAndLoad()
-        }
-      )
-    }
-    .navigationViewStyle(.stack)
+#Preview {
+  NavigationView {
+    NavigateAndLoadView(
+      store: Store(initialState: NavigateAndLoad.State()) {
+        NavigateAndLoad()
+      }
+    )
   }
+  .navigationViewStyle(.stack)
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -56,9 +56,7 @@ struct NavigateAndLoad {
 }
 
 struct NavigateAndLoadView: View {
-  @Bindable var store = Store(initialState: NavigateAndLoad.State()) {
-    NavigateAndLoad()
-  }
+  @Bindable var store: StoreOf<NavigateAndLoad>
 
   var body: some View {
     Form {

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -9,8 +9,6 @@ private let readMe = """
   depends on this data.
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct LoadThenPresent {
   @ObservableState
@@ -53,8 +51,6 @@ struct LoadThenPresent {
   }
 }
 
-// MARK: - Feature view
-
 struct LoadThenPresentView: View {
   @Bindable var store = Store(initialState: LoadThenPresent.State()) {
     LoadThenPresent()
@@ -84,16 +80,12 @@ struct LoadThenPresentView: View {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct LoadThenPresentView_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationView {
-      LoadThenPresentView(
-        store: Store(initialState: LoadThenPresent.State()) {
-          LoadThenPresent()
-        }
-      )
-    }
+#Preview {
+  NavigationStack {
+    LoadThenPresentView(
+      store: Store(initialState: LoadThenPresent.State()) {
+        LoadThenPresent()
+      }
+    )
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -52,9 +52,7 @@ struct LoadThenPresent {
 }
 
 struct LoadThenPresentView: View {
-  @Bindable var store = Store(initialState: LoadThenPresent.State()) {
-    LoadThenPresent()
-  }
+  @Bindable var store: StoreOf<LoadThenPresent>
 
   var body: some View {
     Form {

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -56,9 +56,7 @@ struct PresentAndLoad {
 }
 
 struct PresentAndLoadView: View {
-  @Bindable var store = Store(initialState: PresentAndLoad.State()) {
-    PresentAndLoad()
-  }
+  @Bindable var store: StoreOf<PresentAndLoad>
 
   var body: some View {
     Form {

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -8,8 +8,6 @@ private let readMe = """
   state and fires off an effect that will load this state a second later.
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct PresentAndLoad {
   @ObservableState
@@ -57,8 +55,6 @@ struct PresentAndLoad {
   }
 }
 
-// MARK: - Feature view
-
 struct PresentAndLoadView: View {
   @Bindable var store = Store(initialState: PresentAndLoad.State()) {
     PresentAndLoad()
@@ -84,16 +80,12 @@ struct PresentAndLoadView: View {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct PresentAndLoadView_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationView {
-      PresentAndLoadView(
-        store: Store(initialState: PresentAndLoad.State()) {
-          PresentAndLoad()
-        }
-      )
-    }
+#Preview {
+  NavigationView {
+    PresentAndLoadView(
+      store: Store(initialState: PresentAndLoad.State()) {
+        PresentAndLoad()
+      }
+    )
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-NavigationStack.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-NavigationStack.swift
@@ -90,9 +90,7 @@ struct NavigationDemo {
 }
 
 struct NavigationDemoView: View {
-  @Bindable var store = Store(initialState: NavigationDemo.State()) {
-    NavigationDemo()
-  }
+  @Bindable var store: StoreOf<NavigationDemo>
 
   var body: some View {
     NavigationStack(path: $store.scope(state: \.path, action: \.path)) {

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-NavigationStack.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-NavigationStack.swift
@@ -476,18 +476,16 @@ struct ScreenCView: View {
 
 // MARK: - Previews
 
-struct NavigationStack_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationDemoView(
-      store: Store(
-        initialState: NavigationDemo.State(
-          path: StackState([
-            .screenA(ScreenA.State())
-          ])
-        )
-      ) {
-        NavigationDemo()
-      }
-    )
-  }
+#Preview {
+  NavigationDemoView(
+    store: Store(
+      initialState: NavigationDemo.State(
+        path: StackState([
+          .screenA(ScreenA.State())
+        ])
+      )
+    ) {
+      NavigationDemo()
+    }
+  )
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -8,8 +8,6 @@ private let readMe = """
   its name, or tap the right-hand side of a row to navigate to its own associated list of rows.
   """
 
-// MARK: - Feature domain
-
 @Reducer
 struct Nested {
   @ObservableState
@@ -53,8 +51,6 @@ struct Nested {
   }
 }
 
-// MARK: - Feature view
-
 struct NestedView: View {
   @Bindable var store = Store(initialState: Nested.State(id: UUID())) {
     Nested()
@@ -90,38 +86,35 @@ struct NestedView: View {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct NestedView_Previews: PreviewProvider {
-  static var previews: some View {
-    let initialState = Nested.State(
-      id: UUID(),
-      name: "Foo",
-      rows: [
-        Nested.State(
+#Preview {
+  NavigationView {
+    NestedView(
+      store: Store(
+        initialState: Nested.State(
           id: UUID(),
-          name: "Bar",
+          name: "Foo",
           rows: [
-            Nested.State(id: UUID(), name: "", rows: [])
+            Nested.State(
+              id: UUID(),
+              name: "Bar",
+              rows: [
+                Nested.State(id: UUID(), name: "", rows: [])
+              ]
+            ),
+            Nested.State(
+              id: UUID(),
+              name: "Baz",
+              rows: [
+                Nested.State(id: UUID(), name: "Fizz", rows: []),
+                Nested.State(id: UUID(), name: "Buzz", rows: []),
+              ]
+            ),
+            Nested.State(id: UUID(), name: "", rows: []),
           ]
-        ),
-        Nested.State(
-          id: UUID(),
-          name: "Baz",
-          rows: [
-            Nested.State(id: UUID(), name: "Fizz", rows: []),
-            Nested.State(id: UUID(), name: "Buzz", rows: []),
-          ]
-        ),
-        Nested.State(id: UUID(), name: "", rows: []),
-      ]
+        )
+      ) {
+        Nested()
+      }
     )
-    NavigationView {
-      NestedView(
-        store: Store(initialState: initialState) {
-          Nested()
-        }
-      )
-    }
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -15,6 +15,13 @@ struct Nested {
     let id: UUID
     var name: String = ""
     var rows: IdentifiedArrayOf<State> = []
+
+    init(id: UUID? = nil, name: String = "", rows: IdentifiedArrayOf<State> = []) {
+      @Dependency(\.uuid) var uuid
+      self.id = id ?? uuid()
+      self.name = name
+      self.rows = rows
+    }
   }
 
   enum Action {
@@ -52,9 +59,7 @@ struct Nested {
 }
 
 struct NestedView: View {
-  @Bindable var store = Store(initialState: Nested.State(id: UUID())) {
-    Nested()
-  }
+  @Bindable var store: StoreOf<Nested>
 
   var body: some View {
     Form {
@@ -91,25 +96,22 @@ struct NestedView: View {
     NestedView(
       store: Store(
         initialState: Nested.State(
-          id: UUID(),
           name: "Foo",
           rows: [
             Nested.State(
-              id: UUID(),
               name: "Bar",
               rows: [
-                Nested.State(id: UUID(), name: "", rows: [])
+                Nested.State()
               ]
             ),
             Nested.State(
-              id: UUID(),
               name: "Baz",
               rows: [
-                Nested.State(id: UUID(), name: "Fizz", rows: []),
-                Nested.State(id: UUID(), name: "Buzz", rows: []),
+                Nested.State(name: "Fizz"),
+                Nested.State(name: "Buzz"),
               ]
             ),
-            Nested.State(id: UUID(), name: "", rows: []),
+            Nested.State(),
           ]
         )
       ) {

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
@@ -166,8 +166,14 @@ struct DownloadComponentView: View {
   }
 }
 
-struct DownloadComponent_Previews: PreviewProvider {
-  static var previews: some View {
-    DownloadList_Previews.previews
-  }
+#Preview {
+  DownloadComponentView(
+    store: Store(
+      initialState: DownloadComponent.State(
+        id: "deadbeef",
+        mode: .notDownloaded,
+        url: URL(fileURLWithPath: "/")
+      )
+    ) {}
+  )
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -138,7 +138,7 @@ struct CityMapDetailView: View {
 @Reducer
 struct MapApp {
   struct State: Equatable {
-    var cityMaps: IdentifiedArrayOf<CityMap.State>
+    var cityMaps: IdentifiedArrayOf<CityMap.State> = .mocks
   }
 
   enum Action {
@@ -153,9 +153,7 @@ struct MapApp {
 }
 
 struct CitiesView: View {
-  var store = Store(initialState: MapApp.State(cityMaps: .mocks)) {
-    MapApp()
-  }
+  let store: StoreOf<MapApp>
 
   var body: some View {
     Form {

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -171,26 +171,6 @@ struct CitiesView: View {
   }
 }
 
-struct DownloadList_Previews: PreviewProvider {
-  static var previews: some View {
-    Group {
-      NavigationView {
-        CitiesView(
-          store: Store(initialState: MapApp.State(cityMaps: .mocks)) {
-            MapApp()
-          }
-        )
-      }
-
-      NavigationView {
-        CityMapDetailView(
-          store: Store(initialState: IdentifiedArrayOf<CityMap.State>.mocks.first!) {}
-        )
-      }
-    }
-  }
-}
-
 extension IdentifiedArray where ID == CityMap.State.ID, Element == CityMap.State {
   static let mocks: Self = [
     CityMap.State(
@@ -269,4 +249,22 @@ extension IdentifiedArray where ID == CityMap.State.ID, Element == CityMap.State
       downloadMode: .notDownloaded
     ),
   ]
+}
+
+#Preview("List") {
+  NavigationStack {
+    CitiesView(
+      store: Store(initialState: MapApp.State(cityMaps: .mocks)) {
+        MapApp()
+      }
+    )
+  }
+}
+
+#Preview("Detail") {
+  NavigationView {
+    CityMapDetailView(
+      store: Store(initialState: IdentifiedArrayOf<CityMap.State>.mocks[0]) {}
+    )
+  }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -17,8 +17,6 @@ private let readMe = """
   favorite state and rendering an alert.
   """
 
-// MARK: - Reusable favorite component
-
 struct FavoritingState<ID: Hashable & Sendable>: Equatable {
   @PresentationState var alert: AlertState<FavoritingAction.Alert>?
   let id: ID
@@ -86,8 +84,6 @@ struct FavoriteButton<ID: Hashable & Sendable>: View {
   }
 }
 
-// MARK: - Feature domain
-
 @Reducer
 struct Episode {
   struct State: Equatable, Identifiable {
@@ -114,8 +110,6 @@ struct Episode {
     }
   }
 }
-
-// MARK: - Feature view
 
 struct EpisodeView: View {
   let store: StoreOf<Episode>
@@ -174,24 +168,6 @@ struct EpisodesView: View {
   }
 }
 
-// MARK: - SwiftUI previews
-
-struct EpisodesView_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationView {
-      EpisodesView(
-        store: Store(
-          initialState: Episodes.State(
-            episodes: .mocks
-          )
-        ) {
-          Episodes(favorite: favorite(id:isFavorite:))
-        }
-      )
-    }
-  }
-}
-
 struct FavoriteError: LocalizedError, Equatable {
   var errorDescription: String? {
     "Favoriting failed."
@@ -216,4 +192,18 @@ extension IdentifiedArray where ID == Episode.State.ID, Element == Episode.State
     Episode.State(id: UUID(), isFavorite: false, title: "Parsers"),
     Episode.State(id: UUID(), isFavorite: false, title: "Composable Architecture"),
   ]
+}
+
+#Preview {
+  NavigationStack {
+    EpisodesView(
+      store: Store(
+        initialState: Episodes.State(
+          episodes: .mocks
+        )
+      ) {
+        Episodes(favorite: favorite(id:isFavorite:))
+      }
+    )
+  }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -137,7 +137,7 @@ struct Episodes {
     case episodes(IdentifiedActionOf<Episode>)
   }
 
-  let favorite: @Sendable (UUID, Bool) async throws -> Bool
+  var favorite: @Sendable (UUID, Bool) async throws -> Bool = favoriteRequest
 
   var body: some Reducer<State, Action> {
     Reduce { state, action in
@@ -150,9 +150,7 @@ struct Episodes {
 }
 
 struct EpisodesView: View {
-  var store = Store(initialState: Episodes.State(episodes: .mocks)) {
-    Episodes(favorite: favorite(id:isFavorite:))
-  }
+  let store: StoreOf<Episodes>
 
   var body: some View {
     Form {
@@ -174,7 +172,7 @@ struct FavoriteError: LocalizedError, Equatable {
   }
 }
 
-@Sendable func favorite<ID>(id: ID, isFavorite: Bool) async throws -> Bool {
+@Sendable private func favoriteRequest<ID>(id: ID, isFavorite: Bool) async throws -> Bool {
   try await Task.sleep(for: .seconds(1))
   if .random(in: 0...1) > 0.25 {
     return isFavorite
@@ -197,12 +195,8 @@ extension IdentifiedArray where ID == Episode.State.ID, Element == Episode.State
 #Preview {
   NavigationStack {
     EpisodesView(
-      store: Store(
-        initialState: Episodes.State(
-          episodes: .mocks
-        )
-      ) {
-        Episodes(favorite: favorite(id:isFavorite:))
+      store: Store(initialState: Episodes.State()) {
+        Episodes()
       }
     )
   }

--- a/Examples/CaseStudies/SwiftUICaseStudies/Internal/CircularProgressView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/Internal/CircularProgressView.swift
@@ -16,8 +16,6 @@ struct CircularProgressView: View {
   }
 }
 
-struct CircularProgressView_Previews: PreviewProvider {
-  static var previews: some View {
-    CircularProgressView(value: 0.3).frame(width: 44, height: 44)
-  }
+#Preview {
+  CircularProgressView(value: 0.3).frame(width: 44, height: 44)
 }

--- a/Examples/CaseStudies/tvOSCaseStudies/FocusView.swift
+++ b/Examples/CaseStudies/tvOSCaseStudies/FocusView.swift
@@ -68,17 +68,7 @@ struct FocusView: View {
       // Update the view's focus when the state tells us the focus changed.
       resetFocus(in: namespace)
     }
-    .focusScope(self.namespace)
-  }
-}
-
-struct FocusView_Previews: PreviewProvider {
-  static var previews: some View {
-    FocusView(
-      store: Store(initialState: Focus.State()) {
-        Focus()
-      }
-    )
+    .focusScope(namespace)
   }
 }
 
@@ -95,3 +85,11 @@ private let numbers = [
   "Nine",
   "Ten",
 ]
+
+#Preview {
+  FocusView(
+    store: Store(initialState: Focus.State()) {
+      Focus()
+    }
+  )
+}

--- a/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
+++ b/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
@@ -17,14 +17,12 @@ struct RootView: View {
   }
 }
 
-struct ContentView_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationView {
-      RootView(
-        store: Store(initialState: Root.State()) {
-          Root()
-        }
-      )
-    }
+#Preview {
+  NavigationStack {
+    RootView(
+      store: Store(initialState: Root.State()) {
+        Root()
+      }
+    )
   }
 }

--- a/Examples/Integration/Integration/IntegrationApp.swift
+++ b/Examples/Integration/Integration/IntegrationApp.swift
@@ -284,12 +284,10 @@ struct RuntimeWarnings: View {
   }
 }
 
-struct ContentView_Previews: PreviewProvider {
-  static var previews: some View {
-    ContentView()
-  }
-}
-
 extension Notification.Name {
   static let clearLogs = Self("clear-logs")
+}
+
+#Preview {
+  ContentView()
 }

--- a/Examples/Integration/Integration/Legacy/BindingsAnimationsTestBench.swift
+++ b/Examples/Integration/Integration/Legacy/BindingsAnimationsTestBench.swift
@@ -190,8 +190,6 @@ private struct AnimatedFromBindingWithObservation {
   }
 }
 
-private struct BindingsAnimationsTestBench_Previews: PreviewProvider {
-  static var previews: some View {
-    BindingsAnimationsTestBench()
-  }
+#Preview {
+  BindingsAnimationsTestBench()
 }

--- a/Examples/Integration/Integration/iOS 16+17/NewOldSiblingsTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16+17/NewOldSiblingsTestCase.swift
@@ -74,9 +74,7 @@ struct NewOldSiblingsView: View {
   }
 }
 
-struct NewOldSiblingsPreviews: PreviewProvider {
-  static var previews: some View {
-    let _ = Logger.shared.isEnabled = true
-    NewOldSiblingsView()
-  }
+#Preview {
+  Logger.shared.isEnabled = true
+  return NewOldSiblingsView()
 }

--- a/Examples/Integration/Integration/iOS 16/BasicsTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16/BasicsTestCase.swift
@@ -43,15 +43,13 @@ struct BasicsView: View {
   }
 }
 
-struct BasicsPreviews: PreviewProvider {
-  static var previews: some View {
-    let _ = Logger.shared.isEnabled = true
-    Form {
-      BasicsView(
-        store: Store(initialState: BasicsView.Feature.State()) {
-          BasicsView.Feature()
-        }
-      )
-    }
+#Preview {
+  Logger.shared.isEnabled = true
+  return Form {
+    BasicsView(
+      store: Store(initialState: BasicsView.Feature.State()) {
+        BasicsView.Feature()
+      }
+    )
   }
 }

--- a/Examples/Integration/Integration/iOS 16/EnumTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16/EnumTestCase.swift
@@ -143,16 +143,7 @@ struct EnumView: View {
   }
 }
 
-struct EnumTestCase_Previews: PreviewProvider {
-  static var previews: some View {
-    let _ = Logger.shared.isEnabled = true
-    EnumView()
-  }
-}
-
-struct EnumPreviews: PreviewProvider {
-  static var previews: some View {
-    let _ = Logger.shared.isEnabled = true
-    EnumView()
-  }
+#Preview {
+  Logger.shared.isEnabled = true
+  return EnumView()
 }

--- a/Examples/Integration/Integration/iOS 16/IdentifiedListTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16/IdentifiedListTestCase.swift
@@ -90,11 +90,9 @@ struct IdentifiedListView: View {
   }
 }
 
-struct IdentifiedListPreviews: PreviewProvider {
-  static var previews: some View {
-    let _ = Logger.shared.isEnabled = true
-    NavigationStack {
-      IdentifiedListView()
-    }
+#Preview {
+  Logger.shared.isEnabled = true
+  return NavigationStack {
+    IdentifiedListView()
   }
 }

--- a/Examples/Integration/Integration/iOS 16/NavigationTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16/NavigationTestCase.swift
@@ -44,9 +44,7 @@ struct NavigationTestCaseView: View {
   }
 }
 
-struct NavigationPreviews: PreviewProvider {
-  static var previews: some View {
-    let _ = Logger.shared.isEnabled = true
-    NavigationTestCaseView()
-  }
+#Preview {
+  Logger.shared.isEnabled = true
+  return NavigationTestCaseView()
 }

--- a/Examples/Integration/Integration/iOS 16/OptionalTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16/OptionalTestCase.swift
@@ -76,9 +76,7 @@ struct OptionalView: View {
   }
 }
 
-struct OptionalPreviews: PreviewProvider {
-  static var previews: some View {
-    let _ = Logger.shared.isEnabled = true
-    OptionalView()
-  }
+#Preview {
+  Logger.shared.isEnabled = true
+  return OptionalView()
 }

--- a/Examples/Integration/Integration/iOS 16/PresentationTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16/PresentationTestCase.swift
@@ -168,9 +168,7 @@ struct PresentationView: View {
   }
 }
 
-struct PresentationPreviews: PreviewProvider {
-  static var previews: some View {
-    let _ = Logger.shared.isEnabled = true
-    PresentationView()
-  }
+#Preview {
+  Logger.shared.isEnabled = true
+  return PresentationView()
 }

--- a/Examples/Integration/Integration/iOS 17/ObservableEnumTestCase.swift
+++ b/Examples/Integration/Integration/iOS 17/ObservableEnumTestCase.swift
@@ -129,9 +129,7 @@ struct ObservableEnumView: View {
   }
 }
 
-struct ObservableEnumTestCase_Previews: PreviewProvider {
-  static var previews: some View {
-    let _ = Logger.shared.isEnabled = true
-    ObservableEnumView()
-  }
+#Preview {
+  Logger.shared.isEnabled = true
+  return ObservableEnumView()
 }

--- a/Examples/Search/Search/SearchView.swift
+++ b/Examples/Search/Search/SearchView.swift
@@ -3,8 +3,8 @@ import SwiftUI
 
 private let readMe = """
   This application demonstrates live-searching with the Composable Architecture. As you type the \
-  events are debounced for 300ms, and when you stop typing an API request is made to load \
-  locations. Then tapping on a location will load weather.
+  events are debounced for 300 milliseconds, and when you stop typing an API request is made to \
+  load locations. Then tapping on a location will load weather.
   """
 
 @Reducer

--- a/Examples/Search/Search/SearchView.swift
+++ b/Examples/Search/Search/SearchView.swift
@@ -7,8 +7,6 @@ private let readMe = """
   locations. Then tapping on a location will load weather.
   """
 
-// MARK: - Search feature domain
-
 @Reducer
 struct Search {
   @ObservableState
@@ -113,8 +111,6 @@ struct Search {
   }
 }
 
-// MARK: - Search feature view
-
 struct SearchView: View {
   @Bindable var store: StoreOf<Search>
 
@@ -190,8 +186,6 @@ struct SearchView: View {
   }
 }
 
-// MARK: - Private helpers
-
 private func formattedWeather(day: Search.State.Weather.Day, isToday: Bool) -> String {
   let date =
     isToday
@@ -209,14 +203,10 @@ private let dateFormatter: DateFormatter = {
   return formatter
 }()
 
-// MARK: - SwiftUI previews
-
-struct SearchView_Previews: PreviewProvider {
-  static var previews: some View {
-    SearchView(
-      store: Store(initialState: Search.State()) {
-        Search()
-      }
-    )
-  }
+#Preview {
+  SearchView(
+    store: Store(initialState: Search.State()) {
+      Search()
+    }
+  )
 }

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
@@ -152,12 +152,10 @@ struct SpeechRecognitionView: View {
   }
 }
 
-struct SpeechRecognitionView_Previews: PreviewProvider {
-  static var previews: some View {
-    SpeechRecognitionView(
-      store: Store(initialState: SpeechRecognition.State(transcribedText: "Test test 123")) {
-        SpeechRecognition()
-      }
-    )
-  }
+#Preview {
+  SpeechRecognitionView(
+    store: Store(initialState: SpeechRecognition.State(transcribedText: "Test test 123")) {
+      SpeechRecognition()
+    }
+  )
 }

--- a/Examples/SyncUps/SyncUps/Dependencies/SpeechRecognizer.swift
+++ b/Examples/SyncUps/SyncUps/Dependencies/SpeechRecognizer.swift
@@ -80,7 +80,7 @@ extension SpeechClient: DependencyKey {
       requestAuthorization: { .authorized },
       startTask: { request in
         AsyncThrowingStream { continuation in
-          Task { @MainActor in
+          Task {
             let start = ContinuousClock.now
             do {
               for try await result in await Self.previewValue.startTask(request) {

--- a/Examples/SyncUps/SyncUps/RecordMeeting.swift
+++ b/Examples/SyncUps/SyncUps/RecordMeeting.swift
@@ -378,14 +378,12 @@ struct MeetingFooterView: View {
   }
 }
 
-struct RecordMeeting_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationStack {
-      RecordMeetingView(
-        store: Store(initialState: RecordMeeting.State(syncUp: .mock)) {
-          RecordMeeting()
-        }
-      )
-    }
+#Preview {
+  NavigationStack {
+    RecordMeetingView(
+      store: Store(initialState: RecordMeeting.State(syncUp: .mock)) {
+        RecordMeeting()
+      }
+    )
   }
 }

--- a/Examples/SyncUps/SyncUps/SyncUpDetail.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpDetail.swift
@@ -283,14 +283,12 @@ extension AlertState where Action == SyncUpDetail.Destination.Action.Alert {
   }
 }
 
-struct SyncUpDetail_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationStack {
-      SyncUpDetailView(
-        store: Store(initialState: SyncUpDetail.State(syncUp: .mock)) {
-          SyncUpDetail()
-        }
-      )
-    }
+#Preview {
+  NavigationStack {
+    SyncUpDetailView(
+      store: Store(initialState: SyncUpDetail.State(syncUp: .mock)) {
+        SyncUpDetail()
+      }
+    )
   }
 }

--- a/Examples/SyncUps/SyncUps/SyncUpForm.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpForm.swift
@@ -127,14 +127,12 @@ extension Duration {
   }
 }
 
-struct EditSyncUp_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationStack {
-      SyncUpFormView(
-        store: Store(initialState: SyncUpForm.State(syncUp: .mock)) {
-          SyncUpForm()
-        }
-      )
-    }
+#Preview {
+  NavigationStack {
+    SyncUpFormView(
+      store: Store(initialState: SyncUpForm.State(syncUp: .mock)) {
+        SyncUpForm()
+      }
+    )
   }
 }

--- a/Examples/SyncUps/SyncUps/SyncUpsList.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpsList.swift
@@ -209,34 +209,34 @@ extension LabelStyle where Self == TrailingIconLabelStyle {
   static var trailingIcon: Self { Self() }
 }
 
-struct SyncUpsList_Previews: PreviewProvider {
-  static var previews: some View {
-    SyncUpsListView(
-      store: Store(initialState: SyncUpsList.State()) {
-        SyncUpsList()
-      } withDependencies: {
-        $0.dataManager.load = { @Sendable _ in
-          try JSONEncoder().encode([
-            SyncUp.mock,
-            .designMock,
-            .engineeringMock,
-          ])
-        }
+#Preview {
+  SyncUpsListView(
+    store: Store(initialState: SyncUpsList.State()) {
+      SyncUpsList()
+    } withDependencies: {
+      $0.dataManager.load = { @Sendable _ in
+        try JSONEncoder().encode([
+          SyncUp.mock,
+          .designMock,
+          .engineeringMock,
+        ])
       }
-    )
-
-    SyncUpsListView(
-      store: Store(initialState: SyncUpsList.State()) {
-        SyncUpsList()
-      } withDependencies: {
-        $0.dataManager = .mock(initialData: Data("!@#$% bad data ^&*()".utf8))
-      }
-    )
-    .previewDisplayName("Load data failure")
-  }
+    }
+  )
 }
 
-#Preview {
+#Preview("Load data failure") {
+  SyncUpsListView(
+    store: Store(initialState: SyncUpsList.State()) {
+      SyncUpsList()
+    } withDependencies: {
+      $0.dataManager = .mock(initialData: Data("!@#$% bad data ^&*()".utf8))
+    }
+  )
+  .previewDisplayName("Load data failure")
+}
+
+#Preview("Card") {
   CardView(
     syncUp: SyncUp(
       id: SyncUp.ID(),

--- a/Examples/TicTacToe/App/RootView.swift
+++ b/Examples/TicTacToe/App/RootView.swift
@@ -56,8 +56,6 @@ struct RootView: View {
   }
 }
 
-struct RootView_Previews: PreviewProvider {
-  static var previews: some View {
-    RootView()
-  }
+#Preview {
+  RootView()
 }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
@@ -82,14 +82,12 @@ extension Game.State {
   }
 }
 
-struct Game_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationStack {
-      GameView(
-        store: Store(initialState: Game.State(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr.")) {
-          Game()
-        }
-      )
-    }
+#Preview {
+  NavigationStack {
+    GameView(
+      store: Store(initialState: Game.State(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr.")) {
+        Game()
+      }
+    )
   }
 }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -67,21 +67,19 @@ extension Login.State {
   fileprivate var isLoginButtonDisabled: Bool { !self.isFormValid }
 }
 
-struct LoginView_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationStack {
-      LoginView(
-        store: Store(initialState: Login.State()) {
-          Login()
-        } withDependencies: {
-          $0.authenticationClient.login = { @Sendable _, _ in
-            AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
-          }
-          $0.authenticationClient.twoFactor = { @Sendable _, _ in
-            AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
-          }
+#Preview {
+  NavigationStack {
+    LoginView(
+      store: Store(initialState: Login.State()) {
+        Login()
+      } withDependencies: {
+        $0.authenticationClient.login = { @Sendable _, _ in
+          AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
         }
-      )
-    }
+        $0.authenticationClient.twoFactor = { @Sendable _, _ in
+          AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
+        }
+      }
+    )
   }
 }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -35,7 +35,7 @@ public struct LoginView: View {
       Button {
         // NB: SwiftUI will print errors to the console about "AttributeGraph: cycle detected" if
         //     you disable a text field while it is focused. This hack will force all fields to
-        //     unfocus before we send the action to the view store.
+        //     unfocus before we send the action to the store.
         // CF: https://stackoverflow.com/a/69653555
         _ = UIApplication.shared.sendAction(
           #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil

--- a/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
@@ -50,14 +50,12 @@ extension NewGame.State {
   }
 }
 
-struct NewGame_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationStack {
-      NewGameView(
-        store: Store(initialState: NewGame.State()) {
-          NewGame()
-        }
-      )
-    }
+#Preview {
+  NavigationStack {
+    NewGameView(
+      store: Store(initialState: NewGame.State()) {
+        NewGame()
+      }
+    )
   }
 }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
@@ -51,21 +51,19 @@ extension TwoFactor.State {
   fileprivate var isSubmitButtonDisabled: Bool { !self.isFormValid }
 }
 
-struct TwoFactorView_Previews: PreviewProvider {
-  static var previews: some View {
-    NavigationStack {
-      TwoFactorView(
-        store: Store(initialState: TwoFactor.State(token: "deadbeef")) {
-          TwoFactor()
-        } withDependencies: {
-          $0.authenticationClient.login = { @Sendable _, _ in
-            AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
-          }
-          $0.authenticationClient.twoFactor = { @Sendable _, _ in
-            AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
-          }
+#Preview {
+  NavigationStack {
+    TwoFactorView(
+      store: Store(initialState: TwoFactor.State(token: "deadbeef")) {
+        TwoFactor()
+      } withDependencies: {
+        $0.authenticationClient.login = { @Sendable _, _ in
+          AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
         }
-      )
-    }
+        $0.authenticationClient.twoFactor = { @Sendable _, _ in
+          AuthenticationResponse(token: "deadbeef", twoFactorRequired: false)
+        }
+      }
+    )
   }
 }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
@@ -24,7 +24,7 @@ public struct TwoFactorView: View {
         Button("Submit") {
           // NB: SwiftUI will print errors to the console about "AttributeGraph: cycle detected"
           //     if you disable a text field while it is focused. This hack will force all
-          //     fields to unfocus before we send the action to the view store.
+          //     fields to unfocus before we send the action to the store.
           // CF: https://stackoverflow.com/a/69653555
           UIApplication.shared.sendAction(
             #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -160,12 +160,10 @@ extension IdentifiedArray where ID == Todo.State.ID, Element == Todo.State {
   ]
 }
 
-struct AppView_Previews: PreviewProvider {
-  static var previews: some View {
-    AppView(
-      store: Store(initialState: Todos.State(todos: .mock)) {
-        Todos()
-      }
-    )
-  }
+#Preview {
+  AppView(
+    store: Store(initialState: Todos.State(todos: .mock)) {
+      Todos()
+    }
+  )
 }

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -201,31 +201,29 @@ struct RecordButton: View {
   }
 }
 
-struct VoiceMemos_Previews: PreviewProvider {
-  static var previews: some View {
-    VoiceMemosView(
-      store: Store(
-        initialState: VoiceMemos.State(
-          voiceMemos: [
-            VoiceMemo.State(
-              date: Date(),
-              duration: 5,
-              mode: .notPlaying,
-              title: "Functions",
-              url: URL(string: "https://www.pointfree.co/functions")!
-            ),
-            VoiceMemo.State(
-              date: Date(),
-              duration: 5,
-              mode: .notPlaying,
-              title: "",
-              url: URL(string: "https://www.pointfree.co/untitled")!
-            ),
-          ]
-        )
-      ) {
-        VoiceMemos()
-      }
-    )
-  }
+#Preview {
+  VoiceMemosView(
+    store: Store(
+      initialState: VoiceMemos.State(
+        voiceMemos: [
+          VoiceMemo.State(
+            date: Date(),
+            duration: 5,
+            mode: .notPlaying,
+            title: "Functions",
+            url: URL(string: "https://www.pointfree.co/functions")!
+          ),
+          VoiceMemo.State(
+            date: Date(),
+            duration: 5,
+            mode: .notPlaying,
+            title: "",
+            url: URL(string: "https://www.pointfree.co/untitled")!
+          ),
+        ]
+      )
+    ) {
+      VoiceMemos()
+    }
+  )
 }


### PR DESCRIPTION
- Updates individual case studies to simply use `store: StoreOf<Feature>`, which is more common.
- Updates outdated case study README info.
- Updates previews to use `#Preview`.
- Removes superfluous `// MARK` comments, which were mostly there for organization pre-Reducer protocol conformances.