### PR TITLE
Add AppStorage persistence keys for types that are raw representable as Data

### DIFF
--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
@@ -76,6 +76,16 @@
       AppStorageKey(key)
     }
 
+    /// Creates a persistence key that can read and write to a data user default, transforming
+    /// that to a `RawRepresentable` data type.
+    ///
+    /// - Parameter key: The key to read and write the value to in the user defaults store.
+    /// - Returns: A user defaults persistence key.
+    public static func appStorage<Value: RawRepresentable>(_ key: String) -> Self
+    where Value.RawValue == Data, Self == AppStorageKey<Value> {
+      AppStorageKey(key)
+    }
+
     /// Creates a persistence key that can read and write to an optional boolean user default.
     ///
     /// - Parameter key: The key to read and write the value to in the user defaults store.
@@ -149,6 +159,16 @@
     where Value.RawValue == String, Self == AppStorageKey<Value?> {
       AppStorageKey(key)
     }
+
+    /// Creates a persistence key that can read and write to an optional data user default,
+    /// transforming that to a `RawRepresentable` data type.
+    ///
+    /// - Parameter key: The key to read and write the value to in the user defaults store.
+    /// - Returns: A user defaults persistence key.
+    public static func appStorage<Value: RawRepresentable>(_ key: String) -> Self
+    where Value.RawValue == Data, Self == AppStorageKey<Value?> {
+      AppStorageKey(key)
+    }
   }
 
   /// A type defining a user defaults persistence strategy.
@@ -217,6 +237,14 @@
       self.store = store
     }
 
+    public init(_ key: String)
+    where Value: RawRepresentable, Value.RawValue == Data {
+      @Dependency(\.defaultAppStorage) var store
+      self.lookup = RawRepresentableLookup(base: CastableLookup())
+      self.key = key
+      self.store = store
+    }
+
     public init(_ key: String) where Value == Bool? {
       @Dependency(\.defaultAppStorage) var store
       self.lookup = OptionalLookup(base: CastableLookup())
@@ -269,6 +297,14 @@
 
     public init<R: RawRepresentable>(_ key: String)
     where R.RawValue == String, Value == R? {
+      @Dependency(\.defaultAppStorage) var store
+      self.lookup = OptionalLookup(base: RawRepresentableLookup(base: CastableLookup()))
+      self.key = key
+      self.store = store
+    }
+
+    public init<R: RawRepresentable>(_ key: String)
+    where R.RawValue == Data, Value == R? {
       @Dependency(\.defaultAppStorage) var store
       self.lookup = OptionalLookup(base: RawRepresentableLookup(base: CastableLookup()))
       self.key = key


### PR DESCRIPTION
AppStorage (UserDefaults) supports persisting, among other types, Int, String and Data.  Further, the library can persist types that are raw representable as Int or String, but doesn’t do the bridging for types that are raw representable as Data.

Having support for this, one can then easily persist any type in AppStorage that is Codable (because Codeable types can be coded to and decoded from Data).  While I think the library could/should add support for persisting Codable types out of the box, if that is not desirable for some reason, clients can work around this easily as long as raw representing Data itself is persistable.

A workaround I have been using in my project is to define a property wrapper (this is preferable to conforming types, esp. those one does not own, to RawRepresentable directly):

```swift
import Foundation

@propertyWrapper 
public struct RawRepresentableFromCodable<Value: Codable> {
  public var wrappedValue: Value

  public init(wrappedValue: Value) {
    self.wrappedValue = wrappedValue
  }
}

extension RawRepresentableFromCodable: Equatable where Value: Equatable {}

extension RawRepresentableFromCodable: RawRepresentable {
  public init?(rawValue: Data) {
    guard let value = try? JSONDecoder().decode(Value.self, from: rawValue) else {
      return nil
    }
    self = RawRepresentableFromCodable(wrappedValue: value)
  }

  public var rawValue: Data {
    try! JSONEncoder().encode(wrappedValue)
  }
}
```

and then add add that before `@Shared`:

```swift
@Shared(.appStorage(“someKey”))
@RawRepresentableFromCodable
public var someProperty: SomeCodableType
```