### PR TITLE
[macro] Make _$id and _$willModify() public

### DIFF
--- a/Sources/ComposableArchitectureMacros/ObservableStateMacro.swift
+++ b/Sources/ComposableArchitectureMacros/ObservableStateMacro.swift
@@ -56,19 +56,19 @@ public struct ObservableStateMacro {
       """
   }
 
-  static func idVariable(_ access: DeclModifierListSyntax.Element?) -> DeclSyntax {
+  static func idVariable() -> DeclSyntax {
     return
       """
-      \(access)var _$id: \(raw: qualifiedIDName) {
+      public var _$id: \(raw: qualifiedIDName) {
       \(raw: registrarVariableName).id
       }
       """
   }
 
-  static func willModifyFunction(_ access: DeclModifierListSyntax.Element?) -> DeclSyntax {
+  static func willModifyFunction() -> DeclSyntax {
     return
       """
-      \(access)mutating func _$willModify() {
+      public mutating func _$willModify() {
       \(raw: registrarVariableName)._$willModify()
       }
       """
@@ -253,8 +253,8 @@ extension ObservableStateMacro: MemberMacro {
     }
     declaration.addIfNeeded(
       ObservableStateMacro.registrarVariable(observableType), to: &declarations)
-    declaration.addIfNeeded(ObservableStateMacro.idVariable(access), to: &declarations)
-    declaration.addIfNeeded(ObservableStateMacro.willModifyFunction(access), to: &declarations)
+    declaration.addIfNeeded(ObservableStateMacro.idVariable(), to: &declarations)
+    declaration.addIfNeeded(ObservableStateMacro.willModifyFunction(), to: &declarations)
 
     return declarations
   }
@@ -269,10 +269,6 @@ extension ObservableStateMacro {
     providingMembersOf declaration: Declaration,
     in context: Context
   ) throws -> [DeclSyntax] {
-    let access = declaration.modifiers.first {
-      $0.name.tokenKind == .keyword(.public) || $0.name.tokenKind == .keyword(.package)
-    }
-
     let enumCaseDecls = declaration.memberBlock.members
       .flatMap { $0.decl.as(EnumCaseDeclSyntax.self)?.elements ?? [] }
     var getCases: [String] = []
@@ -314,14 +310,14 @@ extension ObservableStateMacro {
 
     return [
       """
-      \(access)var _$id: \(raw: qualifiedIDName) {
+      public var _$id: \(raw: qualifiedIDName) {
       switch self {
       \(raw: getCases.joined(separator: "\n"))
       }
       }
       """,
       """
-      \(access)mutating func _$willModify() {
+      public mutating func _$willModify() {
       switch self {
       \(raw: willModifyCases.joined(separator: "\n"))
       }

--- a/Tests/ComposableArchitectureMacrosTests/ObservableStateMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ObservableStateMacroTests.swift
@@ -48,11 +48,11 @@
 
           var _$observationRegistrar = ComposableArchitecture.ObservationStateRegistrar()
 
-          var _$id: ComposableArchitecture.ObservableStateID {
+          public var _$id: ComposableArchitecture.ObservableStateID {
             _$observationRegistrar.id
           }
 
-          mutating func _$willModify() {
+          public mutating func _$willModify() {
             _$observationRegistrar._$willModify()
           }
         }
@@ -94,11 +94,11 @@
 
           var _$observationRegistrar = ComposableArchitecture.ObservationStateRegistrar()
 
-          var _$id: ComposableArchitecture.ObservableStateID {
+          public var _$id: ComposableArchitecture.ObservableStateID {
             _$observationRegistrar.id
           }
 
-          mutating func _$willModify() {
+          public mutating func _$willModify() {
             _$observationRegistrar._$willModify()
           }
         }
@@ -183,11 +183,11 @@
 
           var _$observationRegistrar = ComposableArchitecture.ObservationStateRegistrar()
 
-          package var _$id: ComposableArchitecture.ObservableStateID {
+          public var _$id: ComposableArchitecture.ObservableStateID {
             _$observationRegistrar.id
           }
 
-          package mutating func _$willModify() {
+          public mutating func _$willModify() {
             _$observationRegistrar._$willModify()
           }
         }
@@ -211,11 +211,11 @@
 
           var _$observationRegistrar = ComposableArchitecture.ObservationStateRegistrar()
 
-          var _$id: ComposableArchitecture.ObservableStateID {
+          public var _$id: ComposableArchitecture.ObservableStateID {
             _$observationRegistrar.id
           }
 
-          mutating func _$willModify() {
+          public mutating func _$willModify() {
             _$observationRegistrar._$willModify()
           }
         }
@@ -238,7 +238,7 @@
           case feature1(Feature1.State)
           case feature2(Feature2.State)
 
-          var _$id: ComposableArchitecture.ObservableStateID {
+          public var _$id: ComposableArchitecture.ObservableStateID {
             switch self {
             case let .feature1(state):
               return ._$id(for: state)._$tag(0)
@@ -247,7 +247,7 @@
             }
           }
 
-          mutating func _$willModify() {
+          public mutating func _$willModify() {
             switch self {
             case var .feature1(state):
               ComposableArchitecture._$willModify(&state)
@@ -275,14 +275,14 @@
         enum Path {
           case feature1(state: String)
 
-          var _$id: ComposableArchitecture.ObservableStateID {
+          public var _$id: ComposableArchitecture.ObservableStateID {
             switch self {
             case let .feature1(state):
               return ._$id(for: state)._$tag(0)
             }
           }
 
-          mutating func _$willModify() {
+          public mutating func _$willModify() {
             switch self {
             case var .feature1(state):
               ComposableArchitecture._$willModify(&state)
@@ -345,7 +345,7 @@
           case feature1(Feature1.State)
           case feature2(Feature2.State)
 
-          package var _$id: ComposableArchitecture.ObservableStateID {
+          public var _$id: ComposableArchitecture.ObservableStateID {
             switch self {
             case let .feature1(state):
               return ._$id(for: state)._$tag(0)
@@ -354,7 +354,7 @@
             }
           }
 
-          package mutating func _$willModify() {
+          public mutating func _$willModify() {
             switch self {
             case var .feature1(state):
               ComposableArchitecture._$willModify(&state)
@@ -362,6 +362,89 @@
             case var .feature2(state):
               ComposableArchitecture._$willModify(&state)
               self = .feature2(state)
+            }
+          }
+        }
+        """
+      }
+    }
+
+    func testObservableState_Enum_AccessControl_WrappedByExtension() {
+      assertMacro {
+        """
+        public extension Feature {
+          @ObservableState
+          enum Path {
+            case feature1(Feature1.State)
+            case feature2(Feature2.State)
+          }
+        }
+        """
+      } expansion: {
+        """
+        public extension Feature {
+          enum Path {
+            case feature1(Feature1.State)
+            case feature2(Feature2.State)
+
+            public var _$id: ComposableArchitecture.ObservableStateID {
+              switch self {
+              case let .feature1(state):
+                return ._$id(for: state)._$tag(0)
+              case let .feature2(state):
+                return ._$id(for: state)._$tag(1)
+              }
+            }
+
+            public mutating func _$willModify() {
+              switch self {
+              case var .feature1(state):
+                ComposableArchitecture._$willModify(&state)
+                self = .feature1(state)
+              case var .feature2(state):
+                ComposableArchitecture._$willModify(&state)
+                self = .feature2(state)
+              }
+            }
+          }
+        }
+        """
+      }
+      assertMacro {
+        """
+        public extension Feature {
+          @ObservableState
+          package enum Path {
+            case feature1(Feature1.State)
+            case feature2(Feature2.State)
+          }
+        }
+        """
+      } expansion: {
+        """
+        public extension Feature {
+          package enum Path {
+            case feature1(Feature1.State)
+            case feature2(Feature2.State)
+
+            public var _$id: ComposableArchitecture.ObservableStateID {
+              switch self {
+              case let .feature1(state):
+                return ._$id(for: state)._$tag(0)
+              case let .feature2(state):
+                return ._$id(for: state)._$tag(1)
+              }
+            }
+
+            public mutating func _$willModify() {
+              switch self {
+              case var .feature1(state):
+                ComposableArchitecture._$willModify(&state)
+                self = .feature1(state)
+              case var .feature2(state):
+                ComposableArchitecture._$willModify(&state)
+                self = .feature2(state)
+              }
             }
           }
         }

--- a/Tests/ComposableArchitectureMacrosTests/PresentsMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/PresentsMacroTests.swift
@@ -168,11 +168,11 @@
 
           var _$observationRegistrar = ComposableArchitecture.ObservationStateRegistrar()
 
-          var _$id: ComposableArchitecture.ObservableStateID {
+          public var _$id: ComposableArchitecture.ObservableStateID {
             _$observationRegistrar.id
           }
 
-          mutating func _$willModify() {
+          public mutating func _$willModify() {
             _$observationRegistrar._$willModify()
           }
         }


### PR DESCRIPTION
Opening this PR per our discussion on Slack :) 

When using the following syntax:
```swift
public extension Feature {
    @ObservableState
    struct State { } 
}
```

A macro isn't able to determine `State` is public since the macro isn't aware of its surrounding context.
A solution to this is to always give the generated `_$id` and `_$willModify()` a public ACL, which should have no negative effect on other use cases.