### PR TITLE
Add a SharedReader.constant helper.

### DIFF
--- a/Sources/ComposableArchitecture/SharedState/Shared.swift
+++ b/Sources/ComposableArchitecture/SharedState/Shared.swift
@@ -353,7 +353,8 @@ extension Shared {
       keyPath: self.keyPath.appending(path: keyPath)!
     )
   }
-
+  
+  /// Constructs a read-only version of the shared value.
   public var reader: SharedReader<Value> {
     SharedReader(reference: self.reference, keyPath: self.keyPath)
   }

--- a/Sources/ComposableArchitecture/SharedState/SharedReader.swift
+++ b/Sources/ComposableArchitecture/SharedState/SharedReader.swift
@@ -33,6 +33,25 @@ public struct SharedReader<Value> {
   public init(_ base: Shared<Value>) {
     self = base.reader
   }
+  
+  /// Constructs a read-only shared value that remains constant.
+  ///
+  /// This can be useful for providing ``SharedReader`` values to features in previews and tests:
+  ///
+  /// ```swift
+  /// #Preview {
+  ///   FeatureView(
+  ///     store: Store(
+  ///       initialState: Feature.State(count: .constant(42))
+  ///     ) {
+  ///       Feature()
+  ///     }
+  ///   )
+  /// )
+  /// ```
+  public static func constant(_ value: Value) -> Self {
+    Shared(value).reader
+  }
 
   public var wrappedValue: Value {
     func open<Root>(_ reference: some Reference<Root>) -> Value {


### PR DESCRIPTION
Inspired by #3124, this helper may help when needing to provide `SharedReader` values in previews and tests.

At the end of the day it is only a helper for doing `Shared(value).reader`, so maybe not worth it.