### PR TITLE
Don't pass embed functions directly to `AnyCasePath.init`

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -15,7 +15,7 @@ public enum IdentifiedAction<ID: Hashable, Action>: CasePathable {
   public struct AllCasePaths {
     public var element: AnyCasePath<IdentifiedAction, (id: ID, action: Action)> {
       AnyCasePath(
-        embed: IdentifiedAction.element,
+        embed: { .element(id: $0, action: $1) },
         extract: {
           guard case let .element(id, action) = $0 else { return nil }
           return (id, action)
@@ -169,8 +169,8 @@ extension Reducer {
       parent: self,
       toElementsState: toElementsState,
       toElementAction: .init(
-        embed: toElementAction.embed,
-        extract: toElementAction.extract
+        embed: { toElementAction.embed($0) },
+        extract: { toElementAction.extract(from: $0) }
       ),
       element: element(),
       fileID: fileID,

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -274,7 +274,7 @@ extension PresentationAction: CasePathable {
 
     public var presented: AnyCasePath<PresentationAction, Action> {
       AnyCasePath(
-        embed: PresentationAction.presented,
+        embed: { .presented($0) },
         extract: {
           guard case let .presented(value) = $0 else { return nil }
           return value

--- a/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
@@ -242,7 +242,7 @@ public enum StackAction<State, Action>: CasePathable {
   public struct AllCasePaths {
     public var element: AnyCasePath<StackAction, (id: StackElementID, action: Action)> {
       AnyCasePath(
-        embed: StackAction.element,
+        embed: { .element(id: $0, action: $1) },
         extract: {
           guard case let .element(id, action) = $0 else { return nil }
           return (id: id, action: action)
@@ -252,7 +252,7 @@ public enum StackAction<State, Action>: CasePathable {
 
     public var popFrom: AnyCasePath<StackAction, StackElementID> {
       AnyCasePath(
-        embed: StackAction.popFrom,
+        embed: { .popFrom(id: $0) },
         extract: {
           guard case let .popFrom(id) = $0 else { return nil }
           return id
@@ -262,7 +262,7 @@ public enum StackAction<State, Action>: CasePathable {
 
     public var push: AnyCasePath<StackAction, (id: StackElementID, state: State)> {
       AnyCasePath(
-        embed: StackAction.push,
+        embed: { .push(id: $0, state: $1) },
         extract: {
           guard case let .push(id, state) = $0 else { return nil }
           return (id: id, state: state)

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -294,7 +294,7 @@ public protocol BindableAction {
 
 extension BindableAction {
   public var binding: BindingAction<State>? {
-    AnyCasePath(unsafe: Self.binding).extract(from: self)
+    AnyCasePath(unsafe: { .binding($0) }).extract(from: self)
   }
 }
 


### PR DESCRIPTION
`AnyCasePath` closures will be required to be `@Sendable` for Swift 6 data race checking, but `Enum.case` functions are not `@Sendable` implicitly. As such we cannot pass `Enum.case` directly to functions that expect sendable closures. Instead, we must explicitly write:

```swift
{ .case($0) }
```