### PR TITLE
SyncUps: typos fixes

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm.tutorial
@@ -283,7 +283,7 @@
       the other.
       
       Luckily this is easy to fix, using a tool that comes with the Composable Architecture called
-      `bind(_:to:)`. It allows you synchronize two bindings so that when one changes it immediately
+      `bind(_:to:)`. It allows you to synchronize two bindings so that when one changes it immediately
       changes the other. This is useful for dealing with SwiftUI property wrappers that only work
       in the view, such as `@FocusState`.
       

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation.tutorial
@@ -22,7 +22,7 @@
         @Code(name: "App.swift", file: SyncUpDetailNavigation-01-code-0001.swift)
       }
       
-      This feature's primary responsibility will to integrate all the features that can be 
+      This feature's primary responsibility will be to integrate all the features that can be 
       presented in the navigation stack. Currently that is only the `SyncUpsList` feature, which
       is always at the root of the stack, and the `SyncUpDetail` feature. Soon there will be more
       features that can be presented in the stack, such as the record meeting feature and the past
@@ -59,7 +59,7 @@
       and in the future there may be more.
       
       For this reason it is best to do some upfront work to model a feature that can handle any
-      number of features on the stack. This works must like the `Destination` reducer we created
+      number of features on the stack. This works much like the `Destination` reducer we created
       in <doc:EditingAndDeletingSyncUp>.
       
       @Step {


### PR DESCRIPTION
Minor typos I noticed while reading the new SyncUps tutorial. 