### PR TITLE
fix typo in migration guide 1.6

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.6.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.6.md
@@ -12,7 +12,7 @@ APIs, and this article contains some tips for doing so.
 
 ### Asserting on action payloads
 
-In version 1.4 of the library we provided a new a new assertion method on ``TestStore`` for 
+In version 1.4 of the library we provided a new assertion method on ``TestStore`` for 
 asserting on actions received without asserting on the payload in the action (see
 <doc:MigratingTo1.4#Receiving-test-store-actions> for more information). However, sometimes it is
 important to assert on the payload, especially when testing delegate actions from child features,


### PR DESCRIPTION
I found a small typo in migration guide 1.6 .