### PR TITLE
Don’t assume CastableLookup

### DIFF
--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
@@ -298,7 +298,7 @@ extension AppStorageKey: PersistenceKey {
     ) { _ in
       guard !SharedAppStorageLocals.isSetting
       else { return }
-      didSet(self.store.value(forKey: self.key) as? Value ?? initialValue)
+      didSet(load(initialValue: initialValue))
     }
     let willEnterForeground: (any NSObjectProtocol)?
     if let willEnterForegroundNotificationName {
@@ -307,7 +307,7 @@ extension AppStorageKey: PersistenceKey {
         object: nil,
         queue: nil
       ) { _ in
-        didSet(self.store.value(forKey: self.key) as? Value ?? initialValue)
+        didSet(load(initialValue: initialValue))
       }
     } else {
       willEnterForeground = nil

--- a/Tests/ComposableArchitectureTests/AppStorageTests.swift
+++ b/Tests/ComposableArchitectureTests/AppStorageTests.swift
@@ -111,6 +111,16 @@ final class AppStorageTests: XCTestCase {
     XCTAssertEqual(count, 42)
   }
 
+  func testChangeUserDefaultsDirectly_RawRepresentable() {
+    enum Direction: String, CaseIterable {
+      case north, south, east, west
+    }
+    @Dependency(\.defaultAppStorage) var defaults
+    @Shared(.appStorage("direction")) var direction: Direction = .south
+    defaults.set("east", forKey: "direction")
+    XCTAssertEqual(direction, .east)
+  }
+
   func testChangeUserDefaultsDirectly_KeyWithPeriod() {
     @Dependency(\.defaultAppStorage) var defaults
     @Shared(.appStorage("pointfreeco.count")) var count = 0


### PR DESCRIPTION
If the observed value in `UserDefaults` is a `RawRepresentable` type, simply casting to `Value` might fail because the raw representing type could be different from `Value`.  Instead of querying `UserDefaults` directly here, we should call `loadValue()` which will do the right thing for raw representable types (esp. try to call `Value.init(rawValue:)` with the value obtained from `UserDefaults`).

Or am I missing something and there is a reason this is using `UserDefaults.value(forKey:)` directly?  I am especially curious because `CastableLookup` on line 374 is using `UserDefaults.object(forKey:)` instead, so it does look somewhat deliberate.