### PR TITLE
Clean up SyncUps tutorial with mock value

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-01-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-01-code-0002.swift
@@ -59,3 +59,15 @@ enum Theme: String, CaseIterable, Equatable, Identifiable, Codable {
 
   var name: String { rawValue.capitalized }
 }
+
+extension SyncUp {
+  static let mock = SyncUp(
+    id: SyncUp.ID(),
+    attendees: [
+      Attendee(id: Attendee.ID(), name: "Blob"),
+      Attendee(id: Attendee.ID(), name: "Blob Jr."),
+      Attendee(id: Attendee.ID(), name: "Blob Sr."),
+    ],
+    title: "Point-Free Morning Sync"
+  )
+}

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-01-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-01-code-0003.swift
@@ -60,3 +60,15 @@ enum Theme: String, CaseIterable, Equatable, Identifiable, Codable {
 
   var name: String { rawValue.capitalized }
 }
+
+extension SyncUp {
+  static let mock = SyncUp(
+    id: SyncUp.ID(),
+    attendees: [
+      Attendee(id: Attendee.ID(), name: "Blob"),
+      Attendee(id: Attendee.ID(), name: "Blob Jr."),
+      Attendee(id: Attendee.ID(), name: "Blob Sr."),
+    ],
+    title: "Point-Free Morning Sync"
+  )
+}

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-01-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-01-code-0004.swift
@@ -61,3 +61,15 @@ enum Theme: String, CaseIterable, Equatable, Identifiable, Codable {
 
   var name: String { rawValue.capitalized }
 }
