### PR TITLE
Add package access modifier support to @Reducer on enums

### DIFF
--- a/Sources/ComposableArchitectureMacros/ReducerMacro.swift
+++ b/Sources/ComposableArchitectureMacros/ReducerMacro.swift
@@ -190,7 +190,9 @@ extension ReducerMacro: MemberMacro {
     providingMembersOf declaration: D,
     in context: C
   ) throws -> [DeclSyntax] {
-    let access = declaration.modifiers.first { $0.name.tokenKind == .keyword(.public) }
+    let access = declaration.modifiers.first {
+      [.keyword(.public), .keyword(.package)].contains($0.name.tokenKind)
+    }
     let typeNames = declaration.memberBlock.members.compactMap {
       $0.decl.as(StructDeclSyntax.self)?.name.text
         ?? $0.decl.as(TypeAliasDeclSyntax.self)?.name.text

--- a/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
@@ -387,6 +387,106 @@
       }
     }
 
+    func testEnum_Empty_AccessControl_Package() {
+        assertMacro {
+          """
+          @Reducer
+          package enum Destination {
+          }
+          """
+        } expansion: {
+          """
+          package enum Destination {
+
+              @CasePathable
+              @dynamicMemberLookup
+              @ObservableState
+
+              package enum State: ComposableArchitecture.CaseReducerState {
+
+                  package typealias StateReducer = Destination
+
+              }
+
+              @CasePathable
+
+              package enum Action {
+
+              }
+
+              @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
+
+              package static var body: ComposableArchitecture.EmptyReducer<Self.State, Self.Action> {
+                  ComposableArchitecture.EmptyReducer<Self.State, Self.Action>()
+              }
+
+              package enum CaseScope {
+
+              }
+
+              package static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
+                  switch store.state {
+
+                  }
+              }
+          }
+
+          extension Destination: ComposableArchitecture.CaseReducer, ComposableArchitecture.Reducer {
+          }
+          """
+        }
+    }
+
+    func testEnum_Empty_AccessControl_Public() {
+      assertMacro {
+        """
+        @Reducer
+        public enum Destination {
+        }
+        """
+      } expansion: {
+        """
+        public enum Destination {
+
+            @CasePathable
+            @dynamicMemberLookup
+            @ObservableState
+
+            public enum State: ComposableArchitecture.CaseReducerState {
+
+                public typealias StateReducer = Destination
+
+            }
+
+            @CasePathable
+
+            public enum Action {
+
+            }
+
+            @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
+
+            public static var body: ComposableArchitecture.EmptyReducer<Self.State, Self.Action> {
+                ComposableArchitecture.EmptyReducer<Self.State, Self.Action>()
+            }
+
+            public enum CaseScope {
+
+            }
+
+            public static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
+                switch store.state {
+
+                }
+            }
+        }
+
+        extension Destination: ComposableArchitecture.CaseReducer, ComposableArchitecture.Reducer {
+        }
+        """
+      }
+    }
+
     func testEnum_OneAlertCase() {
       assertMacro {
         """


### PR DESCRIPTION
Addresses https://github.com/pointfreeco/swift-composable-architecture/discussions/2936

I'm not sure why the access modifier inserts a leading line break but that seems to have been the case already for `public` so I've left it as is.

Shout if anything needs tweaking!