### PR TITLE
Add `StackActionOf`

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/03-NavigationStack.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-NavigationStack.swift
@@ -22,7 +22,7 @@ struct NavigationDemo {
   enum Action {
     case goBackToScreen(id: StackElementID)
     case goToABCButtonTapped
-    case path(StackAction<Path.State, Path.Action>)
+    case path(StackActionOf<Path>)
     case popToRoot
   }
 

--- a/Examples/Integration/Integration/Legacy/BindingLocalTestCase.swift
+++ b/Examples/Integration/Integration/Legacy/BindingLocalTestCase.swift
@@ -15,7 +15,7 @@ private struct BindingLocalTestCase {
     case fullScreenCoverButtonTapped
     case navigationDestination(PresentationAction<Child.Action>)
     case navigationDestinationButtonTapped
-    case path(StackAction<Child.State, Child.Action>)
+    case path(StackActionOf<Child>)
     case popover(PresentationAction<Child.Action>)
     case popoverButtonTapped
     case sheet(PresentationAction<Child.Action>)

--- a/Examples/Integration/Integration/Legacy/NavigationStackTestCase.swift
+++ b/Examples/Integration/Integration/Legacy/NavigationStackTestCase.swift
@@ -142,7 +142,7 @@ private struct NavigationStackTestCase {
     var childResponse: Int?
   }
   enum Action {
-    case child(StackAction<ChildFeature.State, ChildFeature.Action>)
+    case child(StackActionOf<ChildFeature>)
   }
   var body: some ReducerOf<Self> {
     Reduce { state, action in

--- a/Examples/Integration/Integration/iOS 16/NavigationTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16/NavigationTestCase.swift
@@ -31,7 +31,7 @@ struct NavigationTestCaseView: View {
       var path = StackState<BasicsView.Feature.State>()
     }
     enum Action {
-      case path(StackAction<BasicsView.Feature.State, BasicsView.Feature.Action>)
+      case path(StackActionOf<BasicsView.Feature>)
     }
     var body: some ReducerOf<Self> {
       Reduce { state, action in

--- a/Examples/Integration/Integration/iOS 17/ObservableBindingLocalTest.swift
+++ b/Examples/Integration/Integration/iOS 17/ObservableBindingLocalTest.swift
@@ -16,7 +16,7 @@ private struct ObservableBindingLocalTestCase {
     case fullScreenCoverButtonTapped
     case navigationDestination(PresentationAction<Child.Action>)
     case navigationDestinationButtonTapped
-    case path(StackAction<Child.State, Child.Action>)
+    case path(StackActionOf<Child>)
     case popover(PresentationAction<Child.Action>)
     case popoverButtonTapped
     case sheet(PresentationAction<Child.Action>)

--- a/Examples/Integration/Integration/iOS 17/ObservableNavigationTestCase.swift
+++ b/Examples/Integration/Integration/iOS 17/ObservableNavigationTestCase.swift
@@ -35,7 +35,7 @@ struct ObservableNavigationTestCaseView: View {
     }
     enum Action {
       case path(
-        StackAction<ObservableBasicsView.Feature.State, ObservableBasicsView.Feature.Action>
+        StackActionOf<ObservableBasicsView.Feature>
       )
     }
     var body: some ReducerOf<Self> {

--- a/Examples/SyncUps/SyncUps/AppFeature.swift
+++ b/Examples/SyncUps/SyncUps/AppFeature.swift
@@ -17,7 +17,7 @@ struct AppFeature {
   }
 
   enum Action {
-    case path(StackAction<Path.State, Path.Action>)
+    case path(StackActionOf<Path>)
     case syncUpsList(SyncUpsList.Action)
   }
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Navigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Navigation.md
@@ -28,6 +28,7 @@ use these tools.
 - <doc:StackBasedNavigation>
 - ``StackState``
 - ``StackAction``
+- ``StackActionOf``
 - ``StackElementID``
 - ``Reducer/forEach(_:action:destination:fileID:line:)-yz3v``
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerForEach.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerForEach.md
@@ -10,6 +10,7 @@
 
 - ``StackState``
 - ``StackAction``
+- ``StackActionOf``
 - ``Reducer/forEach(_:action:destination:fileID:line:)-yz3v``
 - ``Reducer/forEach(_:action:)``
 - ``DismissEffect``

--- a/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
@@ -306,7 +306,7 @@ extension Reducer {
   ///     // ...
   ///   }
   ///   enum Action {
-  ///     case path(StackAction<Path.State, Path.Action>)
+  ///     case path(StackActionOf<Path>)
   ///     // ...
   ///   }
   ///   var body: some ReducerOf<Self> {
@@ -411,6 +411,21 @@ extension Reducer {
     )
   }
 }
+
+/// A convenience type alias for referring to a stack action of a given reducer's domain.
+///
+/// Instead of specifying two generics:
+///
+/// ```swift
+///     case path(StackAction<Path.State, Path.Action>)
+/// ```
+///
+/// You can specify a single generic:
+///
+/// ```swift
+///     case path(StackActionOf<Path>)
+/// ```
+public typealias StackActionOf<R: Reducer> = StackAction<R.State, R.Action>
 
 public struct _StackReducer<Base: Reducer, Destination: Reducer>: Reducer {
   let base: Base

--- a/Tests/ComposableArchitectureTests/Reducers/StackReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/StackReducerTests.swift
@@ -89,7 +89,7 @@
           var children = StackState<Child.State>()
         }
         enum Action: Equatable {
-          case children(StackAction<Child.State, Child.Action>)
+          case children(StackActionOf<Child>)
           case pushChild
         }
         var body: some ReducerOf<Self> {
@@ -139,7 +139,7 @@
           var children = StackState<Child.State>()
         }
         enum Action: Equatable {
-          case children(StackAction<Child.State, Child.Action>)
+          case children(StackActionOf<Child>)
           case popChild
           case pushChild
         }
@@ -203,7 +203,7 @@
           var children = StackState<Child.State>()
         }
         enum Action: Equatable {
-          case children(StackAction<Child.State, Child.Action>)
+          case children(StackActionOf<Child>)
           case pushChild
         }
         var body: some ReducerOf<Self> {
@@ -252,7 +252,7 @@
           var children = StackState<Child.State>()
         }
         enum Action: Equatable {
-          case children(StackAction<Child.State, Child.Action>)
+          case children(StackActionOf<Child>)
         }
         var body: some ReducerOf<Self> {
           Reduce { _, _ in .none }.forEach(\.children, action: /Action.children) { Child() }
@@ -307,7 +307,7 @@
           var children = StackState<Child.State>()
         }
         enum Action: Equatable {
-          case child(StackAction<Child.State, Child.Action>)
+          case child(StackActionOf<Child>)
         }
         var body: some ReducerOf<Self> {
           Reduce { _, _ in .none }
@@ -369,7 +369,7 @@
           var children = StackState<Child.State>()
         }
         enum Action: Equatable {
-          case children(StackAction<Child.State, Child.Action>)
+          case children(StackActionOf<Child>)
           case pushChild
         }
         var body: some ReducerOf<Self> {
@@ -452,7 +452,7 @@
           var path = StackState<Path.State>()
         }
         enum Action: Equatable {
-          case path(StackAction<Path.State, Path.Action>)
+          case path(StackActionOf<Path>)
           case pushChild1
           case pushChild2
         }
@@ -507,7 +507,7 @@
           var path = StackState<Child.State>()
         }
         enum Action {
-          case path(StackAction<Child.State, Child.Action>)
+          case path(StackActionOf<Child>)
           case popToRoot
           case pushChild
         }
@@ -598,7 +598,7 @@
           var path = StackState<Path.State>()
         }
         enum Action: Equatable {
-          case path(StackAction<Path.State, Path.Action>)
+          case path(StackActionOf<Path>)
           case pushChild1
           case pushChild2
         }
@@ -697,7 +697,7 @@
           var path = StackState<Path.State>()
         }
         enum Action: Equatable {
-          case path(StackAction<Path.State, Path.Action>)
+          case path(StackActionOf<Path>)
           case popAll
           case popFirst
         }
@@ -861,7 +861,7 @@
             var path = StackState<Child.State>()
           }
           enum Action {
-            case path(StackAction<Child.State, Child.Action>)
+            case path(StackActionOf<Child>)
           }
           var body: some ReducerOf<Self> {
             EmptyReducer()
@@ -933,7 +933,7 @@
           var children: StackState<Child.State>
         }
         enum Action: Equatable {
-          case child(StackAction<Child.State, Child.Action>)
+          case child(StackActionOf<Child>)
         }
         var body: some ReducerOf<Self> {
           Reduce { _, _ in .none }
@@ -982,7 +982,7 @@
           var children: StackState<Child.State>
         }
         enum Action: Equatable {
-          case child(StackAction<Child.State, Child.Action>)
+          case child(StackActionOf<Child>)
         }
         var body: some ReducerOf<Self> {
           Reduce { _, _ in .none }
@@ -1019,7 +1019,7 @@
           var children = StackState<Child.State>()
         }
         enum Action: Equatable {
-          case child(StackAction<Child.State, Child.Action>)
+          case child(StackActionOf<Child>)
           case push
         }
         var body: some ReducerOf<Self> {
@@ -1074,7 +1074,7 @@
             var children = StackState<Child.State>()
           }
           enum Action: Equatable {
-            case child(StackAction<Child.State, Child.Action>)
+            case child(StackActionOf<Child>)
           }
           var body: some ReducerOf<Self> {
             Reduce { _, _ in .none }
@@ -1120,7 +1120,7 @@
             var children = StackState<Child.State>()
           }
           enum Action: Equatable {
-            case child(StackAction<Child.State, Child.Action>)
+            case child(StackActionOf<Child>)
           }
           var body: some ReducerOf<Self> {
             Reduce { _, _ in .none }
@@ -1164,7 +1164,7 @@
           var children = StackState<Child.State>()
         }
         enum Action: Equatable {
-          case child(StackAction<Child.State, Child.Action>)
+          case child(StackActionOf<Child>)
         }
         var body: some ReducerOf<Self> {
           Reduce { _, _ in .none }.forEach(\.children, action: /Action.child) { Child() }
@@ -1265,7 +1265,7 @@
           var children = StackState<Child.State>()
         }
         enum Action: Equatable {
-          case children(StackAction<Child.State, Child.Action>)
+          case children(StackActionOf<Child>)
           case tapAfter
           case tapBefore
         }

--- a/Tests/ComposableArchitectureTests/ScopeLoggerTests.swift
+++ b/Tests/ComposableArchitectureTests/ScopeLoggerTests.swift
@@ -39,7 +39,7 @@
         var path = StackState<BasicsView.Feature.State>()
       }
       enum Action {
-        case path(StackAction<BasicsView.Feature.State, BasicsView.Feature.Action>)
+        case path(StackActionOf<BasicsView.Feature>)
       }
       var body: some ReducerOf<Self> {
         EmptyReducer()


### PR DESCRIPTION
It turns out that this typealias is not real, and now real.

https://github.com/pointfreeco/swift-composable-architecture/blob/a0acf426f7e8e794563b6bcbe4fcf5a9fd6cebef/Sources/ComposableArchitecture/Observation/NavigationStack%2BObservation.swift#L22