### PR TITLE
Make Shared.Subscription.cancel public

### DIFF
--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
@@ -44,7 +44,8 @@ extension Shared {
     deinit {
       self.cancel()
     }
-    func cancel() {
+    /// Cancels this subscription.
+    public func cancel() {
       self.onCancel()
     }
   }


### PR DESCRIPTION
This makes `Shared.Subscription.cancel` public so that we can wrap a `PersistenceKey` and correctly implement `subscribe(initialValue:didSet:)`.

See https://github.com/pointfreeco/swift-composable-architecture/discussions/2857#discussioncomment-9087925