### PR TITLE
Added Privacy Manifest file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,6 +42,9 @@ let package = Package(
         .product(name: "OrderedCollections", package: "swift-collections"),
         .product(name: "SwiftUINavigationCore", package: "swiftui-navigation"),
         .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+      ],
+      resources: [
+        .process("PrivacyInfo.xcprivacy")
       ]
     ),
     .testTarget(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -49,6 +49,9 @@ let package = Package(
         .product(name: "Perception", package: "swift-perception"),
         .product(name: "SwiftUINavigationCore", package: "swiftui-navigation"),
         .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+      ],
+      resources: [
+        .process("PrivacyInfo.xcprivacy")
       ]
     ),
     .testTarget(

--- a/Sources/ComposableArchitecture/PrivacyInfo.xcprivacy
+++ b/Sources/ComposableArchitecture/PrivacyInfo.xcprivacy
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C56D.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>


### PR DESCRIPTION
## Discussion
### "Blank"ish Privacy manifests
Food for thought: GRDB recently, added a Privacy manifest file which is explicitly shows no tracking. That PR is [here](https://github.com/groue/GRDB.swift/commit/1920482158af699c6b3a55860b7697f91a318bf8). This may seem pointless, but I suspect it will be best practice going forward. By explicitly saying that our library does not track the user, we reduce the surface area that devs need to search for compliance. 

### User Defaults
Thankfully it looks like Apple added a privacy reason which perfectly matches our use case: 
- `C56D.1`: https://arc.net/l/quote/aqxlpvkx
> Declare this reason if your third-party SDK is providing a wrapper function around user defaults API(s) for the app to use, and you only access the user defaults APIs when the app calls your wrapper function.

My guess is that this reason will cover the privacy compliance of TCA, but if the app dev uses `.appStorage` for example, they will still be responsible for declaring if their reason is legitimate. 