### PR TITLE
Make Effect.publisher eager

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "3ce83179e5f0c83ad54c305779c6b438e82aaf1d",
-        "version" : "1.2.1"
+        "revision" : "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
+        "version" : "1.3.0"
       }
     },
     {

--- a/Sources/ComposableArchitecture/Effects/Publisher.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher.swift
@@ -13,7 +13,7 @@ extension Effect {
       )
     )
   }
-  }
+}
 
 public struct _EffectPublisher<Action>: Publisher {
   public typealias Output = Action

--- a/Sources/ComposableArchitecture/Effects/Publisher.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher.swift
@@ -5,22 +5,15 @@ extension Effect {
   ///
   /// - Parameter createPublisher: The closure to execute when the effect is performed.
   /// - Returns: An effect wrapping a Combine publisher.
-  public static func publisher<P: Publisher>(_ createPublisher: @escaping () -> P) -> Self
+  public static func publisher<P: Publisher>(_ createPublisher: () -> P) -> Self
   where P.Output == Action, P.Failure == Never {
     Self(
       operation: .publisher(
-        withEscapedDependencies { continuation in
-          Deferred {
-            continuation.yield {
-              createPublisher()
-            }
-          }
-        }
-        .eraseToAnyPublisher()
+        createPublisher().eraseToAnyPublisher()
       )
     )
   }
-}
+  }
 
 public struct _EffectPublisher<Action>: Publisher {
   public typealias Output = Action


### PR DESCRIPTION
Makes the trailing closure of `Effect.publisher { … }` non-escaping, and hence the publisher is created eagerly when the effect is constructed. This means you can access `state` inside the closure, which will be handy in the shared state tools coming to TCA soon:

```swift
return .publisher { 
  state.$shared.publisher
    .map(Action.sharedUpdated)
}
```

Note, however, the publisher is not _run_ eagerly. That is still delayed until state changes have been processed and all effects are started together.

We don't think there is a big use case for needing the construction of a publisher to be lazy since the publisher itself can encapsulate lazy work, but if for whatever reason one needs to lazily create the publisher then you can use `Deferred`:

```swift
return .publisher {
  Deferred {
    // create publisher
  }
}
```