### PR TITLE
Pass initial shared value to strategy / register app storage

### DIFF
--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
@@ -16,7 +16,7 @@
     func load(initialValue: Value?) -> Value?  // TODO: Should this be throwing?
 
     /// Saves a value to storage.
-    func save(_ value: Value?)
+    func save(_ value: Value)
 
     /// Subscribes to external updates.
     func subscribe(

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
@@ -13,20 +13,20 @@
     associatedtype Value
 
     /// Loads the freshest value from storage. Returns `nil` if there is no value in storage.
-    func load(initialValue: Value) -> Value  // TODO: Should this be throwing?
+    func load(initialValue: Value?) -> Value?  // TODO: Should this be throwing?
 
     /// Saves a value to storage.
-    func save(_ value: Value)
+    func save(_ value: Value?)
 
     /// Subscribes to external updates.
     func subscribe(
-      initialValue: Value, didSet: @escaping (Value) -> Void
+      initialValue: Value?, didSet: @escaping (_ newValue: Value?) -> Void
     ) -> Shared<Value>.Subscription
   }
 
   extension PersistenceKey {
     public func subscribe(
-      initialValue: Value, didSet: @escaping (Value) -> Void
+      initialValue: Value?, didSet: @escaping (_ newValue: Value?) -> Void
     ) -> Shared<Value>.Subscription {
       Shared.Subscription {}
     }

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
@@ -13,17 +13,21 @@
     associatedtype Value
 
     /// Loads the freshest value from storage. Returns `nil` if there is no value in storage.
-    func load() -> Value?  // TODO: Should this be throwing?
-    
+    func load(initialValue: Value) -> Value  // TODO: Should this be throwing?
+
     /// Saves a value to storage.
     func save(_ value: Value)
 
     /// Subscribes to external updates.
-    func subscribe(didSet: @escaping (Value?) -> Void) -> Shared<Value>.Subscription
+    func subscribe(
+      initialValue: Value, didSet: @escaping (Value) -> Void
+    ) -> Shared<Value>.Subscription
   }
 
   extension PersistenceKey {
-    public func subscribe(didSet: @escaping (Value?) -> Void) -> Shared<Value>.Subscription {
+    public func subscribe(
+      initialValue: Value, didSet: @escaping (Value) -> Void
+    ) -> Shared<Value>.Subscription {
       Shared.Subscription {}
     }
   }

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
@@ -174,7 +174,7 @@
   /// See ``PersistenceKey/appStorage(_:)-9zd2f`` to create values of this type.
   public struct AppStorageKey<Value> {
     private let _load: () -> Value?
-    private let _save: (Value?) -> Void
+    private let _save: (Value) -> Void
     private let key: Key
     private let store: UserDefaults
 
@@ -186,13 +186,7 @@
     public init(_ keyPath: ReferenceWritableKeyPath<UserDefaults, Value>) {
       @Dependency(\.defaultAppStorage) var store
       self._load = { [store] in store[keyPath: keyPath] }
-      self._save = { [store] in
-        if let value = $0 {
-          store[keyPath: keyPath] = value
-        } else if let key = keyPath._kvcKeyPathString {
-          store.removeObject(forKey: key)
-        }
-      }
+      self._save = { [store] in store[keyPath: keyPath] = $0 }
       self.key = .keyPath(keyPath)
       self.store = store
     }
@@ -251,7 +245,7 @@
       self._load = { [store] in
         (store.object(forKey: key) as? Value.RawValue).flatMap(Value.init(rawValue:))
       }
-      self._save = { [store] in store.set($0?.rawValue, forKey: key) }
+      self._save = { [store] in store.set($0.rawValue, forKey: key) }
       self.key = .string(key)
       self.store = store
     }
@@ -262,7 +256,7 @@
       self._load = { [store] in
         (store.object(forKey: key) as? Value.RawValue).flatMap(Value.init(rawValue:))
       }
-      self._save = { [store] in store.set($0?.rawValue, forKey: key) }
+      self._save = { [store] in store.set($0.rawValue, forKey: key) }
       self.key = .string(key)
       self.store = store
     }
