### PR TITLE
Better shared state change tracking and `TestStore` interactions

### DIFF
--- a/Examples/SyncUps/SyncUpsTests/AppFeatureTests.swift
+++ b/Examples/SyncUps/SyncUpsTests/AppFeatureTests.swift
@@ -110,6 +110,15 @@ final class AppFeatureTests: XCTestCase {
     store.exhaustivity = .off
 
     await store.send(\.path[id:1].record.onTask)
+    store.assert {
+      $0.path[id: 0]?.detail?.syncUp.meetings = [
+        Meeting(
+          id: Meeting.ID(UUID(0)),
+          date: Date(timeIntervalSince1970: 1_234_567_890),
+          transcript: "I completed the project"
+        )
+      ]
+    }
     await store.receive(\.path.popFrom) {
       XCTAssertEqual($0.path.count, 1)
     }

--- a/Sources/ComposableArchitecture/SharedState/Shared.swift
+++ b/Sources/ComposableArchitecture/SharedState/Shared.swift
@@ -30,8 +30,7 @@ public struct Shared<Value> {
       if changeTracker != nil {
         self.snapshot = newValue
       } else {
-        @Dependency(SharedChangeTrackersKey.self)
-        var changeTrackers: Set<SharedChangeTracker>
+        @Dependency(SharedChangeTrackersKey.self) var changeTrackers: Set<SharedChangeTracker>
         for changeTracker in changeTrackers {
           changeTracker.track(self.reference)
         }

--- a/Sources/ComposableArchitecture/SharedState/Shared.swift
+++ b/Sources/ComposableArchitecture/SharedState/Shared.swift
@@ -31,12 +31,9 @@ public struct Shared<Value> {
         self.snapshot = newValue
       } else {
         @Dependency(SharedChangeTrackersKey.self)
-        var changeTrackers: LockIsolated<Set<SharedChangeTracker>>
-
-        changeTrackers.withValue { changeTrackers in
-          for changeTracker in changeTrackers {
-            changeTracker.track(self.reference)
-          }
+        var changeTrackers: Set<SharedChangeTracker>
+        for changeTracker in changeTrackers {
+          changeTracker.track(self.reference)
         }
         self.currentValue = newValue
       }
@@ -133,7 +130,7 @@ public struct Shared<Value> {
   ) rethrows where Value: Equatable {
     @Dependency(SharedChangeTrackersKey.self) var changeTrackers
     guard
-      let changeTracker = changeTrackers.value
+      let changeTracker = changeTrackers
         .first(where: { $0.changes[ObjectIdentifier(self.reference)] != nil })
     else {
       XCTFail("Expected changes, but none occurred.", file: file, line: line)

--- a/Sources/ComposableArchitecture/SharedState/SharedChangeTracking.swift
+++ b/Sources/ComposableArchitecture/SharedState/SharedChangeTracking.swift
@@ -81,18 +81,27 @@ final class SharedChangeTracker: Sendable {
     }
   }
   func track<R>(_ operation: () throws -> R) rethrows -> R {
-    @Dependency(SharedChangeTrackersKey.self)
-    var sharedChangeTrackers: LockIsolated<Set<SharedChangeTracker>>
-    sharedChangeTrackers.withValue { _ = $0.insert(self) }
-    defer { sharedChangeTrackers.withValue { _ = $0.remove(self) } }
-    return try operation()
+//    @Dependency(SharedChangeTrackersKey.self)
+//    var sharedChangeTrackers: LockIsolated<Set<SharedChangeTracker>>
+//    sharedChangeTrackers.withValue { _ = $0.insert(self) }
+//    defer { sharedChangeTrackers.withValue { _ = $0.remove(self) } }
+    try withDependencies {
+      $0[SharedChangeTrackersKey.self].insert(self)
+    } operation: {
+      try operation()
+    }
   }
   func track<R>(_ operation: () async throws -> R) async rethrows -> R {
-    @Dependency(SharedChangeTrackersKey.self)
-    var sharedChangeTrackers: LockIsolated<Set<SharedChangeTracker>>
-    sharedChangeTrackers.withValue { _ = $0.insert(self) }
-    defer { sharedChangeTrackers.withValue { _ = $0.remove(self) } }
-    return try await operation()
+//    @Dependency(SharedChangeTrackersKey.self)
+//    var sharedChangeTrackers: LockIsolated<Set<SharedChangeTracker>>
+//    sharedChangeTrackers.withValue { _ = $0.insert(self) }
+//    defer { sharedChangeTrackers.withValue { _ = $0.remove(self) } }
+//    return try await operation()
+    try await withDependencies {
+      $0[SharedChangeTrackersKey.self].insert(self)
+    } operation: {
+      try await operation()
+    }
   }
   func assert<R>(_ operation: () throws -> R) rethrows -> R {
     try withDependencies {
@@ -113,9 +122,9 @@ extension SharedChangeTracker: Hashable {
 }
 
 enum SharedChangeTrackersKey: DependencyKey {
-  static var liveValue: LockIsolated<Set<SharedChangeTracker>> { LockIsolated([]) }
-  static var testValue: LockIsolated<Set<SharedChangeTracker>> {
-    LockIsolated([SharedChangeTracker()])
+  static var liveValue: Set<SharedChangeTracker> { [] }
+  static var testValue: Set<SharedChangeTracker> {
+    [SharedChangeTracker()]
   }
 }
 

--- a/Sources/ComposableArchitecture/SharedState/SharedChangeTracking.swift
+++ b/Sources/ComposableArchitecture/SharedState/SharedChangeTracking.swift
@@ -81,10 +81,6 @@ final class SharedChangeTracker: Sendable {
     }
   }
   func track<R>(_ operation: () throws -> R) rethrows -> R {
-//    @Dependency(SharedChangeTrackersKey.self)
-//    var sharedChangeTrackers: LockIsolated<Set<SharedChangeTracker>>
-//    sharedChangeTrackers.withValue { _ = $0.insert(self) }
-//    defer { sharedChangeTrackers.withValue { _ = $0.remove(self) } }
     try withDependencies {
       $0[SharedChangeTrackersKey.self].insert(self)
     } operation: {
@@ -92,11 +88,6 @@ final class SharedChangeTracker: Sendable {
     }
   }
   func track<R>(_ operation: () async throws -> R) async rethrows -> R {
-//    @Dependency(SharedChangeTrackersKey.self)
-//    var sharedChangeTrackers: LockIsolated<Set<SharedChangeTracker>>
-//    sharedChangeTrackers.withValue { _ = $0.insert(self) }
-//    defer { sharedChangeTrackers.withValue { _ = $0.remove(self) } }
-//    return try await operation()
     try await withDependencies {
       $0[SharedChangeTrackersKey.self].insert(self)
     } operation: {
@@ -123,9 +114,7 @@ extension SharedChangeTracker: Hashable {
 
 enum SharedChangeTrackersKey: DependencyKey {
   static var liveValue: Set<SharedChangeTracker> { [] }
-  static var testValue: Set<SharedChangeTracker> {
-    [SharedChangeTracker()]
-  }
+  static var testValue: Set<SharedChangeTracker> { [SharedChangeTracker()] }
 }
 
 enum SharedChangeTrackerKey: DependencyKey {

--- a/Tests/ComposableArchitectureTests/SharedTests.swift
+++ b/Tests/ComposableArchitectureTests/SharedTests.swift
@@ -241,7 +241,7 @@ final class SharedTests: XCTestCase {
     }
     XCTExpectFailure {
       $0.compactDescription == """
-        A state change does not match expectation: …
+        Test store completed before asserting against changes to shared state: …
 
               SharedFeature.State(
                 _count: 0,
@@ -252,6 +252,8 @@ final class SharedTests: XCTestCase {
               )
 
         (Expected: −, Actual: +)
+
+        Invoke "TestStore.assert" at the end of this test to assert against changes to shared state.
         """
     }
     await store.send(.longLivingEffect)

--- a/Tests/ComposableArchitectureTests/SharedTests.swift
+++ b/Tests/ComposableArchitectureTests/SharedTests.swift
@@ -224,14 +224,10 @@ final class SharedTests: XCTestCase {
     store.assert {
       $0.sharedCount = 1
     }
-//    store.state.$sharedCount.assert {
-//      $0 = 1
-//    }
   }
 
   @MainActor
   func testMutationOfSharedStateInLongLivingEffect_NoAssertion() async {
-    let sharedCountInitLine = #line + 4
     let store = TestStore(
       initialState: SharedFeature.State(
         profile: Shared(Profile(stats: Shared(Stats()))),
@@ -245,17 +241,17 @@ final class SharedTests: XCTestCase {
     }
     XCTExpectFailure {
       $0.compactDescription == """
-        Tracked changes to \
-        'Shared<Int>@ComposableArchitectureTests/SharedTests.swift:\(sharedCountInitLine)' \
-        but failed to assert: …
+        A state change does not match expectation: …
 
-          − 0
-          + 1
+              SharedFeature.State(
+                _count: 0,
+                _profile: #1 Profile(…),
+            −   _sharedCount: #1 0,
+            +   _sharedCount: #1 1,
+                _stats: #1 Stats(count: 0)
+              )
 
-        (Before: −, After: +)
-
-        Call 'Shared<Int>.assert' to exhaustively test these changes, or call 'skipChanges' to \
-        ignore them.
+        (Expected: −, Actual: +)
         """
     }
     await store.send(.longLivingEffect)
@@ -276,12 +272,17 @@ final class SharedTests: XCTestCase {
     }
     XCTExpectFailure {
       $0.compactDescription == """
-        XCTAssertNoDifference failed: …
+        A state change does not match expectation: …
 
-          − 1
-          + 2
+              SharedFeature.State(
+                _count: 0,
+                _profile: #1 Profile(…),
+            −   _sharedCount: #1 2,
+            +   _sharedCount: #1 1,
+                _stats: #1 Stats(count: 0)
+              )
 
-        (First: −, Second: +)
+        (Expected: −, Actual: +)
         """
     }
     await store.send(.longLivingEffect)
@@ -390,9 +391,9 @@ final class SharedTests: XCTestCase {
     }
     await store.send(.stopTimer)
     await mainQueue.advance(by: .seconds(1))
-//    store.assert {
-//      $0.count = 42
-//    }
+    store.assert {
+      $0.count = 42
+    }
   }
 
   @MainActor

--- a/Tests/ComposableArchitectureTests/SharedTests.swift
+++ b/Tests/ComposableArchitectureTests/SharedTests.swift
@@ -220,10 +220,13 @@ final class SharedTests: XCTestCase {
     } withDependencies: {
       $0.mainQueue = .immediate
     }
-    await store.send(.longLivingEffect)
-    store.state.$sharedCount.assert {
-      $0 = 1
+    await store.send(.longLivingEffect).finish()
+    store.assert {
+      $0.sharedCount = 1
     }
+//    store.state.$sharedCount.assert {
+//      $0 = 1
+//    }
   }
 
   @MainActor
@@ -282,8 +285,8 @@ final class SharedTests: XCTestCase {
         """
     }
     await store.send(.longLivingEffect)
-    store.state.$sharedCount.assert {
-      $0 = 2
+    store.assert {
+      $0.sharedCount = 2
     }
   }
 
@@ -387,9 +390,9 @@ final class SharedTests: XCTestCase {
     }
     await store.send(.stopTimer)
     await mainQueue.advance(by: .seconds(1))
-    store.state.$count.assert {
-      $0 = 42
-    }
+//    store.assert {
+//      $0.count = 42
+//    }
   }
 
   @MainActor

--- a/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreFailureTests.swift
@@ -124,7 +124,7 @@ final class TestStoreFailureTests: BaseTCATestCase {
 
     XCTExpectFailure {
       $0.compactDescription == """
-        The store received 1 unexpected action after this one: …
+        The store received 1 unexpected action by the end of this test: …
 
           Unhandled actions:
             • .second


### PR DESCRIPTION
This tweaks shared change tracking a bit further:

1. Test stores now maintain their own, isolated change trackers instead of sharing the default test change tracker
2. Test stores now emit state-related failures on `deinit` when shared state changes before the end of the test but wasn't asserted on (_e.g._ in an effect)