### PR TITLE
Make PersistenceKeyDefault load its default value lazily

### DIFF
--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/PersistenceKeyDefault.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/PersistenceKeyDefault.swift
@@ -24,9 +24,9 @@
 /// ```
 public struct PersistenceKeyDefault<Base: PersistenceReaderKey>: PersistenceReaderKey {
   let base: Base
-  let defaultValue: Base.Value
+  let defaultValue: () -> Base.Value
 
-  public init(_ key: Base, _ value: Base.Value) {
+  public init(_ key: Base, _ value: @autoclosure @escaping () -> Base.Value) {
     self.base = key
     self.defaultValue = value
   }
@@ -36,7 +36,7 @@ public struct PersistenceKeyDefault<Base: PersistenceReaderKey>: PersistenceRead
   }
 
   public func load(initialValue: Base.Value?) -> Base.Value? {
-    self.base.load(initialValue: initialValue ?? self.defaultValue)
+    self.base.load(initialValue: initialValue ?? self.defaultValue())
   }
 
   public func subscribe(

--- a/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
+++ b/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
@@ -73,7 +73,7 @@ extension Shared {
     line: UInt = #line
   ) where Key.Value == Value {
     self.init(
-      wrappedValue: persistenceKey.load(initialValue: nil) ?? persistenceKey.defaultValue,
+      wrappedValue: persistenceKey.load(initialValue: nil) ?? persistenceKey.defaultValue(),
       persistenceKey.base,
       fileID: fileID,
       line: line
@@ -159,7 +159,7 @@ extension SharedReader {
     line: UInt = #line
   ) where Key.Value == Value {
     self.init(
-      wrappedValue: persistenceKey.load(initialValue: nil) ?? persistenceKey.defaultValue,
+      wrappedValue: persistenceKey.load(initialValue: nil) ?? persistenceKey.defaultValue(),
       persistenceKey.base,
       fileID: fileID,
       line: line

--- a/Tests/ComposableArchitectureTests/SharedTests.swift
+++ b/Tests/ComposableArchitectureTests/SharedTests.swift
@@ -722,6 +722,28 @@ final class SharedTests: XCTestCase {
     XCTAssertEqual(isOn2, true)
     XCTAssertEqual(isOn3, true)
   }
+  
+  func testSharedDefaults_Used() {
+    let didAccess = LockIsolated(false)
+    let logDefault: () -> Bool = {
+      didAccess.setValue(true)
+      return true
+    }
+    @Shared(.isActive(default: logDefault)) var isActive
+    XCTAssertEqual(isActive, true)
+    XCTAssertEqual(didAccess.value, true)
+  }
+
+  func testSharedDefaults_Unused() {
+    let didAccess = LockIsolated(false)
+    let logDefault: () -> Bool = {
+      didAccess.setValue(true)
+      return true
+    }
+    @Shared(.isActive(default: logDefault)) var isActive = false
+    XCTAssertEqual(isActive, false)
+    XCTAssertEqual(didAccess.value, false)
+  }
 
   func testSharedReaderDefaults_MultipleWithDifferentDefaults() async throws {
     @Shared(.appStorage("isOn")) var isOn = false
@@ -1034,6 +1056,10 @@ private struct EarlySharedStateMutation {
 extension PersistenceReaderKey where Self == PersistenceKeyDefault<AppStorageKey<Bool>> {
   static var isOn: Self {
     PersistenceKeyDefault(.appStorage("isOn"), false)
+  }
+  
+  static func isActive(default keyDefault: @escaping () -> Bool) -> Self {
+    PersistenceKeyDefault(.appStorage("isActive"), keyDefault())
   }
 }
 


### PR DESCRIPTION
`PersistenceKeyDefault` eagerly evaluates its `defaultValue`. This means every declaration of a `Shared` value creates a new copy of this value when it's evaluated. Since the normal pattern for persisting shared values is to successfully load from its source, the default value is generated and thrown away without being used.

Additionally, creating this default value can have side effects. Consider a testing context where the default value uses the uuid dependency. Here's a persistence key whose default value creates a `Folder` value whose initializer generates an id from the current uuid dependency.

```swift
extension PersistenceKey where Self == PersistenceKeyDefault<FileStorageKey<Folder>> {
  public static var rootFolder: Self {
    PersistenceKeyDefault(
      .fileStorage(.documentsDirectory.appendingPathComponent("rootFolder", conformingTo: .json)), 
      Folder()
    )
  }
}
```

Now when running a test that overrides the default with a predetermined value, the creation of the default value has incremented the uuid dependency, even though the value isn't used. 

```swift
func testAddFolder() async {
  await withDependencies {
    $0.uuid = .incrementing
  } operation: {
    @Shared(.rootFolder) var root = Folder(…)
    let store = TestStore(
      initialState: Feature.State(),
      reducer: { Feature() }
    )
    await store.send(.addFolderButtonTapped) {
      $0.root.subfolders = [
        Folder(id: UUID(???))
      ]
    }
  }
}
```

This request modifies `PersistenceKeyDefault.defaultValue` to lazily evaluate only when the `load` action fails. It also includes a couple tests to verify the change.