### PR TITLE
Change "inert" state to have an ever-changing ID

### DIFF
--- a/Examples/Integration/IntegrationUITests/Internal/BaseIntegrationTests.swift
+++ b/Examples/Integration/IntegrationUITests/Internal/BaseIntegrationTests.swift
@@ -14,7 +14,7 @@ class BaseIntegrationTests: XCTestCase {
   }
 
   override func setUp() async throws {
-    SnapshotTesting.isRecording = true
+    //SnapshotTesting.isRecording = true
     // self.continueAfterFailure = false
     self.app = XCUIApplication()
     self.app.launchEnvironment["UI_TEST"] = "true"

--- a/Examples/Integration/IntegrationUITests/Internal/BaseIntegrationTests.swift
+++ b/Examples/Integration/IntegrationUITests/Internal/BaseIntegrationTests.swift
@@ -14,7 +14,7 @@ class BaseIntegrationTests: XCTestCase {
   }
 
   override func setUp() async throws {
-    //SnapshotTesting.isRecording = true
+    SnapshotTesting.isRecording = true
     // self.continueAfterFailure = false
     self.app = XCUIApplication()
     self.app.launchEnvironment["UI_TEST"] = "true"

--- a/Examples/Integration/IntegrationUITests/iOS 16+17/NewContainsOldTests.swift
+++ b/Examples/Integration/IntegrationUITests/iOS 16+17/NewContainsOldTests.swift
@@ -66,7 +66,9 @@ final class iOS16_17_NewContainsOldTests: BaseIntegrationTests {
     self.app.buttons["iOS 16 + 17"].tap()
     self.assertLogs {
       """
-
+      StoreOf<BasicsView.Feature>.deinit
+      StoreOf<BasicsView.Feature>.deinit
+      ViewStoreOf<BasicsView.Feature>.deinit
       """
     }
   }

--- a/Examples/Integration/IntegrationUITests/iOS 16+17/NewContainsOldTests.swift
+++ b/Examples/Integration/IntegrationUITests/iOS 16+17/NewContainsOldTests.swift
@@ -17,7 +17,7 @@ final class iOS16_17_NewContainsOldTests: BaseIntegrationTests {
     XCTAssertEqual(self.app.staticTexts["1"].exists, true)
     self.assertLogs {
       """
-      NewContainsOldTestCase.body
+
       """
     }
 
@@ -26,13 +26,7 @@ final class iOS16_17_NewContainsOldTests: BaseIntegrationTests {
     self.assertLogs {
       """
       BasicsView.body
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.init
-      StoreOf<BasicsView.Feature>.init
       ViewStoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature>.init
       ViewStoreOf<BasicsView.Feature>.init
       WithViewStoreOf<BasicsView.Feature>.body
       """
@@ -44,7 +38,7 @@ final class iOS16_17_NewContainsOldTests: BaseIntegrationTests {
     XCTAssertEqual(self.app.staticTexts["Child count: 0"].exists, true)
     self.assertLogs {
       """
-      NewContainsOldTestCase.body
+
       """
     }
   }
@@ -58,19 +52,8 @@ final class iOS16_17_NewContainsOldTests: BaseIntegrationTests {
     self.assertLogs {
       """
       BasicsView.body
-      BasicsView.body
-      NewContainsOldTestCase.body
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.init
-      StoreOf<BasicsView.Feature>.init
-      ViewStoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature>.deinit
       ViewStoreOf<BasicsView.Feature>.deinit
       ViewStoreOf<BasicsView.Feature>.init
-      ViewStoreOf<BasicsView.Feature>.init
-      ViewStoreOf<BasicsView.Feature>.init
-      WithViewStoreOf<BasicsView.Feature>.body
       WithViewStoreOf<BasicsView.Feature>.body
       """
     }
@@ -83,9 +66,7 @@ final class iOS16_17_NewContainsOldTests: BaseIntegrationTests {
     self.app.buttons["iOS 16 + 17"].tap()
     self.assertLogs {
       """
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature>.deinit
+
       """
     }
   }

--- a/Examples/Integration/IntegrationUITests/iOS 16+17/NewPresentsOldTests.swift
+++ b/Examples/Integration/IntegrationUITests/iOS 16+17/NewPresentsOldTests.swift
@@ -44,10 +44,6 @@ final class iOS16_17_NewPresentsOldTests: BaseIntegrationTests {
       StoreOf<BasicsView.Feature>.init
       StoreOf<BasicsView.Feature>.init
       StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.init
-      StoreOf<BasicsView.Feature?>.init
       StoreOf<BasicsView.Feature?>.init
       StoreOf<BasicsView.Feature?>.init
       StoreOf<BasicsView.Feature?>.init
@@ -74,8 +70,6 @@ final class iOS16_17_NewPresentsOldTests: BaseIntegrationTests {
     self.assertLogs {
       """
       BasicsView.body
-      BasicsView.body
-      BasicsView.body
       NewPresentsOldTestCase.body
       NewPresentsOldTestCase.body
       PresentationStoreOf<BasicsView.Feature>.init
@@ -85,31 +79,11 @@ final class iOS16_17_NewPresentsOldTests: BaseIntegrationTests {
       StoreOf<BasicsView.Feature>.deinit
       StoreOf<BasicsView.Feature>.deinit
       StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.init
-      StoreOf<BasicsView.Feature>.init
-      StoreOf<BasicsView.Feature>.init
-      StoreOf<BasicsView.Feature>.init
-      StoreOf<BasicsView.Feature>.init
-      StoreOf<BasicsView.Feature>.init
       StoreOf<BasicsView.Feature>.init
       StoreOf<BasicsView.Feature>.init
       StoreOf<BasicsView.Feature>.init
       StoreOf<BasicsView.Feature?>.deinit
       StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.init
-      StoreOf<BasicsView.Feature?>.init
-      StoreOf<BasicsView.Feature?>.init
-      StoreOf<BasicsView.Feature?>.init
       StoreOf<BasicsView.Feature?>.init
       StoreOf<BasicsView.Feature?>.init
       StoreOf<BasicsView.Feature?>.init
@@ -120,33 +94,13 @@ final class iOS16_17_NewPresentsOldTests: BaseIntegrationTests {
       ViewPresentationStoreOf<BasicsView.Feature>.init
       ViewStoreOf<BasicsView.Feature>.deinit
       ViewStoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature>.init
-      ViewStoreOf<BasicsView.Feature>.init
-      ViewStoreOf<BasicsView.Feature>.init
-      ViewStoreOf<BasicsView.Feature>.init
       ViewStoreOf<BasicsView.Feature>.init
       ViewStoreOf<BasicsView.Feature>.init
       ViewStoreOf<BasicsView.Feature?>.deinit
       ViewStoreOf<BasicsView.Feature?>.deinit
-      ViewStoreOf<BasicsView.Feature?>.deinit
-      ViewStoreOf<BasicsView.Feature?>.deinit
-      ViewStoreOf<BasicsView.Feature?>.deinit
-      ViewStoreOf<BasicsView.Feature?>.deinit
-      ViewStoreOf<BasicsView.Feature?>.init
-      ViewStoreOf<BasicsView.Feature?>.init
-      ViewStoreOf<BasicsView.Feature?>.init
-      ViewStoreOf<BasicsView.Feature?>.init
       ViewStoreOf<BasicsView.Feature?>.init
       ViewStoreOf<BasicsView.Feature?>.init
       WithViewStoreOf<BasicsView.Feature>.body
-      WithViewStoreOf<BasicsView.Feature>.body
-      WithViewStoreOf<BasicsView.Feature>.body
-      WithViewStoreOf<BasicsView.Feature?>.body
-      WithViewStoreOf<BasicsView.Feature?>.body
       WithViewStoreOf<BasicsView.Feature?>.body
       """
     }
@@ -188,10 +142,6 @@ final class iOS16_17_NewPresentsOldTests: BaseIntegrationTests {
       StoreOf<BasicsView.Feature>.init
       StoreOf<BasicsView.Feature>.init
       StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.init
-      StoreOf<BasicsView.Feature?>.init
       StoreOf<BasicsView.Feature?>.init
       StoreOf<BasicsView.Feature?>.init
       StoreOf<BasicsView.Feature?>.init
@@ -222,28 +172,17 @@ final class iOS16_17_NewPresentsOldTests: BaseIntegrationTests {
       """
       BasicsView.body
       BasicsView.body
-      BasicsView.body
       NewPresentsOldTestCase.body
       PresentationStoreOf<BasicsView.Feature>.init
       PresentationStoreOf<BasicsView.Feature>.init
       StoreOf<BasicsView.Feature>.deinit
       StoreOf<BasicsView.Feature>.deinit
       StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.init
-      StoreOf<BasicsView.Feature>.init
-      StoreOf<BasicsView.Feature>.init
       StoreOf<BasicsView.Feature>.init
       StoreOf<BasicsView.Feature>.init
       StoreOf<BasicsView.Feature>.init
       StoreOf<BasicsView.Feature?>.deinit
       StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.init
-      StoreOf<BasicsView.Feature?>.init
       StoreOf<BasicsView.Feature?>.init
       StoreOf<BasicsView.Feature?>.init
       StoreOf<BasicsView.Feature?>.init
@@ -253,25 +192,15 @@ final class iOS16_17_NewPresentsOldTests: BaseIntegrationTests {
       ViewStoreOf<BasicsView.Feature>.deinit
       ViewStoreOf<BasicsView.Feature>.deinit
       ViewStoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature>.init
-      ViewStoreOf<BasicsView.Feature>.init
       ViewStoreOf<BasicsView.Feature>.init
       ViewStoreOf<BasicsView.Feature>.init
       ViewStoreOf<BasicsView.Feature>.init
       ViewStoreOf<BasicsView.Feature?>.deinit
       ViewStoreOf<BasicsView.Feature?>.deinit
-      ViewStoreOf<BasicsView.Feature?>.deinit
-      ViewStoreOf<BasicsView.Feature?>.deinit
-      ViewStoreOf<BasicsView.Feature?>.init
-      ViewStoreOf<BasicsView.Feature?>.init
       ViewStoreOf<BasicsView.Feature?>.init
       ViewStoreOf<BasicsView.Feature?>.init
       WithViewStoreOf<BasicsView.Feature>.body
       WithViewStoreOf<BasicsView.Feature>.body
-      WithViewStoreOf<BasicsView.Feature>.body
-      WithViewStoreOf<BasicsView.Feature?>.body
       WithViewStoreOf<BasicsView.Feature?>.body
       """
     }
@@ -285,8 +214,6 @@ final class iOS16_17_NewPresentsOldTests: BaseIntegrationTests {
     self.assertLogs {
       """
       BasicsView.body
-      BasicsView.body
-      BasicsView.body
       NewPresentsOldTestCase.body
       NewPresentsOldTestCase.body
       PresentationStoreOf<BasicsView.Feature>.init
@@ -296,31 +223,11 @@ final class iOS16_17_NewPresentsOldTests: BaseIntegrationTests {
       StoreOf<BasicsView.Feature>.deinit
       StoreOf<BasicsView.Feature>.deinit
       StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.init
-      StoreOf<BasicsView.Feature>.init
-      StoreOf<BasicsView.Feature>.init
-      StoreOf<BasicsView.Feature>.init
-      StoreOf<BasicsView.Feature>.init
-      StoreOf<BasicsView.Feature>.init
       StoreOf<BasicsView.Feature>.init
       StoreOf<BasicsView.Feature>.init
       StoreOf<BasicsView.Feature>.init
       StoreOf<BasicsView.Feature?>.deinit
       StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.init
-      StoreOf<BasicsView.Feature?>.init
-      StoreOf<BasicsView.Feature?>.init
-      StoreOf<BasicsView.Feature?>.init
       StoreOf<BasicsView.Feature?>.init
       StoreOf<BasicsView.Feature?>.init
       StoreOf<BasicsView.Feature?>.init
@@ -331,33 +238,13 @@ final class iOS16_17_NewPresentsOldTests: BaseIntegrationTests {
       ViewPresentationStoreOf<BasicsView.Feature>.init
       ViewStoreOf<BasicsView.Feature>.deinit
       ViewStoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature>.init
-      ViewStoreOf<BasicsView.Feature>.init
-      ViewStoreOf<BasicsView.Feature>.init
-      ViewStoreOf<BasicsView.Feature>.init
       ViewStoreOf<BasicsView.Feature>.init
       ViewStoreOf<BasicsView.Feature>.init
       ViewStoreOf<BasicsView.Feature?>.deinit
       ViewStoreOf<BasicsView.Feature?>.deinit
-      ViewStoreOf<BasicsView.Feature?>.deinit
-      ViewStoreOf<BasicsView.Feature?>.deinit
-      ViewStoreOf<BasicsView.Feature?>.deinit
-      ViewStoreOf<BasicsView.Feature?>.deinit
-      ViewStoreOf<BasicsView.Feature?>.init
-      ViewStoreOf<BasicsView.Feature?>.init
-      ViewStoreOf<BasicsView.Feature?>.init
-      ViewStoreOf<BasicsView.Feature?>.init
       ViewStoreOf<BasicsView.Feature?>.init
       ViewStoreOf<BasicsView.Feature?>.init
       WithViewStoreOf<BasicsView.Feature>.body
-      WithViewStoreOf<BasicsView.Feature>.body
-      WithViewStoreOf<BasicsView.Feature>.body
-      WithViewStoreOf<BasicsView.Feature?>.body
-      WithViewStoreOf<BasicsView.Feature?>.body
       WithViewStoreOf<BasicsView.Feature?>.body
       """
     }
@@ -374,27 +261,8 @@ final class iOS16_17_NewPresentsOldTests: BaseIntegrationTests {
       """
       PresentationStoreOf<BasicsView.Feature>.deinit
       PresentationStoreOf<BasicsView.Feature>.deinit
-      PresentationStoreOf<BasicsView.Feature>.deinit
-      PresentationStoreOf<BasicsView.Feature>.deinit
-      PresentationStoreOf<BasicsView.Feature>.deinit
-      PresentationStoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
-      StoreOf<BasicsView.Feature?>.deinit
       StoreOf<BasicsView.Feature?>.deinit
       ViewPresentationStoreOf<BasicsView.Feature>.deinit
-      ViewPresentationStoreOf<BasicsView.Feature>.deinit
-      ViewPresentationStoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature>.deinit
-      ViewStoreOf<BasicsView.Feature?>.deinit
       """
     }
   }

--- a/Examples/Integration/IntegrationUITests/iOS 16+17/OldContainsNewTests.swift
+++ b/Examples/Integration/IntegrationUITests/iOS 16+17/OldContainsNewTests.swift
@@ -30,18 +30,8 @@ final class iOS16_17_OldContainsNewTests: BaseIntegrationTests {
       """
       ObservableBasicsView.body
       OldContainsNewTestCase.body
-      OldContainsNewTestCase.body
-      Store<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.deinit
-      Store<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.deinit
-      Store<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.init
-      Store<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.init
-      ViewStore<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.deinit
-      ViewStore<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.deinit
       ViewStore<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.deinit
       ViewStore<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.init
-      ViewStore<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.init
-      ViewStore<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.init
-      WithViewStore<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.body
       WithViewStore<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.body
       """
     }
@@ -70,18 +60,8 @@ final class iOS16_17_OldContainsNewTests: BaseIntegrationTests {
       """
       ObservableBasicsView.body
       OldContainsNewTestCase.body
-      OldContainsNewTestCase.body
-      Store<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.deinit
-      Store<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.deinit
-      Store<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.init
-      Store<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.init
-      ViewStore<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.deinit
-      ViewStore<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.deinit
       ViewStore<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.deinit
       ViewStore<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.init
-      ViewStore<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.init
-      ViewStore<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.init
-      WithViewStore<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.body
       WithViewStore<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.body
       """
     }
@@ -94,9 +74,7 @@ final class iOS16_17_OldContainsNewTests: BaseIntegrationTests {
     self.app.buttons["iOS 16 + 17"].tap()
     self.assertLogs {
       """
-      Store<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.deinit
-      Store<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.deinit
-      ViewStore<OldContainsNewTestCase.ViewState, OldContainsNewTestCase.Feature.Action>.deinit
+
       """
     }
   }

--- a/Examples/Integration/IntegrationUITests/iOS 16+17/OldPresentsNewTests.swift
+++ b/Examples/Integration/IntegrationUITests/iOS 16+17/OldPresentsNewTests.swift
@@ -56,8 +56,11 @@ final class iOS16_17_OldPresentsNewTests: BaseIntegrationTests {
     self.assertLogs {
       """
       OldPresentsNewTestCase.body
+      StoreOf<ObservableBasicsView.Feature?>.deinit
+      StoreOf<ObservableBasicsView.Feature?>.deinit
       ViewStore<OldPresentsNewTestCase.ViewState, OldPresentsNewTestCase.Feature.Action>.deinit
       ViewStore<OldPresentsNewTestCase.ViewState, OldPresentsNewTestCase.Feature.Action>.init
+      ViewStoreOf<ObservableBasicsView.Feature?>.deinit
       WithViewStore<OldPresentsNewTestCase.ViewState, OldPresentsNewTestCase.Feature.Action>.body
       """
     }
@@ -128,9 +131,6 @@ final class iOS16_17_OldPresentsNewTests: BaseIntegrationTests {
     self.assertLogs {
       """
       OldPresentsNewTestCase.body
-      StoreOf<ObservableBasicsView.Feature>.deinit
-      StoreOf<ObservableBasicsView.Feature?>.deinit
-      StoreOf<ObservableBasicsView.Feature?>.deinit
       StoreOf<ObservableBasicsView.Feature?>.deinit
       StoreOf<ObservableBasicsView.Feature?>.deinit
       ViewStore<OldPresentsNewTestCase.ViewState, OldPresentsNewTestCase.Feature.Action>.deinit
@@ -151,10 +151,8 @@ final class iOS16_17_OldPresentsNewTests: BaseIntegrationTests {
     self.assertLogs {
       """
       PresentationStoreOf<ObservableBasicsView.Feature>.deinit
-      PresentationStoreOf<ObservableBasicsView.Feature>.deinit
       Store<OldPresentsNewTestCase.ViewState, OldPresentsNewTestCase.Feature.Action>.deinit
       Store<OldPresentsNewTestCase.ViewState, OldPresentsNewTestCase.Feature.Action>.deinit
-      StoreOf<ObservableBasicsView.Feature?>.deinit
       ViewPresentationStoreOf<ObservableBasicsView.Feature>.deinit
       ViewStore<OldPresentsNewTestCase.ViewState, OldPresentsNewTestCase.Feature.Action>.deinit
       """

--- a/Sources/ComposableArchitecture/Observation/ObservableState.swift
+++ b/Sources/ComposableArchitecture/Observation/ObservableState.swift
@@ -52,15 +52,13 @@
 
     @inlinable
     public static func _$id<T>(for value: T) -> Self {
-      (value as? any ObservableState)?._$id ?? ._$inert
+      (value as? any ObservableState)?._$id ?? Self()
     }
 
     @inlinable
     public static func _$id(for value: some ObservableState) -> Self {
       value._$id
     }
-
-    public static var _$inert: Self { Self() }
 
     public func _$tag(_ tag: Int) -> Self {
       Self(storage: Storage(id: .tag(tag, self.storage.id)))

--- a/Sources/ComposableArchitecture/Observation/ObservableState.swift
+++ b/Sources/ComposableArchitecture/Observation/ObservableState.swift
@@ -60,7 +60,7 @@
       value._$id
     }
 
-    public static let _$inert = Self()
+    public static var _$inert: Self { Self() }
 
     public func _$tag(_ tag: Int) -> Self {
       Self(storage: Storage(id: .tag(tag, self.storage.id)))

--- a/Sources/ComposableArchitectureMacros/ObservableStateMacro.swift
+++ b/Sources/ComposableArchitectureMacros/ObservableStateMacro.swift
@@ -311,7 +311,7 @@ enum ObservableStateCase {
       } else {
         return """
           case .\(element.name.text):
-          return ._$inert._$tag(\(tag))
+          return ObservableStateID()._$tag(\(tag))
           """
       }
     case let .ifConfig(configs):

--- a/Tests/ComposableArchitectureMacrosTests/ObservableStateMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ObservableStateMacroTests.swift
@@ -500,7 +500,7 @@
           public var _$id: ComposableArchitecture.ObservableStateID {
             switch self {
             case .foo:
-              return ._$inert._$tag(0)
+              return ObservableStateID()._$tag(0)
             }
           }
 

--- a/Tests/ComposableArchitectureTests/ObservableTests.swift
+++ b/Tests/ComposableArchitectureTests/ObservableTests.swift
@@ -249,16 +249,18 @@
     }
 
     func testMutatingDestination_NonObservableCase() async {
+      let expectation = self.expectation(description: "destination.didChange")
       var state = ParentState(destination: .inert(0))
 
       withPerceptionTracking {
         _ = state.destination
       } onChange: {
-        XCTFail("destination should not change")
+        expectation.fulfill()
       }
 
       state.destination = .inert(1)
       XCTAssertEqual(state.destination, .inert(1))
+      await self.fulfillment(of: [expectation])
     }
 
     func testReplaceWithCopy() async {
@@ -592,7 +594,6 @@
 
       store.send(())
 
-      XCTTODO("Should this eventually be observed by default?")
       self.wait(for: [onChangeExpectation], timeout: 0)
     }
   }


### PR DESCRIPTION
Fixes #2887 and #2899.

Right now we think of non-`@ObservableState` as "inert" in that its ID never changes. Really it should be the opposite. Non-`@ObservableState`'s ID should change every time you ask it for an ID so that it forces the view to always re-render.

We thought we had already made this change, but perhaps it was in one of our experiments that didn't get merged.