### PR TITLE
Update docs/examples to leverage `TestStore.send(\.path)`

### DIFF
--- a/ComposableArchitecture.xcworkspace/contents.xcworkspacedata
+++ b/ComposableArchitecture.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.9.md">
+   </FileRef>
+   <FileRef
       location = "group:">
    </FileRef>
    <FileRef

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -31,9 +31,11 @@ struct AlertAndConfirmationDialog {
     case confirmationDialog(PresentationAction<ConfirmationDialog>)
     case confirmationDialogButtonTapped
 
+    @CasePathable
     enum Alert {
       case incrementButtonTapped
     }
+    @CasePathable
     enum ConfirmationDialog {
       case incrementButtonTapped
       case decrementButtonTapped

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -37,6 +37,7 @@ struct Animations {
     case setColor(Color)
     case tapped(CGPoint)
 
+    @CasePathable
     enum Alert: Sendable {
       case resetConfirmationButtonTapped
     }

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
@@ -15,6 +15,7 @@ struct DownloadComponent {
     case buttonTapped
     case downloadClient(Result<DownloadClient.Event, Error>)
 
+    @CasePathable
     enum Alert {
       case deleteButtonTapped
       case stopButtonTapped

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndConfirmationDialogsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndConfirmationDialogsTests.swift
@@ -24,11 +24,11 @@ final class AlertsAndConfirmationDialogsTests: XCTestCase {
         TextState("This is an alert")
       }
     }
-    await store.send(.alert(.presented(.incrementButtonTapped))) {
+    await store.send(\.alert.incrementButtonTapped) {
       $0.alert = AlertState { TextState("Incremented!") }
       $0.count = 1
     }
-    await store.send(.alert(.dismiss)) {
+    await store.send(\.alert.dismiss) {
       $0.alert = nil
     }
   }
@@ -55,7 +55,7 @@ final class AlertsAndConfirmationDialogsTests: XCTestCase {
         TextState("This is a confirmation dialog.")
       }
     }
-    await store.send(.confirmationDialog(.presented(.incrementButtonTapped))) {
+    await store.send(\.confirmationDialog.incrementButtonTapped) {
       $0.alert = AlertState { TextState("Incremented!") }
       $0.confirmationDialog = nil
       $0.count = 1

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
@@ -93,7 +93,7 @@ final class AnimationTests: XCTestCase {
       }
     }
 
-    await store.send(.alert(.presented(.resetConfirmationButtonTapped))) {
+    await store.send(\.alert.resetConfirmationButtonTapped) {
       $0 = Animations.State()
     }
 

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-BindingBasicsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-BindingBasicsTests.swift
@@ -10,17 +10,17 @@ final class BindingFormTests: XCTestCase {
       BindingForm()
     }
 
-    await store.send(.set(\.sliderValue, 2)) {
+    await store.send(\.sliderValue, 2) {
       $0.sliderValue = 2
     }
-    await store.send(.set(\.stepCount, 1)) {
+    await store.send(\.stepCount, 1) {
       $0.sliderValue = 1
       $0.stepCount = 1
     }
-    await store.send(.set(\.text, "Blob")) {
+    await store.send(\.text, "Blob") {
       $0.text = "Blob"
     }
-    await store.send(.set(\.toggleIsOn, true)) {
+    await store.send(\.toggleIsOn, true) {
       $0.toggleIsOn = true
     }
     await store.send(.resetButtonTapped) {

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-SharedStateTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-SharedStateTests.swift
@@ -23,15 +23,15 @@ final class SharedStateTests: XCTestCase {
       SharedState()
     }
 
-    await store.send(.counter(.incrementButtonTapped)) {
+    await store.send(\.counter.incrementButtonTapped) {
       $0.counter.stats.increment()
       $0.profile.stats.increment()
     }
-    await store.send(.counter(.decrementButtonTapped)) {
+    await store.send(\.counter.decrementButtonTapped) {
       $0.counter.stats.decrement()
       $0.profile.stats.decrement()
     }
-    await store.send(.profile(.resetStatsButtonTapped)) {
+    await store.send(\.profile.resetStatsButtonTapped) {
       $0.counter.stats = Stats()
       $0.profile.stats = Stats()
     }
@@ -42,7 +42,7 @@ final class SharedStateTests: XCTestCase {
       SharedState()
     }
 
-    await store.send(.counter(.isPrimeButtonTapped)) {
+    await store.send(\.counter.isPrimeButtonTapped) {
       $0.counter.alert = AlertState {
         TextState("👎 The number 0 is not prime :(")
       }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-RecursionTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-RecursionTests.swift
@@ -16,7 +16,7 @@ final class RecursionTests: XCTestCase {
       $0.rows.append(Nested.State(id: UUID(0)))
     }
 
-    await store.send(.rows(.element(id: UUID(0), action: .addRowButtonTapped))) {
+    await store.send(\.rows[id: UUID(0)].addRowButtonTapped) {
       $0.rows[id: UUID(0)]?.rows.append(Nested.State(id: UUID(1)))
     }
   }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
@@ -34,16 +34,16 @@ final class ReusableComponentsFavoritingTests: XCTestCase {
       )
     }
 
-    await store.send(.episodes(.element(id: episodes[0].id, action: .favorite(.buttonTapped)))) {
+    await store.send(\.episodes[id: episodes[0].id].favorite.buttonTapped) {
       $0.episodes[id: episodes[0].id]?.isFavorite = true
     }
     await clock.advance(by: .seconds(1))
     await store.receive(\.episodes[id:episodes[0].id].favorite.response.success)
 
-    await store.send(.episodes(.element(id: episodes[1].id, action: .favorite(.buttonTapped)))) {
+    await store.send(\.episodes[id:episodes[1].id].favorite.buttonTapped) {
       $0.episodes[id: episodes[1].id]?.isFavorite = true
     }
-    await store.send(.episodes(.element(id: episodes[1].id, action: .favorite(.buttonTapped)))) {
+    await store.send(\.episodes[id:episodes[1].id].favorite.buttonTapped) {
       $0.episodes[id: episodes[1].id]?.isFavorite = false
     }
     await clock.advance(by: .seconds(1))
@@ -62,7 +62,7 @@ final class ReusableComponentsFavoritingTests: XCTestCase {
       Episodes(favorite: { _, _ in throw FavoriteError() })
     }
 
-    await store.send(.episodes(.element(id: episodes[0].id, action: .favorite(.buttonTapped)))) {
+    await store.send(\.episodes[id: episodes[0].id].favorite.buttonTapped) {
       $0.episodes[id: episodes[0].id]?.isFavorite = true
     }
 
@@ -72,7 +72,7 @@ final class ReusableComponentsFavoritingTests: XCTestCase {
       }
     }
 
-    await store.send(.episodes(.element(id: episodes[0].id, action: .favorite(.alert(.dismiss))))) {
+    await store.send(\.episodes[id: episodes[0].id].favorite.alert.dismiss) {
       $0.episodes[id: episodes[0].id]?.alert = nil
       $0.episodes[id: episodes[0].id]?.isFavorite = false
     }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableFavoritingTests.swift
@@ -34,17 +34,17 @@ final class ReusableComponentsFavoritingTests: XCTestCase {
       )
     }
 
-    await store.send(\.episodes[id: episodes[0].id].favorite.buttonTapped) {
-      $0.episodes[id: episodes[0].id]?.isFavorite = true
+    await store.send(\.episodes[id: UUID(0)].favorite.buttonTapped) {
+      $0.episodes[id: UUID(0)]?.isFavorite = true
     }
     await clock.advance(by: .seconds(1))
     await store.receive(\.episodes[id:episodes[0].id].favorite.response.success)
 
     await store.send(\.episodes[id:episodes[1].id].favorite.buttonTapped) {
-      $0.episodes[id: episodes[1].id]?.isFavorite = true
+      $0.episodes[id: UUID(1)]?.isFavorite = true
     }
     await store.send(\.episodes[id:episodes[1].id].favorite.buttonTapped) {
-      $0.episodes[id: episodes[1].id]?.isFavorite = false
+      $0.episodes[id: UUID(1)]?.isFavorite = false
     }
     await clock.advance(by: .seconds(1))
     await store.receive(\.episodes[id:episodes[1].id].favorite.response.success)
@@ -62,19 +62,19 @@ final class ReusableComponentsFavoritingTests: XCTestCase {
       Episodes(favorite: { _, _ in throw FavoriteError() })
     }
 
-    await store.send(\.episodes[id: episodes[0].id].favorite.buttonTapped) {
-      $0.episodes[id: episodes[0].id]?.isFavorite = true
+    await store.send(\.episodes[id: UUID(0)].favorite.buttonTapped) {
+      $0.episodes[id: UUID(0)]?.isFavorite = true
     }
 
     await store.receive(\.episodes[id:episodes[0].id].favorite.response.failure) {
-      $0.episodes[id: episodes[0].id]?.alert = AlertState {
+      $0.episodes[id: UUID(0)]?.alert = AlertState {
         TextState("Favoriting failed.")
       }
     }
 
-    await store.send(\.episodes[id: episodes[0].id].favorite.alert.dismiss) {
-      $0.episodes[id: episodes[0].id]?.alert = nil
-      $0.episodes[id: episodes[0].id]?.isFavorite = false
+    await store.send(\.episodes[id: UUID(0)].favorite.alert.dismiss) {
+      $0.episodes[id: UUID(0)]?.alert = nil
+      $0.episodes[id: UUID(0)]?.isFavorite = false
     }
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
@@ -71,7 +71,7 @@ final class ReusableComponentsDownloadComponentTests: XCTestCase {
       }
     }
 
-    await store.send(.alert(.presented(.stopButtonTapped))) {
+    await store.send(\.alert.stopButtonTapped) {
       $0.alert = nil
       $0.mode = .notDownloaded
     }
@@ -143,7 +143,7 @@ final class ReusableComponentsDownloadComponentTests: XCTestCase {
       }
     }
 
-    await store.send(.alert(.presented(.deleteButtonTapped))) {
+    await store.send(\.alert.deleteButtonTapped) {
       $0.alert = nil
       $0.mode = .notDownloaded
     }

--- a/Examples/CaseStudies/UIKitCaseStudiesTests/UIKitCaseStudiesTests.swift
+++ b/Examples/CaseStudies/UIKitCaseStudiesTests/UIKitCaseStudiesTests.swift
@@ -31,24 +31,24 @@ final class UIKitCaseStudiesTests: XCTestCase {
       CounterList()
     }
 
-    await store.send(.counters(.element(id: firstState.id, action: .incrementButtonTapped))) {
+    await store.send(\.counters[id: firstState.id].incrementButtonTapped) {
       $0.counters[id: firstState.id]?.count = 1
     }
-    await store.send(.counters(.element(id: firstState.id, action: .decrementButtonTapped))) {
+    await store.send(\.counters[id: firstState.id].decrementButtonTapped) {
       $0.counters[id: firstState.id]?.count = 0
     }
 
-    await store.send(.counters(.element(id: secondState.id, action: .incrementButtonTapped))) {
+    await store.send(\.counters[id: secondState.id].incrementButtonTapped) {
       $0.counters[id: secondState.id]?.count = 1
     }
-    await store.send(.counters(.element(id: secondState.id, action: .decrementButtonTapped))) {
+    await store.send(\.counters[id: secondState.id].decrementButtonTapped) {
       $0.counters[id: secondState.id]?.count = 0
     }
 
-    await store.send(.counters(.element(id: thirdState.id, action: .incrementButtonTapped))) {
+    await store.send(\.counters[id: thirdState.id].incrementButtonTapped) {
       $0.counters[id: thirdState.id]?.count = 1
     }
-    await store.send(.counters(.element(id: thirdState.id, action: .decrementButtonTapped))) {
+    await store.send(\.counters[id: thirdState.id].decrementButtonTapped) {
       $0.counters[id: thirdState.id]?.count = 0
     }
   }

--- a/Examples/SyncUps/SyncUps/RecordMeeting.swift
+++ b/Examples/SyncUps/SyncUps/RecordMeeting.swift
@@ -27,6 +27,7 @@ struct RecordMeeting {
     case speechFailure
     case speechResult(SpeechRecognitionResult)
 
+    @CasePathable
     enum Alert {
       case confirmDiscard
       case confirmSave

--- a/Examples/SyncUps/SyncUps/SyncUpDetail.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpDetail.swift
@@ -8,6 +8,7 @@ struct SyncUpDetail {
     case alert(AlertState<Alert>)
     case edit(SyncUpForm)
 
+    @CasePathable
     enum Alert {
       case confirmDeletion
       case continueWithoutRecording

--- a/Examples/SyncUps/SyncUps/SyncUpsList.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpsList.swift
@@ -8,6 +8,7 @@ struct SyncUpsList {
     case add(SyncUpForm)
     case alert(AlertState<Alert>)
 
+    @CasePathable
     enum Alert {
       case confirmLoadMockData
     }

--- a/Examples/SyncUps/SyncUpsTests/AppFeatureTests.swift
+++ b/Examples/SyncUps/SyncUpsTests/AppFeatureTests.swift
@@ -65,7 +65,7 @@ final class AppFeatureTests: XCTestCase {
     }
 
     syncUp.title = "Blob"
-    await store.send(\.path[id:0].detail.destination.edit.binding.syncUp, syncUp) {
+    await store.send(\.path[id:0].detail.destination.edit.syncUp, syncUp) {
       $0.path[id: 0, case: \.detail]?.$destination[case: \.edit]?.syncUp.title = "Blob"
     }
 

--- a/Examples/SyncUps/SyncUpsTests/AppFeatureTests.swift
+++ b/Examples/SyncUps/SyncUpsTests/AppFeatureTests.swift
@@ -17,24 +17,22 @@ final class AppFeatureTests: XCTestCase {
       )
     }
 
-    await store.send(.path(.push(id: 0, state: .detail(SyncUpDetail.State(syncUp: syncUp))))) {
+    await store.send(\.path[id:0], .detail(SyncUpDetail.State(syncUp: syncUp))) {
       $0.path[id: 0] = .detail(SyncUpDetail.State(syncUp: syncUp))
     }
 
-    await store.send(.path(.element(id: 0, action: .detail(.deleteButtonTapped)))) {
+    await store.send(\.path[id:0].detail.deleteButtonTapped) {
       $0.path[id: 0, case: \.detail]?.destination = .alert(.deleteSyncUp)
     }
 
-    await store.send(
-      .path(.element(id: 0, action: .detail(.destination(.presented(.alert(.confirmDeletion))))))
-    ) {
+    await store.send(\.path[id:0].detail.destination.alert.confirmDeletion) {
       $0.path[id: 0, case: \.detail]?.destination = nil
     }
 
     await store.receive(\.path[id:0].detail.delegate.deleteSyncUp) {
       $0.syncUpsList.syncUps = []
     }
-    await store.receive(\.path.popFrom) {
+    await store.receive(\.path[id:0], nil) {
       $0.path = StackState()
     }
   }
@@ -56,29 +54,22 @@ final class AppFeatureTests: XCTestCase {
       }
     }
 
-    await store.send(.path(.push(id: 0, state: .detail(SyncUpDetail.State(syncUp: syncUp))))) {
+    await store.send(\.path[id:0], .detail(SyncUpDetail.State(syncUp: syncUp))) {
       $0.path[id: 0] = .detail(SyncUpDetail.State(syncUp: syncUp))
     }
 
-    await store.send(.path(.element(id: 0, action: .detail(.editButtonTapped)))) {
+    await store.send(\.path[id:0].detail.editButtonTapped) {
       $0.path[id: 0, case: \.detail]?.destination = .edit(
         SyncUpForm.State(syncUp: syncUp)
       )
     }
 
     syncUp.title = "Blob"
-    await store.send(
-      .path(
-        .element(
-          id: 0,
-          action: .detail(.destination(.presented(.edit(.set(\.syncUp, syncUp)))))
-        )
-      )
-    ) {
+    await store.send(\.path[id:0].detail.destination.edit.binding.syncUp, syncUp) {
       $0.path[id: 0, case: \.detail]?.$destination[case: \.edit]?.syncUp.title = "Blob"
     }
 
-    await store.send(.path(.element(id: 0, action: .detail(.doneEditingButtonTapped)))) {
+    await store.send(\.path[id:0].detail.doneEditingButtonTapped) {
       $0.path[id: 0, case: \.detail]?.destination = nil
       $0.path[id: 0, case: \.detail]?.syncUp.title = "Blob"
     }
@@ -134,7 +125,7 @@ final class AppFeatureTests: XCTestCase {
     }
     store.exhaustivity = .off
 
-    await store.send(.path(.element(id: 1, action: .record(.onTask))))
+    await store.send(\.path[id:1].record.onTask)
     await store.receive(\.path[id:1].record.delegate.save) {
       $0.path[id: 0, case: \.detail]?.syncUp.meetings = [
         Meeting(
@@ -144,7 +135,7 @@ final class AppFeatureTests: XCTestCase {
         )
       ]
     }
-    await store.receive(\.path.popFrom) {
+    await store.receive(\.path[id:1], nil) {
       XCTAssertEqual($0.path.count, 1)
     }
   }

--- a/Examples/SyncUps/SyncUpsTests/AppFeatureTests.swift
+++ b/Examples/SyncUps/SyncUpsTests/AppFeatureTests.swift
@@ -17,7 +17,7 @@ final class AppFeatureTests: XCTestCase {
       )
     }
 
-    await store.send(\.path[id:0], .detail(SyncUpDetail.State(syncUp: syncUp))) {
+    await store.send(\.path.push, (id: 0, .detail(SyncUpDetail.State(syncUp: syncUp)))) {
       $0.path[id: 0] = .detail(SyncUpDetail.State(syncUp: syncUp))
     }
 
@@ -32,7 +32,7 @@ final class AppFeatureTests: XCTestCase {
     await store.receive(\.path[id:0].detail.delegate.deleteSyncUp) {
       $0.syncUpsList.syncUps = []
     }
-    await store.receive(\.path[id:0], nil) {
+    await store.receive(\.path.popFrom) {
       $0.path = StackState()
     }
   }
@@ -54,7 +54,7 @@ final class AppFeatureTests: XCTestCase {
       }
     }
 
-    await store.send(\.path[id:0], .detail(SyncUpDetail.State(syncUp: syncUp))) {
+    await store.send(\.path.push, (id: 0, .detail(SyncUpDetail.State(syncUp: syncUp)))) {
       $0.path[id: 0] = .detail(SyncUpDetail.State(syncUp: syncUp))
     }
 
@@ -135,7 +135,7 @@ final class AppFeatureTests: XCTestCase {
         )
       ]
     }
-    await store.receive(\.path[id:1], nil) {
+    await store.receive(\.path.popFrom) {
       XCTAssertEqual($0.path.count, 1)
     }
   }

--- a/Examples/SyncUps/SyncUpsTests/RecordMeetingTests.swift
+++ b/Examples/SyncUps/SyncUpsTests/RecordMeetingTests.swift
@@ -160,7 +160,7 @@ final class RecordMeetingTests: XCTestCase {
     await store.receive(\.timerTick)
     await store.receive(\.timerTick)
 
-    await store.send(.alert(.presented(.confirmSave))) {
+    await store.send(\.alert.confirmSave) {
       $0.alert = nil
     }
 
@@ -188,7 +188,7 @@ final class RecordMeetingTests: XCTestCase {
       $0.alert = .endMeeting(isDiscardable: true)
     }
 
-    await store.send(.alert(.presented(.confirmDiscard))) {
+    await store.send(\.alert.confirmDiscard) {
       $0.alert = nil
     }
 
@@ -236,7 +236,7 @@ final class RecordMeetingTests: XCTestCase {
       $0.alert = .endMeeting(isDiscardable: false)
     }
 
-    await store.send(.alert(.presented(.confirmSave))) {
+    await store.send(\.alert.confirmSave) {
       $0.alert = nil
     }
 
@@ -292,7 +292,7 @@ final class RecordMeetingTests: XCTestCase {
       $0.transcript = "I completed the project ❌"
     }
 
-    await store.send(.alert(.dismiss)) {
+    await store.send(\.alert.dismiss) {
       $0.alert = nil
     }
 
@@ -336,7 +336,7 @@ final class RecordMeetingTests: XCTestCase {
       $0.alert = .speechRecognizerFailed
     }
 
-    await store.send(.alert(.presented(.confirmDiscard))) {
+    await store.send(\.alert.confirmDiscard) {
       $0.alert = nil
     }
 

--- a/Examples/SyncUps/SyncUpsTests/SyncUpDetailTests.swift
+++ b/Examples/SyncUps/SyncUpsTests/SyncUpDetailTests.swift
@@ -46,7 +46,7 @@ final class SyncUpDetailTests: XCTestCase {
       $0.speechClient.authorizationStatus = { .denied }
     }
 
-    await store.send(.destination(.presented(.alert(.openSettings)))) {
+    await store.send(\.destination.alert.openSettings) {
       $0.destination = nil
     }
     XCTAssertEqual(settingsOpened.value, true)
@@ -64,7 +64,7 @@ final class SyncUpDetailTests: XCTestCase {
       $0.speechClient.authorizationStatus = { .denied }
     }
 
-    await store.send(.destination(.presented(.alert(.continueWithoutRecording)))) {
+    await store.send(\.destination.alert.continueWithoutRecording) {
       $0.destination = nil
     }
 
@@ -96,7 +96,7 @@ final class SyncUpDetailTests: XCTestCase {
     }
 
     syncUp.title = "Blob's Meeting"
-    await store.send(.destination(.presented(.edit(.set(\.syncUp, syncUp))))) {
+    await store.send(\.destination.edit.binding.syncUp, syncUp) {
       $0.$destination[case: \.edit]?.syncUp.title = "Blob's Meeting"
     }
 
@@ -124,7 +124,7 @@ final class SyncUpDetailTests: XCTestCase {
     await store.send(.deleteButtonTapped) {
       $0.destination = .alert(.deleteSyncUp)
     }
-    await store.send(.destination(.presented(.alert(.confirmDeletion)))) {
+    await store.send(\.destination.alert.confirmDeletion) {
       $0.destination = nil
     }
     await store.receive(\.delegate.deleteSyncUp)

--- a/Examples/SyncUps/SyncUpsTests/SyncUpDetailTests.swift
+++ b/Examples/SyncUps/SyncUpsTests/SyncUpDetailTests.swift
@@ -96,7 +96,7 @@ final class SyncUpDetailTests: XCTestCase {
     }
 
     syncUp.title = "Blob's Meeting"
-    await store.send(\.destination.edit.binding.syncUp, syncUp) {
+    await store.send(\.destination.edit.syncUp, syncUp) {
       $0.$destination[case: \.edit]?.syncUp.title = "Blob's Meeting"
     }
 

--- a/Examples/SyncUps/SyncUpsTests/SyncUpsListTests.swift
+++ b/Examples/SyncUps/SyncUpsTests/SyncUpsListTests.swift
@@ -25,7 +25,7 @@ final class SyncUpsListTests: XCTestCase {
     }
 
     syncUp.title = "Engineering"
-    await store.send(.destination(.presented(.add(.set(\.syncUp, syncUp))))) {
+    await store.send(\.destination.add.binding.syncUp, syncUp) {
       $0.$destination[case: \.add]?.syncUp.title = "Engineering"
     }
 
@@ -87,7 +87,7 @@ final class SyncUpsListTests: XCTestCase {
 
     XCTAssertEqual(store.state.destination, .alert(.dataFailedToLoad))
 
-    await store.send(.destination(.presented(.alert(.confirmLoadMockData)))) {
+    await store.send(\.destination.alert.confirmLoadMockData) {
       $0.destination = nil
       $0.syncUps = [
         .mock,

--- a/Examples/SyncUps/SyncUpsTests/SyncUpsListTests.swift
+++ b/Examples/SyncUps/SyncUpsTests/SyncUpsListTests.swift
@@ -25,7 +25,7 @@ final class SyncUpsListTests: XCTestCase {
     }
 
     syncUp.title = "Engineering"
-    await store.send(\.destination.add.binding.syncUp, syncUp) {
+    await store.send(\.destination.add.syncUp, syncUp) {
       $0.$destination[case: \.add]?.syncUp.title = "Engineering"
     }
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameCore/GameCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameCore/GameCore.swift
@@ -24,7 +24,7 @@ public struct Game: Sendable {
   }
 
   public enum Action: Sendable {
-    case cellTapped(Cell)
+    case cellTapped(row: Int, column: Int)
     case playAgainButtonTapped
     case quitButtonTapped
   }
@@ -36,13 +36,13 @@ public struct Game: Sendable {
   public var body: some Reducer<State, Action> {
     Reduce { state, action in
       switch action {
-      case let .cellTapped(cell):
+      case let .cellTapped(row, column):
         guard
-          state.board[cell.row][cell.column] == nil,
+          state.board[row][column] == nil,
           !state.board.hasWinner
         else { return .none }
 
-        state.board[cell.row][cell.column] = state.currentPlayer
+        state.board[row][column] = state.currentPlayer
 
         if !state.board.hasWinner {
           state.currentPlayer.toggle()
@@ -79,16 +79,6 @@ public enum Player: Equatable, Sendable {
     case .o: return "⭕️"
     case .x: return "❌"
     }
-  }
-}
-
-public struct Cell: Equatable, Sendable {
-  public var row: Int
-  public var column: Int
-
-  public init(row: Int, column: Int) {
-    self.row = row
-    self.column = column
   }
 }
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameCore/GameCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameCore/GameCore.swift
@@ -24,7 +24,7 @@ public struct Game: Sendable {
   }
 
   public enum Action: Sendable {
-    case cellTapped(row: Int, column: Int)
+    case cellTapped(Cell)
     case playAgainButtonTapped
     case quitButtonTapped
   }
@@ -36,13 +36,13 @@ public struct Game: Sendable {
   public var body: some Reducer<State, Action> {
     Reduce { state, action in
       switch action {
-      case let .cellTapped(row, column):
+      case let .cellTapped(cell):
         guard
-          state.board[row][column] == nil,
+          state.board[cell.row][cell.column] == nil,
           !state.board.hasWinner
         else { return .none }
 
-        state.board[row][column] = state.currentPlayer
+        state.board[cell.row][cell.column] = state.currentPlayer
 
         if !state.board.hasWinner {
           state.currentPlayer.toggle()
@@ -63,7 +63,7 @@ public struct Game: Sendable {
   }
 }
 
-public enum Player: Equatable {
+public enum Player: Equatable, Sendable {
   case o
   case x
 
@@ -79,6 +79,16 @@ public enum Player: Equatable {
     case .o: return "⭕️"
     case .x: return "❌"
     }
+  }
+}
+
+public struct Cell: Equatable, Sendable {
+  public var row: Int
+  public var column: Int
+
+  public init(row: Int, column: Int) {
+    self.row = row
+    self.column = column
   }
 }
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameCore/Three.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameCore/Three.swift
@@ -44,3 +44,4 @@ extension Three: RandomAccessCollection {}
 
 extension Three: Equatable where Element: Equatable {}
 extension Three: Hashable where Element: Hashable {}
+extension Three: Sendable where Element: Sendable {}

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
@@ -56,7 +56,7 @@ public struct GameView: View {
     proxy: GeometryProxy
   ) -> some View {
     Button {
-      store.send(.cellTapped(Cell(row: row, column: column)))
+      store.send(.cellTapped(row: row, column: column))
     } label: {
       Text(store.rows[row][column])
         .frame(width: proxy.size.width / 3, height: proxy.size.width / 3)

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
@@ -56,7 +56,7 @@ public struct GameView: View {
     proxy: GeometryProxy
   ) -> some View {
     Button {
-      store.send(.cellTapped(row: row, column: column))
+      store.send(.cellTapped(Cell(row: row, column: column)))
     } label: {
       Text(store.rows[row][column])
         .frame(width: proxy.size.width / 3, height: proxy.size.width / 3)

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameUIKit/GameViewController.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameUIKit/GameViewController.swift
@@ -121,15 +121,15 @@ public final class GameViewController: UIViewController {
     }
   }
 
-  @objc private func gridCell11Tapped() { self.store.send(.cellTapped(Cell(row: 0, column: 0))) }
-  @objc private func gridCell12Tapped() { self.store.send(.cellTapped(Cell(row: 0, column: 1))) }
-  @objc private func gridCell13Tapped() { self.store.send(.cellTapped(Cell(row: 0, column: 2))) }
-  @objc private func gridCell21Tapped() { self.store.send(.cellTapped(Cell(row: 1, column: 0))) }
-  @objc private func gridCell22Tapped() { self.store.send(.cellTapped(Cell(row: 1, column: 1))) }
-  @objc private func gridCell23Tapped() { self.store.send(.cellTapped(Cell(row: 1, column: 2))) }
-  @objc private func gridCell31Tapped() { self.store.send(.cellTapped(Cell(row: 2, column: 0))) }
-  @objc private func gridCell32Tapped() { self.store.send(.cellTapped(Cell(row: 2, column: 1))) }
-  @objc private func gridCell33Tapped() { self.store.send(.cellTapped(Cell(row: 2, column: 2))) }
+  @objc private func gridCell11Tapped() { self.store.send(.cellTapped(row: 0, column: 0)) }
+  @objc private func gridCell12Tapped() { self.store.send(.cellTapped(row: 0, column: 1)) }
+  @objc private func gridCell13Tapped() { self.store.send(.cellTapped(row: 0, column: 2)) }
+  @objc private func gridCell21Tapped() { self.store.send(.cellTapped(row: 1, column: 0)) }
+  @objc private func gridCell22Tapped() { self.store.send(.cellTapped(row: 1, column: 1)) }
+  @objc private func gridCell23Tapped() { self.store.send(.cellTapped(row: 1, column: 2)) }
+  @objc private func gridCell31Tapped() { self.store.send(.cellTapped(row: 2, column: 0)) }
+  @objc private func gridCell32Tapped() { self.store.send(.cellTapped(row: 2, column: 1)) }
+  @objc private func gridCell33Tapped() { self.store.send(.cellTapped(row: 2, column: 2)) }
 
   @objc private func quitButtonTapped() {
     self.store.send(.quitButtonTapped)

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameUIKit/GameViewController.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameUIKit/GameViewController.swift
@@ -121,15 +121,15 @@ public final class GameViewController: UIViewController {
     }
   }
 
-  @objc private func gridCell11Tapped() { self.store.send(.cellTapped(row: 0, column: 0)) }
-  @objc private func gridCell12Tapped() { self.store.send(.cellTapped(row: 0, column: 1)) }
-  @objc private func gridCell13Tapped() { self.store.send(.cellTapped(row: 0, column: 2)) }
-  @objc private func gridCell21Tapped() { self.store.send(.cellTapped(row: 1, column: 0)) }
-  @objc private func gridCell22Tapped() { self.store.send(.cellTapped(row: 1, column: 1)) }
-  @objc private func gridCell23Tapped() { self.store.send(.cellTapped(row: 1, column: 2)) }
-  @objc private func gridCell31Tapped() { self.store.send(.cellTapped(row: 2, column: 0)) }
-  @objc private func gridCell32Tapped() { self.store.send(.cellTapped(row: 2, column: 1)) }
-  @objc private func gridCell33Tapped() { self.store.send(.cellTapped(row: 2, column: 2)) }
+  @objc private func gridCell11Tapped() { self.store.send(.cellTapped(Cell(row: 0, column: 0))) }
+  @objc private func gridCell12Tapped() { self.store.send(.cellTapped(Cell(row: 0, column: 1))) }
+  @objc private func gridCell13Tapped() { self.store.send(.cellTapped(Cell(row: 0, column: 2))) }
+  @objc private func gridCell21Tapped() { self.store.send(.cellTapped(Cell(row: 1, column: 0))) }
+  @objc private func gridCell22Tapped() { self.store.send(.cellTapped(Cell(row: 1, column: 1))) }
+  @objc private func gridCell23Tapped() { self.store.send(.cellTapped(Cell(row: 1, column: 2))) }
+  @objc private func gridCell31Tapped() { self.store.send(.cellTapped(Cell(row: 2, column: 0))) }
+  @objc private func gridCell32Tapped() { self.store.send(.cellTapped(Cell(row: 2, column: 1))) }
+  @objc private func gridCell33Tapped() { self.store.send(.cellTapped(Cell(row: 2, column: 2))) }
 
   @objc private func quitButtonTapped() {
     self.store.send(.quitButtonTapped)

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginCore/LoginCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginCore/LoginCore.swift
@@ -25,6 +25,7 @@ public struct Login: Sendable {
 
     public enum Alert: Equatable, Sendable {}
 
+    @CasePathable
     public enum View: BindableAction, Sendable {
       case binding(BindingAction<State>)
       case loginButtonTapped

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
@@ -25,6 +25,7 @@ public struct TwoFactor: Sendable {
 
     public enum Alert: Equatable, Sendable {}
 
+    @CasePathable
     public enum View: BindableAction, Sendable {
       case binding(BindingAction<State>)
       case submitButtonTapped

--- a/Examples/TicTacToe/tic-tac-toe/Tests/AppCoreTests/AppCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/AppCoreTests/AppCoreTests.swift
@@ -17,18 +17,18 @@ final class AppCoreTests: XCTestCase {
       }
     }
 
-    await store.send(.login(.view(.set(\.email, "blob@pointfree.co")))) {
+    await store.send(\.login.view.email, "blob@pointfree.co") {
       $0.modify(\.login) {
         $0.email = "blob@pointfree.co"
       }
     }
-    await store.send(.login(.view(.set(\.password, "bl0bbl0b")))) {
+    await store.send(\.login.view.password, "bl0bbl0b") {
       $0.modify(\.login) {
         $0.password = "bl0bbl0b"
         $0.isFormValid = true
       }
     }
-    await store.send(.login(.view(.loginButtonTapped))) {
+    await store.send(\.login.view.loginButtonTapped) {
       $0.modify(\.login) {
         $0.isLoginRequestInFlight = true
       }
@@ -36,12 +36,12 @@ final class AppCoreTests: XCTestCase {
     await store.receive(\.login.loginResponse.success) {
       $0 = .newGame(NewGame.State())
     }
-    await store.send(.newGame(.set(\.oPlayerName, "Blob Sr."))) {
+    await store.send(\.newGame.oPlayerName, "Blob Sr.") {
       $0.modify(\.newGame) {
         $0.oPlayerName = "Blob Sr."
       }
     }
-    await store.send(.newGame(.logoutButtonTapped)) {
+    await store.send(\.newGame.logoutButtonTapped) {
       $0 = .login(Login.State())
     }
   }
@@ -58,20 +58,20 @@ final class AppCoreTests: XCTestCase {
       }
     }
 
-    await store.send(.login(.view(.set(\.email, "blob@pointfree.co")))) {
+    await store.send(\.login.view.email, "blob@pointfree.co") {
       $0.modify(\.login) {
         $0.email = "blob@pointfree.co"
       }
     }
 
-    await store.send(.login(.view(.set(\.password, "bl0bbl0b")))) {
+    await store.send(\.login.view.password, "bl0bbl0b") {
       $0.modify(\.login) {
         $0.password = "bl0bbl0b"
         $0.isFormValid = true
       }
     }
 
-    await store.send(.login(.view(.loginButtonTapped))) {
+    await store.send(\.login.view.loginButtonTapped) {
       $0.modify(\.login) {
         $0.isLoginRequestInFlight = true
       }
@@ -83,14 +83,14 @@ final class AppCoreTests: XCTestCase {
       }
     }
 
-    await store.send(.login(.twoFactor(.presented(.view(.set(\.code, "1234")))))) {
+    await store.send(\.login.twoFactor.view.code, "1234") {
       $0.modify(\.login) {
         $0.twoFactor?.code = "1234"
         $0.twoFactor?.isFormValid = true
       }
     }
 
-    await store.send(.login(.twoFactor(.presented(.view(.submitButtonTapped))))) {
+    await store.send(\.login.twoFactor.view.submitButtonTapped) {
       $0.modify(\.login) {
         $0.twoFactor?.isTwoFactorRequestInFlight = true
       }

--- a/Examples/TicTacToe/tic-tac-toe/Tests/GameCoreTests/GameCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/GameCoreTests/GameCoreTests.swift
@@ -14,61 +14,61 @@ final class GameCoreTests: XCTestCase {
   }
 
   func testFlow_Winner_Quit() async {
-    await self.store.send(.cellTapped(Cell(row: 0, column: 0))) {
+    await self.store.send(.cellTapped(row: 0, column: 0)) {
       $0.board[0][0] = .x
       $0.currentPlayer = .o
     }
-    await self.store.send(.cellTapped(Cell(row: 2, column: 1))) {
+    await self.store.send(.cellTapped(row: 2, column: 1)) {
       $0.board[2][1] = .o
       $0.currentPlayer = .x
     }
-    await self.store.send(.cellTapped(Cell(row: 1, column: 0))) {
+    await self.store.send(.cellTapped(row: 1, column: 0)) {
       $0.board[1][0] = .x
       $0.currentPlayer = .o
     }
-    await self.store.send(.cellTapped(Cell(row: 1, column: 1))) {
+    await self.store.send(.cellTapped(row: 1, column: 1)) {
       $0.board[1][1] = .o
       $0.currentPlayer = .x
     }
-    await self.store.send(.cellTapped(Cell(row: 2, column: 0))) {
+    await self.store.send(.cellTapped(row: 2, column: 0)) {
       $0.board[2][0] = .x
     }
   }
 
   func testFlow_Tie() async {
-    await self.store.send(.cellTapped(Cell(row: 0, column: 0))) {
+    await self.store.send(.cellTapped(row: 0, column: 0)) {
       $0.board[0][0] = .x
       $0.currentPlayer = .o
     }
-    await self.store.send(.cellTapped(Cell(row: 2, column: 2))) {
+    await self.store.send(.cellTapped(row: 2, column: 2)) {
       $0.board[2][2] = .o
       $0.currentPlayer = .x
     }
-    await self.store.send(.cellTapped(Cell(row: 1, column: 0))) {
+    await self.store.send(.cellTapped(row: 1, column: 0)) {
       $0.board[1][0] = .x
       $0.currentPlayer = .o
     }
-    await self.store.send(.cellTapped(Cell(row: 2, column: 0))) {
+    await self.store.send(.cellTapped(row: 2, column: 0)) {
       $0.board[2][0] = .o
       $0.currentPlayer = .x
     }
-    await self.store.send(.cellTapped(Cell(row: 2, column: 1))) {
+    await self.store.send(.cellTapped(row: 2, column: 1)) {
       $0.board[2][1] = .x
       $0.currentPlayer = .o
     }
-    await self.store.send(.cellTapped(Cell(row: 1, column: 2))) {
+    await self.store.send(.cellTapped(row: 1, column: 2)) {
       $0.board[1][2] = .o
       $0.currentPlayer = .x
     }
-    await self.store.send(.cellTapped(Cell(row: 0, column: 2))) {
+    await self.store.send(.cellTapped(row: 0, column: 2)) {
       $0.board[0][2] = .x
       $0.currentPlayer = .o
     }
-    await self.store.send(.cellTapped(Cell(row: 0, column: 1))) {
+    await self.store.send(.cellTapped(row: 0, column: 1)) {
       $0.board[0][1] = .o
       $0.currentPlayer = .x
     }
-    await self.store.send(.cellTapped(Cell(row: 1, column: 1))) {
+    await self.store.send(.cellTapped(row: 1, column: 1)) {
       $0.board[1][1] = .x
       $0.currentPlayer = .o
     }

--- a/Examples/TicTacToe/tic-tac-toe/Tests/GameCoreTests/GameCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/GameCoreTests/GameCoreTests.swift
@@ -14,61 +14,61 @@ final class GameCoreTests: XCTestCase {
   }
 
   func testFlow_Winner_Quit() async {
-    await self.store.send(.cellTapped(row: 0, column: 0)) {
+    await self.store.send(.cellTapped(Cell(row: 0, column: 0))) {
       $0.board[0][0] = .x
       $0.currentPlayer = .o
     }
-    await self.store.send(.cellTapped(row: 2, column: 1)) {
+    await self.store.send(.cellTapped(Cell(row: 2, column: 1))) {
       $0.board[2][1] = .o
       $0.currentPlayer = .x
     }
-    await self.store.send(.cellTapped(row: 1, column: 0)) {
+    await self.store.send(.cellTapped(Cell(row: 1, column: 0))) {
       $0.board[1][0] = .x
       $0.currentPlayer = .o
     }
-    await self.store.send(.cellTapped(row: 1, column: 1)) {
+    await self.store.send(.cellTapped(Cell(row: 1, column: 1))) {
       $0.board[1][1] = .o
       $0.currentPlayer = .x
     }
-    await self.store.send(.cellTapped(row: 2, column: 0)) {
+    await self.store.send(.cellTapped(Cell(row: 2, column: 0))) {
       $0.board[2][0] = .x
     }
   }
 
   func testFlow_Tie() async {
-    await self.store.send(.cellTapped(row: 0, column: 0)) {
+    await self.store.send(.cellTapped(Cell(row: 0, column: 0))) {
       $0.board[0][0] = .x
       $0.currentPlayer = .o
     }
-    await self.store.send(.cellTapped(row: 2, column: 2)) {
+    await self.store.send(.cellTapped(Cell(row: 2, column: 2))) {
       $0.board[2][2] = .o
       $0.currentPlayer = .x
     }
-    await self.store.send(.cellTapped(row: 1, column: 0)) {
+    await self.store.send(.cellTapped(Cell(row: 1, column: 0))) {
       $0.board[1][0] = .x
       $0.currentPlayer = .o
     }
-    await self.store.send(.cellTapped(row: 2, column: 0)) {
+    await self.store.send(.cellTapped(Cell(row: 2, column: 0))) {
       $0.board[2][0] = .o
       $0.currentPlayer = .x
     }
-    await self.store.send(.cellTapped(row: 2, column: 1)) {
+    await self.store.send(.cellTapped(Cell(row: 2, column: 1))) {
       $0.board[2][1] = .x
       $0.currentPlayer = .o
     }
-    await self.store.send(.cellTapped(row: 1, column: 2)) {
+    await self.store.send(.cellTapped(Cell(row: 1, column: 2))) {
       $0.board[1][2] = .o
       $0.currentPlayer = .x
     }
-    await self.store.send(.cellTapped(row: 0, column: 2)) {
+    await self.store.send(.cellTapped(Cell(row: 0, column: 2))) {
       $0.board[0][2] = .x
       $0.currentPlayer = .o
     }
-    await self.store.send(.cellTapped(row: 0, column: 1)) {
+    await self.store.send(.cellTapped(Cell(row: 0, column: 1))) {
       $0.board[0][1] = .o
       $0.currentPlayer = .x
     }
-    await self.store.send(.cellTapped(row: 1, column: 1)) {
+    await self.store.send(.cellTapped(Cell(row: 1, column: 1))) {
       $0.board[1][1] = .x
       $0.currentPlayer = .o
     }

--- a/Examples/TicTacToe/tic-tac-toe/Tests/LoginCoreTests/LoginCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/LoginCoreTests/LoginCoreTests.swift
@@ -18,25 +18,25 @@ final class LoginCoreTests: XCTestCase {
       }
     }
 
-    await store.send(.view(.set(\.email, "2fa@pointfree.co"))) {
+    await store.send(\.view.email, "2fa@pointfree.co") {
       $0.email = "2fa@pointfree.co"
     }
-    await store.send(.view(.set(\.password, "password"))) {
+    await store.send(\.view.password, "password") {
       $0.password = "password"
       $0.isFormValid = true
     }
-    let twoFactorPresentationTask = await store.send(.view(.loginButtonTapped)) {
+    let twoFactorPresentationTask = await store.send(\.view.loginButtonTapped) {
       $0.isLoginRequestInFlight = true
     }
     await store.receive(\.loginResponse.success) {
       $0.isLoginRequestInFlight = false
       $0.twoFactor = TwoFactor.State(token: "deadbeefdeadbeef")
     }
-    await store.send(.twoFactor(.presented(.view(.set(\.code, "1234"))))) {
+    await store.send(\.twoFactor.view.code, "1234") {
       $0.twoFactor?.code = "1234"
       $0.twoFactor?.isFormValid = true
     }
-    await store.send(.twoFactor(.presented(.view(.submitButtonTapped)))) {
+    await store.send(\.twoFactor.view.submitButtonTapped) {
       $0.twoFactor?.isTwoFactorRequestInFlight = true
     }
     await store.receive(\.twoFactor.twoFactorResponse.success) {
@@ -58,28 +58,28 @@ final class LoginCoreTests: XCTestCase {
       }
     }
 
-    await store.send(.view(.set(\.email, "2fa@pointfree.co"))) {
+    await store.send(\.view.email, "2fa@pointfree.co") {
       $0.email = "2fa@pointfree.co"
     }
-    await store.send(.view(.set(\.password, "password"))) {
+    await store.send(\.view.password, "password") {
       $0.password = "password"
       $0.isFormValid = true
     }
-    await store.send(.view(.loginButtonTapped)) {
+    await store.send(\.view.loginButtonTapped) {
       $0.isLoginRequestInFlight = true
     }
     await store.receive(\.loginResponse.success) {
       $0.isLoginRequestInFlight = false
       $0.twoFactor = TwoFactor.State(token: "deadbeefdeadbeef")
     }
-    await store.send(.twoFactor(.presented(.view(.set(\.code, "1234"))))) {
+    await store.send(\.twoFactor.view.code, "1234") {
       $0.twoFactor?.code = "1234"
       $0.twoFactor?.isFormValid = true
     }
-    await store.send(.twoFactor(.presented(.view(.submitButtonTapped)))) {
+    await store.send(\.twoFactor.view.submitButtonTapped) {
       $0.twoFactor?.isTwoFactorRequestInFlight = true
     }
-    await store.send(.twoFactor(.dismiss)) {
+    await store.send(\.twoFactor.dismiss) {
       $0.twoFactor = nil
     }
     await store.finish()

--- a/Examples/TicTacToe/tic-tac-toe/Tests/NewGameCoreTests/NewGameCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/NewGameCoreTests/NewGameCoreTests.swift
@@ -19,7 +19,7 @@ final class NewGameCoreTests: XCTestCase {
     await self.store.send(.letsPlayButtonTapped) {
       $0.game = Game.State(oPlayerName: "Blob Sr.", xPlayerName: "Blob Jr.")
     }
-    await self.store.send(\.game.cellTapped, Cell(row: 0, column: 0)) {
+    await self.store.send(\.game.cellTapped, (row: 0, column: 0)) {
       $0.game!.board[0][0] = .x
       $0.game!.currentPlayer = .o
     }

--- a/Examples/TicTacToe/tic-tac-toe/Tests/NewGameCoreTests/NewGameCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/NewGameCoreTests/NewGameCoreTests.swift
@@ -10,27 +10,27 @@ final class NewGameCoreTests: XCTestCase {
   }
 
   func testFlow_NewGame_Integration() async {
-    await self.store.send(.set(\.oPlayerName, "Blob Sr.")) {
+    await self.store.send(\.oPlayerName, "Blob Sr.") {
       $0.oPlayerName = "Blob Sr."
     }
-    await self.store.send(.set(\.xPlayerName, "Blob Jr.")) {
+    await self.store.send(\.xPlayerName, "Blob Jr.") {
       $0.xPlayerName = "Blob Jr."
     }
     await self.store.send(.letsPlayButtonTapped) {
       $0.game = Game.State(oPlayerName: "Blob Sr.", xPlayerName: "Blob Jr.")
     }
-    await self.store.send(.game(.presented(.cellTapped(row: 0, column: 0)))) {
+    await self.store.send(\.game.cellTapped, Cell(row: 0, column: 0)) {
       $0.game!.board[0][0] = .x
       $0.game!.currentPlayer = .o
     }
-    await self.store.send(.game(.presented(.quitButtonTapped)))
+    await self.store.send(\.game.quitButtonTapped)
     await self.store.receive(\.game.dismiss) {
       $0.game = nil
     }
     await self.store.send(.letsPlayButtonTapped) {
       $0.game = Game.State(oPlayerName: "Blob Sr.", xPlayerName: "Blob Jr.")
     }
-    await self.store.send(.game(.dismiss)) {
+    await self.store.send(\.game.dismiss) {
       $0.game = nil
     }
     await self.store.send(.logoutButtonTapped)

--- a/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorCoreTests/TwoFactorCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/TwoFactorCoreTests/TwoFactorCoreTests.swift
@@ -14,20 +14,20 @@ final class TwoFactorCoreTests: XCTestCase {
       }
     }
 
-    await store.send(.view(.set(\.code, "1"))) {
+    await store.send(\.view.code, "1") {
       $0.code = "1"
     }
-    await store.send(.view(.set(\.code, "12"))) {
+    await store.send(\.view.code, "12") {
       $0.code = "12"
     }
-    await store.send(.view(.set(\.code, "123"))) {
+    await store.send(\.view.code, "123") {
       $0.code = "123"
     }
-    await store.send(.view(.set(\.code, "1234"))) {
+    await store.send(\.view.code, "1234") {
       $0.code = "1234"
       $0.isFormValid = true
     }
-    await store.send(.view(.submitButtonTapped)) {
+    await store.send(\.view.submitButtonTapped) {
       $0.isTwoFactorRequestInFlight = true
     }
     await store.receive(\.twoFactorResponse.success) {
@@ -44,11 +44,11 @@ final class TwoFactorCoreTests: XCTestCase {
       }
     }
 
-    await store.send(.view(.set(\.code, "1234"))) {
+    await store.send(\.view.code, "1234") {
       $0.code = "1234"
       $0.isFormValid = true
     }
-    await store.send(.view(.submitButtonTapped)) {
+    await store.send(\.view.submitButtonTapped) {
       $0.isTwoFactorRequestInFlight = true
     }
     await store.receive(\.twoFactorResponse.failure) {
@@ -57,7 +57,7 @@ final class TwoFactorCoreTests: XCTestCase {
       }
       $0.isTwoFactorRequestInFlight = false
     }
-    await store.send(.alert(.dismiss)) {
+    await store.send(\.alert.dismiss) {
       $0.alert = nil
     }
     await store.finish()

--- a/Examples/Todos/TodosTests/TodosTests.swift
+++ b/Examples/Todos/TodosTests/TodosTests.swift
@@ -56,8 +56,8 @@ final class TodosTests: XCTestCase {
       Todos()
     }
 
-    await store.send(\.todos[id:state.todos[0].id].description, "Learn Composable Architecture") {
-      $0.todos[id: state.todos[0].id]?.description = "Learn Composable Architecture"
+    await store.send(\.todos[id:UUID(0)].description, "Learn Composable Architecture") {
+      $0.todos[id: UUID(0)]?.description = "Learn Composable Architecture"
     }
   }
 
@@ -83,8 +83,8 @@ final class TodosTests: XCTestCase {
       $0.continuousClock = self.clock
     }
 
-    await store.send(\.todos[id:state.todos[0].id].isComplete, true) {
-      $0.todos[id: state.todos[0].id]?.isComplete = true
+    await store.send(\.todos[id:UUID(0)].isComplete, true) {
+      $0.todos[id: UUID(0)]?.isComplete = true
     }
     await self.clock.advance(by: .seconds(1))
     await store.receive(\.sortCompletedTodos) {
@@ -117,12 +117,12 @@ final class TodosTests: XCTestCase {
       $0.continuousClock = self.clock
     }
 
-    await store.send(\.todos[id: state.todos[0].id].isComplete, true) {
-      $0.todos[id: state.todos[0].id]?.isComplete = true
+    await store.send(\.todos[id: UUID(0)].isComplete, true) {
+      $0.todos[id: UUID(0)]?.isComplete = true
     }
     await self.clock.advance(by: .milliseconds(500))
-    await store.send(\.todos[id: state.todos[0].id].isComplete, false) {
-      $0.todos[id: state.todos[0].id]?.isComplete = false
+    await store.send(\.todos[id: UUID(0)].isComplete, false) {
+      $0.todos[id: UUID(0)]?.isComplete = false
     }
     await self.clock.advance(by: .seconds(1))
     await store.receive(\.sortCompletedTodos)
@@ -337,10 +337,8 @@ final class TodosTests: XCTestCase {
     await store.send(\.filter, .completed) {
       $0.filter = .completed
     }
-    await store.send(
-      .todos(.element(id: state.todos[1].id, action: .set(\.description, "Did this already")))
-    ) {
-      $0.todos[id: state.todos[1].id]?.description = "Did this already"
+    await store.send(\.todos[id: UUID(1)].description, "Did this already") {
+      $0.todos[id: UUID(1)]?.description = "Did this already"
     }
   }
 }

--- a/Examples/Todos/TodosTests/TodosTests.swift
+++ b/Examples/Todos/TodosTests/TodosTests.swift
@@ -56,13 +56,7 @@ final class TodosTests: XCTestCase {
       Todos()
     }
 
-    await store.send(
-      .todos(
-        .element(
-          id: state.todos[0].id, action: .set(\.description, "Learn Composable Architecture")
-        )
-      )
-    ) {
+    await store.send(\.todos[id:state.todos[0].id].description, "Learn Composable Architecture") {
       $0.todos[id: state.todos[0].id]?.description = "Learn Composable Architecture"
     }
   }
@@ -89,7 +83,7 @@ final class TodosTests: XCTestCase {
       $0.continuousClock = self.clock
     }
 
-    await store.send(.todos(.element(id: state.todos[0].id, action: .set(\.isComplete, true)))) {
+    await store.send(\.todos[id:state.todos[0].id].isComplete, true) {
       $0.todos[id: state.todos[0].id]?.isComplete = true
     }
     await self.clock.advance(by: .seconds(1))
@@ -123,11 +117,11 @@ final class TodosTests: XCTestCase {
       $0.continuousClock = self.clock
     }
 
-    await store.send(.todos(.element(id: state.todos[0].id, action: .set(\.isComplete, true)))) {
+    await store.send(\.todos[id: state.todos[0].id].isComplete, true) {
       $0.todos[id: state.todos[0].id]?.isComplete = true
     }
     await self.clock.advance(by: .milliseconds(500))
-    await store.send(.todos(.element(id: state.todos[0].id, action: .set(\.isComplete, false)))) {
+    await store.send(\.todos[id: state.todos[0].id].isComplete, false) {
       $0.todos[id: state.todos[0].id]?.isComplete = false
     }
     await self.clock.advance(by: .seconds(1))
@@ -255,7 +249,7 @@ final class TodosTests: XCTestCase {
       $0.continuousClock = self.clock
     }
 
-    await store.send(.set(\.editMode, .active)) {
+    await store.send(\.editMode, .active) {
       $0.editMode = .active
     }
     await store.send(.move([0], 2)) {
@@ -302,10 +296,10 @@ final class TodosTests: XCTestCase {
       $0.uuid = .incrementing
     }
 
-    await store.send(.set(\.editMode, .active)) {
+    await store.send(\.editMode, .active) {
       $0.editMode = .active
     }
-    await store.send(.set(\.filter, .completed)) {
+    await store.send(\.filter, .completed) {
       $0.filter = .completed
     }
     await store.send(.move([0], 2)) {
@@ -340,7 +334,7 @@ final class TodosTests: XCTestCase {
       Todos()
     }
 
-    await store.send(.set(\.filter, .completed)) {
+    await store.send(\.filter, .completed) {
       $0.filter = .completed
     }
     await store.send(

--- a/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
+++ b/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
@@ -43,8 +43,8 @@ final class VoiceMemosTests: XCTestCase {
         url: deadbeefURL
       )
     }
-    await store.send(.recordingMemo(.presented(.onTask)))
-    await store.send(.recordingMemo(.presented(.stopButtonTapped))) {
+    await store.send(\.recordingMemo.onTask)
+    await store.send(\.recordingMemo.stopButtonTapped) {
       $0.recordingMemo?.mode = .encoding
     }
     await store.receive(\.recordingMemo.finalRecordingTime) {
@@ -63,7 +63,7 @@ final class VoiceMemosTests: XCTestCase {
         )
       ]
     }
-    await store.send(.voiceMemos(.element(id: deadbeefURL, action: .playButtonTapped))) {
+    await store.send(\.voiceMemos[id:deadbeefURL].playButtonTapped) {
       $0.voiceMemos[id: deadbeefURL]?.mode = .playing(progress: 0)
     }
     await store.receive(\.voiceMemos[id:deadbeefURL].delegate.playbackStarted)
@@ -117,7 +117,7 @@ final class VoiceMemosTests: XCTestCase {
         url: URL(fileURLWithPath: "/tmp/DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF.m4a")
       )
     }
-    let recordingMemoTask = await store.send(.recordingMemo(.presented(.onTask)))
+    let recordingMemoTask = await store.send(\.recordingMemo.onTask)
     await self.clock.advance(by: .seconds(1))
     await store.receive(\.recordingMemo.timerUpdated) {
       $0.recordingMemo?.duration = 1
@@ -127,7 +127,7 @@ final class VoiceMemosTests: XCTestCase {
       $0.recordingMemo?.duration = 2
     }
     await self.clock.advance(by: .milliseconds(500))
-    await store.send(.recordingMemo(.presented(.stopButtonTapped))) {
+    await store.send(\.recordingMemo.stopButtonTapped) {
       $0.recordingMemo?.mode = .encoding
     }
     await store.receive(\.recordingMemo.finalRecordingTime) {
@@ -163,7 +163,7 @@ final class VoiceMemosTests: XCTestCase {
       $0.alert = AlertState { TextState("Permission is required to record voice memos.") }
       $0.audioRecorderPermission = .denied
     }
-    await store.send(.alert(.dismiss)) {
+    await store.send(\.alert.dismiss) {
       $0.alert = nil
     }
     await store.send(.openSettingsButtonTapped).finish()
@@ -196,7 +196,7 @@ final class VoiceMemosTests: XCTestCase {
         url: deadbeefURL
       )
     }
-    await store.send(.recordingMemo(.presented(.onTask)))
+    await store.send(\.recordingMemo.onTask)
 
     didFinish.continuation.finish(throwing: SomeError())
     await store.receive(\.recordingMemo.audioRecorderDidFinish.failure)
@@ -228,7 +228,7 @@ final class VoiceMemosTests: XCTestCase {
     store.exhaustivity = .off(showSkippedAssertions: true)
 
     await store.send(.recordButtonTapped)
-    await store.send(.recordingMemo(.presented(.onTask)))
+    await store.send(\.recordingMemo.onTask)
     didFinish.continuation.finish(throwing: SomeError())
     await store.receive(\.recordingMemo.delegate.didFinish.failure) {
       $0.alert = AlertState { TextState("Voice memo recording failed.") }
@@ -260,7 +260,7 @@ final class VoiceMemosTests: XCTestCase {
       $0.continuousClock = self.clock
     }
 
-    await store.send(.voiceMemos(.element(id: url, action: .playButtonTapped))) {
+    await store.send(\.voiceMemos[id:url].playButtonTapped) {
       $0.voiceMemos[id: url]?.mode = .playing(progress: 0)
     }
     await store.receive(\.voiceMemos[id:url].delegate.playbackStarted)
@@ -301,7 +301,7 @@ final class VoiceMemosTests: XCTestCase {
       $0.continuousClock = self.clock
     }
 
-    let task = await store.send(.voiceMemos(.element(id: url, action: .playButtonTapped))) {
+    let task = await store.send(\.voiceMemos[id:url].playButtonTapped) {
       $0.voiceMemos[id: url]?.mode = .playing(progress: 0)
     }
     await store.receive(\.voiceMemos[id:url].delegate.playbackStarted)
@@ -332,7 +332,7 @@ final class VoiceMemosTests: XCTestCase {
       VoiceMemos()
     }
 
-    await store.send(.voiceMemos(.element(id: url, action: .playButtonTapped))) {
+    await store.send(\.voiceMemos[id:url].playButtonTapped) {
       $0.voiceMemos[id: url]?.mode = .notPlaying
     }
   }
@@ -434,7 +434,7 @@ final class VoiceMemosTests: XCTestCase {
       $0.continuousClock = self.clock
     }
 
-    await store.send(.voiceMemos(.element(id: url, action: .playButtonTapped))) {
+    await store.send(\.voiceMemos[id:url].playButtonTapped) {
       $0.voiceMemos[id: url]?.mode = .playing(progress: 0)
     }
     await store.receive(\.voiceMemos[id:url].delegate.playbackStarted)

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
@@ -288,17 +288,17 @@ var body: some Reducer<State, Action> {
 Binding actions can also be tested in much the same way regular actions are tested. Rather than send
 a specific action describing how a binding changed, such as `.displayNameChanged("Blob")`, you will
 send a ``BindingAction`` action that describes which key path is being set to what value, such as
-`.set(\.displayName, "Blob")`:
+`\.displayName, "Blob"`:
 
 ```swift
 let store = TestStore(initialState: Settings.State()) {
   Settings()
 }
 
-store.send(.set(\.displayName, "Blob")) {
+store.send(\.displayName, "Blob") {
   $0.displayName = "Blob"
 }
-store.send(.set(\.protectMyPosts, true)) {
+store.send(\.protectMyPosts, true) {
   $0.protectMyPosts = true
 )
 ```

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides.md
@@ -10,10 +10,11 @@ in favor of newer ones. We recommend people update their code as quickly as poss
 APIs, and these guides contain tips to do so.
 
 > Important: Before following any particular migration guide be sure you have followed all the 
-preceeding migration guides.
+> preceding migration guides.
 
 ## Topics
 
+- <doc:MigratingTo1.9>
 - <doc:MigratingTo1.8>
 - <doc:MigratingTo1.7>
 - <doc:MigratingTo1.6>

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.9.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.9.md
@@ -1,7 +1,8 @@
 # Migrating to 1.9
 
-Update your code to make use of the new ``TestStore/send(_:assert:file:line:)-1oopl`` and
-``Reducer/dependency(_:)`` methods.
+Update your code to make use of the new ``TestStore/send(_:assert:file:line:)-1oopl`` method on 
+``TestStore`` which gives a succinct syntax for sending actions with case key paths, and the
+``Reducer/dependency(_:)`` method for overriding dependencies.
 
 ## Overview
 
@@ -82,3 +83,30 @@ features, and provide symmetry to how actions are received:
 > -)
 > +store.send(\.path[id: 0].destination.sheet.password, "blobisawesome")
 > ```
+
+### Overriding dependencies
+
+Version 1.2 of [swift-dependencies](http://github.com/pointfreeco/swift-dependencies) introduced an
+alternative syntax for referencing a dependency:
+
+```diff
+-@Dependency(\.apiClient) var apiClient
++@Dependency(APIClient.self) var apiClient
+```
+
+The primary benefit of this syntax is that you do not need to define a dedicated computed property
+on `DependencyValues`, which saves a small amount of boilerplate.
+
+There is now a similar API for overriding dependencies on a reducer, ``Reducer/dependency(_:)``, 
+which can be used like so:
+
+```swift
+MyFeature()
+  .dependency(mockAPIClient)
+```
+
+The type of `mockAPIClient` determines how the dependency is overridden.
+
+This style of accessing and overriding dependencies is really only approprirate for dependencies
+defined directly in your project. If you are shipping a dependency client that is used by others, 
+then still prefer adding a computed property to `DependencyValues` in order to be more discoverable.

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.9.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.9.md
@@ -29,8 +29,8 @@ store.receive(\.child.presented.success, "Hello")
 
 Version 1.9 introduces similar affordances for _sending_ actions to test stores via
 ``TestStore/send(_:assert:file:line:)-1oopl`` and ``TestStore/send(_:_:assert:file:line:)``. These
-methods can significantly simplify tests that send deeply-nested actions to child features, and
-provide symmetry to how actions are received:
+methods can significantly simplify integration-style tests that send deeply-nested actions to child
+features, and provide symmetry to how actions are received:
 
 ```diff
 -store.send(.path(.element(id: 0, action: .destination(.presented(.record(.startButtonTapped))))))

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.9.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.9.md
@@ -107,6 +107,6 @@ MyFeature()
 
 The type of `mockAPIClient` determines how the dependency is overridden.
 
-This style of accessing and overriding dependencies is really only approprirate for dependencies
+This style of accessing and overriding dependencies is really only appropriate for dependencies
 defined directly in your project. If you are shipping a dependency client that is used by others, 
 then still prefer adding a computed property to `DependencyValues` in order to be more discoverable.

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.9.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.9.md
@@ -1,0 +1,84 @@
+# Migrating to 1.9
+
+Update your code to make use of the new ``TestStore/send(_:assert:file:line:)-1oopl`` and
+``Reducer/dependency(_:)`` methods.
+
+## Overview
+
+The Composable Architecture is under constant development, and we are always looking for ways to
+simplify the library, and make it more powerful. As such, we often need to deprecate certain APIs
+in favor of newer ones. We recommend people update their code as quickly as possible to the newest
+APIs, and this article contains some tips for doing so.
+
+### Sending test store actions
+
+Version 1.4 of the library introduced the ability to receive test store actions using case key path
+syntax, massively simplifying how one asserts on actions received in a test:
+
+```diff
+-store.receive(.child(.presented(.response(.success("Hello"))
++store.receive(\.child.response.success)
+```
+
+While version 1.6 of the library introduced the ability to assert against the payload of a received
+action:
+
+```swift
+store.receive(\.child.presented.success, "Hello")
+```
+
+Version 1.9 introduces similar affordances for _sending_ actions to test stores via
+``TestStore/send(_:assert:file:line:)-1oopl`` and ``TestStore/send(_:_:assert:file:line:)``. These
+methods can significantly simplify tests that send deeply-nested actions to child features, and
+provide symmetry to how actions are received:
+
+```diff
+-store.send(.path(.element(id: 0, action: .destination(.presented(.record(.startButtonTapped))))))
++store.send(\.path[id: 0].destination.record.startButtonTapped)
+ store.receive(\.path[id: 0].destination.record.timerTick)
+```
+
+> Tip: Case key paths offer specialized syntax for many different action types.
+>
+>   * ``PresentationAction``'s `presented` case can be collapsed:
+>
+>     ```diff
+>     -store.send(.destination(.presented(.tap)))
+>     +store.send(\.destination.tap)
+>     ```
+>
+>   * ``IdentifiedAction`` and ``StackAction`` can be subscripted into:
+>
+>     ```diff
+>     -store.send(.path(.element(id: 0, action: .tap)))
+>     +store.send(\.path[id: 0].tap)
+>     ```
+>
+>   * And ``BindableAction``s can dynamically chain into a key path of state:
+>
+>     ```diff
+>     -store.send(.binding(.set(\.firstName, "Blob")))
+>     +store.send(\.firstName, "Blob")
+>     ```
+>
+> Together, these helpers can massively simplify asserting against nested actions:
+>
+> ```diff
+> -store.send(
+> -  .path(
+> -    .element(
+> -      id: 0,
+> -      action: .destination(
+> -        .presented(
+> -          .sheet(
+> -            .binding(
+> -              .set(\.password, "blobisawesome")
+> -            )
+> -          )
+> -        )
+> -      )
+> -    )
+> -  )
+> -)
+> +store.send(\.path[id: 0].destination.sheet.password, "blobisawesome")
+> ```

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
@@ -409,7 +409,7 @@ stack in order to confirm that the count goes up by one, but in order to do so w
 an ID:
 
 ```swift
-await store.send(.path(.element(id: ???, action: .incrementButtonTapped))) {
+await store.send(\.path[id: ???].incrementButtonTapped) {
   // ...
 }
 ```
@@ -423,7 +423,7 @@ This means that when the ``TestStore`` were constructed with a single element al
 that it was given an ID of 0, and so that is the ID we can use when sending an action:
 
 ```swift
-await store.send(.path(.element(id: 0, action: .incrementButtonTapped))) {
+await store.send(\.path[id: 0].incrementButtonTapped) {
   // ...
 }
 ```
@@ -437,7 +437,7 @@ The library provides two different tools to perform all of these steps in a sing
 use the `XCTModify` helper:
 
 ```swift
-await store.send(.path(.element(id: 0, action: .incrementButtonTapped))) {
+await store.send(\.path[id: 0].incrementButtonTapped) {
   XCTModify(&$0.path[id: 0], case: \.counter) {
     $0.count = 4
   }
@@ -455,7 +455,7 @@ Another option is to use ``StackState/subscript(id:case:)-7gczr`` to simultaneou
 ID on the stack _and_ a case of the path enum:
 
 ```swift
-await store.send(.path(.element(id: 0, action: .incrementButtonTapped))) {
+await store.send(\.path[id: 0].incrementButtonTapped) {
   $0.path[id: 0, case: \.counter]?.count = 4
 }
 ```
@@ -466,7 +466,7 @@ The `XCTModify` style is best when you have many things you need to modify on th
 Continuing with the test, we can send it one more time to see that the count goes up to 5:
 
 ```swift
-await store.send(.path(.element(id: 0, action: .incrementButtonTapped))) {
+await store.send(\.path[id: 0].incrementButtonTapped) {
   XCTModify(&$0.path[id: 0], case: \.counter) {
     $0.count = 5
   }
@@ -525,8 +525,8 @@ func testDismissal() {
   }
   store.exhaustivity = .off
 
-  await store.send(.path(.element(id: 0, action: .incrementButtonTapped))) 
-  await store.send(.path(.element(id: 0, action: .incrementButtonTapped))) 
+  await store.send(\.path[id: 0].incrementButtonTapped)
+  await store.send(\.path[id: 0].incrementButtonTapped)
   await store.receive(\.path.popFrom)
 }
 ```

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
@@ -452,7 +452,7 @@ let store = TestStore(initialState: AppFeature.State()) {
 }
 
 // 1️⃣ Emulate user tapping on submit button.
-await store.send(.login(.submitButtonTapped)) {
+await store.send(\.login.submitButtonTapped) {
   // 2️⃣ Assert how all state changes in the login feature
   $0.login?.isLoading = true
   // ...
@@ -500,7 +500,7 @@ let store = TestStore(initialState: AppFeature.State()) {
 }
 store.exhaustivity = .off  // ⬅️
 
-await store.send(.login(.submitButtonTapped))
+await store.send(\.login.submitButtonTapped)
 await store.receive(\.login.delegate.didLogin) {
   $0.selectedTab = .activity
 }
@@ -522,7 +522,7 @@ let store = TestStore(initialState: AppFeature.State()) {
 }
 store.exhaustivity = .off(showSkippedAssertions: true)  // ⬅️
 
-await store.send(.login(.submitButtonTapped))
+await store.send(\.login.submitButtonTapped)
 await store.receive(\.login.delegate.didLogin) {
   $0.selectedTab = .activity
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
@@ -622,7 +622,7 @@ Then we can send the `.incrementButtonTapped` action in the counter child featur
 that the count goes up by one:
 
 ```swift
-await store.send(.counter(.presented(.incrementButtonTapped))) {
+await store.send(\.counter.incrementButtonTapped) {
   $0.counter?.count = 4
 }
 ```
@@ -630,7 +630,7 @@ await store.send(.counter(.presented(.incrementButtonTapped))) {
 And then we can send it one more time to see that the count goes up to 5:
 
 ```swift 
-await store.send(.counter(.presented(.incrementButtonTapped))) {
+await store.send(\.counter.incrementButtonTapped) {
   $0.counter?.count = 5
 }
 ```
@@ -672,8 +672,8 @@ func testDismissal() {
   }
   store.exhaustivity = .off
 
-  await store.send(.counter(.presented(.incrementButtonTapped)))
-  await store.send(.counter(.presented(.incrementButtonTapped)))
+  await store.send(\.counter.incrementButtonTapped)
+  await store.send(\.counter.incrementButtonTapped)
   await store.receive(\.counter.dismiss) 
 }
 ```
@@ -692,7 +692,7 @@ The library provides a tool to perform these steps in a single step. It's the
 modify the data inside a case of the destination enum:
 
 ```swift
-await store.send(.destination(.presented(.counter(.incrementButtonTapped)))) {
+await store.send(\.destination.counter.incrementButtonTapped) {
   $0.$destination[case: \.counter]?.count = 4
 }
 ```

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0007.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0007.swift
@@ -8,6 +8,6 @@ final class AppFeatureTests: XCTestCase {
       AppFeature()
     }
     
-    await store.send(.tab1(.incrementButtonTapped))
+    await store.send(\.tab1.incrementButtonTapped)
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0008.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0008.swift
@@ -8,7 +8,7 @@ final class AppFeatureTests: XCTestCase {
       AppFeature()
     }
     
-    await store.send(.tab1(.incrementButtonTapped)) {
+    await store.send(\.tab1.incrementButtonTapped) {
       $0.tab1.count = 1
     }
   }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-ComposingFeatures.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-ComposingFeatures.tutorial
@@ -149,11 +149,13 @@
       
       @Step {
         Send an action into the test store to emulate the user tapping on the increment button
-        in the first tab. 
+        in the first tab.
+        
+        > Tip: Use case key path syntax when sending actions through multiple layers of features.
         
         > Note: The nesting of the action enums of the features gives us a natural way to 
-        distinguish between actions in different tabs. Sending `.tab1(.incrementButtonTapped)` is 
-        very different from sending  `.tab2(.incrementButtonTapped)`.
+        distinguish between actions in different tabs. Sending `\.tab1.incrementButtonTapped` is 
+        very different from sending  `\.tab2.incrementButtonTapped`.
         
         @Code(name: "AppFeatureTests.swift", file: 01-04-02-code-0007.swift)
       }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-01-code-0010.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-01-code-0010.swift
@@ -19,7 +19,7 @@ final class ContactsFeatureTests: XCTestCase {
         )
       )
     }
-    await store.send(.destination(.presented(.addContact(.setName("Blob Jr."))))) {
+    await store.send(\.destination.addContact.setName, "Blob Jr.") {
     }
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-01-code-0011.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-01-code-0011.swift
@@ -19,7 +19,7 @@ final class ContactsFeatureTests: XCTestCase {
         )
       )
     }
-    await store.send(.destination(.presented(.addContact(.setName("Blob Jr."))))) {
+    await store.send(\.destination.addContact.setName, "Blob Jr.") {
       $0.$destination[case: \.addContact]?.contact.name = "Blob Jr."
     }
   }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-01-code-0012.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-01-code-0012.swift
@@ -19,9 +19,9 @@ final class ContactsFeatureTests: XCTestCase {
         )
       )
     }
-    await store.send(.destination(.presented(.addContact(.setName("Blob Jr."))))) {
+    await store.send(\.destination.addContact.setName, "Blob Jr.") {
       $0.$destination[case: \.addContact]?.contact.name = "Blob Jr."
     }
-    await store.send(.destination(.presented(.addContact(.saveButtonTapped))))
+    await store.send(\.destination.addContact.saveButtonTapped)
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-01-code-0013.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-01-code-0013.swift
@@ -19,10 +19,10 @@ final class ContactsFeatureTests: XCTestCase {
         )
       )
     }
-    await store.send(.destination(.presented(.addContact(.setName("Blob Jr."))))) {
+    await store.send(\.destination.addContact.setName, "Blob Jr.") {
       $0.$destination[case: \.addContact]?.contact.name = "Blob Jr."
     }
-    await store.send(.destination(.presented(.addContact(.saveButtonTapped))))
+    await store.send(\.destination.addContact.saveButtonTapped)
     await store.receive(
       \.destination.addContact.delegate.saveContact,
       Contact(id: UUID(0), name: "Blob Jr.")

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-01-code-0014.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-01-code-0014.swift
@@ -19,10 +19,10 @@ final class ContactsFeatureTests: XCTestCase {
         )
       )
     }
-    await store.send(.destination(.presented(.addContact(.setName("Blob Jr."))))) {
+    await store.send(\.destination.addContact.setName, "Blob Jr.") {
       $0.$destination[case: \.addContact]?.contact.name = "Blob Jr."
     }
-    await store.send(.destination(.presented(.addContact(.saveButtonTapped))))
+    await store.send(\.destination.addContact.saveButtonTapped)
     await store.receive(
       \.destination.addContact.delegate.saveContact,
       Contact(id: UUID(0), name: "Blob Jr.")

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-01-code-0016.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-01-code-0016.swift
@@ -19,10 +19,10 @@ final class ContactsFeatureTests: XCTestCase {
         )
       )
     }
-    await store.send(.destination(.presented(.addContact(.setName("Blob Jr."))))) {
+    await store.send(\.destination.addContact.setName, "Blob Jr.") {
       $0.$destination[case: \.addContact]?.contact.name = "Blob Jr."
     }
-    await store.send(.destination(.presented(.addContact(.saveButtonTapped))))
+    await store.send(\.destination.addContact.saveButtonTapped)
     await store.receive(
       \.destination.addContact.delegate.saveContact,
       Contact(id: UUID(0), name: "Blob Jr.")

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-01-code-0017.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-01-code-0017.swift
@@ -19,10 +19,10 @@ final class ContactsFeatureTests: XCTestCase {
         )
       )
     }
-    await store.send(.destination(.presented(.addContact(.setName("Blob Jr."))))) {
+    await store.send(\.destination.addContact.setName, "Blob Jr.") {
       $0.$destination[case: \.addContact]?.contact.name = "Blob Jr."
     }
-    await store.send(.destination(.presented(.addContact(.saveButtonTapped))))
+    await store.send(\.destination.addContact.saveButtonTapped)
     await store.receive(
       \.destination.addContact.delegate.saveContact,
       Contact(id: UUID(0), name: "Blob Jr.")

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-02-code-0003.swift
@@ -14,6 +14,6 @@ final class ContactsFeatureTests: XCTestCase {
     store.exhaustivity = .off
     
     await store.send(.addButtonTapped)
-    await store.send(.destination(.presented(.addContact(.setName("Blob Jr.")))))
+    await store.send(\.destination.addContact.setName, "Blob Jr.")
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-02-code-0004.swift
@@ -14,7 +14,7 @@ final class ContactsFeatureTests: XCTestCase {
     store.exhaustivity = .off
     
     await store.send(.addButtonTapped)
-    await store.send(.destination(.presented(.addContact(.setName("Blob Jr.")))))
-    await store.send(.destination(.presented(.addContact(.saveButtonTapped))))
+    await store.send(\.destination.addContact.setName, "Blob Jr.")
+    await store.send(\.destination.addContact.saveButtonTapped)
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-02-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-02-code-0005.swift
@@ -14,8 +14,8 @@ final class ContactsFeatureTests: XCTestCase {
     store.exhaustivity = .off
     
     await store.send(.addButtonTapped)
-    await store.send(.destination(.presented(.addContact(.setName("Blob Jr.")))))
-    await store.send(.destination(.presented(.addContact(.saveButtonTapped))))
+    await store.send(\.destination.addContact.setName, "Blob Jr.")
+    await store.send(\.destination.addContact.saveButtonTapped)
     await store.skipReceivedActions()
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-02-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-02-code-0006.swift
@@ -14,8 +14,8 @@ final class ContactsFeatureTests: XCTestCase {
     store.exhaustivity = .off
     
     await store.send(.addButtonTapped)
-    await store.send(.destination(.presented(.addContact(.setName("Blob Jr.")))))
-    await store.send(.destination(.presented(.addContact(.saveButtonTapped))))
+    await store.send(\.destination.addContact.setName, "Blob Jr.")
+    await store.send(\.destination.addContact.saveButtonTapped)
     await store.skipReceivedActions()
     store.assert {
       $0.contacts = [

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-TestingPresentation.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-TestingPresentation.tutorial
@@ -103,6 +103,9 @@
         Emulate the user typing into the name text field of the contact. The trailing closure is
         where we can assert on how state changed after sending the action.
         
+        > Tip: The payload of an action can be sent as a second argument when using case key path
+        > syntax.
+        
         @Code(name: "ContactsFeatureTests.swift", file: 02-03-01-code-0010.swift)
       }
       

--- a/Sources/ComposableArchitecture/Observation/Binding+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Binding+Observation.swift
@@ -222,4 +222,15 @@
       }
     }
   }
+
+  extension Case where Value: BindableAction, Value.State: ObservableState {
+    public subscript<Member: Equatable & Sendable>(
+      dynamicMember keyPath: WritableKeyPath<Value.State, Member>
+    ) -> Case<Member> {
+      Case<Member>(
+        embed: { self.embed(.binding(.set(keyPath, $0))) },
+        extract: { self.extract(from: $0)?.binding?.value.base as? Member }
+      )
+    }
+  }
 #endif

--- a/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
@@ -280,6 +280,23 @@ public enum StackAction<State, Action>: CasePathable {
         }
       )
     }
+
+    @_disfavoredOverload
+    public subscript(id id: StackElementID) -> AnyCasePath<StackAction, State?> {
+      AnyCasePath(
+        embed: { $0.map { StackAction.push(id: id, state: $0) } ?? .popFrom(id: id) },
+        extract: {
+          switch $0 {
+          case .popFrom(id):
+            return .some(nil)
+          case .push(id, let state):
+            return .some(state)
+          default:
+            return .none
+          }
+        }
+      )
+    }
   }
 }
 

--- a/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
@@ -280,23 +280,6 @@ public enum StackAction<State, Action>: CasePathable {
         }
       )
     }
-
-    @_disfavoredOverload
-    public subscript(id id: StackElementID) -> AnyCasePath<StackAction, State?> {
-      AnyCasePath(
-        embed: { $0.map { StackAction.push(id: id, state: $0) } ?? .popFrom(id: id) },
-        extract: {
-          switch $0 {
-          case .popFrom(id):
-            return .some(nil)
-          case .push(id, let state):
-            return .some(state)
-          default:
-            return .none
-          }
-        }
-      )
-    }
   }
 }
 

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -305,7 +305,8 @@ import XCTestDynamicOverlay
 /// }
 ///
 /// // 1️⃣ Emulate user tapping on submit button.
-/// await store.send(.login(.submitButtonTapped)) {
+/// //    (You can use case key path syntax to send actions to deeply nested features.)
+/// await store.send(\.login.submitButtonTapped) {
 ///   // 2️⃣ Assert how all state changes in the login feature
 ///   $0.login?.isLoading = true
 ///   …
@@ -353,7 +354,7 @@ import XCTestDynamicOverlay
 /// }
 /// store.exhaustivity = .off  // ⬅️
 ///
-/// await store.send(.login(.submitButtonTapped))
+/// await store.send(\.login.submitButtonTapped)
 /// await store.receive(\.login.delegate.didLogin) {
 ///   $0.selectedTab = .activity
 /// }
@@ -375,7 +376,7 @@ import XCTestDynamicOverlay
 /// }
 /// store.exhaustivity = .off(showSkippedAssertions: true)  // ⬅️
 ///
-/// await store.send(.login(.submitButtonTapped))
+/// await store.send(\.login.submitButtonTapped)
 /// await store.receive(\.login.delegate.didLogin) {
 ///   $0.selectedTab = .profile
 /// }
@@ -939,7 +940,7 @@ extension TestStore where State: Equatable {
   ///
   /// ```swift
   /// store.exhaustivity = .off
-  /// await store.send(.child(.closeButtonTapped))
+  /// await store.send(\.child.closeButtonTapped)
   /// await store.finish()
   /// await store.skipReceivedActions()
   /// store.assert {
@@ -1937,23 +1938,22 @@ extension TestStore where State: Equatable {
 extension TestStore where State: Equatable {
   /// Sends an action to the store and asserts when state changes.
   ///
-  /// This method is similar to ``send(_:assert:file:line:)-2co21``, except it allows
-  /// you to specify a `CaseKeyPath` of an action with no associated value to be sent to the store.
-  ///
-  /// It can be useful when sending nested action.  For example::
+  /// This method is similar to ``send(_:assert:file:line:)-2co21``, except it allows you to specify
+  /// a case key path to an action, which can be useful when testing the integration of features and
+  /// sending deeply nested actions. For example:
   ///
   /// ```swift
-  /// await store.send(.view(.tap))
+  /// await store.send(.destination(.presented(.child(.tap))))
   /// ```
   ///
   /// Can be simplified to:
   ///
   /// ```swift
-  ///  await store.send(\.view.tap)
+  /// await store.send(\.destination.child.tap)
   /// ```
   ///
   /// - Parameters:
-  ///   - action: A `CaseKeyPath` to an action.
+  ///   - action: A case key path to an action.
   ///   - updateStateToExpectedResult: A closure that asserts state changed by sending the action to
   ///     the store. The mutable state sent to this closure must be modified to match the state of
   ///     the store after processing the given action. Do not provide a closure if no change is
@@ -1980,18 +1980,18 @@ extension TestStore where State: Equatable {
   /// It can be useful when sending nested action.  For example::
   ///
   /// ```swift
-  /// await store.send(.view(.delete([19, 23]))
+  /// await store.send(.destination(.presented(.child(.emailChanged("blob@pointfree.co")))))
   /// ```
   ///
   /// Can be simplified to:
   ///
   /// ```swift
-  ///  await store.send(\.view.delete, [19, 23])
+  /// await store.send(\.destination.child.emailChanged, "blob@pointfree.co")
   /// ```
   ///
   /// - Parameters:
-  ///   - action: A `CaseKeyPath` to an action with an associated value.
-  ///   - value: A value for the associated value specified in `action`.
+  ///   - action: A case key path to an action.
+  ///   - value: A value to embed in `action`.
   ///   - updateStateToExpectedResult: A closure that asserts state changed by sending the action to
   ///     the store. The mutable state sent to this closure must be modified to match the state of
   ///     the store after processing the given action. Do not provide a closure if no change is

--- a/Tests/ComposableArchitectureTests/Reducers/ForEachReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/ForEachReducerTests.swift
@@ -17,10 +17,10 @@
         Elements()
       }
 
-      await store.send(.rows(.element(id: 1, action: "Blob Esq."))) {
+      await store.send(\.rows[id:1], "Blob Esq.") {
         $0.rows[id: 1]?.value = "Blob Esq."
       }
-      await store.send(.rows(.element(id: 2, action: ""))) {
+      await store.send(\.rows[id:2], "") {
         $0.rows[id: 2]?.value = ""
       }
       await store.receive(\.rows[id:2]) {
@@ -66,7 +66,7 @@
             """
         }
 
-        await store.send(.rows(.element(id: 1, action: "Blob Esq.")))
+        await store.send(\.rows[id:1], "Blob Esq.")
       }
     #endif
 


### PR DESCRIPTION
With #2681 merged, let's update the code base accordingly.