### PR TITLE
Disfavor new subscript

### DIFF
--- a/Sources/ComposableArchitecture/Observation/Binding+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Binding+Observation.swift
@@ -224,6 +224,7 @@
   }
 
   extension Case where Value: BindableAction, Value.State: ObservableState {
+    @_disfavoredOverload
     public subscript<Member: Equatable & Sendable>(
       dynamicMember keyPath: WritableKeyPath<Value.State, Member>
     ) -> Case<Member> {

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -184,7 +184,7 @@ public struct BindingAction<Root>: CasePathable, Equatable, @unchecked Sendable 
       ) -> AnyCasePath<BindingAction, Value> where Root: ObservableState {
         AnyCasePath(
           embed: { .set(keyPath, $0) },
-          extract: { $0.keyPath == keyPath ? $0.value as? Value : nil }
+          extract: { $0.keyPath == keyPath ? $0.value.base as? Value : nil }
         )
       }
     #endif

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -597,6 +597,14 @@
       }
       await store.receive(\.delegate.success, 42)
     }
+
+    func testBindingTestStore_WhenStateAndActionHaveSameName() async {
+      let store = TestStore(initialState: .init()) {
+        SameNameForStateAndAction()
+      }
+      await store.send(.onAppear)
+      await store.receive(\.isOn)
+    }
   }
 
   private struct Client: DependencyKey {
@@ -623,6 +631,30 @@
     enum View {
       case tap
       case delete(IndexSet)
+    }
+  }
+
+  @Reducer
+  struct SameNameForStateAndAction {
+    @ObservableState
+    struct State: Equatable { var isOn = false }
+    enum Action: BindableAction {
+      case binding(BindingAction<State>)
+      case onAppear
+      case isOn(Bool)
+    }
+    var body: some ReducerOf<Self> {
+      BindingReducer()
+      Reduce { state, action in
+        switch action {
+        case .binding:
+          return .none
+        case .onAppear:
+          return .send(.isOn(true))
+        case .isOn:
+          return .none
+        }
+      }
     }
   }
 #endif

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -604,6 +604,8 @@
       }
       await store.send(.onAppear)
       await store.receive(\.isOn)
+      XCTExpectFailure()
+      await store.receive(\.binding.isOn)
     }
   }
 
@@ -652,7 +654,7 @@
         case .onAppear:
           return .send(.isOn(true))
         case .isOn:
-          return .none
+          return .send(.set(\.isOn, true))
         }
       }
     }

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -604,8 +604,9 @@
       }
       await store.send(.onAppear)
       await store.receive(\.isOn)
-      XCTExpectFailure()
-      await store.receive(\.binding.isOn)
+      await store.receive(\.binding.isOn) {
+        $0.isOn = true
+      }
     }
   }
 


### PR DESCRIPTION
Version 1.9 introduced a new `Case` subscript to allow the `store.send(\.field, …)` syntax for binding actions, but that created potential ambiguity. This fixes #2874 and #2872.