### PR TITLE
Cancel `TestStore` effects when root feature is dismissed

### DIFF
--- a/Examples/SyncUps/SyncUpsTests/SyncUpDetailTests.swift
+++ b/Examples/SyncUps/SyncUpsTests/SyncUpDetailTests.swift
@@ -113,9 +113,6 @@ final class SyncUpDetailTests: XCTestCase {
 
   @MainActor
   func testDelete() async throws {
-    let didDismiss = LockIsolated(false)
-    defer { XCTAssertEqual(didDismiss.value, true) }
-
     let syncUp = SyncUp.mock
     @Shared(.syncUps) var syncUps = [syncUp]
     // TODO: Can this exhaustively be caught?
@@ -124,11 +121,8 @@ final class SyncUpDetailTests: XCTestCase {
     let sharedSyncUp = try XCTUnwrap($syncUps[id: syncUp.id])
     let store = TestStore(initialState: SyncUpDetail.State(syncUp: sharedSyncUp)) {
       SyncUpDetail()
-    } withDependencies: {
-      $0.dismiss = DismissEffect {
-        didDismiss.setValue(true)
-      }
     }
+    defer { XCTAssert(store.isDismissed) }
 
     await store.send(.deleteButtonTapped) {
       $0.destination = .alert(.deleteSyncUp)

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStore.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStore.md
@@ -25,6 +25,7 @@
 - ``receive(_:timeout:assert:file:line:)-7md3m``
 - ``assert(_:file:line:)``
 - ``finish(timeout:file:line:)-53gi5``
+- ``isDismissed``
 - ``TestStoreTask``
 
 ### Skipping actions and effects

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -492,6 +492,8 @@ public final class TestStore<State, Action> {
   let reducer: TestReducer<State, Action>
   private let sharedChangeTracker: SharedChangeTracker
   private let store: Store<State, TestReducer<State, Action>.TestAction>
+
+  /// Returns `true` if the store's feature has been dismissed.
   public fileprivate(set) var isDismissed = false
 
   /// Creates a test store with an initial state and a reducer powering its runtime.


### PR DESCRIPTION
Right now, if a leaf feature is tested and it dismisses itself while effects are in-flight, the only way to get tests passing is to explicitly tell the store or any tasks returned by `store.send` to cancel. Further, you must use an expectation in such tests to assert that `dismiss` was called in the first place.

This PR changes this behavior to automatically cancel a test store's effects if it is dismissed, and it prohibits sending more actions to it after dismiss has been called.