### PR TITLE
Add deep-linking support to UIKit navigation for modal views

### DIFF
--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginUIKit/LoginViewController.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginUIKit/LoginViewController.swift
@@ -87,7 +87,6 @@ public class LoginViewController: UIViewController {
       divider.heightAnchor.constraint(equalToConstant: 1),
     ])
 
-    var alertController: UIAlertController?
     var twoFactorController: TwoFactorViewController?
 
     observe { [weak self] in
@@ -98,16 +97,6 @@ public class LoginViewController: UIViewController {
       passwordTextField.isEnabled = store.isPasswordTextFieldEnabled
       loginButton.isEnabled = store.isLoginButtonEnabled
       activityIndicator.isHidden = store.isActivityIndicatorHidden
-
-      if let store = store.scope(state: \.alert, action: \.alert),
-        alertController == nil
-      {
-        alertController = UIAlertController(store: store)
-        present(alertController!, animated: true, completion: nil)
-      } else if store.alert == nil, alertController != nil {
-        alertController?.dismiss(animated: true)
-        alertController = nil
-      }
 
       if let store = store.scope(state: \.twoFactor, action: \.twoFactor.presented),
         twoFactorController == nil
@@ -126,6 +115,24 @@ public class LoginViewController: UIViewController {
 
   public override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
+
+    var alertController: UIAlertController?
+
+    // Modal views can only be presented after self has been
+    // added to the navigation stack
+    observe { [weak self] in
+      guard let self else { return }
+
+      if let store = store.scope(state: \.alert, action: \.alert),
+        alertController == nil
+      {
+        alertController = UIAlertController(store: store)
+        present(alertController!, animated: true, completion: nil)
+      } else if store.alert == nil, alertController != nil {
+        alertController?.dismiss(animated: true)
+        alertController = nil
+      }
+    }
 
     if !isMovingToParent {
       store.twoFactorDismissed()


### PR DESCRIPTION
One of the benefits of tree-based navigation is its deep-linking capabilities, but it seems like all the UIKit examples will only support deep-linking for view controllers that will be pushed or popped into UINavigationController's view controller stack and not modal view controllers that reside within the presented view controller. This is because it's only when `viewDidAppear` has been called that the now-presented view controller is ready to present modal view controllers.

The initial commit for this PR is one way of treating modal navigation a bit differently. @mbrandonw @stephencelis if you think this is the right approach, I can go ahead and make changes elsewhere in the codebase since right now, I just started with `LoginViewController`.