### PR TITLE
Use notification center instead of KVO for user defaults observation.

### DIFF
--- a/Sources/ComposableArchitecture/Internal/NotificationName.swift
+++ b/Sources/ComposableArchitecture/Internal/NotificationName.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+#if canImport(AppKit)
+  import AppKit
+#endif
+#if canImport(UIKit)
+  import UIKit
+#endif
+#if canImport(WatchKit)
+  import WatchKit
+#endif
+
+@_spi(Internals)
+public var willResignNotificationName: Notification.Name? {
+  #if os(iOS) || os(tvOS) || os(visionOS)
+    return UIApplication.willResignActiveNotification
+  #elseif os(macOS)
+    return NSApplication.willResignActiveNotification
+  #else
+    if #available(watchOS 7, *) {
+      return WKExtension.applicationWillResignActiveNotification
+    } else {
+      return nil
+    }
+  #endif
+}
+
+@_spi(Internals)
+public var willEnterForegroundNotificationName: Notification.Name? {
+  #if os(iOS) || os(tvOS) || os(visionOS)
+    return UIApplication.willEnterForegroundNotification
+  #elseif os(macOS)
+    return NSApplication.willBecomeActiveNotification
+  #else
+    if #available(watchOS 7, *) {
+      return WKExtension.applicationWillEnterForegroundNotification
+    } else {
+      return nil
+    }
+  #endif
+}
+
+var canListenForResignActive: Bool {
+  willResignNotificationName != nil
+}

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
@@ -154,7 +154,7 @@ extension PersistenceKey {
 /// A type defining a user defaults persistence strategy.
 ///
 /// See ``PersistenceKey/appStorage(_:)-9zd2f`` to create values of this type.
-public struct AppStorageKey<Value: Equatable> {
+public struct AppStorageKey<Value> {
   private let lookup: any Lookup<Value>
   private let key: String
   private let store: UserDefaults

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
@@ -290,7 +290,7 @@ extension AppStorageKey: PersistenceKey {
   public func subscribe(
     initialValue: Value?, didSet: @escaping (_ newValue: Value?) -> Void
   ) -> Shared<Value>.Subscription {
-    let observation = NotificationCenter.default.addObserver(
+    let userDefaultsDidChange = NotificationCenter.default.addObserver(
       forName: UserDefaults.didChangeNotification,
       object: self.store,
       queue: nil
@@ -299,8 +299,16 @@ extension AppStorageKey: PersistenceKey {
       else { return }
       didSet(self.store.value(forKey: self.key) as? Value ?? initialValue)
     }
+    let willEnterForeground = NotificationCenter.default.addObserver(
+      forName: willEnterForegroundNotificationName,
+      object: nil,
+      queue: nil
+    ) { _ in
+      didSet(self.store.value(forKey: self.key) as? Value ?? initialValue)
+    }
     return Shared.Subscription {
-      NotificationCenter.default.removeObserver(observation)
+      NotificationCenter.default.removeObserver(userDefaultsDidChange)
+      NotificationCenter.default.removeObserver(willEnterForeground)
     }
   }
 }

--- a/Tests/ComposableArchitectureTests/AppStorageTests.swift
+++ b/Tests/ComposableArchitectureTests/AppStorageTests.swift
@@ -94,6 +94,13 @@ final class AppStorageTests: XCTestCase {
     XCTAssertEqual(count, 42)
   }
 
+  func testChangeUserDefaultsDirectly_KeyWithPeriod() {
+    @Dependency(\.defaultAppStorage) var defaults
+    @Shared(.appStorage("pointfreeco.count")) var count = 0
+    defaults.setValue(count + 42, forKey: "pointfreeco.count")
+    XCTAssertEqual(count, 42)
+  }
+
   func testDeleteUserDefault() {
     @Dependency(\.defaultAppStorage) var defaults
     @Shared(.appStorage("count")) var count = 0

--- a/Tests/ComposableArchitectureTests/AppStorageTests.swift
+++ b/Tests/ComposableArchitectureTests/AppStorageTests.swift
@@ -109,7 +109,7 @@ final class AppStorageTests: XCTestCase {
     XCTAssertEqual(count, 0)
   }
 
-  func testKeyPath() async throws {
+  func testKeyPath() {
     @Dependency(\.defaultAppStorage) var defaults
     @Shared(.appStorage(\.count)) var count = 0
     defaults.count += 1


### PR DESCRIPTION
This was brought up by @jegnux in [Slack](https://pointfreecommunity.slack.com/archives/C04L56P2VEF/p1712753624317759?thread_ts=1712534913.585879&cid=C04L56P2VEF). Right now observation of user defaults is broken if someone uses a "." in their key, e.g. `@Shared(.appStorage("pointfree.isOn"))`. To fix we will use `NotificationCenter` to subscribe to the whole firehose of _any_ change to `UserDefaults`. 

Now technically this does mean we could be playing back changes to `@Shared` when the key does not actually change. We can't easily de-dupe the `didSet` from within `AppStorageKey` because we don't have access to the current value. So we could explore doing some de-duping in `ValueReference`, but then we'd need to cast to `any Equatable` and open the existential. That might be worth it though.