### PR TITLE
Add `ifLet` SwiftUI integration warning

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
@@ -115,7 +115,7 @@ struct InventoryView: View {
 ```
 
 > Note: We use SwiftUI's `@Bindable` property wrapper to produce a binding to a store, which can be
-> further scoped using ``SwiftUI/Binding/scope(state:action:)-4mj4d``.
+> further scoped using ``SwiftUI/Binding/scope(state:action:fileID:line:)``.
 
 With those few steps completed the domains and views of the parent and child features are now
 integrated together, and when the `addItem` state flips to a non-`nil` value the sheet will be
@@ -269,8 +269,8 @@ struct InventoryView: View {
 }
 ```
 
-And then in the `body` of the view you can use the ``SwiftUI/Binding/scope(state:action:)-4mj4d``
-operator to derive bindings from `$store`:
+And then in the `body` of the view you can use the
+``SwiftUI/Binding/scope(state:action:fileID:line:)`` operator to derive bindings from `$store`:
 
 ```swift
 var body: some View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Store.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Store.md
@@ -29,7 +29,7 @@
 
 ### Scoping store bindings
 
-- ``SwiftUI/Binding/scope(state:action:)-4mj4d``
+- ``SwiftUI/Binding/scope(state:action:fileID:line:)``
 - ``SwiftUI/Binding/scope(state:action:)-35r82``
 
 ### Combine integration

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwiftUIIntegration.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwiftUIIntegration.md
@@ -17,7 +17,7 @@ designed with SwiftUI in mind, and comes with many powerful tools to integrate i
 
 ### Presentation
 
-- ``SwiftUI/Binding/scope(state:action:)-4mj4d``
+- ``SwiftUI/Binding/scope(state:action:fileID:line:)``
 
 ### Navigation stacks and links
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm.tutorial
@@ -112,8 +112,8 @@
       
       Luckily the library comes with the tools necessary. Just as there is a scoping operation on
       stores for focusing on sub-domains of a parent domain, there is also a scope on _bindings_ of
-      stores for doing the same: ``SwiftUI/Binding/scope(state:action:)-4mj4d``. This tool can be
-      used to derive a binding that is appropriate to pass to `sheet(item:)`.
+      stores for doing the same: ``SwiftUI/Binding/scope(state:action:fileID:line:)``. This tool can
+      be used to derive a binding that is appropriate to pass to `sheet(item:)`.
       
       @Step {
         Since we want to derive bindings from the store we need to decorate the property in the view
@@ -127,8 +127,8 @@
       }
       
       @Step {
-        Use the ``SwiftUI/Binding/scope(state:action:)-4mj4d`` operator on `$store` to focus the
-        binding to the presentation domain of the `SyncUpForm`. The `sheet(item:)` modifier will 
+        Use the ``SwiftUI/Binding/scope(state:action:fileID:line:)`` operator on `$store` to focus
+        the binding to the presentation domain of the `SyncUpForm`. The `sheet(item:)` modifier will
         hand the trailing closure a `StoreOf<SyncUpForm>`, and that is exactly what can be handed to
         the `SyncUpFormView`.
         

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp.tutorial
@@ -70,7 +70,7 @@
       
       @Step {
         At the very bottom of the view use the `sheet(item:)` modifier by deriving a binding to the 
-        `SyncUpForm` domain using ``SwiftUI/Binding/scope(state:action:)-4mj4d``.
+        `SyncUpForm` domain using ``SwiftUI/Binding/scope(state:action:fileID:line:)``.
         
         @Code(name: "SyncUpDetail.swift", file: EditingAndDeletingSyncUp-01-code-0006.swift)
       }

--- a/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
@@ -70,7 +70,7 @@ import SwiftUI
   extension SwiftUI.Bindable {
     /// Derives a binding to a store focused on ``StackState`` and ``StackAction``.
     ///
-    /// See ``SwiftUI/Binding/scope(state:action:)-4mj4d`` defined on `Binding` for more
+    /// See ``SwiftUI/Binding/scope(state:action:fileID:line:)`` defined on `Binding` for more
     /// information.
     public func scope<State: ObservableState, Action, ElementState, ElementAction>(
       state: KeyPath<State, StackState<ElementState>>,
@@ -88,7 +88,7 @@ import SwiftUI
   extension Perception.Bindable {
     /// Derives a binding to a store focused on ``StackState`` and ``StackAction``.
     ///
-    /// See ``SwiftUI/Binding/scope(state:action:)-4mj4d`` defined on `Binding` for more
+    /// See ``SwiftUI/Binding/scope(state:action:fileID:line:)`` defined on `Binding` for more
     /// information.
     public func scope<State: ObservableState, Action, ElementState, ElementAction>(
       state: KeyPath<State, StackState<ElementState>>,


### PR DESCRIPTION
We recently added a warning when we detect that `forEach` wasn't integrated with a reducer when path elements are pushed or popped from the stack, and I realized that we could do similarly for `ifLet` during dismissal.