### PR TITLE
Add missing opening brace in a TreeBasedNavigation example

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
@@ -375,7 +375,7 @@ extension View {
     @ViewBuilder destination: @escaping (D) -> C
   ) -> some View {
     navigationDestination(isPresented: item.isPresented) {
-      if let item = item.wrappedValue
+      if let item = item.wrappedValue {
         destination(item)
       }
     }


### PR DESCRIPTION
Just adding a missing opening brace in one of the examples in TreeBasedNavigation.md