### PR TITLE
Give persistence keys a synchronous update interface

### DIFF
--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
@@ -19,15 +19,36 @@
     /// Saves a value to storage.
     func save(_ value: Value)
 
-    /// An async sequence that emits when the external storage is changed from the outisde.
+    /// An async sequence that emits when the external storage is changed from the outside.
     ///
     /// An "empty" sequence that does not emit and finishes immediately is provided by default.
     var updates: Updates { get }
+
+    func subscribe(didSet: @escaping (Value?) -> Void) -> Shared<Value>.Subscription
   }
 
   extension PersistenceKey where Updates == _Empty<Value?> {
     public var updates: _Empty<Value?> {
       _Empty()
+    }
+
+    public func subscribe(didSet: @escaping (Value?) -> Void) -> Shared<Value>.Subscription {
+      Shared.Subscription {}
+    }
+  }
+
+  extension Shared {
+    public class Subscription {
+      let onCancel: () -> Void
+      init(onCancel: @escaping () -> Void) {
+        self.onCancel = onCancel
+      }
+      deinit {
+        self.cancel()
+      }
+      func cancel() {
+        self.onCancel()
+      }
     }
   }
 

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
@@ -11,7 +11,6 @@
   /// <doc:SharingState#Custom-persistence> section.
   public protocol PersistenceKey<Value>: Hashable {
     associatedtype Value
-    associatedtype Updates: AsyncSequence = _Empty<Value?> where Updates.Element == Value?
 
     /// Loads the freshest value from storage. Returns `nil` if there is no value in storage.
     func load() -> Value?  // TODO: Should this be throwing?
@@ -19,19 +18,11 @@
     /// Saves a value to storage.
     func save(_ value: Value)
 
-    /// An async sequence that emits when the external storage is changed from the outside.
-    ///
-    /// An "empty" sequence that does not emit and finishes immediately is provided by default.
-    var updates: Updates { get }
-
+    /// Subscribes to external updates.
     func subscribe(didSet: @escaping (Value?) -> Void) -> Shared<Value>.Subscription
   }
 
-  extension PersistenceKey where Updates == _Empty<Value?> {
-    public var updates: _Empty<Value?> {
-      _Empty()
-    }
-
+  extension PersistenceKey {
     public func subscribe(didSet: @escaping (Value?) -> Void) -> Shared<Value>.Subscription {
       Shared.Subscription {}
     }
@@ -49,15 +40,6 @@
       func cancel() {
         self.onCancel()
       }
-    }
-  }
-
-  public struct _Empty<Element>: AsyncSequence {
-    public struct AsyncIterator: AsyncIteratorProtocol {
-      public func next() async throws -> Element? { nil }
-    }
-    public func makeAsyncIterator() -> AsyncIterator {
-      AsyncIterator()
     }
   }
 

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
@@ -359,15 +359,6 @@
       }
     }
 
-    public var updates: AsyncStream<Value?> {
-      AsyncStream { continuation in
-        let subscription = self.subscribe { continuation.yield($0) }
-        continuation.onTermination = { _ in
-          _ = subscription
-        }
-      }
-    }
-
     public func load() -> Value? {
       self._load()
     }

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/FileStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/FileStorageKey.swift
@@ -107,15 +107,6 @@
         cancellable.cancel()
       }
     }
-
-    public var updates: AsyncStream<Value?> {
-      AsyncStream { continuation in
-        let subscription = self.subscribe { continuation.yield($0) }
-        continuation.onTermination = { _ in
-          _ = subscription
-        }
-      }
-    }
   }
 
   extension FileStorageKey: Hashable {

--- a/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
+++ b/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
@@ -73,6 +73,7 @@
     }
     private var _snapshot: Value?
     fileprivate var persistenceKey: (any PersistenceKey<Value>)?  // TODO: Should this not be an `any`?
+    private var subscription: Shared<Value>.Subscription?
     private let fileID: StaticString
     private let line: UInt
     private let lock = NSRecursiveLock()
@@ -93,10 +94,8 @@
       self.persistenceKey = persistenceKey
       self.fileID = fileID
       self.line = line
-      Task { @MainActor [weak self, initialValue] in
-        for try await value in persistenceKey.updates {
-          self?.currentValue = value ?? initialValue()
-        }
+      self.subscription = persistenceKey.subscribe { [weak self, initialValue] value in
+        self?.currentValue = value ?? initialValue()
       }
     }
 

--- a/Tests/ComposableArchitectureTests/AppStorageTests.swift
+++ b/Tests/ComposableArchitectureTests/AppStorageTests.swift
@@ -43,38 +43,26 @@ final class AppStorageTests: XCTestCase {
     self.wait(for: [countDidChange], timeout: 0)
   }
 
-  func testChangeUserDefaultsDirectly() async throws {
+  func testChangeUserDefaultsDirectly() {
     @Dependency(\.defaultAppStorage) var defaults
     @Shared(.appStorage("count")) var count = 0
-
-    try await Task.sleep(nanoseconds: 10_000_000)
     defaults.setValue(count + 42, forKey: "count")
-    try await Task.sleep(nanoseconds: 100_000_000)
     XCTAssertEqual(count, 42)
   }
 
-  func testDeleteUserDefault() async throws {
+  func testDeleteUserDefault() {
     @Dependency(\.defaultAppStorage) var defaults
     @Shared(.appStorage("count")) var count = 0
     count = 42
-
-    try await Task.sleep(nanoseconds: 1_000_000)
     defaults.removeObject(forKey: "count")
-    try await Task.sleep(nanoseconds: 1_000_000)
     XCTAssertEqual(count, 0)
   }
 
   func testKeyPath() async throws {
-    try await withMainSerialExecutor {
-      @Dependency(\.defaultAppStorage) var defaults
-      @Shared(.appStorage(\.count)) var count = 0
-      _ = count
-      await Task.yield()
-
-      defaults.count += 1
-      try await Task.sleep(nanoseconds: 1_000_000)
-      XCTAssertEqual(count, 1)
-    }
+    @Dependency(\.defaultAppStorage) var defaults
+    @Shared(.appStorage(\.count)) var count = 0
+    defaults.count += 1
+    XCTAssertEqual(count, 1)
   }
 }
 


### PR DESCRIPTION
Adding an async sequence around persistence updates caused a bunch of synchronization issues, so let's change things to use a synchronous API instead.