### PR TITLE
Remove `@unchecked` from `StackState`'s `Sendable` conformance

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "a902f1823a7ff3c9ab2fba0f992396b948eda307",
-        "version" : "1.0.5"
+        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
+        "version" : "1.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7.2
+// swift-tools-version:5.7.1
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7.1
+// swift-tools-version:5.7.2
 
 import PackageDescription
 
@@ -17,7 +17,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-collections", from: "1.0.2"),
+    .package(url: "https://github.com/apple/swift-collections", from: "1.1.0"),
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.0"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -18,7 +18,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-collections", from: "1.0.2"),
+    .package(url: "https://github.com/apple/swift-collections", from: "1.1.0"),
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"511.0.0"),
     .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0"),

--- a/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
@@ -183,8 +183,7 @@ extension StackState: Hashable where Element: Hashable {
   }
 }
 
-// NB: We can remove `@unchecked` when swift-collections 1.1 is released.
-extension StackState: @unchecked Sendable where Element: Sendable {}
+extension StackState: Sendable where Element: Sendable {}
 
 extension StackState: Decodable where Element: Decodable {
   public init(from decoder: Decoder) throws {


### PR DESCRIPTION
I was digging around in the internals of the library, and I noticed this comment about removing this `@unchecked` when Swift Collections 1.1 is released.
I checked, and it has been released now. So I've updated TCA's dependency version, removing the `@unchecked` bit of `StackState`'s `Sendable` conformance.

This does have the potentially unfortunate side effect of needing to update the minimum Swift version to 5.7.2 from 5.7.1, as Swift Collections 1.1 bumps its minimum Swift version: https://github.com/apple/swift-collections/releases/tag/1.1.0