### PR TITLE
fix attendee creation with uuid in syncup tutorial

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/TestingSyncUpForm-02-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/TestingSyncUpForm-02-code-0005.swift
@@ -28,7 +28,7 @@ struct SyncUpForm {
     Reduce { state, action in
       switch action {
       case .addAttendeeButtonTapped:
-        let attendee = Attendee(id: uuid())
+        let attendee = Attendee(id: Attendee.ID(uuid()))
         state.syncUp.attendees.append(attendee)
         state.focus = .attendee(attendee.id)
         return .none
@@ -44,7 +44,7 @@ struct SyncUpForm {
         state.syncUp.attendees.remove(atOffsets: indexSet)
         if state.syncUp.attendees.isEmpty {
           state.syncUp.attendees.append(
-            Attendee(id: uuid())
+            Attendee(id: Attendee.ID(uuid()))
           )
         }
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/TestingSyncUpForm-02-code-0007.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/TestingSyncUpForm-02-code-0007.swift
@@ -18,8 +18,8 @@ class SyncUpFormTests: XCTestCase {
     }
 
     await store.send(.addAttendeeButtonTapped) {
-      state.focus = .attendee(Attendee.ID(0))
-      state.syncUp.attendees.append(Attendee(id: Attendee.ID(0)))
+      state.focus = .attendee(Attendee.ID(UUID(0)))
+      state.syncUp.attendees.append(Attendee(id: Attendee.ID(UUID(0))))
     }
   }
 


### PR DESCRIPTION
Alternative fix for #3073. I have been following the tutorial, using Tagged IDs. Most of the readers will do that. Also in the example code, tagged IDs are used.