### PR TITLE
Don't perception check in `WithViewStore`

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -210,7 +210,11 @@ public final class Store<State, Action> {
   ///   it conforms to ``ObservableState``.
   /// - Returns: The return value, if any, of the `body` closure.
   public func withState<R>(_ body: (_ state: State) -> R) -> R {
-    body(self.currentState)
+    #if canImport(Perception)
+      _withoutPerceptionChecking { body(self.currentState) }
+    #else
+      body(self.currentState)
+    #endif
   }
 
   /// Sends an action to the store.

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -156,9 +156,9 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
       action: fromViewAction,
       isInvalid: nil
     )
-    self._state = CurrentValueRelay(self.store.currentState)
+    self._state = CurrentValueRelay(self.store.withState { $0 })
     self.viewCancellable = self.store.rootStore.didSet
-      .compactMap { [weak self] in self?.store.currentState }
+      .compactMap { [weak self] in self?.store.withState { $0 } }
       .removeDuplicates(by: isDuplicate)
       .dropFirst()
       .sink { [weak self] in


### PR DESCRIPTION
We currently scope in `WithViewStore.init`, which can lead to perception warnings. We can safely silence those.