### PR TITLE
Don't warn when dismissing two layers of tree nav

### DIFF
--- a/Sources/ComposableArchitecture/Observation/Store+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Store+Observation.swift
@@ -292,7 +292,7 @@
         #endif
       }
       set {
-        if newValue == nil, self.state[keyPath: state] != nil {
+        if newValue == nil, self.state[keyPath: state] != nil, !self._isInvalidated() {
           self.send(action(.dismiss))
         }
       }


### PR DESCRIPTION
Currently, popping two layers in a nav tree will cause intermediate, invalid stores to send `dismiss` actions when they shouldn't. This branch avoids this by checking the store's validity before sending the action along.

Fixes #3031.