### PR TITLE
Add `ViewStore.binding` migration examples to guide

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.7.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.7.md
@@ -721,6 +721,53 @@ TabView(selection: $store.tab.sending(\.tabChanged)) {
 }
 ```
 
+If the binding depends on more complex business logic, you can define a custom `get`-`set` property
+(or subscript, if this logic depends on external state) on the store to incorporate this logic. For
+example:
+
+@Row {
+  @Column {
+    ```swift
+    // Before
+
+    // In the view:
+    ForEach(Flag.allCases) { flag in
+      Toggle(
+        flag.description,
+        isOn: viewStore.binding(
+          get: { store.featureFlags.contains(flag) }
+          send: { store.send(.toggleFeature(flag)) }
+        )
+      )
+    }
+    ```
+  }
+  @Column {
+    ```swift
+    // After
+
+    // In the file:
+    extension StoreOf<Feature> {
+      subscript(hasFeatureFlag flag: Flag) {
+        get { featureFlags.contains(flag) }
+        set { send(.toggleFeature(flag) }
+      }
+    }
+
+    // In the view:
+    ForEach(Flag.allCases) { flag in
+      Toggle(
+        flag.description,
+        isOn: $store[hasFeatureFlag: flag]
+      )
+    }
+    ```
+  }
+}
+
+> **Tip:** When possible, consider moving complex binding logic into the reducer so that it can be
+> more easily tested.
+
 ## Computed view state
 
 If you are using the `ViewState` pattern in your application, then you may be computing values 

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.7.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.7.md
@@ -735,8 +735,8 @@ example:
       Toggle(
         flag.description,
         isOn: viewStore.binding(
-          get: { store.featureFlags.contains(flag) }
-          send: { store.send(.flagToggled(flag, isOn: $0)) }
+          get: { $0.featureFlags.contains(flag) }
+          send: { .flagToggled(flag, isOn: $0) }
         )
       )
     }
@@ -750,7 +750,9 @@ example:
     extension StoreOf<Feature> {
       subscript(hasFeatureFlag flag: Flag) -> Bool {
         get { featureFlags.contains(flag) }
-        set { send(.flagToggled(flag, isOn: newValue)) }
+        set {
+          send(.flagToggled(flag, isOn: newValue))
+        }
       }
     }
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.7.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.7.md
@@ -736,7 +736,7 @@ example:
         flag.description,
         isOn: viewStore.binding(
           get: { store.featureFlags.contains(flag) }
-          send: { store.send(.toggleFeature(flag)) }
+          send: { store.send(.flagToggled(flag, isOn: $0)) }
         )
       )
     }
@@ -748,9 +748,9 @@ example:
 
     // In the file:
     extension StoreOf<Feature> {
-      subscript(hasFeatureFlag flag: Flag) {
+      subscript(hasFeatureFlag flag: Flag) -> Bool {
         get { featureFlags.contains(flag) }
-        set { send(.toggleFeature(flag) }
+        set { send(.flagToggled(flag, isOn: newValue)) }
       }
     }
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.7.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.7.md
@@ -765,8 +765,8 @@ example:
   }
 }
 
-> **Tip:** When possible, consider moving complex binding logic into the reducer so that it can be
-> more easily tested.
+> Tip: When possible, consider moving complex binding logic into the reducer so that it can be more
+> easily tested.
 
 ## Computed view state
 


### PR DESCRIPTION
The 1.7 guide doesn't have examples of more complex bindings, so let's add one.

Trying out the column-based format:

---

<img width="1001" alt="image" src="https://github.com/pointfreeco/swift-composable-architecture/assets/658/9bedb731-2942-42a6-95ce-d77963fe88aa">
