### PR TITLE
Add ignore list parameter to ObservableStateMacro

### DIFF
--- a/Sources/ComposableArchitecture/Macros.swift
+++ b/Sources/ComposableArchitecture/Macros.swift
@@ -121,7 +121,7 @@
   @attached(extension, conformances: Observable, ObservableState)
   @attached(member, names: named(_$id), named(_$observationRegistrar), named(_$willModify))
   @attached(memberAttribute)
-  public macro ObservableState() =
+  public macro ObservableState(ignore: String...) =
     #externalMacro(module: "ComposableArchitectureMacros", type: "ObservableStateMacro")
 
   @attached(accessor, names: named(init), named(get), named(set))

--- a/Sources/ComposableArchitectureMacros/Extensions.swift
+++ b/Sources/ComposableArchitectureMacros/Extensions.swift
@@ -101,6 +101,20 @@ extension VariableDeclSyntax {
     return false
   }
 
+  func hasMacroApplication(_ names: [String]) -> Bool {
+    for attribute in attributes {
+      switch attribute {
+      case .attribute(let attr):
+        if attr.attributeName.tokens(viewMode: .all).map({ $0.tokenKind }) == names.map { .identifier($0) } {
+          return true
+        }
+      default:
+        break
+      }
+    }
+    return false
+  }
+
   func firstAttribute(for name: String) -> AttributeSyntax? {
     for attribute in attributes {
       switch attribute {


### PR DESCRIPTION
It allows to specify a list of macro names that should be ignored inside of the state struct. Without that it is impossible to use custom macroses, as they will interfere with the `@ObservationStateTracked` macro.

We have some custom property wrapper that will not work with the `@ObservableState`. Rewriting it into macro turned out as not an easy task. I tried several approaches and nothing worked. I also checked how you did implement `@Presented` part, and you had to add exceptions into `@ObservableState` code itself.

This PR extends `@ObservableState` with an ability to specify a list of custom macroses that one could have in their project. It would be the final user's responsibility to implement a custom macro properly to work with the state changes tracking stuff. But it would make the following code work.

```swift
@Reducer
struct ChildFeature {

}

@Reducer
struct Feature {
    @ObservableState(ignore: "Heapify")
    struct State {
        @Heapify
        var childState: ChildFeature.State?
    }

    enum Action {
        case childStaet(ChildFeature.Action)
    }
}
```

Obviously, I just might not know other way it could be achieved with, would be thankful for any insites or help =)