### PR TITLE
Alert with binding

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -40,11 +40,20 @@ struct RootView: View {
           }
           NavigationLink("Alerts and Confirmation Dialogs") {
             Demo(
-              store: Store(initialState: AlertAndConfirmationDialog.State()) {
-                AlertAndConfirmationDialog()
+              store: Store(initialState: AlertsAndConfirmationDialogs.State()) {
+                AlertsAndConfirmationDialogs()
               }
             ) { store in
-              AlertAndConfirmationDialogView(store: store)
+              AlertsAndConfirmationDialogsView(store: store)
+            }
+          }
+          NavigationLink("Alert and Confirmation Dialog State") {
+            Demo(
+              store: Store(initialState: AlertAndConfirmationDialogState.State()) {
+                AlertAndConfirmationDialogState()
+              }
+            ) { store in
+              AlertAndConfirmationDialogStateView(store: store)
             }
           }
           NavigationLink("Focus State") {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertAndConfirmationDialogState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertAndConfirmationDialogState.swift
@@ -1,0 +1,130 @@
+import ComposableArchitecture
+import SwiftUI
+
+private let readMe = """
+  This demonstrates handling alerts and confirmation dialogs in the Composable Architecture using \
+  the `AlertState` and `ConfirmationDialogState` types.
+
+  These are both data descriptions of the state and actions of an alert or dialog. These types \
+  can be constructed in reducers to control whether or not an alert or confirmation dialog is \
+  displayed, and corresponding view modifiers, `alert(_:)` and `confirmationDialog(_:)`, can be \
+  handed bindings to a store focused on an alert or dialog domain so that the alert or dialog can \
+  be displayed in the view.
+
+  The benefit of using these types is that you can get full test coverage on how a user interacts \
+  with alerts and dialogs in your application.
+  """
+
+@Reducer
+struct AlertAndConfirmationDialogState {
+  @ObservableState
+  struct State: Equatable {
+    @Presents var alert: AlertState<Action.Alert>?
+    @Presents var confirmationDialog: ConfirmationDialogState<Action.ConfirmationDialog>?
+    var count = 0
+  }
+
+  enum Action {
+    case alert(PresentationAction<Alert>)
+    case alertButtonTapped
+    case confirmationDialog(PresentationAction<ConfirmationDialog>)
+    case confirmationDialogButtonTapped
+
+    @CasePathable
+    enum Alert {
+      case incrementButtonTapped
+    }
+    @CasePathable
+    enum ConfirmationDialog {
+      case incrementButtonTapped
+      case decrementButtonTapped
+    }
+  }
+
+  var body: some Reducer<State, Action> {
+    Reduce { state, action in
+      switch action {
+      case .alert(.presented(.incrementButtonTapped)),
+        .confirmationDialog(.presented(.incrementButtonTapped)):
+        state.alert = AlertState { TextState("Incremented!") }
+        state.count += 1
+        return .none
+
+      case .alert:
+        return .none
+
+      case .alertButtonTapped:
+        state.alert = AlertState {
+          TextState("Alert!")
+        } actions: {
+          ButtonState(role: .cancel) {
+            TextState("Cancel")
+          }
+          ButtonState(action: .incrementButtonTapped) {
+            TextState("Increment")
+          }
+        } message: {
+          TextState("This is an alert")
+        }
+        return .none
+
+      case .confirmationDialog(.presented(.decrementButtonTapped)):
+        state.alert = AlertState { TextState("Decremented!") }
+        state.count -= 1
+        return .none
+
+      case .confirmationDialog:
+        return .none
+
+      case .confirmationDialogButtonTapped:
+        state.confirmationDialog = ConfirmationDialogState {
+          TextState("Confirmation dialog")
+        } actions: {
+          ButtonState(role: .cancel) {
+            TextState("Cancel")
+          }
+          ButtonState(action: .incrementButtonTapped) {
+            TextState("Increment")
+          }
+          ButtonState(action: .decrementButtonTapped) {
+            TextState("Decrement")
+          }
+        } message: {
+          TextState("This is a confirmation dialog.")
+        }
+        return .none
+      }
+    }
+    .ifLet(\.$alert, action: \.alert)
+    .ifLet(\.$confirmationDialog, action: \.confirmationDialog)
+  }
+}
+
+struct AlertAndConfirmationDialogStateView: View {
+  @Bindable var store: StoreOf<AlertAndConfirmationDialogState>
+
+  var body: some View {
+    Form {
+      Section {
+        AboutView(readMe: readMe)
+      }
+
+      Text("Count: \(store.count)")
+      Button("Alert") { store.send(.alertButtonTapped) }
+      Button("Confirmation Dialog") { store.send(.confirmationDialogButtonTapped) }
+    }
+    .navigationTitle("Alerts & Dialogs")
+    .alert($store.scope(state: \.alert, action: \.alert))
+    .confirmationDialog($store.scope(state: \.confirmationDialog, action: \.confirmationDialog))
+  }
+}
+
+#Preview {
+  NavigationStack {
+    AlertAndConfirmationDialogStateView(
+      store: Store(initialState: AlertAndConfirmationDialogState.State()) {
+        AlertAndConfirmationDialogState()
+      }
+    )
+  }
+}

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -2,129 +2,165 @@ import ComposableArchitecture
 import SwiftUI
 
 private let readMe = """
-  This demonstrates how to best handle alerts and confirmation dialogs in the Composable \
-  Architecture.
+  This demonstrates handling alerts and confirmation dialogs in the Composable Architecture using \
+  bindable state objects.
 
-  The library comes with two types, `AlertState` and `ConfirmationDialogState`, which are data \
-  descriptions of the state and actions of an alert or dialog. These types can be constructed in \
-  reducers to control whether or not an alert or confirmation dialog is displayed, and \
-  corresponding view modifiers, `alert(_:)` and `confirmationDialog(_:)`, can be handed bindings \
-  to a store focused on an alert or dialog domain so that the alert or dialog can be displayed in \
-  the view.
+  The library comes with `View.alert` overrides which allow optional state values to be bound, and \
+  alert or confirmation dialogs will be displayed in the view when set to a non-`nil` value.
 
   The benefit of using these types is that you can get full test coverage on how a user interacts \
   with alerts and dialogs in your application
   """
 
 @Reducer
-struct AlertAndConfirmationDialog {
+struct AlertsAndConfirmationDialogs {
+  @Reducer
+  struct Increment {
+    @ObservableState
+    struct State: Equatable {
+      
+    }
+    enum Action {
+      case cancelButtonTapped
+      case incrementButtonTapped
+    }
+  }
+  
+  @Reducer
+  struct IncrementOrDecrement {
+    enum Action {
+      case cancelButtonTapped
+      case decrementButtonTapped
+      case incrementButtonTapped
+    }
+  }
+  
+  @Reducer
+  struct Notice {
+    @ObservableState
+    struct State: Equatable {
+      let title: LocalizedStringKey
+    }
+    
+    enum Action {
+      case okButtonTapped
+    }
+  }
+  
+  @Reducer(state: .equatable)
+  enum Destination {
+    case increment(Increment)
+    case incrementOrDecrement(IncrementOrDecrement)
+    case notice(Notice)
+  }
+  
   @ObservableState
   struct State: Equatable {
-    @Presents var alert: AlertState<Action.Alert>?
-    @Presents var confirmationDialog: ConfirmationDialogState<Action.ConfirmationDialog>?
+    @Presents var destination: Destination.State?
     var count = 0
   }
 
   enum Action {
-    case alert(PresentationAction<Alert>)
     case alertButtonTapped
-    case confirmationDialog(PresentationAction<ConfirmationDialog>)
     case confirmationDialogButtonTapped
-
-    @CasePathable
-    enum Alert {
-      case incrementButtonTapped
-    }
-    @CasePathable
-    enum ConfirmationDialog {
-      case incrementButtonTapped
-      case decrementButtonTapped
-    }
+    case destination(PresentationAction<Destination.Action>)
   }
 
   var body: some Reducer<State, Action> {
     Reduce { state, action in
       switch action {
-      case .alert(.presented(.incrementButtonTapped)),
-        .confirmationDialog(.presented(.incrementButtonTapped)):
-        state.alert = AlertState { TextState("Incremented!") }
+      case .alertButtonTapped:
+        state.destination = .increment(Increment.State())
+        return .none
+        
+      case .destination(.presented(.increment(.incrementButtonTapped))),
+          .destination(.presented(.incrementOrDecrement(.incrementButtonTapped))):
+        state.destination = .notice(Notice.State(title: "Incremented!"))
         state.count += 1
         return .none
 
-      case .alert:
-        return .none
-
-      case .alertButtonTapped:
-        state.alert = AlertState {
-          TextState("Alert!")
-        } actions: {
-          ButtonState(role: .cancel) {
-            TextState("Cancel")
-          }
-          ButtonState(action: .incrementButtonTapped) {
-            TextState("Increment")
-          }
-        } message: {
-          TextState("This is an alert")
-        }
-        return .none
-
-      case .confirmationDialog(.presented(.decrementButtonTapped)):
-        state.alert = AlertState { TextState("Decremented!") }
+      case .destination(.presented(.incrementOrDecrement(.decrementButtonTapped))):
+        state.destination = .notice(Notice.State(title: "Decremented!"))
         state.count -= 1
         return .none
-
-      case .confirmationDialog:
+      
+      case .destination(.presented(.notice(.okButtonTapped))):
+        state.destination = nil
+        return .none
+        
+      case .destination:
         return .none
 
       case .confirmationDialogButtonTapped:
-        state.confirmationDialog = ConfirmationDialogState {
-          TextState("Confirmation dialog")
-        } actions: {
-          ButtonState(role: .cancel) {
-            TextState("Cancel")
-          }
-          ButtonState(action: .incrementButtonTapped) {
-            TextState("Increment")
-          }
-          ButtonState(action: .decrementButtonTapped) {
-            TextState("Decrement")
-          }
-        } message: {
-          TextState("This is a confirmation dialog.")
-        }
+        state.destination = .incrementOrDecrement(IncrementOrDecrement.State())
         return .none
       }
     }
-    .ifLet(\.$alert, action: \.alert)
-    .ifLet(\.$confirmationDialog, action: \.confirmationDialog)
+    .ifLet(\.$destination, action: \.destination) {
+      Destination.body
+    }
   }
 }
 
-struct AlertAndConfirmationDialogView: View {
-  @Bindable var store: StoreOf<AlertAndConfirmationDialog>
-
+struct AlertsAndConfirmationDialogsView: View {
+  @Bindable var store: StoreOf<AlertsAndConfirmationDialogs>
+  
   var body: some View {
     Form {
       Section {
         AboutView(readMe: readMe)
       }
-
+      
       Text("Count: \(store.count)")
       Button("Alert") { store.send(.alertButtonTapped) }
       Button("Confirmation Dialog") { store.send(.confirmationDialogButtonTapped) }
     }
     .navigationTitle("Alerts & Dialogs")
-    .alert($store.scope(state: \.alert, action: \.alert))
-    .confirmationDialog($store.scope(state: \.confirmationDialog, action: \.confirmationDialog))
+    // Notices
+    .alert(item: $store.scope(state: \.destination?.notice, action: \.destination.notice)) { store in
+      Text(store.title)
+    } actions: { store in
+      Button("OK") {
+        store.send(.okButtonTapped)
+      }
+    }
+    // Increment Alert
+    .alert("Alert", item: $store.scope(state: \.destination?.increment, action: \.destination.increment)) { store in
+      Button("Cancel", role: .cancel) {
+        store.send(.cancelButtonTapped)
+      }
+      Button("Increment") {
+        store.send(.incrementButtonTapped)
+      }
+    } message: { _ in
+      Text("This is an alert.")
+    }
+    // Increment & Decrement Confirmation Dialog
+    .confirmationDialog(
+      "Confirmation dialog",
+      item: $store.scope(state: \.destination?.incrementOrDecrement, action: \.destination.incrementOrDecrement),
+      titleVisibility: .visible
+    ) { store in
+      Button("Cancel", role: .cancel) {
+        store.send(.cancelButtonTapped)
+      }
+      Button("Increment") {
+        store.send(.incrementButtonTapped)
+      }
+      Button("Decrement") {
+        store.send(.decrementButtonTapped)
+      }
+    } message: { _ in
+      Text("This is a confirmation dialog.")
+    }
   }
 }
 
 #Preview {
   NavigationStack {
-    AlertAndConfirmationDialogView(
-      store: Store(initialState: AlertAndConfirmationDialog.State()) {
-        AlertAndConfirmationDialog()
+    AlertsAndConfirmationDialogsView(
+      store: Store(initialState: AlertsAndConfirmationDialogs.State()) {
+        AlertsAndConfirmationDialogs()
       }
     )
   }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertAndConfirmationDialogStateTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertAndConfirmationDialogStateTests.swift
@@ -1,0 +1,65 @@
+import ComposableArchitecture
+import XCTest
+
+@testable import SwiftUICaseStudies
+
+final class AlertAndConfirmationDialogStateTests: XCTestCase {
+  @MainActor
+  func testAlert() async {
+    let store = TestStore(initialState: AlertAndConfirmationDialogState.State()) {
+      AlertAndConfirmationDialogState()
+    }
+
+    await store.send(.alertButtonTapped) {
+      $0.alert = AlertState {
+        TextState("Alert!")
+      } actions: {
+        ButtonState(role: .cancel) {
+          TextState("Cancel")
+        }
+        ButtonState(action: .incrementButtonTapped) {
+          TextState("Increment")
+        }
+      } message: {
+        TextState("This is an alert")
+      }
+    }
+    await store.send(\.alert.incrementButtonTapped) {
+      $0.alert = AlertState { TextState("Incremented!") }
+      $0.count = 1
+    }
+    await store.send(\.alert.dismiss) {
+      $0.alert = nil
+    }
+  }
+
+  @MainActor
+  func testConfirmationDialog() async {
+    let store = TestStore(initialState: AlertAndConfirmationDialogState.State()) {
+      AlertAndConfirmationDialogState()
+    }
+
+    await store.send(.confirmationDialogButtonTapped) {
+      $0.confirmationDialog = ConfirmationDialogState {
+        TextState("Confirmation dialog")
+      } actions: {
+        ButtonState(role: .cancel) {
+          TextState("Cancel")
+        }
+        ButtonState(action: .incrementButtonTapped) {
+          TextState("Increment")
+        }
+        ButtonState(action: .decrementButtonTapped) {
+          TextState("Decrement")
+        }
+      } message: {
+        TextState("This is a confirmation dialog.")
+      }
+    }
+    await store.send(\.confirmationDialog.incrementButtonTapped) {
+      $0.alert = AlertState { TextState("Incremented!") }
+      $0.confirmationDialog = nil
+      $0.count = 1
+    }
+  }
+}

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndConfirmationDialogsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AlertsAndConfirmationDialogsTests.swift
@@ -6,60 +6,49 @@ import XCTest
 final class AlertsAndConfirmationDialogsTests: XCTestCase {
   @MainActor
   func testAlert() async {
-    let store = TestStore(initialState: AlertAndConfirmationDialog.State()) {
-      AlertAndConfirmationDialog()
+    let store = TestStore(initialState: AlertsAndConfirmationDialogs.State()) {
+      AlertsAndConfirmationDialogs()
     }
 
     await store.send(.alertButtonTapped) {
-      $0.alert = AlertState {
-        TextState("Alert!")
-      } actions: {
-        ButtonState(role: .cancel) {
-          TextState("Cancel")
-        }
-        ButtonState(action: .incrementButtonTapped) {
-          TextState("Increment")
-        }
-      } message: {
-        TextState("This is an alert")
-      }
+      $0.destination = .increment(.init())
     }
-    await store.send(\.alert.incrementButtonTapped) {
-      $0.alert = AlertState { TextState("Incremented!") }
+    await store.send(\.destination.presented.increment.incrementButtonTapped) {
+      $0.destination = .notice(.init(title: "Incremented!"))
       $0.count = 1
     }
-    await store.send(\.alert.dismiss) {
-      $0.alert = nil
+    await store.send(\.destination.presented.notice.okButtonTapped) {
+      $0.destination = nil
     }
   }
 
   @MainActor
   func testConfirmationDialog() async {
-    let store = TestStore(initialState: AlertAndConfirmationDialog.State()) {
-      AlertAndConfirmationDialog()
+    let store = TestStore(initialState: AlertsAndConfirmationDialogs.State()) {
+      AlertsAndConfirmationDialogs()
     }
 
     await store.send(.confirmationDialogButtonTapped) {
-      $0.confirmationDialog = ConfirmationDialogState {
-        TextState("Confirmation dialog")
-      } actions: {
-        ButtonState(role: .cancel) {
-          TextState("Cancel")
-        }
-        ButtonState(action: .incrementButtonTapped) {
-          TextState("Increment")
-        }
-        ButtonState(action: .decrementButtonTapped) {
-          TextState("Decrement")
-        }
-      } message: {
-        TextState("This is a confirmation dialog.")
-      }
+      $0.destination = .incrementOrDecrement(.init())
     }
-    await store.send(\.confirmationDialog.incrementButtonTapped) {
-      $0.alert = AlertState { TextState("Incremented!") }
-      $0.confirmationDialog = nil
+    await store.send(\.destination.presented.incrementOrDecrement.incrementButtonTapped) {
+      $0.destination = .notice(.init(title: "Incremented!"))
       $0.count = 1
     }
+    await store.send(\.destination.presented.notice.okButtonTapped) {
+      $0.destination = nil
+    }
+    
+    await store.send(.confirmationDialogButtonTapped) {
+      $0.destination = .incrementOrDecrement(.init())
+    }
+    await store.send(\.destination.presented.incrementOrDecrement.decrementButtonTapped) {
+      $0.destination = .notice(.init(title: "Decremented!"))
+      $0.count = 0
+    }
+    await store.send(\.destination.presented.notice.okButtonTapped) {
+      $0.destination = nil
+    }
+
   }
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -147,10 +147,10 @@
     {
       "identity" : "swiftui-navigation",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swiftui-navigation",
+      "location" : "https://github.com/randomeizer/swiftui-navigation",
       "state" : {
-        "revision" : "78f9d72cf667adb47e2040aa373185c88c63f0dc",
-        "version" : "1.2.0"
+        "branch" : "assert-with-binding",
+        "revision" : "44e94f0f1f73c7a86fbeaa935caa848840bb0079"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,8 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "1.0.0"),
-    .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "1.1.0"),
+//    .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "1.1.0"),
+    .package(url: "https://github.com/randomeizer/swiftui-navigation", branch: "assert-with-binding"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.1.0"),
   ],
   targets: [

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -30,7 +30,8 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
     .package(url: "https://github.com/pointfreeco/swift-perception", from: "1.1.1"),
-    .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "1.1.0"),
+//    .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "1.1.0"),
+    .package(url: "https://github.com/randomeizer/swiftui-navigation", branch: "assert-with-binding"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.1.0"),
   ],
   targets: [


### PR DESCRIPTION
Added Case Study for using new `alert` and `confirmationDialog` view modifiers.