### PR TITLE
README.md: Update package addition wording to match latest Xcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ a particular problem, there are a number of places you can discuss with fellow
 
 You can add ComposableArchitecture to an Xcode project by adding it as a package dependency.
 
-  1. From the **File** menu, select **Add Packages...**
+  1. From the **File** menu, select **Add Package Dependencies...**
   2. Enter "https://github.com/pointfreeco/swift-composable-architecture" into the package 
      repository URL text field
   3. Depending on how your project is structured:


### PR DESCRIPTION
Just updating the readme to reflect the UI on Xcode 15.3

<img width="381" alt="Screenshot 2024-04-18 at 3 07 38 PM" src="https://github.com/pointfreeco/swift-composable-architecture/assets/10556242/46a6ef7e-c34d-4185-9639-a5aa813938be">
