### PR TITLE
Remove force unwrap!

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -683,7 +683,20 @@ private enum PartialToState<State> {
   func appending<ChildState>(_ state: PartialToState<ChildState>) -> PartialToState<ChildState> {
     switch (self, state) {
     case let (.keyPath(lhs), .keyPath(rhs)):
+      #if DEBUG
+      guard let appended = lhs.appending(path: rhs) else {
+        fatalError("""
+          ℹ️ Key path has failed to append. This can occur if the \
+          root or value types have been replaced. If you are using \
+          InjectionIII.app v4.8.4+, you can create an environment \
+          variable INJECTION_KEYPATHS in your scheme to avoid this \
+          problem.
+          """)
+      }
+      return .keyPath(appended)
+      #else
       return .keyPath(lhs.appending(path: rhs)!)
+      #endif
     case let (.closure(lhs), .keyPath(rhs)):
       return .appended(lhs, rhs)
     case let (.appended(lhsClosure, lhsKeyPath), .keyPath(rhs)):

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -687,10 +687,7 @@ private enum PartialToState<State> {
       guard let appended = lhs.appending(path: rhs) else {
         fatalError("""
           ℹ️ Key path has failed to append. This can occur if the \
-          root or value types have been replaced. If you are using \
-          InjectionIII.app v4.8.4+, you can create an environment \
-          variable INJECTION_KEYPATHS in your scheme to avoid this \
-          problem.
+          root or value types have been replaced.
           """)
       }
       return .keyPath(appended)


### PR DESCRIPTION
Hi,

I was wondering if you'd be prepared to replace a force unwrap that has been problematic for [InjectionIII](https://github.com/johnno1962/InjectionIII) users with an explanatory message suggesting they could set an environment variable during development to avoid the problem. This arose out of [this GitHub issue](https://github.com/krzysztofzablocki/Inject/issues/87#issuecomment-2015514768) where injection and key paths were not happy bed fellows. 

Perhaps you don't want to clutter your code with something so specific to InjectionIII but it would seem better than a force unwrap failure my users are encountering!

Cheers,

John