### PR TITLE
Surface persistence strategy of a Shared property

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/02-SharedState-Notifications.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-SharedState-Notifications.swift
@@ -107,7 +107,7 @@ struct NotificationReaderKey<Value: Sendable>: PersistenceReaderKey {
   func subscribe(
     initialValue: Value?,
     didSet: @Sendable @escaping (Value?) -> Void
-  ) -> Shared<Value>.Subscription {
+  ) -> Shared<Value, Self>.Subscription {
     let token = NotificationCenter.default.addObserver(
       forName: name,
       object: nil,

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-SharedState-Onboarding.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-SharedState-Onboarding.swift
@@ -34,7 +34,7 @@ private struct SignUpFeature {
   @ObservableState
   struct State {
     var path = StackState<Path.State>()
-    @Shared var signUpData: SignUpData
+    @AnyShared var signUpData: SignUpData
   }
   enum Action {
     case path(StackAction<Path.State, Path.Action>)
@@ -130,7 +130,7 @@ private struct BasicsFeature {
   @ObservableState
   struct State {
     var isEditingFromSummary = false
-    @Shared var signUpData: SignUpData
+    @AnyShared var signUpData: SignUpData
   }
   enum Action: BindableAction {
     case binding(BindingAction<State>)
@@ -180,7 +180,7 @@ private struct PersonalInfoFeature {
   @ObservableState
   struct State {
     var isEditingFromSummary = false
-    @Shared var signUpData: SignUpData
+    @AnyShared var signUpData: SignUpData
   }
   enum Action: BindableAction {
     case binding(BindingAction<State>)
@@ -229,7 +229,7 @@ private struct TopicsFeature {
   struct State {
     @Presents var alert: AlertState<Never>?
     var isEditingFromSummary = false
-    @Shared var topics: Set<SignUpData.Topic>
+    @AnyShared var topics: Set<SignUpData.Topic>
   }
   enum Action: BindableAction {
     case alert(PresentationAction<Never>)
@@ -316,7 +316,7 @@ private struct SummaryFeature {
   @ObservableState
   struct State {
     @Presents var destination: Destination.State?
-    @Shared var signUpData: SignUpData
+    @AnyShared var signUpData: SignUpData
   }
   enum Action {
     case destination(PresentationAction<Destination.Action>)

--- a/Examples/SyncUps/SyncUps/RecordMeeting.swift
+++ b/Examples/SyncUps/SyncUps/RecordMeeting.swift
@@ -9,7 +9,7 @@ struct RecordMeeting {
     @Presents var alert: AlertState<Action.Alert>?
     var secondsElapsed = 0
     var speakerIndex = 0
-    @Shared var syncUp: SyncUp
+    @AnyShared var syncUp: SyncUp
     var transcript = ""
 
     var durationRemaining: Duration {

--- a/Examples/SyncUps/SyncUps/RecordMeeting.swift
+++ b/Examples/SyncUps/SyncUps/RecordMeeting.swift
@@ -383,7 +383,7 @@ struct MeetingFooterView: View {
 #Preview {
   NavigationStack {
     RecordMeetingView(
-      store: Store(initialState: RecordMeeting.State(syncUp: Shared(.mock))) {
+      store: Store(initialState: RecordMeeting.State(syncUp: Shared(value: .mock))) {
         RecordMeeting()
       }
     )

--- a/Examples/SyncUps/SyncUps/RecordMeeting.swift
+++ b/Examples/SyncUps/SyncUps/RecordMeeting.swift
@@ -383,7 +383,7 @@ struct MeetingFooterView: View {
 #Preview {
   NavigationStack {
     RecordMeetingView(
-      store: Store(initialState: RecordMeeting.State(syncUp: Shared(value: .mock))) {
+      store: Store(initialState: RecordMeeting.State(syncUp: Shared(.mock))) {
         RecordMeeting()
       }
     )

--- a/Examples/SyncUps/SyncUps/SyncUpDetail.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpDetail.swift
@@ -263,7 +263,7 @@ extension AlertState where Action == SyncUpDetail.Destination.Alert {
 #Preview {
   NavigationStack {
     SyncUpDetailView(
-      store: Store(initialState: SyncUpDetail.State(syncUp: Shared(value: .mock))) {
+      store: Store(initialState: SyncUpDetail.State(syncUp: Shared(.mock))) {
         SyncUpDetail()
       }
     )

--- a/Examples/SyncUps/SyncUps/SyncUpDetail.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpDetail.swift
@@ -19,7 +19,7 @@ struct SyncUpDetail {
   @ObservableState
   struct State: Equatable {
     @Presents var destination: Destination.State?
-    @Shared var syncUp: SyncUp
+    @AnyShared var syncUp: SyncUp
   }
 
   enum Action: Sendable {

--- a/Examples/SyncUps/SyncUps/SyncUpDetail.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpDetail.swift
@@ -263,7 +263,7 @@ extension AlertState where Action == SyncUpDetail.Destination.Alert {
 #Preview {
   NavigationStack {
     SyncUpDetailView(
-      store: Store(initialState: SyncUpDetail.State(syncUp: Shared(.mock))) {
+      store: Store(initialState: SyncUpDetail.State(syncUp: Shared(value: .mock))) {
         SyncUpDetail()
       }
     )

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
@@ -8,14 +8,14 @@ public protocol PersistenceReaderKey<Value>: Hashable {
   func subscribe(
     initialValue: Value?,
     didSet: @Sendable @escaping (_ newValue: Value?) -> Void
-  ) -> Shared<Value>.Subscription
+  ) -> Shared<Value, Self>.Subscription
 }
 
 extension PersistenceReaderKey {
   public func subscribe(
     initialValue: Value?,
     didSet: @Sendable @escaping (_ newValue: Value?) -> Void
-  ) -> Shared<Value>.Subscription {
+  ) -> Shared<Value, Self>.Subscription {
     Shared.Subscription {}
   }
 }

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
@@ -290,7 +290,7 @@ extension AppStorageKey: PersistenceKey {
   public func subscribe(
     initialValue: Value?,
     didSet: @Sendable @escaping (_ newValue: Value?) -> Void
-  ) -> Shared<Value>.Subscription {
+  ) -> Shared<Value, AppStorageKey<Value>>.Subscription {
     let userDefaultsDidChange = NotificationCenter.default.addObserver(
       forName: UserDefaults.didChangeNotification,
       object: self.store,

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKeyPathKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKeyPathKey.swift
@@ -49,7 +49,7 @@ extension AppStorageKeyPathKey: PersistenceKey {
   public func subscribe(
     initialValue: Value?,
     didSet: @Sendable @escaping (_ newValue: Value?) -> Void
-  ) -> Shared<Value>.Subscription {
+  ) -> Shared<Value, AppStorageKeyPathKey<Value>>.Subscription {
     let observer = self.store.observe(self.keyPath, options: .new) { _, change in
       guard
         !SharedAppStorageLocals.isSetting

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/FileStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/FileStorageKey.swift
@@ -60,7 +60,7 @@ public final class FileStorageKey<Value: Codable & Sendable>: PersistenceKey, @u
   public func subscribe(
     initialValue: Value?,
     didSet: @Sendable @escaping (_ newValue: Value?) -> Void
-  ) -> Shared<Value>.Subscription {
+  ) -> Shared<Value, FileStorageKey<Value>>.Subscription {
     // NB: Make sure there is a file to create a source for.
     if !self.storage.fileExists(at: self.url) {
       try? self.storage

--- a/Sources/ComposableArchitecture/SharedState/Reference.swift
+++ b/Sources/ComposableArchitecture/SharedState/Reference.swift
@@ -5,6 +5,7 @@
 protocol Reference<Value>: AnyObject, CustomStringConvertible {
   associatedtype Value
   var value: Value { get set }
+  var persistence: Any? { get }
 
   #if canImport(Combine)
     var publisher: AnyPublisher<Value, Never> { get }

--- a/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
+++ b/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
@@ -62,7 +62,7 @@ extension Shared where Persistence: PersistenceKey<Value> {
 extension SharedReader where Persistence: PersistenceReaderKey<Value> {
   public init(
     wrappedValue value: Value,
-    _ persistenceKey: some PersistenceReaderKey<Value>,
+    _ persistenceKey: Persistence,
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) {
@@ -89,7 +89,7 @@ extension SharedReader where Persistence: PersistenceReaderKey<Value> {
   }
 
   public init<Wrapped>(
-    _ persistenceKey: some PersistenceReaderKey<Value>,
+    _ persistenceKey: Persistence,
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) where Value == Wrapped? {
@@ -98,7 +98,7 @@ extension SharedReader where Persistence: PersistenceReaderKey<Value> {
 
   @_disfavoredOverload
   public init(
-    _ persistenceKey: some PersistenceReaderKey<Value>,
+    _ persistenceKey: Persistence,
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) throws {

--- a/Sources/ComposableArchitecture/SharedState/Shared.swift
+++ b/Sources/ComposableArchitecture/SharedState/Shared.swift
@@ -324,3 +324,9 @@ extension Shared {
     )
   }
 }
+
+extension Shared {
+  public func eraseToAnyShared() -> AnyShared<Value> {
+    self[dynamicMember: \.self]
+  }
+}

--- a/Sources/ComposableArchitecture/SharedState/Shared.swift
+++ b/Sources/ComposableArchitecture/SharedState/Shared.swift
@@ -80,9 +80,9 @@ public struct Shared<Value> {
     self.keyPath = keyPath
   }
 
-  public init(_ value: Value, fileID: StaticString = #fileID, line: UInt = #line) {
+  public init(value: Value, fileID: StaticString = #fileID, line: UInt = #line) {
     self.init(
-      reference: ValueReference<Value, InMemoryKey<Value>>(
+      reference: ValueReference(
         initialValue: value,
         fileID: fileID,
         line: line

--- a/Sources/ComposableArchitecture/SharedState/SharedReader.swift
+++ b/Sources/ComposableArchitecture/SharedState/SharedReader.swift
@@ -23,7 +23,7 @@ public struct SharedReader<Value> {
 
   public init(_ value: Value, fileID: StaticString = #fileID, line: UInt = #line) {
     self.init(
-      reference: ValueReference<Value, InMemoryKey<Value>>(
+      reference: ValueReference(
         initialValue: value,
         fileID: fileID,
         line: line

--- a/Sources/ComposableArchitecture/SharedState/SharedReader.swift
+++ b/Sources/ComposableArchitecture/SharedState/SharedReader.swift
@@ -138,3 +138,9 @@ where Value: RandomAccessCollection & MutableCollection, Value.Index: Hashable &
     }
   }
 }
+
+extension SharedReader {
+  public func eraseToAnySharedReader() -> AnySharedReader<Value> {
+    self[dynamicMember: \.self]
+  }
+}

--- a/Sources/ComposableArchitectureMacros/ObservableStateMacro.swift
+++ b/Sources/ComposableArchitectureMacros/ObservableStateMacro.swift
@@ -46,6 +46,8 @@ public struct ObservableStateMacro {
   static let ignoredMacroName = "ObservationStateIgnored"
   static let presentsMacroName = "Presents"
   static let presentationStatePropertyWrapperName = "PresentationState"
+  static let anySharedPropertyWrapperName = "AnyShared"
+  static let anySharedReaderPropertyWrapperName = "AnySharedReader"
   static let sharedPropertyWrapperName = "Shared"
   static let sharedReaderPropertyWrapperName = "SharedReader"
 
@@ -446,7 +448,9 @@ extension ObservableStateMacro: MemberAttributeMacro {
       context: context
     )
 
-    if property.hasMacroApplication(ObservableStateMacro.presentsMacroName)
+    if property.hasMacroApplication(ObservableStateMacro.anySharedPropertyWrapperName)
+      || property.hasMacroApplication(ObservableStateMacro.anySharedReaderPropertyWrapperName)
+      || property.hasMacroApplication(ObservableStateMacro.presentsMacroName)
       || property.hasMacroApplication(ObservableStateMacro.sharedPropertyWrapperName)
       || property.hasMacroApplication(ObservableStateMacro.sharedReaderPropertyWrapperName)
     {
@@ -537,10 +541,13 @@ public struct ObservationStateTrackedMacro: AccessorMacro {
       return []
     }
 
-    if property.hasMacroApplication(ObservableStateMacro.ignoredMacroName)
+    if property.hasMacroApplication(ObservableStateMacro.anySharedPropertyWrapperName)
+      || property.hasMacroApplication(ObservableStateMacro.anySharedReaderPropertyWrapperName)
+      || property.hasMacroApplication(ObservableStateMacro.ignoredMacroName)
       || property.hasMacroApplication(ObservableStateMacro.presentationStatePropertyWrapperName)
       || property.hasMacroApplication(ObservableStateMacro.presentsMacroName)
       || property.hasMacroApplication(ObservableStateMacro.sharedPropertyWrapperName)
+      || property.hasMacroApplication(ObservableStateMacro.sharedReaderPropertyWrapperName)
     {
       return []
     }
@@ -596,10 +603,13 @@ extension ObservationStateTrackedMacro: PeerMacro {
       return []
     }
 
-    if property.hasMacroApplication(ObservableStateMacro.ignoredMacroName)
+    if property.hasMacroApplication(ObservableStateMacro.anySharedPropertyWrapperName)
+      || property.hasMacroApplication(ObservableStateMacro.anySharedReaderPropertyWrapperName)
+      || property.hasMacroApplication(ObservableStateMacro.ignoredMacroName)
       || property.hasMacroApplication(ObservableStateMacro.presentationStatePropertyWrapperName)
       || property.hasMacroApplication(ObservableStateMacro.presentsMacroName)
       || property.hasMacroApplication(ObservableStateMacro.sharedPropertyWrapperName)
+      || property.hasMacroApplication(ObservableStateMacro.sharedReaderPropertyWrapperName)
       || property.hasMacroApplication(ObservableStateMacro.trackedMacroName)
     {
       return []

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -183,7 +183,7 @@
       )
 
       struct State {
-        @Shared var count: Int
+        @AnyShared var count: Int
       }
 
       let store = Store<State, Bool>(initialState: State(count: Shared(0))) {

--- a/Tests/ComposableArchitectureTests/SharedReaderTests.swift
+++ b/Tests/ComposableArchitectureTests/SharedReaderTests.swift
@@ -5,8 +5,7 @@ import XCTest
 final class SharedReaderTests: XCTestCase {
   @MainActor
   func testSharedReader() {
-    @Shared var count: Int
-    _count = Shared(0)
+    @Shared(0) var count: Int
     let countReader = $count.reader
 
     count += 1

--- a/Tests/ComposableArchitectureTests/SharedTests.swift
+++ b/Tests/ComposableArchitectureTests/SharedTests.swift
@@ -291,7 +291,7 @@ final class SharedTests: XCTestCase {
   func testComplexSharedEffect_ReducerMutation() async {
     struct Feature: Reducer {
       struct State: Equatable {
-        @Shared var count: Int
+        @AnyShared var count: Int
       }
       enum Action {
         case startTimer
@@ -338,7 +338,7 @@ final class SharedTests: XCTestCase {
   func testComplexSharedEffect_EffectMutation() async {
     struct Feature: Reducer {
       struct State: Equatable {
-        @Shared var count: Int
+        @AnyShared var count: Int
       }
       enum Action {
         case startTimer
@@ -436,8 +436,7 @@ final class SharedTests: XCTestCase {
   }
 
   func testObservation() {
-    @Shared var count: Int
-    _count = Shared(0)
+    @Shared(0) var count: Int
     let countDidChange = self.expectation(description: "countDidChange")
     withPerceptionTracking {
       _ = count
@@ -451,8 +450,7 @@ final class SharedTests: XCTestCase {
   @available(*, deprecated)
   @MainActor
   func testObservation_Object() {
-    @Shared var object: SharedObject
-    _object = Shared(SharedObject())
+    @Shared(SharedObject()) var object: SharedObject
     let countDidChange = self.expectation(description: "countDidChange")
     withPerceptionTracking {
       _ = object.count
@@ -670,9 +668,9 @@ private struct SharedFeature {
   @ObservableState
   struct State: Equatable {
     var count = 0
-    @Shared var profile: Profile
-    @Shared var sharedCount: Int
-    @Shared var stats: Stats
+    @AnyShared var profile: Profile
+    @AnyShared var sharedCount: Int
+    @AnyShared var stats: Stats
   }
   enum Action {
     case increment
@@ -720,12 +718,12 @@ private struct Stats: Codable, Equatable {
   var count = 0
 }
 private struct Profile: Equatable {
-  @Shared var stats: Stats
+  @AnyShared var stats: Stats
 }
 @Reducer
 private struct SimpleFeature {
   struct State: Equatable {
-    @Shared var count: Int
+    @AnyShared var count: Int
   }
   enum Action {
     case incrementInEffect
@@ -757,7 +755,7 @@ private struct RowFeature {
   struct State: Equatable, Identifiable {
     let id: Int
     var text: String
-    @Shared var value: Int
+    @AnyShared var value: Int
   }
 
   enum Action: Equatable {
@@ -787,7 +785,7 @@ private struct RowFeature {
 private struct ListFeature {
   @ObservableState
   struct State: Equatable {
-    @Shared var value: Int
+    @AnyShared var value: Int
     var children: IdentifiedArrayOf<RowFeature.State>
 
     init(value: Int = 0) {
@@ -826,7 +824,7 @@ private struct ListFeature {
 private struct EarlySharedStateMutation {
   @ObservableState
   struct State: Equatable {
-    @Shared var count: Int
+    @AnyShared var count: Int
   }
   enum Action {
     case action


### PR DESCRIPTION
This branch introduces a second generic to `Shared` that tracks the underlying persistence strategy:

```swift
Shared<Value, Persistence>
```

This means that a particular persistence strategy can expose endpoints that the `Shared` could statically call. For example, a remotely-backed `Shared` could expose a `refresh` endpoint for fetching the latest data:

```swift
@Shared(.api(.config)) var config = Config()

// ...

$config.persistence.refresh()
```

Now this change comes with some complications and source incompatibilities with earlier periods in the beta. In particular, `Shared` properties that are _not_ backed by a persistence key can no longer be specified simply:

```swift
@Shared var count: Int
```

Due to limitations in Swift (lack of default generics, for example), the new generic cannot be inferred in this situation. The type used to describe the persistence strategy of such a shared value is `Any`, and so there is a type alias to simplify:

```swift
// Instead of:
@Shared<Int, Any> var count: Int

// Do:
@AnyShared var count: Int
```

In the future, if Swift ever does get default generics, we could maybe get rid of these type aliases.

We'd love it if folks could take this change for a spin and/or provide feedback. We're trying to strike the right balance for shared state in terms of features and power without sacrificing too much in the way of usability and API surface area.