### PR TITLE
Properly tag observable enums

### DIFF
--- a/Sources/ComposableArchitecture/Observation/ObservableState.swift
+++ b/Sources/ComposableArchitecture/Observation/ObservableState.swift
@@ -74,7 +74,10 @@
 
     @inlinable
     public func _$tag(_ tag: Int?) -> Self {
-      Self(location: self.location, tag: tag)
+      Self(
+        location: self.location,
+        tag: self.tag ?? tag
+      )
     }
 
     @inlinable

--- a/Tests/ComposableArchitectureTests/ObservableTests.swift
+++ b/Tests/ComposableArchitectureTests/ObservableTests.swift
@@ -537,6 +537,39 @@
 
       state.children[0].count += 1
     }
+
+    func testEnumStateWithInertCases() {
+      let store = Store<EnumState, Void>(initialState: EnumState.count(.one)) {
+        Reduce { state, _ in
+          state = .count(.two)
+          return .none
+        }
+      }
+      let onChangeExpectation = self.expectation(description: "onChange")
+      withPerceptionTracking {
+        _ = store.state
+      } onChange: {
+        onChangeExpectation.fulfill()
+      }
+
+      store.send(())
+
+      self.wait(for: [onChangeExpectation], timeout: 0)
+    }
+
+    func testEnumStateWithIntCase() {
+      var state = EnumState.int(0)
+      let onChangeExpectation = self.expectation(description: "onChange")
+      withPerceptionTracking {
+        _ = state
+      } onChange: {
+        onChangeExpectation.fulfill()
+      }
+
+      state = .int(1)
+
+      self.wait(for: [onChangeExpectation], timeout: 0)
+    }
   }
 
   @ObservableState
@@ -575,5 +608,14 @@
     case child1(ChildState)
     case child2(ChildState)
     case inert(Int)
+  }
+  @ObservableState
+  fileprivate enum EnumState: Equatable {
+    case count(Count)
+    case int(Int)
+    @ObservableState
+    enum Count: String {
+      case one, two
+    }
   }
 #endif

--- a/Tests/ComposableArchitectureTests/ObservableTests.swift
+++ b/Tests/ComposableArchitectureTests/ObservableTests.swift
@@ -577,15 +577,20 @@
     }
 
     func testEnumStateWithIntCase() {
-      var state = EnumState.int(0)
+      let store = Store<EnumState, Void>(initialState: EnumState.int(0)) {
+        Reduce { state, _ in
+          state = .int(1)
+          return .none
+        }
+      }
       let onChangeExpectation = self.expectation(description: "onChange")
       withPerceptionTracking {
-        _ = state
+        _ = store.state
       } onChange: {
         onChangeExpectation.fulfill()
       }
 
-      state = .int(1)
+      store.send(())
 
       self.wait(for: [onChangeExpectation], timeout: 0)
     }

--- a/Tests/ComposableArchitectureTests/ObservableTests.swift
+++ b/Tests/ComposableArchitectureTests/ObservableTests.swift
@@ -592,6 +592,7 @@
 
       store.send(())
 
+      XCTTODO("Should this eventually be observed by default?")
       self.wait(for: [onChangeExpectation], timeout: 0)
     }
   }

--- a/Tests/ComposableArchitectureTests/ObservableTests.swift
+++ b/Tests/ComposableArchitectureTests/ObservableTests.swift
@@ -557,6 +557,25 @@
       self.wait(for: [onChangeExpectation], timeout: 0)
     }
 
+    func testEnumStateWithInertCasesTricky() {
+      let store = Store<EnumState, Void>(initialState: EnumState.count(.one)) {
+        Reduce { state, _ in
+          state = .anotherCount(.one)
+          return .none
+        }
+      }
+      let onChangeExpectation = self.expectation(description: "onChange")
+      withPerceptionTracking {
+        _ = store.state
+      } onChange: {
+        onChangeExpectation.fulfill()
+      }
+
+      store.send(())
+
+      self.wait(for: [onChangeExpectation], timeout: 0)
+    }
+
     func testEnumStateWithIntCase() {
       var state = EnumState.int(0)
       let onChangeExpectation = self.expectation(description: "onChange")
@@ -612,6 +631,7 @@
   @ObservableState
   fileprivate enum EnumState: Equatable {
     case count(Count)
+    case anotherCount(Count)
     case int(Int)
     @ObservableState
     enum Count: String {


### PR DESCRIPTION
It's possible for nested, inert enums to have the same "tag" and thus identity when they are distinct structures, which prevents cases changes from being observed. Let's allow tagging to happen recursively, which will allow for distinct identity in these cases.