### PR TITLE
Test store tutorial/documentation fixes

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
@@ -81,8 +81,8 @@ class CounterTests: XCTestCase {
 > Tip: Test cases that use ``TestStore`` should be annotated as `@MainActor` and test methods should
 be marked as `async` since most assertion helpers on ``TestStore`` can suspend.
 
-Test stores have a ``TestStore/send(_:assert:file:line:)`` method, but it behaves differently from
-stores and view stores. You provide an action to send into the system, but then you must also
+Test stores have a ``TestStore/send(_:assert:file:line:)-2co21`` method, but it behaves differently
+from stores and view stores. You provide an action to send into the system, but then you must also
 provide a trailing closure to describe how the state of the feature changed after sending the
 action:
 
@@ -102,8 +102,8 @@ await store.send(.incrementButtonTapped) {
 }
 ```
 
-> The ``TestStore/send(_:assert:file:line:)`` method is `async` for technical reasons that we do not
-> have to worry about right now.
+> The ``TestStore/send(_:assert:file:line:)-2co21`` method is `async` for technical reasons that we
+> do not have to worry about right now.
 
 If your mutation is incorrect, meaning you perform a mutation that is different from what happened
 in the ``Reducer``, then you will get a test failure with a nicely formatted message showing exactly
@@ -156,7 +156,7 @@ await store.send(.decrementButtonTapped) {
 > by one, but we haven't proven we know the precise value of `count` at each step of the way.
 >
 > In general, the less logic you have in the trailing closure of
-> ``TestStore/send(_:assert:file:line:)``, the stronger your assertion will be. It is best to
+> ``TestStore/send(_:assert:file:line:)-2co21``, the stronger your assertion will be. It is best to
 > use simple, hard-coded data for the mutation.
 
 Test stores do expose a ``TestStore/state`` property, which can be useful for performing assertions
@@ -170,7 +170,7 @@ store.send(.incrementButtonTapped) {
 XCTAssertTrue(store.state.isPrime)
 ```
 
-However, when inside the trailing closure of ``TestStore/send(_:assert:file:line:)``, the
+However, when inside the trailing closure of ``TestStore/send(_:assert:file:line:)-2co21``, the
 ``TestStore/state`` property is equal to the state _before_ sending the action, not after. That
 prevents you from being able to use an escape hatch to get around needing to actually describe the
 state mutation, like so:
@@ -571,7 +571,7 @@ It can be important to understand how non-exhaustive testing works under the hoo
 limit the ways in which you can assert on state changes.
 
 When you construct an _exhaustive_ test store, which is the default, the `$0` used inside the
-trailing closure of ``TestStore/send(_:assert:file:line:)`` represents the state _before_ the 
+trailing closure of ``TestStore/send(_:assert:file:line:)-2co21`` represents the state _before_ the 
 action is sent:
 
 ```swift
@@ -663,10 +663,10 @@ await store.send(.removeButtonTapped) {
 
 Further, when using non-exhaustive test stores that also show skipped assertions (via
 ``Exhaustivity/off(showSkippedAssertions:)``), then there is another caveat to keep in mind. In
-such test stores, the trailing closure of ``TestStore/send(_:assert:file:line:)`` is invoked _twice_
-by the test store. First with `$0` representing the state after the action is sent to see if it does
-not match the true state, and then again with `$0` representing the state before the action is sent
-so that we can show what state assertions were skipped.
+such test stores, the trailing closure of ``TestStore/send(_:assert:file:line:)-2co21`` is invoked
+_twice_ by the test store. First with `$0` representing the state after the action is sent to see if
+it does not match the true state, and then again with `$0` representing the state before the action
+is sent so that we can show what state assertions were skipped.
 
 Because the test store can invoke your trailing assertion closure twice you must be careful if your
 closure performs any side effects, because those effects will be executed twice. For example,

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
@@ -68,8 +68,8 @@ concise. It's called ``TestStore``, and it is constructed similarly to ``Store``
 initial state of the feature and the ``Reducer`` that runs the feature's logic:
 
 ```swift
-@MainActor
 class CounterTests: XCTestCase {
+  @MainActor
   func testBasics() async {
     let store = TestStore(initialState: Feature.State(count: 0)) {
       Feature()
@@ -78,8 +78,8 @@ class CounterTests: XCTestCase {
 }
 ```
 
-> Tip: Test cases that use ``TestStore`` should be annotated as `@MainActor` and test methods should
-be marked as `async` since most assertion helpers on ``TestStore`` can suspend.
+> Tip: Tests that use ``TestStore`` should be annotated as `@MainActor` and marked as `async` since
+> most assertion helpers on ``TestStore`` can suspend.
 
 Test stores have a ``TestStore/send(_:assert:file:line:)-2co21`` method, but it behaves differently
 from stores and view stores. You provide an action to send into the system, but then you must also
@@ -233,8 +233,8 @@ To test this we can start off similar to how we did in the [previous section][Te
 when testing state mutations:
 
 ```swift
-@MainActor
 class TimerTests: XCTestCase {
+  @MainActor
   func testBasics() async {
     let store = TestStore(initialState: Feature.State(count: 0)) {
       Feature()

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStore.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStore.md
@@ -16,7 +16,9 @@
 
 ### Testing a reducer
 
-- ``send(_:assert:file:line:)``
+- ``send(_:assert:file:line:)-2co21``
+- ``send(_:assert:file:line:)-1oopl``
+- ``send(_:_:assert:file:line:)``
 - ``receive(_:timeout:assert:file:line:)-6325h``
 - ``receive(_:_:timeout:assert:file:line:)-dkei``
 - ``receive(_:timeout:assert:file:line:)-5awso``
@@ -33,8 +35,8 @@
 ### Accessing state
 
 While the most common way of interacting with a test store's state is via its
-``send(_:assert:file:line:)`` and ``receive(_:timeout:assert:file:line:)-6325h`` methods, you may
-also access it directly throughout a test.
+``send(_:assert:file:line:)-2co21`` and ``receive(_:timeout:assert:file:line:)-6325h`` methods, you
+may also access it directly throughout a test.
 
 - ``state``
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-01-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-01-code-0003.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 @Reducer
 struct CounterFeature {
   @ObservableState
-  struct State: Equatable {
+  struct State {
     
   }
   

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-01-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-01-code-0004.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 @Reducer
 struct CounterFeature {
   @ObservableState
-  struct State: Equatable {
+  struct State {
     var count = 0
   }
   

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-01-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-01-code-0005.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 @Reducer
 struct CounterFeature {
   @ObservableState
-  struct State: Equatable {
+  struct State {
     var count = 0
   }
   

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-01-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-01-code-0006.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 @Reducer
 struct CounterFeature {
   @ObservableState
-  struct State: Equatable {
+  struct State {
     var count = 0
   }
   

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-01-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-01-code-0003.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 @Reducer
 struct CounterFeature {
   @ObservableState
-  struct State: Equatable {
+  struct State {
     var count = 0
   }
   

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-01-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-01-code-0004.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 @Reducer
 struct CounterFeature {
   @ObservableState
-  struct State: Equatable {
+  struct State {
     var count = 0
     var fact: String?
     var isLoading = false

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-01-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-01-code-0005.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 @Reducer
 struct CounterFeature {
   @ObservableState
-  struct State: Equatable {
+  struct State {
     var count = 0
     var fact: String?
     var isLoading = false

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0001.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 @Reducer
 struct CounterFeature {
   @ObservableState
-  struct State: Equatable {
+  struct State {
     var count = 0
     var fact: String?
     var isLoading = false

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0002.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 @Reducer
 struct CounterFeature {
   @ObservableState
-  struct State: Equatable {
+  struct State {
     var count = 0
     var fact: String?
     var isLoading = false

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0003.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 @Reducer
 struct CounterFeature {
   @ObservableState
-  struct State: Equatable {
+  struct State {
     var count = 0
     var fact: String?
     var isLoading = false

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0004.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 @Reducer
 struct CounterFeature {
   @ObservableState
-  struct State: Equatable {
+  struct State {
     var count = 0
     var fact: String?
     var isLoading = false

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0005.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 @Reducer
 struct CounterFeature {
   @ObservableState
-  struct State: Equatable {
+  struct State {
     var count = 0
     var fact: String?
     var isLoading = false

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0002.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 @Reducer
 struct CounterFeature {
   @ObservableState
-  struct State: Equatable {
+  struct State {
     var count = 0
     var fact: String?
     var isLoading = false

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0003.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 @Reducer
 struct CounterFeature {
   @ObservableState
-  struct State: Equatable {
+  struct State {
     var count = 0
     var fact: String?
     var isLoading = false

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0004.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 @Reducer
 struct CounterFeature {
   @ObservableState
-  struct State: Equatable {
+  struct State {
     var count = 0
     var fact: String?
     var isLoading = false

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0006.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 @Reducer
 struct CounterFeature {
   @ObservableState
-  struct State: Equatable {
+  struct State {
     var count = 0
     var fact: String?
     var isLoading = false

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-01-code-0003-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-01-code-0003-previous.swift
@@ -9,7 +9,7 @@ struct CounterFeature {
     var isLoading = false
     var isTimerRunning = false
   }
-  
+
   enum Action {
     case decrementButtonTapped
     case factButtonTapped
@@ -18,9 +18,9 @@ struct CounterFeature {
     case timerTick
     case toggleTimerButtonTapped
   }
-  
+
   enum CancelID { case timer }
-  
+
   var body: some ReducerOf<Self> {
     Reduce { state, action in
       switch action {
@@ -28,7 +28,7 @@ struct CounterFeature {
         state.count -= 1
         state.fact = nil
         return .none
-        
+
       case .factButtonTapped:
         state.fact = nil
         state.isLoading = true
@@ -38,22 +38,22 @@ struct CounterFeature {
           let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }
-        
+
       case let .factResponse(fact):
         state.fact = fact
         state.isLoading = false
         return .none
-        
+
       case .incrementButtonTapped:
         state.count += 1
         state.fact = nil
         return .none
-        
+
       case .timerTick:
         state.count += 1
         state.fact = nil
         return .none
-        
+
       case .toggleTimerButtonTapped:
         state.isTimerRunning.toggle()
         if state.isTimerRunning {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-01-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-01-code-0003.swift
@@ -1,14 +1,73 @@
 import ComposableArchitecture
-import XCTest
 
-@MainActor
-final class CounterFeatureTests: XCTestCase {
-  func testCounter() async {
-    let store = TestStore(initialState: CounterFeature.State()) {
-      CounterFeature()
+@Reducer
+struct CounterFeature {
+  @ObservableState
+  struct State: Equatable {
+    var count = 0
+    var fact: String?
+    var isLoading = false
+    var isTimerRunning = false
+  }
+
+  enum Action {
+    case decrementButtonTapped
+    case factButtonTapped
+    case factResponse(String)
+    case incrementButtonTapped
+    case timerTick
+    case toggleTimerButtonTapped
+  }
+
+  enum CancelID { case timer }
+
+  var body: some ReducerOf<Self> {
+    Reduce { state, action in
+      switch action {
+      case .decrementButtonTapped:
+        state.count -= 1
+        state.fact = nil
+        return .none
+
+      case .factButtonTapped:
+        state.fact = nil
+        state.isLoading = true
+        return .run { [count = state.count] send in
+          let (data, _) = try await URLSession.shared
+            .data(from: URL(string: "http://numbersapi.com/\(count)")!)
+          let fact = String(decoding: data, as: UTF8.self)
+          await send(.factResponse(fact))
+        }
+
+      case let .factResponse(fact):
+        state.fact = fact
+        state.isLoading = false
+        return .none
+
+      case .incrementButtonTapped:
+        state.count += 1
+        state.fact = nil
+        return .none
+
+      case .timerTick:
+        state.count += 1
+        state.fact = nil
+        return .none
+
+      case .toggleTimerButtonTapped:
+        state.isTimerRunning.toggle()
+        if state.isTimerRunning {
+          return .run { send in
+            while true {
+              try await Task.sleep(for: .seconds(1))
+              await send(.timerTick)
+            }
+          }
+          .cancellable(id: CancelID.timer)
+        } else {
+          return .cancel(id: CancelID.timer)
+        }
+      }
     }
-    
-    await store.send(.incrementButtonTapped)
-    await store.send(.decrementButtonTapped)
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-01-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-01-code-0005.swift
@@ -8,11 +8,29 @@ final class CounterFeatureTests: XCTestCase {
       CounterFeature()
     }
     
-    await store.send(.incrementButtonTapped) {
-      $0.count = 1
-    }
-    await store.send(.decrementButtonTapped) {
-      $0.count = 0
-    }
+    await store.send(.incrementButtonTapped)
+    // ❌ State was not expected to change, but a change occurred: …
+    //
+    //       CounterFeature.State(
+    //     −   count: 0,
+    //     +   count: 1,
+    //         fact: nil,
+    //         isLoading: false,
+    //         isTimerRunning: false
+    //       )
+    //
+    // (Expected: −, Actual: +)
+    await store.send(.decrementButtonTapped)
+    // ❌ State was not expected to change, but a change occurred: …
+    //
+    //       CounterFeature.State(
+    //     −   count: 1,
+    //     +   count: 0,
+    //         fact: nil,
+    //         isLoading: false,
+    //         isTimerRunning: false
+    //       )
+    //
+    // (Expected: −, Actual: +)
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-01-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-01-code-0006.swift
@@ -8,7 +8,11 @@ final class CounterFeatureTests: XCTestCase {
       CounterFeature()
     }
     
-    await store.send(.incrementButtonTapped)
-    await store.send(.decrementButtonTapped)
+    await store.send(.incrementButtonTapped) {
+      $0.count = 1
+    }
+    await store.send(.decrementButtonTapped) {
+      $0.count = 0
+    }
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-TestingYourFeature.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-TestingYourFeature.tutorial
@@ -44,15 +44,22 @@
       }
       
       @Step {
+        ``ComposableArchitecture/TestStore`` requires equatable state in order to make its
+        assertions, so we must add a conformance.
+        
+        @Code(name: "CounterFeature.swift", file: 01-03-01-code-0003.swift, previousFile: 01-03-01-code-0003-previous.swift)
+      }
+      
+      @Step {
         Then we can start sending actions into the store in order to emulate something the user is
         doing. For example, we can emulate tapping the increment button and then the decrement 
         button.
         
-        > Note: The ``ComposableArchitecture/TestStore/send(_:assert:file:line:)`` method on
+        > Note: The ``ComposableArchitecture/TestStore/send(_:assert:file:line:)-2co21`` method on
         the test store is async because most features involve asynchronous side effects, and the
         test store using the async context to track those effects.
         
-        @Code(name: "CounterFeatureTests.swift", file: 01-03-01-code-0003.swift)
+        @Code(name: "CounterFeatureTests.swift", file: 01-03-01-code-0004.swift, previousFile: file: 01-03-01-code-0002.swift)
       }
       
       @Step {
@@ -63,7 +70,7 @@
         failure message showing you exactly how state differed from what you expected (the lines
         with the minus "-") and the actual value (the lines with the plus "+").
         
-        @Code(name: "CounterFeatureTests.swift", file: 01-03-01-code-0004.swift)
+        @Code(name: "CounterFeatureTests.swift", file: 01-03-01-code-0005.swift)
       }
       
       @Step {
@@ -78,7 +85,7 @@
         know the exact state your feature is in rather than merely what transformation was applied
         to your state.
         
-        @Code(name: "CounterFeatureTests.swift", file: 01-03-01-code-0005.swift)
+        @Code(name: "CounterFeatureTests.swift", file: 01-03-01-code-0006.swift)
       }
       
       Now the test passes and so proves that the incrementing and decrementing logic does work

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -261,11 +261,11 @@ import XCTestDynamicOverlay
 /// complete before the test is finished. To turn off exhaustivity you can set ``exhaustivity``
 /// to ``Exhaustivity/off``. When that is done the ``TestStore``'s behavior changes:
 ///
-///   * The trailing closures of ``send(_:assert:file:line:)`` and
+///   * The trailing closures of ``send(_:assert:file:line:)-2co21`` and
 ///     ``receive(_:timeout:assert:file:line:)-6325h`` no longer need to assert on all state
 ///     changes. They can assert on any subset of changes, and only if they make an incorrect
 ///     mutation will a test failure be reported.
-///   * The ``send(_:assert:file:line:)`` and ``receive(_:timeout:assert:file:line:)-6325h``
+///   * The ``send(_:assert:file:line:)-2co21`` and ``receive(_:timeout:assert:file:line:)-6325h``
 ///     methods are allowed to be called even when actions have been received from effects that have
 ///     not been asserted on yet. Any pending actions will be cleared.
 ///   * Tests are allowed to finish with unasserted, received actions and in-flight effects. No test
@@ -474,7 +474,7 @@ public final class TestStore<State, Action> {
 
   /// The current state of the test store.
   ///
-  /// When read from a trailing closure assertion in ``send(_:assert:file:line:)`` or
+  /// When read from a trailing closure assertion in ``send(_:assert:file:line:)-2co21`` or
   /// ``receive(_:timeout:assert:file:line:)-6325h``, it will equal the `inout` state passed to the
   /// closure.
   public var state: State {


### PR DESCRIPTION
This fixes some old DocC references to the proper overload and as suggested in #2808 defers the introduction of equatable state to the testing section of the tutorial.