### PR TITLE
Undisfavor some `Store[dynamicMember:]` overloads

### DIFF
--- a/Sources/ComposableArchitecture/Observation/Binding+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Binding+Observation.swift
@@ -68,7 +68,6 @@
   }
 
   extension Store where State: ObservableState, Action: BindableAction, Action.State == State {
-    @_disfavoredOverload
     public subscript<Value: Equatable>(
       dynamicMember keyPath: WritableKeyPath<State, Value>
     ) -> Value {
@@ -88,9 +87,8 @@
     Action: BindableAction,
     Action.State == State
   {
-    @_disfavoredOverload
     public var state: State {
-      get { self.state }
+      get { self.observableState }
       set {
         BindingLocal.$isActive.withValue(true) {
           self.send(.binding(.set(\.self, newValue)))
@@ -106,7 +104,6 @@
     Action.ViewAction: BindableAction,
     Action.ViewAction.State == State
   {
-    @_disfavoredOverload
     public subscript<Value: Equatable>(
       dynamicMember keyPath: WritableKeyPath<State, Value>
     ) -> Value {
@@ -127,9 +124,8 @@
     Action.ViewAction: BindableAction,
     Action.ViewAction.State == State
   {
-    @_disfavoredOverload
     public var state: State {
-      get { self.state }
+      get { self.observableState }
       set {
         BindingLocal.$isActive.withValue(true) {
           self.send(.view(.binding(.set(\.self, newValue))))

--- a/Sources/ComposableArchitecture/Observation/Store+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Store+Observation.swift
@@ -15,10 +15,14 @@
   #endif
 
   extension Store where State: ObservableState {
-    /// Direct access to state in the store when `State` conforms to ``ObservableState``.
-    public var state: State {
+    var observableState: State {
       self._$observationRegistrar.access(self, keyPath: \.currentState)
       return self.currentState
+    }
+
+    /// Direct access to state in the store when `State` conforms to ``ObservableState``.
+    public var state: State {
+      self.observableState
     }
 
     public subscript<Value>(dynamicMember keyPath: KeyPath<State, Value>) -> Value {


### PR DESCRIPTION
Came up on Slack.

These current disfavored overloads can lead to more difficult to debug error messages, like when trying to form a binding over bindable actions with state that isn't equatable.