### PR TITLE
Remove `Reducer._Body` workaround

### DIFF
--- a/Sources/ComposableArchitecture/CaseReducer.swift
+++ b/Sources/ComposableArchitecture/CaseReducer.swift
@@ -6,6 +6,7 @@ public protocol CaseReducer<State, Action>: Reducer
 where State: CaseReducerState, Body: Reducer, Body.State == State, Body.Action == Action {
   associatedtype State = State
   associatedtype Action = Action
+  associatedtype Body = Body
   associatedtype CaseScope
 
   @ReducerBuilder<State, Action>

--- a/Sources/ComposableArchitecture/CaseReducer.swift
+++ b/Sources/ComposableArchitecture/CaseReducer.swift
@@ -6,12 +6,6 @@ public protocol CaseReducer<State, Action>: Reducer
 where State: CaseReducerState, Body: Reducer, Body.State == State, Body.Action == Action {
   associatedtype State = State
   associatedtype Action = Action
-  #if DEBUG
-    associatedtype _Body = _Body
-    typealias Body = _Body
-  #else
-    associatedtype Body
-  #endif
   associatedtype CaseScope
 
   @ReducerBuilder<State, Action>

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerBody.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerBody.md
@@ -4,4 +4,4 @@
 
 ### Associated type
 
-- ``Body-swift.typealias``
+- ``Body``

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -11,30 +11,14 @@ public protocol Reducer<State, Action> {
   /// and/or kick off a side ``Effect`` that can communicate with the outside world.
   associatedtype Action
 
-  // NB: For Xcode to favor autocompleting `var body: Body` over `var body: Never` we must use a
-  //     type alias. We compile it out of release because this workaround is incompatible with
-  //     library evolution.
-  #if DEBUG
-    associatedtype _Body
-
-    /// A type representing the body of this reducer.
-    ///
-    /// When you create a custom reducer by implementing the ``body-swift.property``, Swift infers
-    /// this type from the value returned.
-    ///
-    /// If you create a custom reducer by implementing the ``reduce(into:action:)-1t2ri``, Swift
-    /// infers this type to be `Never`.
-    typealias Body = _Body
-  #else
-    /// A type representing the body of this reducer.
-    ///
-    /// When you create a custom reducer by implementing the ``body-swift.property``, Swift infers
-    /// this type from the value returned.
-    ///
-    /// If you create a custom reducer by implementing the ``reduce(into:action:)-1t2ri``, Swift
-    /// infers this type to be `Never`.
-    associatedtype Body
-  #endif
+  /// A type representing the body of this reducer.
+  ///
+  /// When you create a custom reducer by implementing the ``body-swift.property``, Swift infers
+  /// this type from the value returned.
+  ///
+  /// If you create a custom reducer by implementing the ``reduce(into:action:)-1t2ri``, Swift
+  /// infers this type to be `Never`.
+  associatedtype Body
 
   /// Evolves the current state of the reducer to the next state.
   ///


### PR DESCRIPTION
This type was mainly introduced to improve Xcode autocomplete of the `body` property, but since the `@Reducer` macro we don't really get any autocomplete anyway...