### PR TITLE
Runtime warn when stack integration is missing from store's reducer

### DIFF
--- a/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
@@ -287,7 +287,7 @@ import SwiftUI
   }
 
   extension Store {
-    fileprivate subscript<ElementState, ElementAction>(
+    @_spi(Internals) public subscript<ElementState, ElementAction>(
       fileID fileID: String,
       line line: UInt
     ) -> StackState<ElementState>.PathView

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -785,7 +785,7 @@ extension WithViewStore where ViewState: Equatable, Content: View {
         customDump(self.value, to: &value, maxDepth: 0)
         runtimeWarn(
           """
-          A binding action sent from a view store \
+          A binding action sent from a store \
           \(self.context == .bindingState ? "for binding state defined " : "")at \
           "\(self.fileID):\(self.line)" was not handled. …
 

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -536,7 +536,6 @@ public final class TestStore<State, Action> {
     self.timeout = 1 * NSEC_PER_SEC
     self.sharedChangeTracker = sharedChangeTracker
     self.useMainSerialExecutor = true
-    let dismiss = self.reducer.dependencies.dismiss.dismiss
     self.reducer.store = self
   }
 

--- a/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
+++ b/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
@@ -193,7 +193,7 @@
         ViewStore(store, observe: { $0 }).$value.wrappedValue = 42
       } issueMatcher: {
         $0.compactDescription == """
-          A binding action sent from a view store for binding state defined at \
+          A binding action sent from a store for binding state defined at \
           "\(#fileID):\(line)" was not handled. …
 
             Action:
@@ -219,7 +219,7 @@
         ViewStore(store, observe: { $0 }).$value.wrappedValue = 42
       } issueMatcher: {
         $0.compactDescription == """
-          A binding action sent from a view store for binding state defined at \
+          A binding action sent from a store for binding state defined at \
           "\(#fileID):\(line)" was not handled. …
 
             Action:


### PR DESCRIPTION
If SwiftUI writes to a binding and the state is invalid (it is not inserting or removing elements from the stack), then the most likely cause is a missing `forEach` in the reducer (or a missing integration in some parent reducer).

This commit adds a runtime warning to detect this issue:

![image](https://github.com/pointfreeco/swift-composable-architecture/assets/658/60247eed-e625-4df8-8381-f59647d7ce25)
