### PR TITLE
feat: Implement withoutWarnings function

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
@@ -256,29 +256,31 @@ public struct _IfLetReducer<Parent: Reducer, Child: Reducer>: Reducer {
     guard let childAction = self.toChildAction.extract(from: action)
     else { return .none }
     guard state[keyPath: self.toChildState] != nil else {
-      runtimeWarn(
-        """
-        An "ifLet" at "\(self.fileID):\(self.line)" received a child action when child state was \
-        "nil". …
-
-          Action:
-        \(String(customDumping: action).indent(by: 4))
-
-        This is generally considered an application logic error, and can happen for a few reasons:
-
-        • A parent reducer set child state to "nil" before this reducer ran. This reducer must run \
-        before any other reducer sets child state to "nil". This ensures that child reducers can \
-        handle their actions while their state is still available.
-
-        • An in-flight effect emitted this action when child state was "nil". While it may be \
-        perfectly reasonable to ignore this action, consider canceling the associated effect \
-        before child state becomes "nil", especially if it is a long-living effect.
-
-        • This action was sent to the store while state was "nil". Make sure that actions for this \
-        reducer can only be sent from a view store when state is non-"nil". In SwiftUI \
-        applications, use "IfLetStore".
-        """
-      )
+      if !IgnoreWarningsLocals.shouldIgnore {
+        runtimeWarn(
+          """
+          An "ifLet" at "\(self.fileID):\(self.line)" received a child action when child state was \
+          "nil". …
+          
+            Action:
+          \(String(customDumping: action).indent(by: 4))
+          
+          This is generally considered an application logic error, and can happen for a few reasons:
+          
+          • A parent reducer set child state to "nil" before this reducer ran. This reducer must run \
+          before any other reducer sets child state to "nil". This ensures that child reducers can \
+          handle their actions while their state is still available.
+          
+          • An in-flight effect emitted this action when child state was "nil". While it may be \
+          perfectly reasonable to ignore this action, consider canceling the associated effect \
+          before child state becomes "nil", especially if it is a long-living effect.
+          
+          • This action was sent to the store while state was "nil". Make sure that actions for this \
+          reducer can only be sent from a view store when state is non-"nil". In SwiftUI \
+          applications, use "IfLetStore".
+          """
+        )
+      }
       return .none
     }
     let navigationID = NavigationID(
@@ -289,4 +291,14 @@ public struct _IfLetReducer<Parent: Reducer, Child: Reducer>: Reducer {
       .map { self.toChildAction.embed($0) }
       ._cancellable(id: navigationID, navigationIDPath: self.navigationIDPath)
   }
+}
+
+enum IgnoreWarningsLocals {
+    @TaskLocal static var shouldIgnore = false
+}
+
+public func withoutWarnings(_ transaction: () -> Void) {
+    IgnoreWarningsLocals.$shouldIgnore.withValue(true) {
+        transaction()
+    }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -589,27 +589,29 @@ public struct _PresentationReducer<Base: Reducer, Destination: Reducer>: Reducer
       baseEffects = self.base.reduce(into: &state, action: action)
 
     case (.none, .some):
-      runtimeWarn(
-        """
-        An "ifLet" at "\(self.fileID):\(self.line)" received a presentation action when \
-        destination state was absent. …
-
-          Action:
-            \(debugCaseOutput(action))
-
-        This is generally considered an application logic error, and can happen for a few \
-        reasons:
-
-        • A parent reducer set destination state to "nil" before this reducer ran. This reducer \
-        must run before any other reducer sets destination state to "nil". This ensures that \
-        destination reducers can handle their actions while their state is still present.
-
-        • This action was sent to the store while destination state was "nil". Make sure that \
-        actions for this reducer can only be sent from a view store when state is present, or \
-        from effects that start from this reducer. In SwiftUI applications, use a Composable \
-        Architecture view modifier like "sheet(store:…)".
-        """
-      )
+      if !IgnoreWarningsLocals.shouldIgnore {
+        runtimeWarn(
+          """
+          An "ifLet" at "\(self.fileID):\(self.line)" received a presentation action when \
+          destination state was absent. …
+          
+            Action:
+              \(debugCaseOutput(action))
+          
+          This is generally considered an application logic error, and can happen for a few \
+          reasons:
+          
+          • A parent reducer set destination state to "nil" before this reducer ran. This reducer \
+          must run before any other reducer sets destination state to "nil". This ensures that \
+          destination reducers can handle their actions while their state is still present.
+          
+          • This action was sent to the store while destination state was "nil". Make sure that \
+          actions for this reducer can only be sent from a view store when state is present, or \
+          from effects that start from this reducer. In SwiftUI applications, use a Composable \
+          Architecture view modifier like "sheet(store:…)".
+          """
+        )
+      }
       destinationEffects = .none
       baseEffects = self.base.reduce(into: &state, action: action)
     }

--- a/Tests/ComposableArchitectureTests/Reducers/IfLetReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/IfLetReducerTests.swift
@@ -37,7 +37,19 @@ final class IfLetReducerTests: BaseTCATestCase {
 
     await store.send(())
   }
-
+    
+  @MainActor
+  func test_GivenShouldIgnoreWarningsTrue_WhenSendingActionToNilChild_ThenDoesNotGenerateRuntimeWarning() async {
+    let store = Store(initialState: Int?.none) {
+      EmptyReducer<Int?, Void>()
+        .ifLet(\.self, action: \.self) {}
+    }
+    
+    withoutWarnings {
+      store.send(())
+    }
+  }
+  
   @MainActor
   func testEffectCancellation() async {
     if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {


### PR DESCRIPTION
There was a discussion in TCA Slack about how to send actions from the onDisappear modifier while not receiving warnings when the view is actually dismissed. @mbrandonw suggested exploring a 'withoutWarnings' function to allow for explicit ignoring of runtime warnings when they are expected. This PR scratches the surface of that suggestion.

A link to the thread:
https://pointfreecommunity.slack.com/archives/C04KQQ7NXHV/p1715628109148009