### PR TITLE
Add syntax highlighting

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -124,7 +124,7 @@ extension Effect {
 /// If the operation is in-flight when `Task.cancel(id:)` is called with the same identifier, the
 /// operation will be cancelled.
 ///
-/// ```
+/// ```swift
 /// enum CancelID { case timer }
 ///
 /// await withTaskCancellation(id: CancelID.timer) {


### PR DESCRIPTION
This PR adds missing syntax highlighting to the `withTaskCancellation(id:cancelInFlight:operation:)`'s comment.