### PR TITLE
chore: Add a sheet example for ReducerCaseIgnored

### DIFF
--- a/Sources/ComposableArchitecture/Macros.swift
+++ b/Sources/ComposableArchitecture/Macros.swift
@@ -113,6 +113,16 @@
   ///   case meeting(id: Meeting.ID)
   ///   // ...
   /// }
+  ///
+  /// //in your view
+  /// .sheet(
+  ///    item: $store.scope(
+  ///      state: \.destination.meeting,
+  ///      action: \.destination
+  ///    )
+  /// ) { store in
+  ///   MeetingView(id: store.state)
+  /// }
   /// ```
   @attached(peer, names: named(_))
   public macro ReducerCaseIgnored() =


### PR DESCRIPTION
This PR aims to improve the documentation example for the ReducerCaseIgnored Macro by adding a demonstration of how to scope a store for the sheet modifier