@@ -321,7 +315,7 @@
       self._load = { [store] in
         (store.object(forKey: key) as? R.RawValue).flatMap(R.init(rawValue:))
       }
-      self._save = { [store] in store.set($0??.rawValue, forKey: key) }
+      self._save = { [store] in store.set($0?.rawValue, forKey: key) }
       self.key = .string(key)
       self.store = store
     }
@@ -332,7 +326,7 @@
       self._load = { [store] in
         (store.object(forKey: key) as? R.RawValue).flatMap(R.init(rawValue:))
       }
-      self._save = { [store] in store.set($0??.rawValue, forKey: key) }
+      self._save = { [store] in store.set($0?.rawValue, forKey: key) }
       self.key = .string(key)
       self.store = store
     }
@@ -346,7 +340,7 @@
       return self._load() ?? initialValue
     }
 
-    public func save(_ value: Value?) {
+    public func save(_ value: Value) {
       SharedAppStorageLocals.$isSetting.withValue(true) {
         self._save(value)
       }

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
@@ -333,14 +333,30 @@
   }
 
   extension AppStorageKey: PersistenceKey {
-    public func subscribe(didSet: @escaping (_ newValue: Value?) -> Void) -> Shared<Value>.Subscription {
+    public func load(initialValue: Value) -> Value {
+      if case let .string(key) = self.key {
+        self.store.register(defaults: [key: initialValue])
+      }
+      return self._load() ?? initialValue
+    }
+
+    public func save(_ value: Value) {
+      SharedAppStorageLocals.$isSetting.withValue(true) {
+        self._save(value)
+      }
+    }
+
+    public func subscribe(
+      initialValue: Value,
+      didSet: @escaping (_ newValue: Value) -> Void
+    ) -> Shared<Value>.Subscription {
       switch self.key {
       case let .keyPath(key):
         let observer = self.store.observe(key, options: .new) { _, change in
           guard
             !SharedAppStorageLocals.isSetting
           else { return }
-          didSet(change.newValue)
+          didSet(change.newValue ?? initialValue)
         }
         return Shared.Subscription {
           observer.invalidate()
@@ -350,22 +366,12 @@
           guard
             !SharedAppStorageLocals.isSetting
           else { return }
-          didSet(value)
+          didSet(value ?? initialValue)
         }
         self.store.addObserver(observer, forKeyPath: key, options: .new, context: nil)
         return Shared.Subscription {
           self.store.removeObserver(observer, forKeyPath: key)
         }
-      }
-    }
-
-    public func load() -> Value? {
-      self._load()
-    }
-
-    public func save(_ value: Value) {
-      SharedAppStorageLocals.$isSetting.withValue(true) {
-        self._save(value)
       }
     }
 

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/FileStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/FileStorageKey.swift
@@ -64,7 +64,7 @@
       NotificationCenter.default.removeObserver(self.notificationListener!)
     }
 
-    public func load(initialValue: Value) -> Value {
+    public func load(initialValue: Value?) -> Value? {
       do {
         return try JSONDecoder().decode(Value.self, from: self.storage.load(from: self.url))
       } catch {
@@ -72,7 +72,7 @@
       }
     }
 
-    public func save(_ value: Value) {
+    public func save(_ value: Value?) {
       self.workItem?.cancel()
       let workItem = DispatchWorkItem { [weak self] in
         guard let self else { return }
@@ -89,7 +89,7 @@
     }
 
     public func subscribe(
-      initialValue: Value, didSet: @escaping (Value) -> Void
+      initialValue: Value?, didSet: @escaping (_ newValue: Value?) -> Void
     ) -> Shared<Value>.Subscription {
       // NB: Make sure there is a file to create a source for.
       if !self.storage.fileExists(at: self.url) {

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/FileStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/FileStorageKey.swift
@@ -64,8 +64,12 @@
       NotificationCenter.default.removeObserver(self.notificationListener!)
     }
 
-    public func load() -> Value? {
-      try? JSONDecoder().decode(Value.self, from: self.storage.load(from: self.url))
+    public func load(initialValue: Value) -> Value {
+      do {
+        return try JSONDecoder().decode(Value.self, from: self.storage.load(from: self.url))
+      } catch {
+        return initialValue
+      }
     }
 
     public func save(_ value: Value) {
@@ -84,7 +88,9 @@
       }
     }
 
-    public func subscribe(didSet: @escaping (Value?) -> Void) -> Shared<Value>.Subscription {
+    public func subscribe(
+      initialValue: Value, didSet: @escaping (Value) -> Void
+    ) -> Shared<Value>.Subscription {
       // NB: Make sure there is a file to create a source for.
       if !self.storage.fileExists(at: self.url) {
         try? self.storage
@@ -100,7 +106,7 @@
         if self.storage.isSetting() == true {
           self.storage.setIsSetting(false)
         } else {
-          didSet(self.load())
+          didSet(self.load(initialValue: initialValue))
         }
       }
       return Shared.Subscription {

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/InMemoryKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/InMemoryKey.swift
@@ -26,7 +26,7 @@
     public init(_ key: String) {
       self.key = key
     }
-    public func load(initialValue: Value) -> Value { initialValue }
-    public func save(_ value: Value) {}
+    public func load(initialValue: Value?) -> Value? { initialValue }
+    public func save(_ value: Value?) {}
   }
 #endif

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/InMemoryKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/InMemoryKey.swift
@@ -27,6 +27,6 @@
       self.key = key
     }
     public func load(initialValue: Value?) -> Value? { initialValue }
-    public func save(_ value: Value?) {}
+    public func save(_ value: Value) {}
   }
 #endif

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/InMemoryKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/InMemoryKey.swift
@@ -26,7 +26,7 @@
     public init(_ key: String) {
       self.key = key
     }
-    public func load() -> Value? { nil }
+    public func load(initialValue: Value) -> Value { initialValue }
     public func save(_ value: Value) {}
   }
 #endif

--- a/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
+++ b/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
@@ -22,7 +22,7 @@
     }
     
     public init(
-      wrappedValue value: @autoclosure @escaping () -> Value,
+      wrappedValue value: Value,
       _ persistenceKey: some PersistenceKey<Value>,
       fileID: StaticString = #fileID,
       line: UInt = #line
@@ -85,7 +85,7 @@
       message: "Use '@Shared' with a value type or supported reference type"
     )
     public init(
-      wrappedValue value: @autoclosure @escaping () -> Value,
+      wrappedValue value: Value,
       _ persistenceKey: some PersistenceKey<Value>,
       fileID: StaticString = #fileID,
       line: UInt = #line

--- a/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
+++ b/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
@@ -114,18 +114,20 @@
     #endif
 
     init(
-      initialValue: @autoclosure @escaping () -> Value,
+      initialValue: Value,
       persistenceKey: some PersistenceKey<Value>,
       fileID: StaticString,
       line: UInt
     ) {
-      self._currentValue = persistenceKey.load() ?? initialValue()
+      self._currentValue = persistenceKey.load(initialValue: initialValue)
       self._subject = CurrentValueRelay(self._currentValue)
       self.persistenceKey = persistenceKey
       self.fileID = fileID
       self.line = line
-      self.subscription = persistenceKey.subscribe { [weak self, initialValue] value in
-        self?.currentValue = value ?? initialValue()
+      self.subscription = persistenceKey.subscribe(
+        initialValue: initialValue
+      ) { [weak self] value in
+        self?.currentValue = value
       }
     }
 

--- a/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
+++ b/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
@@ -35,7 +35,7 @@
               return reference
             } else {
               let reference = ValueReference(
-                initialValue: value(),
+                initialValue: value,
                 persistenceKey: persistenceKey,
                 fileID: fileID,
                 line: line
@@ -57,26 +57,17 @@
       self.init(wrappedValue: nil, persistenceKey, fileID: fileID, line: line)
     }
 
-    @available(
-      *,
-      unavailable,
-      message: "'@Shared' must be initialized with a default value when using a persistence key"
-    )
     public init(
       _ persistenceKey: some PersistenceKey<Value>,
       fileID: StaticString = #fileID,
       line: UInt = #line
-    ) {
-      fatalError()
+    ) throws {
+      guard let initialValue = persistenceKey.load(initialValue: nil)
+      else {
+        throw LoadError()
+      }
+      self.init(wrappedValue: initialValue, persistenceKey, fileID: fileID, line: line)
     }
-
-    // public init(
-    //   _ persistenceKey: some PersistenceKey<Value>,
-    //   fileID: StaticString = #fileID,
-    //   line: UInt = #line
-    // ) throws {
-    //   fatalError("TODO")
-    // }
 
     @_disfavoredOverload
     @available(
@@ -90,9 +81,11 @@
       fileID: StaticString = #fileID,
       line: UInt = #line
     ) where Value: AnyObject {
-      self.init(wrappedValue: value(), persistenceKey, fileID: fileID, line: line)
+      self.init(wrappedValue: value, persistenceKey, fileID: fileID, line: line)
     }
   }
+
+  private struct LoadError: Error {}
 
   private final class ValueReference<Value>: Reference {
     private var _currentValue: Value {
@@ -119,7 +112,7 @@
       fileID: StaticString,
       line: UInt
     ) {
-      self._currentValue = persistenceKey.load(initialValue: initialValue)
+      self._currentValue = persistenceKey.load(initialValue: initialValue) ?? initialValue
       self._subject = CurrentValueRelay(self._currentValue)
       self.persistenceKey = persistenceKey
       self.fileID = fileID
@@ -127,7 +120,7 @@
       self.subscription = persistenceKey.subscribe(
         initialValue: initialValue
       ) { [weak self] value in
-        self?.currentValue = value
+        self?.currentValue = value ?? initialValue
       }
     }
 

--- a/Tests/ComposableArchitectureTests/AppStorageTests.swift
+++ b/Tests/ComposableArchitectureTests/AppStorageTests.swift
@@ -14,6 +14,16 @@ final class AppStorageTests: XCTestCase {
     XCTAssertEqual(defaults.integer(forKey: "count"), 1)
   }
 
+  func testDefaultsRegistered() {
+    @Dependency(\.defaultAppStorage) var defaults
+    @Shared(.appStorage("count")) var count = 42
+    XCTAssertEqual(defaults.integer(forKey: "count"), 42)
+
+    count += 1
+    XCTAssertEqual(count, 43)
+    XCTAssertEqual(defaults.integer(forKey: "count"), 43)
+  }
+
   func testDefaultAppStorageOverride() {
     let defaults = UserDefaults(suiteName: "tests")!
     defaults.removePersistentDomain(forName: "tests")

--- a/Tests/ComposableArchitectureTests/SharedTests.swift
+++ b/Tests/ComposableArchitectureTests/SharedTests.swift
@@ -583,13 +583,6 @@ final class SharedTests: XCTestCase {
       $0.count = 42
     }
   }
-
-  func testPersistenceAutoclosure() {
-    @Dependency(\.defaultAppStorage) var storage
-    storage.set(1, forKey: "count")
-    @Shared(.appStorage("count")) var count = { () -> Int in fatalError() }()
-    XCTAssertEqual(count, 1)
-  }
 }
 
 @Reducer


### PR DESCRIPTION
This PR modifies the `PersistenceKey` protocol so that its `load` and `subscribe` endpoints are handed the initial value and must return a non-optional value. By feeding this value in, we can ensure that `.appStorage` declared in a feature is registered outside the feature.