### PR TITLE
[Enhancement] - Scope init overload for enum reducers

### DIFF
--- a/Sources/ComposableArchitecture/CaseReducer.swift
+++ b/Sources/ComposableArchitecture/CaseReducer.swift
@@ -61,3 +61,21 @@ extension Store where State: CaseReducerState, State.StateReducer.Action == Acti
     State.StateReducer.scope(self)
   }
 }
+
+extension Scope {
+    
+    /// A special overload of ``Scope/init(state:action:child:)`` for enum reducers.
+    @inlinable
+    public init<ChildState: CaseReducerState, ChildAction>(
+        state toChildState: WritableKeyPath<ParentState, ChildState>,
+        action toChildAction: CaseKeyPath<ParentAction, ChildAction>
+    )
+    where
+    ChildState == Child.State,
+    ChildAction == Child.Action,
+    ChildState.StateReducer.Body == Child {
+        self.init(state: toChildState, action: toChildAction) {
+            ChildState.StateReducer.body
+        }
+    }
+}


### PR DESCRIPTION
Added an overload for `Scope` to work with enum reducers. This is really useful for when you want to utilize the `Destination` pattern but non-optionally. I use this pattern when I want to have a top-level `enum` state but also need to include additional information:


```swift
@Reducer 
struct App {
    
    @ObservableState
    struct State {
        var flow: Flow.State = .onboarding(.init())
        var firstTimeLaunching = false
        var networkIsConnected = true
    }
    
    enum Action {
        case flow(Flow.Action)
    }
}

@Reducer
enum Flow {
    case onboarding(Onboarding)
    case dashboard(Dashboard)
}
```

Before this change, I couldn't use enum reducers for `Flow` because I was unable to create an instance of it in `Scope`

```swift
Scope(state: \.flow, action: \.flow) { 
    Flow()
}
```

Now, I can integrate this sub-reducer into my domain like `Scope(state: \.flow, action: \.flow)`