### PR TITLE
Deprecate `Shared`'s optional dynamic member lookup overload

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,6 +10,24 @@
       }
     },
     {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "c8ed701b513cf5177118a175d85fbbbcd707ab41",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-benchmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/swift-benchmark",
+      "state" : {
+        "revision" : "8163295f6fe82356b0bcf8e1ab991645de17d096",
+        "version" : "0.1.2"
+      }
+    },
+    {
       "identity" : "swift-case-paths",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
@@ -64,12 +82,39 @@
       }
     },
     {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
+      }
+    },
+    {
       "identity" : "swift-identified-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",
       "state" : {
         "revision" : "d533cd18b0b456b106694a9899f917ee595f2666",
         "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "swift-macro-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-macro-testing",
+      "state" : {
+        "revision" : "90e38eec4bf661ec0da1bbfd3ec507d0f0c05310",
+        "version" : "0.3.0"
       }
     },
     {

--- a/Sources/ComposableArchitecture/SharedState/Shared.swift
+++ b/Sources/ComposableArchitecture/SharedState/Shared.swift
@@ -364,13 +364,6 @@ extension Shared {
   public subscript<Member>(
     dynamicMember keyPath: KeyPath<Value, Member?>
   ) -> SharedReader<Member>? {
-    guard let initialValue = self.wrappedValue[keyPath: keyPath]
-    else { return nil }
-    return SharedReader<Member>(
-      reference: self.reference,
-      keyPath: self.keyPath.appending(
-        path: keyPath.appending(path: \.[default:DefaultSubscript(initialValue)])
-      )!
-    )
+    SharedReader(self[dynamicMember: keyPath])
   }
 }

--- a/Sources/ComposableArchitecture/SharedState/Shared.swift
+++ b/Sources/ComposableArchitecture/SharedState/Shared.swift
@@ -37,8 +37,12 @@ public struct Shared<Value> {
   }
 
   public init?(_ base: Shared<Value?>) {
-    guard let shared = base[dynamicMember: \.self] else { return nil }
-    self = shared
+    guard let initialValue = base.wrappedValue
+    else { return nil }
+    self.init(
+      reference: base.reference,
+      keyPath: base.keyPath.appending(path: \Value?.[default:DefaultSubscript(initialValue)])!
+    )
   }
 
   public var wrappedValue: Value {
@@ -117,17 +121,13 @@ public struct Shared<Value> {
     Shared<Member>(reference: self.reference, keyPath: self.keyPath.appending(path: keyPath)!)
   }
 
+  @available(
+    *, deprecated, message: "Use 'Shared($value.optional)' to unwrap optional shared values"
+  )
   public subscript<Member>(
     dynamicMember keyPath: WritableKeyPath<Value, Member?>
   ) -> Shared<Member>? {
-    guard let initialValue = self.wrappedValue[keyPath: keyPath]
-    else { return nil }
-    return Shared<Member>(
-      reference: self.reference,
-      keyPath: self.keyPath.appending(
-        path: keyPath.appending(path: \.[default:DefaultSubscript(initialValue)])
-      )!
-    )
+    Shared<Member>(self[dynamicMember: keyPath])
   }
 
   public func assert(
@@ -358,6 +358,9 @@ extension Shared {
     SharedReader(reference: self.reference, keyPath: self.keyPath)
   }
 
+  @available(
+    *, deprecated, message: "Use 'SharedReader($optional.value)' to unwrap optional shared values"
+  )
   public subscript<Member>(
     dynamicMember keyPath: KeyPath<Value, Member?>
   ) -> SharedReader<Member>? {

--- a/Sources/ComposableArchitecture/SharedState/Shared.swift
+++ b/Sources/ComposableArchitecture/SharedState/Shared.swift
@@ -359,7 +359,7 @@ extension Shared {
   }
 
   @available(
-    *, deprecated, message: "Use 'SharedReader($optional.value)' to unwrap optional shared values"
+    *, deprecated, message: "Use 'SharedReader($value.optional)' to unwrap optional shared values"
   )
   public subscript<Member>(
     dynamicMember keyPath: KeyPath<Value, Member?>

--- a/Sources/ComposableArchitecture/SharedState/SharedReader.swift
+++ b/Sources/ComposableArchitecture/SharedState/SharedReader.swift
@@ -66,7 +66,7 @@ public struct SharedReader<Value> {
   }
 
   @available(
-    *, deprecated, message: "Use 'SharedReader($optional)' to unwrap optional shared values"
+    *, deprecated, message: "Use 'SharedReader($optional.value)' to unwrap optional shared values"
   )
   public subscript<Member>(
     dynamicMember keyPath: KeyPath<Value, Member?>

--- a/Sources/ComposableArchitecture/SharedState/SharedReader.swift
+++ b/Sources/ComposableArchitecture/SharedState/SharedReader.swift
@@ -66,7 +66,7 @@ public struct SharedReader<Value> {
   }
 
   @available(
-    *, deprecated, message: "Use 'SharedReader($optional.value)' to unwrap optional shared values"
+    *, deprecated, message: "Use 'SharedReader($value.optional)' to unwrap optional shared values"
   )
   public subscript<Member>(
     dynamicMember keyPath: KeyPath<Value, Member?>


### PR DESCRIPTION
Currently, `Shared`'s dynamic member lookup is overloaded for convenience:

```swift
$shared                // Shared<Root>
$shared.value          // Shared<Value>
$shared.optionalValue  // Shared<Value>?
```

Unfortunately, this is also perhaps surprising, and goes against the grain when folks might expect to be handed a `Shared<Value?>`.

Also, there are times when you have a `Shared<Value?>` already, and you want to unwrap it. Dynamic member lookup doesn't help there (unless you know you can call `$shared[dynamicMember: \.self]`), and so you need a totally different operation to handle it:

```swift
if let unwrappedShared = Shared($optional) {
  // Do something with 'Shared<Value>'
}
```

So let's avoid this confusion in the future and focus on a single API for unwrapping shared values, which is the failable initializer that mirrors an API on `Binding`.