### PR TITLE
Add @_SPI(Internal) to some more navigation apis

### DIFF
--- a/Sources/ComposableArchitecture/Internal/StackIDGenerator.swift
+++ b/Sources/ComposableArchitecture/Internal/StackIDGenerator.swift
@@ -11,7 +11,8 @@ extension DependencyValues {
   public let next: @Sendable () -> StackElementID
   public let peek: @Sendable () -> StackElementID
 
-  func callAsFunction() -> StackElementID {
+  @_spi(Internals)
+  public func callAsFunction() -> StackElementID {
     self.next()
   }
 

--- a/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
@@ -237,6 +237,14 @@ import SwiftUI
     let line: UInt
     @Environment(\.navigationDestinationType) var navigationDestinationType
 
+    @_spi(Internals)
+    public init(state: State?, @ViewBuilder label: () -> Label, fileID: StaticString, line: UInt) {
+      self.state = state
+      self.label = label()
+      self.fileID = fileID
+      self.line = line
+    }
+
     public var body: some View {
       #if DEBUG
         self.label.onAppear {
@@ -331,7 +339,8 @@ import SwiftUI
     }
   }
 
-  var _isInPerceptionTracking: Bool {
+  @_spi(Internals)
+  public var _isInPerceptionTracking: Bool {
     #if !os(visionOS)
       return _PerceptionLocals.isInPerceptionTracking
     #else
@@ -352,8 +361,16 @@ extension StackState {
   }
 
   public struct Component: Hashable {
-    let id: StackElementID
-    var element: Element
+    @_spi(Internals)
+    public let id: StackElementID
+    @_spi(Internals)
+    public var element: Element
+
+    @_spi(Internals)
+    public init(id: StackElementID, element: Element) {
+      self.id = id
+      self.element = element
+    }
 
     public static func == (lhs: Self, rhs: Self) -> Bool {
       lhs.id == rhs.id
@@ -416,7 +433,8 @@ private struct NavigationDestinationTypeKey: EnvironmentKey {
 }
 
 extension EnvironmentValues {
-  var navigationDestinationType: Any.Type? {
+  @_spi(Internals)
+  public var navigationDestinationType: Any.Type? {
     get { self[NavigationDestinationTypeKey.self] }
     set { self[NavigationDestinationTypeKey.self] = newValue }
   }


### PR DESCRIPTION
I'm working on back-porting iOS 16 NavigationStack and every TCA related apis. I managed to make a demo [here](https://github.com/Alex293/swift-composable-architecture/tree/observable-navigation-backport) but I needed to `@testable  import ComposableArchitecture` 

This branch contains the apis required but keep them behind `@_SPI(Internals)` as the rest of those apis.