### PR TITLE
Add missing NSPrivacyCollectedDataTypes to PrivacyInfo.xcprivacy

### DIFF
--- a/Sources/ComposableArchitecture/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/ComposableArchitecture/Resources/PrivacyInfo.xcprivacy
@@ -3,20 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/Sources/ComposableArchitecture/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/ComposableArchitecture/Resources/PrivacyInfo.xcprivacy
@@ -2,6 +2,21 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Revision of: https://github.com/pointfreeco/swift-composable-architecture/pull/2930
Per: https://github.com/pointfreeco/swift-composable-architecture/issues/3021

The Xcode behavior appears to be different from when I submitted PR 2930. I originally created the manifest without NSPrivacyCollectedDataTypes (since TCA is not actually collecting anything) and Xcode generated an empty Privacy Report. 

Now it generates the error `Missing an expected key: 'NSPrivacyCollectedDataTypes'`

I've now added the key in however, it no longer generates an empty Privacy Report, so I think it needs to be a library decision how we proceed. Here's the new generated report. 

<img width="568" alt="Screenshot 2024-04-29 at 1 10 41 PM" src="https://github.com/pointfreeco/swift-composable-architecture/assets/72824209/87798924-fed4-4949-85ae-ec29e24db7d2">

According to this we are collecting "other" data even though TCA isn't collecting anything and even though we already have an Apple-approved exemption (C56D.1). I believe that this is misleading to library users, and Apple may force app makers to include this in their final App Store nutrition label declaration, which would be further misleading to customers. 


