### PR TITLE
Revert perception availability changes

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "03d51ee56a5fa27daccbc9539cebe336e0b45bc0",
-        "version" : "1.1.6"
+        "revision" : "8e8ca36c02abc7775a3ab81f9468c0df5fe22c2c",
+        "version" : "1.1.7"
       }
     },
     {

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -29,7 +29,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.1.0"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
-    .package(url: "https://github.com/pointfreeco/swift-perception", from: "1.1.6"),
+    .package(url: "https://github.com/pointfreeco/swift-perception", from: "1.1.7"),
     .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "1.1.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.1.0"),
   ],

--- a/Sources/ComposableArchitecture/Observation/ObservationStateRegistrar.swift
+++ b/Sources/ComposableArchitecture/Observation/ObservationStateRegistrar.swift
@@ -21,7 +21,7 @@
   }
 
   #if canImport(Observation)
-    @available(iOS 17.0.1, macOS 14, tvOS 17.0.1, watchOS 10.0.1, *)
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     extension ObservationStateRegistrar {
       /// Registers access to a specific property for observation.
       ///


### PR DESCRIPTION
Perception 1.1.6 introduced availability changes intended to prevent crashes in iOS 17.0 beta users, but had unintended downstream consequences in projects with a minimum deployment target of 17.0 (in particular these projects began to emit runtime warnings when they shouldn't have), and so it was reverted. This PR is a follow-up that pins to the latest Perception 1.1.7, which reverts these checks.