### PR TITLE
Add important note about delegate actions.

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-YourFirstPresentation.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-YourFirstPresentation.tutorial
@@ -256,6 +256,15 @@
         @Code(name: "AddContactFeature.swift", file: 02-01-04-code-0000.swift, previousFile: 02-01-04-code-0000-previous.swift)
       }
       
+      > Important: Delegate actions are the most general way of communicating from the child domain
+      back to the parent, but there are other techniques. We could have also utilized the 
+      [`@Shared`](<doc:Shared>) property wrapper for the collection of sync ups, which would allow
+      the `AddContactFeature` to insert a new contact directly into the parent collection without
+      any further steps. This can be powerful, but we will use delegate actions for this tutorial.
+      To read more about `@Shared` see the <doc:SharingState> article, and see the
+      <doc:BuildingSyncUps> tutorial where we see this technique, in particular in
+      <doc:EditingAndDeletingSyncUp#Deleting-the-sync-up> section.
+      
       @Step {
         Handle the new case in the reducer, but we should never actually perform any logic in this
         case. Only the parent should listen for `delegate` actions and respond accordingly.


### PR DESCRIPTION
The "Meet the Composable Architecture" tutorial was not updated to make use of `@Shared`, and one could argue that maybe it shouldn't. It should be just a very basic introduction to the library, and it may be too advanced to jump into state sharing topics.

However, that does lead people to believe that delegate actions are the only way to achieve what we do in the tutorial, so I have added a note to make it clear that is not the case.