### PR TITLE
Runtime warn for nested `observe` calls

### DIFF
--- a/Sources/ComposableArchitecture/UIKit/NSObject+Observation.swift
+++ b/Sources/ComposableArchitecture/UIKit/NSObject+Observation.swift
@@ -142,8 +142,10 @@
       if ObserveLocals.isApplying {
         runtimeWarn(
           """
-          An "observe" was called from another "observe" closure, which can lead to unintentional, \
-          over-observation.
+          An "observe" was called from another "observe" closure, which can lead to \
+          over-observation and unintended side effects.
+
+          Avoid nested closures by moving child observation into their own lifecycle methods.
           """
         )
       }

--- a/Sources/ComposableArchitecture/UIKit/NSObject+Observation.swift
+++ b/Sources/ComposableArchitecture/UIKit/NSObject+Observation.swift
@@ -140,7 +140,12 @@
     @discardableResult
     public func observe(_ apply: @escaping () -> Void) -> ObservationToken {
       if ObserveLocals.isApplying {
-        runtimeWarn("BAD")
+        runtimeWarn(
+          """
+          An "observe" was called from another "observe" closure, which can lead to unintentional, \
+          over-observation.
+          """
+        )
       }
       let token = ObservationToken()
       self.tokens.insert(token)

--- a/Tests/ComposableArchitectureTests/ObserveTests.swift
+++ b/Tests/ComposableArchitectureTests/ObserveTests.swift
@@ -14,9 +14,13 @@
       model.count += 1
       try await Task.sleep(nanoseconds: 1_000_000)
       XCTAssertEqual(counts, [0, 1])
+
+      model.otherCount += 1
+      try await Task.sleep(nanoseconds: 1_000_000)
+      XCTAssertEqual(counts, [0, 1])
+
       _ = observation
     }
-
     func testCancellation() async throws {
       let model = Model()
       var counts: [Int] = []
@@ -30,10 +34,48 @@
       XCTAssertEqual(counts, [0])
       _ = observation
     }
+
+    @MainActor
+    func testNestedObservation() async throws {
+      XCTExpectFailure {
+        $0.compactDescription == """
+          An "observe" was called from another "observe" closure, which can lead to \
+          over-observation and unintended side effects.
+
+          Avoid nested closures by moving child observation into their own lifecycle methods.
+          """
+      }
+
+      let model = Model()
+      var counts: [Int] = []
+      var innerObservation: Any!
+      let observation = observe { [weak self] in
+        guard let self else { return }
+        counts.append(model.count)
+        innerObservation = observe {
+          _ = model.otherCount
+        }
+      }
+      defer {
+        _ = observation
+        _ = innerObservation
+      }
+
+      XCTAssertEqual(counts, [0])
+
+      model.count += 1
+      try await Task.sleep(nanoseconds: 1_000_000)
+      XCTAssertEqual(counts, [0, 1])
+
+      model.otherCount += 1
+      try await Task.sleep(nanoseconds: 1_000_000)
+      XCTAssertEqual(counts, [0, 1, 1])
+    }
   }
 
   @Perceptible
   class Model {
     var count = 0
+    var otherCount = 0
   }
 #endif


### PR DESCRIPTION
It is possible for `observe` to be invoked inside an `observe` closure, especially if a view controller navigates to another view controller from its `observe`. This can lead to the parent `observe` over-observing all the child access/mutation.

Let's runtime warn to detect this problem so that folks can better avoid it.