### PR TITLE
Add `Reducer.dependency(value)`

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
@@ -79,6 +79,22 @@ extension Reducer {
     _DependencyKeyWritingReducer(base: self) { $0[keyPath: keyPath] = value }
   }
 
+  /// Places a value in the reducer's dependencies.
+  ///
+  /// - Parameter value: The value to set for this value's type in the dependencies.
+  /// - Returns: A reducer that has the given value set in its dependencies.
+  @inlinable
+  @warn_unqualified_access
+  public func dependency<Value: TestDependencyKey>(
+    _ value: Value
+  )
+    // NB: We should not return `some Reducer<State, Action>` here. That would prevent the
+    //     specialization defined below from being called, which fuses chained calls.
+    -> _DependencyKeyWritingReducer<Self>
+  where Value.Value == Value {
+    _DependencyKeyWritingReducer(base: self) { $0[Value.self] = value }
+  }
+
   /// Transform a reducer's dependency value at the specified key path with the given function.
   ///
   /// This is similar to ``dependency(_:_:)``, except it allows you to mutate a dependency value


### PR DESCRIPTION
This new reducer operator can be used to directly assign a dependency key value to the reducer's dependencies.

```swift
// Before;

@Dependency(\.apiClient) var apiClient
// ...
.dependency(\.apiClient, apiClient)

// After:

@Dependency(APIClient.self) var apiClient
// ...
.dependency(apiClient)
```