### PR TITLE
Clarify that tagged is not assumed in the tutorial.

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps.tutorial
@@ -70,7 +70,8 @@
       
       @Step {
         Add the `Tagged` library to your project by navigating to the build settings, and then to
-        the package dependencies tab.
+        the package dependencies tab, and input the GitHub URL:
+        [https://github.com/pointfreeco/swift-tagged](https://github.com/pointfreeco/swift-tagged).
         
         @Image(source: syncups-02-package-dependencies-tagged.png)
       }
@@ -87,6 +88,12 @@
         
         @Code(name: "Models.swift", file: ListsOfSyncUps-01-code-0004.swift)
       }
+      
+      > Important: To keep things simple for the rest of this tutorial we will _not_ assume that
+      you have implemented the `Tagged` type into your domain. If you choose to use `Tagged` then
+      you will need to do some extra work to construct tagged values that is not covered in
+      the tutorial. For example, once we get to using dependencies to control UUIDs, you will need
+      to write `Attendee.ID(uuid())` instead of just `uuid()`.
     }
   }
     


### PR DESCRIPTION
Fixes #3073.

We've had a few people confused about the tagged digression, so I added a note to clarify that we will not be using `Tagged` for the rest of the tutorial. It's just a side quest. If it continues to be confusing we should consider just removing it from the tutorial.