### PR TITLE
Make `FileStorage` more opaque

### DIFF
--- a/Examples/SyncUps/SyncUps/App.swift
+++ b/Examples/SyncUps/SyncUps/App.swift
@@ -9,7 +9,7 @@ struct SyncUpsApp: App {
       ._printChanges()
   } withDependencies: {
     if ProcessInfo.processInfo.environment["UITesting"] == "true" {
-      $0.defaultFileStorage = InMemoryFileStorage()
+      $0.defaultFileStorage = .inMemory
     }
   }
 

--- a/Examples/SyncUps/SyncUpsTests/AppFeatureTests.swift
+++ b/Examples/SyncUps/SyncUpsTests/AppFeatureTests.swift
@@ -7,14 +7,12 @@ final class AppFeatureTests: XCTestCase {
   @MainActor
   func testDetailEdit() async throws {
     var syncUp = SyncUp.mock
-
-    let store = TestStore(
-      initialState: AppFeature.State(syncUpsList: SyncUpsList.State(syncUps: [syncUp]))
-    ) {
+    @Shared(.syncUps) var syncUps = [syncUp]
+    let store = TestStore(initialState: AppFeature.State()) {
       AppFeature()
     }
 
-    let sharedSyncUp = try XCTUnwrap(store.state.syncUpsList.$syncUps[id: syncUp.id])
+    let sharedSyncUp = try XCTUnwrap($syncUps[id: syncUp.id])
 
     await store.send(\.path.push, (id: 0, .detail(SyncUpDetail.State(syncUp: sharedSyncUp)))) {
       $0.path[id: 0] = .detail(SyncUpDetail.State(syncUp: sharedSyncUp))
@@ -41,15 +39,12 @@ final class AppFeatureTests: XCTestCase {
   @MainActor
   func testDelete() async throws {
     let syncUp = SyncUp.mock
-
-    let store = TestStore(
-      initialState: AppFeature.State(syncUpsList: SyncUpsList.State(syncUps: [syncUp]))
-    ) {
+    @Shared(.syncUps) var syncUps = [syncUp]
+    let store = TestStore(initialState: AppFeature.State()) {
       AppFeature()
     }
 
-    guard let sharedSyncUp = store.state.syncUpsList.$syncUps[id: syncUp.id]
-    else { return }
+    let sharedSyncUp = try XCTUnwrap($syncUps[id: syncUp.id])
 
     await store.send(\.path.push, (id: 0, .detail(SyncUpDetail.State(syncUp: sharedSyncUp)))) {
       $0.path[id: 0] = .detail(SyncUpDetail.State(syncUp: Shared(syncUp)))

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/AppStorageKey.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/AppStorageKey.md
@@ -27,3 +27,4 @@
 ### Key-path access
 
 - ``PersistenceReaderKey/appStorage(_:)-5jsie``
+- ``AppStorageKeyPathKey``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/FileStorageKey.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/FileStorageKey.md
@@ -5,3 +5,7 @@
 ### Storing a value
 
 - ``PersistenceReaderKey/fileStorage(_:)``
+
+### Overriding storage
+
+- ``FileStorage``

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -1,3 +1,13 @@
+// NB: Deprecated with 1.10.0:
+
+@available(*, deprecated, message: "Use '.fileSystem' ('FileStorage.fileSystem') instead")
+public func LiveFileStorage() -> FileStorage { .fileSystem }
+
+@available(*, deprecated, message: "Use '.inMemory' ('FileStorage.inMemory') instead")
+public func InMemoryFileStorage() -> FileStorage { .inMemory }
+
+// NB: Deprecated with 1.0.0:
+
 @available(*, unavailable, renamed: "Effect")
 public typealias EffectTask = Effect
 

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/FileStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/FileStorageKey.swift
@@ -256,7 +256,7 @@ public struct FileStorage: Sendable {
       },
       save: { data, url in
         fileSystem.withValue { $0[url] = data }
-        sourceHandlers.withValue { $0[url]?.forEach { $0() } }
+        sourceHandlers.withValue { $0[url]?.forEach { $0.operation() } }
       }
     )
   }

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/FileStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/FileStorageKey.swift
@@ -222,16 +222,6 @@ public struct FileStorage: Sendable {
     fileSystem: LockIsolated<[URL: Data]>,
     scheduler: AnySchedulerOf<DispatchQueue> = .immediate
   ) -> Self {
-    struct Handler: Hashable {
-      let id = UUID()
-      let operation: () -> Void
-      static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.id == rhs.id
-      }
-      func hash(into hasher: inout Hasher) {
-        hasher.combine(self.id)
-      }
-    }
     let sourceHandlers = LockIsolated<[URL: Set<Handler>]>([:])
     return Self(
       id: AnyHashableSendable(ObjectIdentifier(fileSystem)),
@@ -259,5 +249,16 @@ public struct FileStorage: Sendable {
         sourceHandlers.withValue { $0[url]?.forEach { $0.operation() } }
       }
     )
+  }
+
+  fileprivate struct Handler: Hashable {
+    let id = UUID()
+    let operation: () -> Void
+    static func == (lhs: Self, rhs: Self) -> Bool {
+      lhs.id == rhs.id
+    }
+    func hash(into hasher: inout Hasher) {
+      hasher.combine(self.id)
+    }
   }
 }

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/FileStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/FileStorageKey.swift
@@ -241,9 +241,9 @@ public struct FileStorage: Sendable {
       fileExists: { fileSystem.keys.contains($0) },
       fileSystemSource: { url, _, handler in
         let handler = Handler(operation: handler)
-        sourceHandlers.withValue { $0[url, default: []].insert(handler) }
+        sourceHandlers.withValue { _ = $0[url, default: []].insert(handler) }
         return AnyCancellable {
-          sourceHandlers.withValue { $0[url]?.remove(handler) }
+          sourceHandlers.withValue { _ = $0[url]?.remove(handler) }
         }
       },
       load: {

--- a/Tests/ComposableArchitectureTests/FileStorageTests.swift
+++ b/Tests/ComposableArchitectureTests/FileStorageTests.swift
@@ -346,7 +346,7 @@ final class FileStorageTests: XCTestCase {
     }
   }
 
-  func testMismatchTypes() {
+  func testMismatchTypesSameCodability() {
     @Shared(.fileStorage(.fileURL)) var users: [User] = []
     @Shared(.fileStorage(.fileURL)) var users1: [User] = []
     @Shared(.fileStorage(.fileURL)) var users2: IdentifiedArrayOf<User> = []
@@ -354,7 +354,23 @@ final class FileStorageTests: XCTestCase {
     users.append(User(id: 1, name: "Blob"))
     XCTAssertEqual(users, [User(id: 1, name: "Blob")])
     XCTAssertEqual(users1, [User(id: 1, name: "Blob")])
-    XCTAssertEqual(users2, [])
+    XCTAssertEqual(users2, [User(id: 1, name: "Blob")])
+  }
+
+  func testMismatchTypesDifferentCodability() {
+    @Shared(.fileStorage(.fileURL)) var users: [User] = []
+    @Shared(.fileStorage(.fileURL)) var users1: [User] = []
+    @Shared(.fileStorage(.fileURL)) var users2 = false
+
+    users.append(User(id: 1, name: "Blob"))
+    XCTAssertEqual(users, [User(id: 1, name: "Blob")])
+    XCTAssertEqual(users1, [User(id: 1, name: "Blob")])
+    XCTAssertEqual(users2, false)
+
+    users2 = true
+    XCTAssertEqual(users, [])
+    XCTAssertEqual(users1, [])
+    XCTAssertEqual(users2, true)
   }
 
   func testTwoInMemoryFileStorages() {

--- a/Tests/ComposableArchitectureTests/FileStorageTests.swift
+++ b/Tests/ComposableArchitectureTests/FileStorageTests.swift
@@ -7,7 +7,7 @@ final class FileStorageTests: XCTestCase {
   func testBasics() throws {
     let fileStorage = InMemoryFileStorage(scheduler: .immediate)
     try withDependencies {
-      $0.defaultFileStorage = fileStorage
+      $0.defaultFileStorage = FileStorage(rawValue: fileStorage)
     } operation: {
       @Shared(.fileStorage(.fileURL)) var users = [User]()
       XCTAssertNoDifference(fileStorage.fileSystem.value, [.fileURL: Data()])
@@ -20,7 +20,7 @@ final class FileStorageTests: XCTestCase {
     let testScheduler = DispatchQueue.test
     let fileStorage = InMemoryFileStorage(scheduler: testScheduler.eraseToAnyScheduler())
     try withDependencies {
-      $0.defaultFileStorage = fileStorage
+      $0.defaultFileStorage = FileStorage(rawValue: fileStorage)
     } operation: {
       @Shared(.fileStorage(.fileURL)) var users = [User]()
       XCTAssertNoDifference(fileStorage.fileSystem.value, [.fileURL: Data()])
@@ -40,7 +40,7 @@ final class FileStorageTests: XCTestCase {
     let testScheduler = DispatchQueue.test
     let fileStorage = InMemoryFileStorage(scheduler: testScheduler.eraseToAnyScheduler())
     try withDependencies {
-      $0.defaultFileStorage = fileStorage
+      $0.defaultFileStorage = FileStorage(rawValue: fileStorage)
     } operation: {
       @Shared(.fileStorage(.fileURL)) var users = [User]()
       XCTAssertNoDifference(fileStorage.fileSystem.value, [.fileURL: Data()])
@@ -81,7 +81,7 @@ final class FileStorageTests: XCTestCase {
     let testScheduler = DispatchQueue.test
     let fileStorage = InMemoryFileStorage(scheduler: testScheduler.eraseToAnyScheduler())
     try withDependencies {
-      $0.defaultFileStorage = fileStorage
+      $0.defaultFileStorage = FileStorage(rawValue: fileStorage)
     } operation: {
       @Shared(.fileStorage(.fileURL)) var users = [User]()
       XCTAssertNoDifference(fileStorage.fileSystem.value, [.fileURL: Data()])
@@ -101,7 +101,7 @@ final class FileStorageTests: XCTestCase {
     let testScheduler = DispatchQueue.test
     let fileStorage = InMemoryFileStorage(scheduler: testScheduler.eraseToAnyScheduler())
     try withDependencies {
-      $0.defaultFileStorage = fileStorage
+      $0.defaultFileStorage = FileStorage(rawValue: fileStorage)
     } operation: {
       @Shared(.fileStorage(.fileURL)) var users = [User]()
       XCTAssertNoDifference(fileStorage.fileSystem.value, [.fileURL: Data()])
@@ -120,7 +120,7 @@ final class FileStorageTests: XCTestCase {
     let testScheduler = DispatchQueue.test
     let fileStorage = InMemoryFileStorage(scheduler: testScheduler.eraseToAnyScheduler())
     try withDependencies {
-      $0.defaultFileStorage = fileStorage
+      $0.defaultFileStorage = FileStorage(rawValue: fileStorage)
     } operation: {
       @Shared(.fileStorage(.fileURL)) var users = [User]()
       XCTAssertNoDifference(fileStorage.fileSystem.value, [.fileURL: Data()])
@@ -147,7 +147,7 @@ final class FileStorageTests: XCTestCase {
   func testMultipleFiles() throws {
     let fileStorage = InMemoryFileStorage()
     try withDependencies {
-      $0.defaultFileStorage = fileStorage
+      $0.defaultFileStorage = FileStorage(rawValue: fileStorage)
     } operation: {
       @Shared(.fileStorage(.fileURL)) var users = [User]()
       @Shared(.fileStorage(.anotherFileURL)) var otherUsers = [User]()
@@ -168,7 +168,7 @@ final class FileStorageTests: XCTestCase {
     try? FileManager.default.removeItem(at: .fileURL)
 
     try await withDependencies {
-      $0.defaultFileStorage = LiveFileStorage(queue: DispatchQueue.main)
+      $0.defaultFileStorage = FileStorage(rawValue: LiveFileStorage(queue: .main))
     } operation: {
       @Shared(.fileStorage(.fileURL)) var users = [User]()
 
@@ -189,7 +189,7 @@ final class FileStorageTests: XCTestCase {
       let fileStorage = InMemoryFileStorage()
       try fileStorage.save(JSONEncoder().encode([User.blob]), to: .fileURL)
       try await withDependencies {
-        $0.defaultFileStorage = fileStorage
+        $0.defaultFileStorage = FileStorage(rawValue: fileStorage)
       } operation: {
         @Shared(.fileStorage(.fileURL)) var users = [User]()
         _ = users
@@ -205,7 +205,7 @@ final class FileStorageTests: XCTestCase {
       try JSONEncoder().encode([User.blob]).write(to: .fileURL)
 
       try await withDependencies {
-        $0.defaultFileStorage = LiveFileStorage(queue: DispatchQueue.main)
+        $0.defaultFileStorage = FileStorage(rawValue: LiveFileStorage(queue: .main))
       } operation: {
         @Shared(.fileStorage(.fileURL)) var users = [User]()
         _ = users
@@ -225,7 +225,7 @@ final class FileStorageTests: XCTestCase {
       try JSONEncoder().encode([User.blob]).write(to: .fileURL)
 
       try await withDependencies {
-        $0.defaultFileStorage = LiveFileStorage(queue: DispatchQueue.main)
+        $0.defaultFileStorage = FileStorage(rawValue: LiveFileStorage(queue: .main))
       } operation: {
         @Shared(.fileStorage(.fileURL)) var users = [User]()
         await Task.yield()
@@ -244,7 +244,7 @@ final class FileStorageTests: XCTestCase {
     let fileStorage = InMemoryFileStorage(scheduler: scheduler.eraseToAnyScheduler())
 
     try withDependencies {
-      $0.defaultFileStorage = fileStorage
+      $0.defaultFileStorage = FileStorage(rawValue: fileStorage)
     } operation: {
       @Shared(.fileStorage(.fileURL)) var users = [User]()
 
@@ -263,7 +263,7 @@ final class FileStorageTests: XCTestCase {
       try JSONEncoder().encode([User.blob]).write(to: .fileURL)
 
       try await withDependencies {
-        $0.defaultFileStorage = LiveFileStorage(queue: DispatchQueue.main)
+        $0.defaultFileStorage = FileStorage(rawValue: LiveFileStorage(queue: .main))
       } operation: {
         @Shared(.fileStorage(.fileURL)) var users = [User]()
         await Task.yield()
@@ -284,7 +284,7 @@ final class FileStorageTests: XCTestCase {
       try JSONEncoder().encode([User.blob]).write(to: .fileURL)
 
       try await withDependencies {
-        $0.defaultFileStorage = LiveFileStorage(queue: DispatchQueue.main)
+        $0.defaultFileStorage = FileStorage(rawValue: LiveFileStorage(queue: .main))
       } operation: {
         @Shared(.fileStorage(.fileURL)) var users = [User]()
         await Task.yield()
@@ -304,7 +304,7 @@ final class FileStorageTests: XCTestCase {
       try JSONEncoder().encode([User.blob]).write(to: .fileURL)
 
       try await withDependencies {
-        $0.defaultFileStorage = LiveFileStorage(queue: DispatchQueue.main)
+        $0.defaultFileStorage = FileStorage(rawValue: LiveFileStorage(queue: .main))
       } operation: {
         @Shared(.fileStorage(.fileURL)) var users = [User]()
         await Task.yield()
@@ -339,13 +339,13 @@ final class FileStorageTests: XCTestCase {
 
   func testTwoInMemoryFileStorages() {
     let shared1 = withDependencies {
-      $0.defaultFileStorage = InMemoryFileStorage()
+      $0.defaultFileStorage = .inMemory
     } operation: {
       @Shared(.fileStorage(.userURL)) var user = User(id: 1, name: "Blob")
       return $user
     }
     let shared2 = withDependencies {
-      $0.defaultFileStorage = InMemoryFileStorage()
+      $0.defaultFileStorage = .inMemory
     } operation: {
       @Shared(.fileStorage(.userURL)) var user = User(id: 1, name: "Blob")
       return $user

--- a/Tests/ComposableArchitectureTests/ObserveTests.swift
+++ b/Tests/ComposableArchitectureTests/ObserveTests.swift
@@ -35,43 +35,45 @@
       _ = observation
     }
 
-    @MainActor
-    func testNestedObservation() async throws {
-      XCTExpectFailure {
-        $0.compactDescription == """
-          An "observe" was called from another "observe" closure, which can lead to \
-          over-observation and unintended side effects.
+    #if DEBUG
+      @MainActor
+      func testNestedObservation() async throws {
+        XCTExpectFailure {
+          $0.compactDescription == """
+            An "observe" was called from another "observe" closure, which can lead to \
+            over-observation and unintended side effects.
 
-          Avoid nested closures by moving child observation into their own lifecycle methods.
-          """
-      }
-
-      let model = Model()
-      var counts: [Int] = []
-      var innerObservation: Any!
-      let observation = observe { [weak self] in
-        guard let self else { return }
-        counts.append(model.count)
-        innerObservation = observe {
-          _ = model.otherCount
+            Avoid nested closures by moving child observation into their own lifecycle methods.
+            """
         }
+
+        let model = Model()
+        var counts: [Int] = []
+        var innerObservation: Any!
+        let observation = observe { [weak self] in
+          guard let self else { return }
+          counts.append(model.count)
+          innerObservation = observe {
+            _ = model.otherCount
+          }
+        }
+        defer {
+          _ = observation
+          _ = innerObservation
+        }
+
+        XCTAssertEqual(counts, [0])
+
+        model.count += 1
+        try await Task.sleep(nanoseconds: 1_000_000)
+        XCTAssertEqual(counts, [0, 1])
+
+        model.otherCount += 1
+        try await Task.sleep(nanoseconds: 1_000_000)
+        XCTAssertEqual(counts, [0, 1, 1])
       }
-      defer {
-        _ = observation
-        _ = innerObservation
-      }
-
-      XCTAssertEqual(counts, [0])
-
-      model.count += 1
-      try await Task.sleep(nanoseconds: 1_000_000)
-      XCTAssertEqual(counts, [0, 1])
-
-      model.otherCount += 1
-      try await Task.sleep(nanoseconds: 1_000_000)
-      XCTAssertEqual(counts, [0, 1, 1])
     }
-  }
+  #endif
 
   @Perceptible
   class Model {

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -1047,7 +1047,7 @@
       let store = Store(initialState: Feature.State()) {
         Feature()
       }
-      let task = store.send(.onAppear)
+      store.send(.onAppear)
       store.send(.tap)
       try? await Task.sleep(nanoseconds: 1_000_000)
       XCTAssertEqual(


### PR DESCRIPTION
Previously, we had a public protocol and conformances, but we don't expect anyone to conform outside the library, so instead let's hide things in a more opaque struct.

The downside of this PR is that it's a breaking API change pretty late in the game:

```diff
-$0.defaultFileStorage = InMemoryFileStorage()
+$0.defaultFileStorage = .inMemory
```

We could add public deprecated functions that emulate the old initializers if we think it's worth it...