### PR TITLE
Add conditional Hashable conformance to Shared

### DIFF
--- a/Sources/ComposableArchitecture/SharedState/Shared.swift
+++ b/Sources/ComposableArchitecture/SharedState/Shared.swift
@@ -298,6 +298,12 @@ extension Shared: Equatable where Value: Equatable {
   }
 }
 
+extension Shared: Hashable where Value: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    self.wrappedValue.hash(into: &hasher)
+  }
+}
+
 extension Shared: Identifiable where Value: Identifiable {
   public var id: Value.ID {
     self.wrappedValue.id

--- a/Tests/ComposableArchitectureTests/SharedTests.swift
+++ b/Tests/ComposableArchitectureTests/SharedTests.swift
@@ -934,6 +934,13 @@ final class SharedTests: XCTestCase {
     XCTAssertEqual(count, count)
     XCTAssertEqual(count.wrappedValue, count.wrappedValue)
   }
+
+  func testHashableConformance() {
+    struct HashableState: Hashable {
+      @Shared var count: Int
+    }
+    XCTAssertTrue((HashableState(count: Shared(0)) as Any) is any Hashable)
+  }
 }
 
 @Reducer


### PR DESCRIPTION
Here's a small PR that adds conditional `Hashable` conformance to `Shared` in a similar fashion to `BindingState`.