### PR TITLE
Replace usage of 'viewStore' with 'store' in UIKit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,13 +269,13 @@ the store. The code is a bit longer than the SwiftUI version, so we have collaps
     }
 
     @objc private func incrementButtonTapped() {
-      self.viewStore.send(.incrementButtonTapped)
+      self.store.send(.incrementButtonTapped)
     }
     @objc private func decrementButtonTapped() {
-      self.viewStore.send(.decrementButtonTapped)
+      self.store.send(.decrementButtonTapped)
     }
     @objc private func factButtonTapped() {
-      self.viewStore.send(.numberFactButtonTapped)
+      self.store.send(.numberFactButtonTapped)
     }
   }
   ```


### PR DESCRIPTION
Hi folks 👋 
Just a small fix to the `README.md` file where `viewStore` was still being used within the UIKit code.