### PR TITLE
fix document in PresentationReducer.swift

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -341,7 +341,7 @@ extension Reducer {
   /// @Reducer
   /// struct Parent {
   ///   struct State {
-  ///     @PresentationState var child: Child.State?
+  ///     @Presents var child: Child.State?
   ///     // ...
   ///   }
   ///   enum Action {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -340,6 +340,7 @@ extension Reducer {
   /// ```swift
   /// @Reducer
   /// struct Parent {
+  ///   @ObservableState
   ///   struct State {
   ///     @Presents var child: Child.State?
   ///     // ...


### PR DESCRIPTION
Hi, I thought this part should be `@Presents`, not `@PresentationState`.
The document just before says
> This version of `ifLet` requires the usage of the ``Presents()`` macro

so I thought maybe it should be `@Presents`.