### PR TITLE
Swift bug workaround for `TestStore` completion

### DIFF
--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -499,13 +499,17 @@ public final class TestStore<State, Action> {
   ///
   /// - Parameters:
   ///   - initialState: The state the feature starts in.
-  ///   - reducer: The reducer that powers the runtime of the feature.
+  ///   - reducer: The reducer that powers the runtime of the feature. Unlike
+  ///     ``Store/init(initialState:reducer:withDependencies:)``, this is _not_ a builder closure
+  ///     due to a [Swift bug](https://github.com/apple/swift/issues/72399) that is more likely to
+  ///     affect test store initialization. If you must compose multiple reducers in this closure,
+  ///     wrap them in ``CombineReducers``.
   ///   - prepareDependencies: A closure that can be used to override dependencies that will be
   ///     accessed during the test. These dependencies will be used when producing the initial
   ///     state.
   public init<R: Reducer>(
-    initialState: @autoclosure () -> R.State,
-    @ReducerBuilder<State, Action> reducer: () -> R,
+    initialState: @autoclosure () -> State,
+    reducer: () -> R,
     withDependencies prepareDependencies: (inout DependencyValues) -> Void = { _ in
     },
     file: StaticString = #file,

--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -45,10 +45,12 @@
         let clock = TestClock()
 
         let store = TestStore(initialState: 0) {
-          Feature_testCombine_EffectsAreMerged(
-            delay: .seconds(1), setValue: { @MainActor in fastValue = 42 })
-          Feature_testCombine_EffectsAreMerged(
-            delay: .seconds(2), setValue: { @MainActor in slowValue = 1729 })
+          CombineReducers {
+            Feature_testCombine_EffectsAreMerged(
+              delay: .seconds(1), setValue: { @MainActor in fastValue = 42 })
+            Feature_testCombine_EffectsAreMerged(
+              delay: .seconds(2), setValue: { @MainActor in slowValue = 1729 })
+          }
         } withDependencies: {
           $0.continuousClock = clock
         }
@@ -90,8 +92,10 @@
       var second = false
 
       let store = TestStore(initialState: 0) {
-        Feature_testCombine(effect: { @MainActor in first = true })
-        Feature_testCombine(effect: { @MainActor in second = true })
+        CombineReducers {
+          Feature_testCombine(effect: { @MainActor in first = true })
+          Feature_testCombine(effect: { @MainActor in second = true })
+        }
       }
 
       await store


### PR DESCRIPTION
Due to a Swift bug, stores and test stores initialized with type inference are broken when it comes to autocomplete:

https://github.com/apple/swift/issues/72399

For example, this test store cannot be completed from:

```swift
let store = TestStore(initialState: Feature.State()) {
  Feature()
}
```

While this can affect regular stores, as well, it is less likely outside of root stores, since stores are typically declared in views and view controllers as properties, and inference isn't required:

```swift
let store: StoreOf<Feature>
```

While the user can employ a workaround in their project by making the types very explicit:

```diff
-let store = TestStore(initialState: Feature.State()) {
+let store: TestStoreOf<Feature> = TestStore(initialState: Feature.State()) {
   Feature()
 }
```

This PR takes the approach of removing the builder context from `TestStore.init`, since the issue is more common in tests, and because composing a reducer for a test store is less common.