### PR TITLE
Enum reducers: generate `Never` actions for non-features

### DIFF
--- a/Sources/ComposableArchitectureMacros/ReducerMacro.swift
+++ b/Sources/ComposableArchitectureMacros/ReducerMacro.swift
@@ -245,9 +245,7 @@ extension ReducerMacro: MemberMacro {
 
       for enumCaseElement in enumCaseElements {
         stateCaseDecls.append(enumCaseElement.stateCaseDecl)
-        if let actionCaseDecl = enumCaseElement.actionCaseDecl {
-          actionCaseDecls.append(actionCaseDecl)
-        }
+        actionCaseDecls.append(enumCaseElement.actionCaseDecl)
         if let reducerScope = enumCaseElement.reducerScope {
           reducerScopes.append(reducerScope)
         }
@@ -486,7 +484,7 @@ private enum ReducerCase {
     }
   }
 
-  var actionCaseDecl: String? {
+  var actionCaseDecl: String {
     switch self {
     case let .element(element, attribute):
       if attribute != .ignored,
@@ -497,14 +495,14 @@ private enum ReducerCase {
       {
         return "case \(element.suffixed("Action").trimmedDescription)"
       } else {
-        return nil
+        return "case \(element.name)(Swift.Never)"
       }
 
     case let .ifConfig(configs):
       return
         configs
         .map {
-          let actionCaseDecls = $0.cases.compactMap(\.actionCaseDecl)
+          let actionCaseDecls = $0.cases.map(\.actionCaseDecl)
           return """
             \($0.poundKeyword.text) \($0.condition?.trimmedDescription ?? "")
             \(actionCaseDecls.joined(separator: "\n"))

--- a/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
@@ -527,6 +527,7 @@
           @CasePathable
           enum Action {
             case timeline(Timeline.Action)
+            case meeting(Swift.Never)
           }
 
           @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
@@ -591,6 +592,7 @@
           enum Action {
             case alert(AlertState<Alert> .Action)
             case dialog(ConfirmationDialogState<Dialog> .Action)
+            case meeting(Swift.Never)
           }
 
           @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
@@ -1025,6 +1027,7 @@
             case phone(PhoneFeature.Action)
             #else
             case other(OtherFeature.Action)
+            case another(Swift.Never)
             #endif
 
             #if DEBUG


### PR DESCRIPTION
This adjusts the `@Reducer` macro to expand extra `case feature(Never)` for actions that aren't TCA features.

This allows folks to scope down to stores of non-features for sheets, etc.:

```swift
.sheet(
  item: $store.scope(state: \.meeting, action: \.meeting)
) { meetingStore in
  // Must use 'Store.withState' here for non-observed feature.
  MeetingView(meeting: meetingStore.withState(\.meeting))
}
```