+
+extension SyncUp {
+  static let mock = SyncUp(
+    id: SyncUp.ID(),
+    attendees: [
+      Attendee(id: Attendee.ID(), name: "Blob"),
+      Attendee(id: Attendee.ID(), name: "Blob Jr."),
+      Attendee(id: Attendee.ID(), name: "Blob Sr."),
+    ],
+    title: "Point-Free Morning Sync"
+  )
+}

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-02-code-0009.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-02-code-0009.swift
@@ -73,17 +73,7 @@ extension LabelStyle where Self == TrailingIconLabelStyle {
     SyncUpsListView(
       store: Store(
         initialState: SyncUpsList.State(
-          syncUps: [
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          ]
+          syncUps: [.mock]
         )
       ) {
         SyncUpsList()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-03-code-0001-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-03-code-0001-previous.swift
@@ -73,17 +73,7 @@ extension LabelStyle where Self == TrailingIconLabelStyle {
     SyncUpsListView(
       store: Store(
         initialState: SyncUpsList.State(
-          syncUps: [
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          ]
+          syncUps: [.mock]
         )
       ) {
         SyncUpsList()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-03-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-03-code-0001.swift
@@ -73,17 +73,7 @@ extension LabelStyle where Self == TrailingIconLabelStyle {
     SyncUpsListView(
       store: Store(
         initialState: SyncUpsList.State(
-          syncUps: [
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          ]
+          syncUps: [.mock]
         )
       ) {
         SyncUpsList()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-02-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-02-code-0006.swift
@@ -89,15 +89,7 @@ extension Duration {
   SyncUpFormView(
     store: Store(
       initialState: SyncUpForm.State(
-        syncUp: SyncUp(
-          id: SyncUp.ID(),
-          attendees: [
-            Attendee(id: Attendee.ID(), name: "Blob"),
-            Attendee(id: Attendee.ID(), name: "Blob Jr."),
-            Attendee(id: Attendee.ID(), name: "Blob Sr."),
-          ],
-          title: "Point-Free Morning Sync"
-        )
+        syncUp: .mock
       )
     ) {
       SyncUpForm()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-03-code-0004-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-03-code-0004-previous.swift
@@ -89,15 +89,7 @@ extension Duration {
   SyncUpFormView(
     store: Store(
       initialState: SyncUpForm.State(
-        syncUp: SyncUp(
-          id: SyncUp.ID(),
-          attendees: [
-            Attendee(id: Attendee.ID(), name: "Blob"),
-            Attendee(id: Attendee.ID(), name: "Blob Jr."),
-            Attendee(id: Attendee.ID(), name: "Blob Sr."),
-          ],
-          title: "Point-Free Morning Sync"
-        )
+        syncUp: .mock
       )
     ) {
       SyncUpForm()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-03-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-03-code-0004.swift
@@ -90,15 +90,7 @@ extension Duration {
   SyncUpFormView(
     store: Store(
       initialState: SyncUpForm.State(
-        syncUp: SyncUp(
-          id: SyncUp.ID(),
-          attendees: [
-            Attendee(id: Attendee.ID(), name: "Blob"),
-            Attendee(id: Attendee.ID(), name: "Blob Jr."),
-            Attendee(id: Attendee.ID(), name: "Blob Sr."),
-          ],
-          title: "Point-Free Morning Sync"
-        )
+        syncUp: .mock
       )
     ) {
       SyncUpForm()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-03-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-03-code-0005.swift
@@ -77,15 +77,7 @@ extension Duration {
   SyncUpFormView(
     store: Store(
       initialState: SyncUpForm.State(
-        syncUp: SyncUp(
-          id: SyncUp.ID(),
-          attendees: [
-            Attendee(id: Attendee.ID(), name: "Blob"),
-            Attendee(id: Attendee.ID(), name: "Blob Jr."),
-            Attendee(id: Attendee.ID(), name: "Blob Sr."),
-          ],
-          title: "Point-Free Morning Sync"
-        )
+        syncUp: .mock
       )
     ) {
       SyncUpForm()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-02-code-0001-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-02-code-0001-previous.swift
@@ -70,17 +70,7 @@ extension LabelStyle where Self == TrailingIconLabelStyle {
     SyncUpsListView(
       store: Store(
         initialState: SyncUpsList.State(
-          syncUps: [
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          ]
+          syncUps: [.mock]
         )
       ) {
         SyncUpsList()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-02-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-02-code-0001.swift
@@ -73,17 +73,7 @@ extension LabelStyle where Self == TrailingIconLabelStyle {
     SyncUpsListView(
       store: Store(
         initialState: SyncUpsList.State(
-          syncUps: [
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          ]
+          syncUps: [.mock]
         )
       ) {
         SyncUpsList()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-02-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-02-code-0002.swift
@@ -73,17 +73,7 @@ extension LabelStyle where Self == TrailingIconLabelStyle {
     SyncUpsListView(
       store: Store(
         initialState: SyncUpsList.State(
-          syncUps: [
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          ]
+          syncUps: [.mock]
         )
       ) {
         SyncUpsList()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-02-code-0003.swift
@@ -73,17 +73,7 @@ extension LabelStyle where Self == TrailingIconLabelStyle {
     SyncUpsListView(
       store: Store(
         initialState: SyncUpsList.State(
-          syncUps: [
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          ]
+          syncUps: [.mock]
         )
       ) {
         SyncUpsList()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-03-code-0001-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-03-code-0001-previous.swift
@@ -73,17 +73,7 @@ extension LabelStyle where Self == TrailingIconLabelStyle {
     SyncUpsListView(
       store: Store(
         initialState: SyncUpsList.State(
-          syncUps: [
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          ]
+          syncUps: [.mock]
         )
       ) {
         SyncUpsList()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-03-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-03-code-0001.swift
@@ -86,17 +86,7 @@ extension LabelStyle where Self == TrailingIconLabelStyle {
     SyncUpsListView(
       store: Store(
         initialState: SyncUpsList.State(
-          syncUps: [
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          ]
+          syncUps: [.mock]
         )
       ) {
         SyncUpsList()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-03-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-03-code-0002.swift
@@ -88,17 +88,7 @@ extension LabelStyle where Self == TrailingIconLabelStyle {
     SyncUpsListView(
       store: Store(
         initialState: SyncUpsList.State(
-          syncUps: [
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          ]
+          syncUps: [.mock]
         )
       ) {
         SyncUpsList()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-01-code-0005-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-01-code-0005-previous.swift
@@ -84,17 +84,7 @@ struct SyncUpDetailView: View {
     SyncUpDetailView(
       store: Store(
         initialState: SyncUpDetail.State(
-          syncUp: Shared(
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          )
+          syncUp: Shared(.mock)
         )
       ) {
         SyncUpDetail()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-01-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-01-code-0005.swift
@@ -84,17 +84,7 @@ struct SyncUpDetailView: View {
     SyncUpDetailView(
       store: Store(
         initialState: SyncUpDetail.State(
-          syncUp: Shared(
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          )
+          syncUp: Shared(.mock)
         )
       ) {
         SyncUpDetail()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-01-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-01-code-0006.swift
@@ -89,17 +89,7 @@ struct SyncUpDetailView: View {
     SyncUpDetailView(
       store: Store(
         initialState: SyncUpDetail.State(
-          syncUp: Shared(
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          )
+          syncUp: Shared(.mock)
         )
       ) {
         SyncUpDetail()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-01-code-0007.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-01-code-0007.swift
@@ -100,17 +100,7 @@ struct SyncUpDetailView: View {
     SyncUpDetailView(
       store: Store(
         initialState: SyncUpDetail.State(
-          syncUp: Shared(
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          )
+          syncUp: Shared(.mock)
         )
       ) {
         SyncUpDetail()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-01-code-0008.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-01-code-0008.swift
@@ -101,17 +101,7 @@ struct SyncUpDetailView: View {
     SyncUpDetailView(
       store: Store(
         initialState: SyncUpDetail.State(
-          syncUp: Shared(
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          )
+          syncUp: Shared(.mock)
         )
       ) {
         SyncUpDetail()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-02-code-0014-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-02-code-0014-previous.swift
@@ -102,17 +102,7 @@ struct SyncUpDetailView: View {
     SyncUpDetailView(
       store: Store(
         initialState: SyncUpDetail.State(
-          syncUp: Shared(
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          )
+          syncUp: Shared(.mock)
         )
       ) {
         SyncUpDetail()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-02-code-0014.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-02-code-0014.swift
@@ -103,17 +103,7 @@ struct SyncUpDetailView: View {
     SyncUpDetailView(
       store: Store(
         initialState: SyncUpDetail.State(
-          syncUp: Shared(
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          )
+          syncUp: Shared(.mock)
         )
       ) {
         SyncUpDetail()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-03-code-0013-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-03-code-0013-previous.swift
@@ -103,17 +103,7 @@ struct SyncUpDetailView: View {
     SyncUpDetailView(
       store: Store(
         initialState: SyncUpDetail.State(
-          syncUp: Shared(
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          )
+          syncUp: Shared(.mock)
         )
       ) {
         SyncUpDetail()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-03-code-0013.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-03-code-0013.swift
@@ -105,17 +105,7 @@ struct SyncUpDetailView: View {
     SyncUpDetailView(
       store: Store(
         initialState: SyncUpDetail.State(
-          syncUp: Shared(
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          )
+          syncUp: Shared(.mock)
         )
       ) {
         SyncUpDetail()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/SyncUpDetail-01-code-0007.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/SyncUpDetail-01-code-0007.swift
@@ -84,17 +84,7 @@ struct SyncUpDetailView: View {
     SyncUpDetailView(
       store: Store(
         initialState: SyncUpDetail.State(
-          syncUp: Shared(
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          )
+          syncUp: Shared(.mock)
         )
       ) {
         SyncUpDetail()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/MeetingNavigation-02-code-0004-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/MeetingNavigation-02-code-0004-previous.swift
@@ -104,17 +104,7 @@ struct SyncUpDetailView: View {
     SyncUpDetailView(
       store: Store(
         initialState: SyncUpDetail.State(
-          syncUp: Shared(
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          )
+          syncUp: Shared(.mock)
         )
       ) {
         SyncUpDetail()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/MeetingNavigation-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/MeetingNavigation-02-code-0004.swift
@@ -106,17 +106,7 @@ struct SyncUpDetailView: View {
     SyncUpDetailView(
       store: Store(
         initialState: SyncUpDetail.State(
-          syncUp: Shared(
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          )
+          syncUp: Shared(.mock)
         )
       ) {
         SyncUpDetail()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0001-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0001-previous.swift
@@ -88,17 +88,7 @@ extension LabelStyle where Self == TrailingIconLabelStyle {
     SyncUpsListView(
       store: Store(
         initialState: SyncUpsList.State(
-          syncUps: [
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          ]
+          syncUps: [.mock]
         )
       ) {
         SyncUpsList()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0001.swift
@@ -88,17 +88,7 @@ extension LabelStyle where Self == TrailingIconLabelStyle {
     SyncUpsListView(
       store: Store(
         initialState: SyncUpsList.State(
-          syncUps: [
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          ]
+          syncUps: [.mock]
         )
       ) {
         SyncUpsList()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0002.swift
@@ -88,17 +88,7 @@ extension LabelStyle where Self == TrailingIconLabelStyle {
     SyncUpsListView(
       store: Store(
         initialState: SyncUpsList.State(
-          syncUps: [
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          ]
+          syncUps: [.mock]
         )
       ) {
         SyncUpsList()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0003.swift
@@ -88,17 +88,7 @@ extension LabelStyle where Self == TrailingIconLabelStyle {
     SyncUpsListView(
       store: Store(
         initialState: SyncUpsList.State(
-          syncUps: [
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          ]
+          syncUps: [.mock]
         )
       ) {
         SyncUpsList()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0004.swift
@@ -88,17 +88,7 @@ extension LabelStyle where Self == TrailingIconLabelStyle {
     SyncUpsListView(
       store: Store(
         initialState: SyncUpsList.State(
-          syncUps: [
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          ]
+          syncUps: [.mock]
         )
       ) {
         SyncUpsList()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-02-code-0003-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-02-code-0003-previous.swift
@@ -106,17 +106,7 @@ struct SyncUpDetailView: View {
     SyncUpDetailView(
       store: Store(
         initialState: SyncUpDetail.State(
-          syncUp: Shared(
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          )
+          syncUp: Shared(.mock)
         )
       ) {
         SyncUpDetail()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-02-code-0003.swift
@@ -107,17 +107,7 @@ struct SyncUpDetailView: View {
     SyncUpDetailView(
       store: Store(
         initialState: SyncUpDetail.State(
-          syncUp: Shared(
-            SyncUp(
-              id: SyncUp.ID(),
-              attendees: [
-                Attendee(id: Attendee.ID(), name: "Blob"),
-                Attendee(id: Attendee.ID(), name: "Blob Jr."),
-                Attendee(id: Attendee.ID(), name: "Blob Sr."),
-              ],
-              title: "Point-Free Morning Sync"
-            )
-          )
+          syncUp: Shared(.mock)
         )
       ) {
         SyncUpDetail()


### PR DESCRIPTION
We have one step in the tutorial that isn't quite right because it uses `SyncUp.mock` for a preview when it is never defined.

I think the mock value is probably good to add early in the tutorial as the same value is used in a bunch of previews, so this commit does just that!