### PR TITLE
Fix macro compiler bug in release mode.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "aedcf6f4cd486ccef5b312ccac85d4b3f6e58605",
-        "version" : "1.1.2"
+        "revision" : "6ea3b1b6a4957806d72030a32360d4bcb155a0d2",
+        "version" : "1.2.0"
       }
     },
     {

--- a/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
@@ -233,10 +233,9 @@
 
             }
 
-            static var body: some ComposableArchitecture.Reducer<Self.State, Self.Action> {
-                ComposableArchitecture.CombineReducers {
+            @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
+            static var body: EmptyReducer<Self.State, Self.Action> {
 
-                }
             }
 
             enum CaseScope {
@@ -260,6 +259,7 @@
         """
         @Reducer
         enum Destination {
+          case activity(Activity)
           case timeline(Timeline)
           case tweet(Tweet)
           case alert(AlertState<Alert>)
@@ -272,6 +272,7 @@
       } expansion: {
         #"""
         enum Destination {
+          case activity(Activity)
           case timeline(Timeline)
           case tweet(Tweet)
           @ReducerCaseEphemeral
@@ -286,6 +287,7 @@
           @ObservableState
           enum State: ComposableArchitecture.CaseReducerState {
             typealias StateReducer = Destination
+            case activity(Activity.State)
             case timeline(Timeline.State)
             case tweet(Tweet.State)
             case alert(AlertState<Alert>)
@@ -293,23 +295,27 @@
 
           @CasePathable
           enum Action {
+            case activity(Activity.Action)
             case timeline(Timeline.Action)
             case tweet(Tweet.Action)
             case alert(AlertState<Alert>.Action)
           }
 
-          static var body: some ComposableArchitecture.Reducer<Self.State, Self.Action> {
-            ComposableArchitecture.CombineReducers {
-              ComposableArchitecture.Scope(state: \Self.State.Cases.timeline, action: \Self.Action.Cases.timeline) {
-                Timeline()
-              }
-              ComposableArchitecture.Scope(state: \Self.State.Cases.tweet, action: \Self.Action.Cases.tweet) {
-                Tweet()
-              }
+          @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
+          static var body: ReducerBuilder<Self.State, Self.Action>._Sequence<ReducerBuilder<Self.State, Self.Action>._Sequence<Scope<Self.State, Self.Action, Activity>, Scope<Self.State, Self.Action, Timeline>>, Scope<Self.State, Self.Action, Tweet>> {
+            ComposableArchitecture.Scope(state: \Self.State.Cases.activity, action: \Self.Action.Cases.activity) {
+              Activity()
+            }
+            ComposableArchitecture.Scope(state: \Self.State.Cases.timeline, action: \Self.Action.Cases.timeline) {
+              Timeline()
+            }
+            ComposableArchitecture.Scope(state: \Self.State.Cases.tweet, action: \Self.Action.Cases.tweet) {
+              Tweet()
             }
           }
 
           enum CaseScope {
+            case activity(ComposableArchitecture.StoreOf<Activity>)
             case timeline(ComposableArchitecture.StoreOf<Timeline>)
             case tweet(ComposableArchitecture.StoreOf<Tweet>)
             case alert(AlertState<Alert>)
@@ -317,6 +323,8 @@
 
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
+            case .activity:
+              return .activity(store.scope(state: \.activity, action: \.activity)!)
             case .timeline:
               return .timeline(store.scope(state: \.timeline, action: \.timeline)!)
             case .tweet:
@@ -364,11 +372,10 @@
             case timeline(Timeline.Action)
           }
 
-          static var body: some ComposableArchitecture.Reducer<Self.State, Self.Action> {
-            ComposableArchitecture.CombineReducers {
-              ComposableArchitecture.Scope(state: \Self.State.Cases.timeline, action: \Self.Action.Cases.timeline) {
-                Timeline()
-              }
+          @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
+          static var body: Scope<Self.State, Self.Action, Timeline> {
+            ComposableArchitecture.Scope(state: \Self.State.Cases.timeline, action: \Self.Action.Cases.timeline) {
+              Timeline()
             }
           }
 
@@ -429,10 +436,9 @@
             case dialog(ConfirmationDialogState<Dialog>.Action)
           }
 
-          static var body: some ComposableArchitecture.Reducer<Self.State, Self.Action> {
-            ComposableArchitecture.CombineReducers {
+          @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
+          static var body: EmptyReducer<Self.State, Self.Action> {
 
-            }
           }
 
           enum CaseScope {
@@ -493,17 +499,16 @@
             case sheet(Counter.Action)
           }
 
-          static var body: some ComposableArchitecture.Reducer<Self.State, Self.Action> {
-            ComposableArchitecture.CombineReducers {
-              ComposableArchitecture.Scope(state: \Self.State.Cases.drillDown, action: \Self.Action.Cases.drillDown) {
-                Counter()
-              }
-              ComposableArchitecture.Scope(state: \Self.State.Cases.popover, action: \Self.Action.Cases.popover) {
-                Counter()
-              }
-              ComposableArchitecture.Scope(state: \Self.State.Cases.sheet, action: \Self.Action.Cases.sheet) {
-                Counter()
-              }
+          @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
+          static var body: ReducerBuilder<Self.State, Self.Action>._Sequence<ReducerBuilder<Self.State, Self.Action>._Sequence<Scope<Self.State, Self.Action, Counter>, Scope<Self.State, Self.Action, Counter>>, Scope<Self.State, Self.Action, Counter>> {
+            ComposableArchitecture.Scope(state: \Self.State.Cases.drillDown, action: \Self.Action.Cases.drillDown) {
+              Counter()
+            }
+            ComposableArchitecture.Scope(state: \Self.State.Cases.popover, action: \Self.Action.Cases.popover) {
+              Counter()
+            }
+            ComposableArchitecture.Scope(state: \Self.State.Cases.sheet, action: \Self.Action.Cases.sheet) {
+              Counter()
             }
           }
 
@@ -557,11 +562,10 @@
             case feature(Nested.Feature.Action)
           }
 
-          static var body: some ComposableArchitecture.Reducer<Self.State, Self.Action> {
-            ComposableArchitecture.CombineReducers {
-              ComposableArchitecture.Scope(state: \Self.State.Cases.feature, action: \Self.Action.Cases.feature) {
-                Nested.Feature()
-              }
+          @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
+          static var body: Scope<Self.State, Self.Action, Nested.Feature> {
+            ComposableArchitecture.Scope(state: \Self.State.Cases.feature, action: \Self.Action.Cases.feature) {
+              Nested.Feature()
             }
           }
 

--- a/Tests/ComposableArchitectureTests/MacroTests.swift
+++ b/Tests/ComposableArchitectureTests/MacroTests.swift
@@ -55,28 +55,28 @@
     }
   }
 
-//  enum TestEnumReducer_Basics {
-//    @Reducer struct Feature {}
-//    @Reducer
-//    enum Destination {
-//      case feature(Feature)
-//    }
-//  }
+  enum TestEnumReducer_Basics {
+    @Reducer struct Feature {}
+    @Reducer
+    enum Destination {
+      case feature(Feature)
+    }
+  }
 
-//  enum TestEnumReducer_SynthesizedConformances {
-//    @Reducer
-//    struct Feature {
-//    }
-//    @Reducer(
-//      state: .codable, .decodable, .encodable, .equatable, .hashable, .sendable,
-//      action: .equatable, .hashable, .sendable
-//    )
-//    enum Destination {
-//      case feature(Feature)
-//    }
-//    func stateRequirements(_: some Codable & Equatable & Hashable & Sendable) {}
-//    func actionRequirements(_: some Equatable & Hashable & Sendable) {}
-//    func givenState(_ state: Destination.State) { stateRequirements(state) }
-//    func givenAction(_ action: Destination.Action) { actionRequirements(action) }
-//  }
+  enum TestEnumReducer_SynthesizedConformances {
+    @Reducer
+    struct Feature {
+    }
+    @Reducer(
+      state: .codable, .decodable, .encodable, .equatable, .hashable, .sendable,
+      action: .equatable, .hashable, .sendable
+    )
+    enum Destination {
+      case feature(Feature)
+    }
+    func stateRequirements(_: some Codable & Equatable & Hashable & Sendable) {}
+    func actionRequirements(_: some Equatable & Hashable & Sendable) {}
+    func givenState(_ state: Destination.State) { stateRequirements(state) }
+    func givenAction(_ action: Destination.Action) { actionRequirements(action) }
+  }
 #endif

--- a/Tests/ComposableArchitectureTests/MacroTests.swift
+++ b/Tests/ComposableArchitectureTests/MacroTests.swift
@@ -58,8 +58,26 @@
   enum TestEnumReducer_Basics {
     @Reducer struct Feature {}
     @Reducer
-    enum Destination {
-      case feature(Feature)
+    enum Destination1 {
+      case feature1(Feature)
+    }
+    @Reducer
+    enum Destination2 {
+      case feature1(Feature)
+      case feature2(Feature)
+    }
+    @Reducer
+    enum Destination3 {
+      case feature1(Feature)
+      case feature2(Feature)
+      case feature3(Feature)
+    }
+    @Reducer
+    enum Destination4 {
+      case feature1(Feature)
+      case feature2(Feature)
+      case feature3(Feature)
+      case feature4(Feature)
     }
   }
 


### PR DESCRIPTION
Fixes #2824.

There is a Swift compiler/macro bug that causes the compiler to choke on constrained opaque types (e.g. `some Reducer<State, Action>`) when the `State` and `Action` are also generated by the macro. It doesn't happen in all situations, but something about enum reducers exacerbates the problem (perhaps it's cause of the `static var body`?).

The fix is to just not use opaque types in the macro generated code and instead expand the whole type for the `static var body`. It's a bit messy, but it works.