### PR TITLE
Propagate `@ViewAction` macro availability

### DIFF
--- a/Sources/ComposableArchitectureMacros/ViewActionMacro.swift
+++ b/Sources/ComposableArchitectureMacros/ViewActionMacro.swift
@@ -68,7 +68,8 @@ public struct ViewActionMacro: ExtensionMacro {
 
     let ext: DeclSyntax =
       """
-      extension \(type.trimmed): ComposableArchitecture.ViewActionSending {}
+      \(declaration.attributes.availability)extension \(type.trimmed): \
+      ComposableArchitecture.ViewActionSending {}
       """
     return [ext.cast(ExtensionDeclSyntax.self)]
   }

--- a/Tests/ComposableArchitectureMacrosTests/ViewActionMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ViewActionMacroTests.swift
@@ -438,5 +438,33 @@
         """
       }
     }
+
+    func testAvailability() {
+      assertMacro {
+        """
+        @available(iOS 17, macOS 14, tvOS 17, visionOS 1, watchOS 10, *)
+        @ViewAction(for: Feature.self)
+        struct FeatureView: View {
+          @State var store: StoreOf<Feature>
+          var body: some View {
+            EmptyView()
+          }
+        }
+        """
+      } expansion: {
+        """
+        @available(iOS 17, macOS 14, tvOS 17, visionOS 1, watchOS 10, *)
+        struct FeatureView: View {
+          @State var store: StoreOf<Feature>
+          var body: some View {
+            EmptyView()
+          }
+        }
+
+        @available(iOS 17, macOS 14, tvOS 17, visionOS 1, watchOS 10, *) extension FeatureView: ComposableArchitecture.ViewActionSending {
+        }
+        """
+      }
+    }
   }
 #endif


### PR DESCRIPTION
Right now availability on the parent is not propagated down to the extension, which can cause build failures.