### PR TITLE
Propagate dependencies to reducer all the time.

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -170,21 +170,14 @@ public final class Store<State, Action> {
     @ReducerBuilder<State, Action> reducer: () -> R,
     withDependencies prepareDependencies: ((inout DependencyValues) -> Void)? = nil
   ) where R.State == State, R.Action == Action {
-    if let prepareDependencies {
-      let (initialState, reducer, dependencies) = withDependencies(prepareDependencies) {
-        @Dependency(\.self) var dependencies
-        return (initialState(), reducer(), dependencies)
-      }
-      self.init(
-        initialState: initialState,
-        reducer: reducer.dependency(\.self, dependencies)
-      )
-    } else {
-      self.init(
-        initialState: initialState(),
-        reducer: reducer()
-      )
+    let (initialState, reducer, dependencies) = withDependencies(prepareDependencies ?? { _ in }) {
+      @Dependency(\.self) var dependencies
+      return (initialState(), reducer(), dependencies)
     }
+    self.init(
+      initialState: initialState,
+      reducer: reducer.dependency(\.self, dependencies)
+    )
   }
 
   init() {

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -1114,6 +1114,32 @@
       store.send(.child(.dismiss))
       grandchildStoreBinding.wrappedValue = nil
     }
+
+    @MainActor
+    func testSurroundingDependencies() {
+      let store = withDependencies {
+        $0.uuid = .incrementing
+      } operation: {
+        Store<UUID, Void>(initialState: UUID()) {
+          Reduce { state, _ in
+            @Dependency(\.uuid) var uuid
+            state = uuid()
+            return .none
+          }
+        }
+      }
+
+      store.send(())
+      XCTAssertEqual(
+        store.withState { $0 },
+        UUID(0)
+      )
+      store.send(())
+      XCTAssertEqual(
+        store.withState { $0 },
+        UUID(1)
+      )
+    }
   }
 
   private struct Count: TestDependencyKey {


### PR DESCRIPTION
Right now we only propagate dependencies to the reducer in `Store` when using the `withDependencies` trailing closure. But let's do it all the time for when one needs to do `withDependencies { Store }`.