### PR TITLE
Give internal presentation store an id

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/PresentationModifier.swift
@@ -215,7 +215,7 @@ public struct PresentationStore<
     ) -> Content
   ) where State == DestinationState, Action == DestinationAction {
     let store = store.scope(
-      id: nil,
+      id: store.id(state: \.self, action: \.self),
       state: ToState(\.self),
       action: { $0 },
       isInvalid: { $0.wrappedValue == nil }


### PR DESCRIPTION
Addresses the problem raised in #2907 where using legacy presentation APIs (e.g. `sheet(store:)`) result in the presented destination always receiving a store that does not support store caching due to the hardcoded `nil` ID given to the internal store that is created.

This prevents you from presenting features that uses observation tools using these APIs without lots of purple runtime warnings even though there's no reason why you shouldn't be able to do this.

Note: An [earlier implementation](https://github.com/pointfreeco/swift-composable-architecture/commit/087b6b5730df5494ec7cefa8add8ced89c645429#diff-a7aa3773363760502a84ef57acd54a1b745cee8cedad7a01a065bd9083546c7eL220) in of this logic used to have a comment stating that a `\.self` ID could not be used because it would prevent dismissal. In my [example app](https://gist.github.com/lukeredpath/f895504cc16fd11f9c0f541f6bf4573e) I am able to present and dismiss sheets using both the SwiftUI `dismiss` environment value, or by sending an action to the store and setting the destination state to `nil`.