### PR TITLE
Share state appstorage nullable

### DIFF
--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
@@ -434,9 +434,7 @@ private struct OptionalLookup<Base: Lookup>: Lookup {
     if let newValue {
       base.saveValue(newValue, to: store, at: key)
     } else {
-      SharedAppStorageLocals.$isSetting.withValue(true) {
-        store.removeObject(forKey: key)
-      }
+      store.removeObject(forKey: key)
     }
   }
 }

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
@@ -434,7 +434,9 @@ private struct OptionalLookup<Base: Lookup>: Lookup {
     if let newValue {
       base.saveValue(newValue, to: store, at: key)
     } else {
-      store.removeObject(forKey: key)
+      SharedAppStorageLocals.$isSetting.withValue(true) {
+        store.removeObject(forKey: key)
+      }
     }
   }
 }

--- a/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
+++ b/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
@@ -139,7 +139,7 @@ extension Shared {
     line: UInt = #line
   ) where Key.Value == Value {
     self.init(
-      wrappedValue: persistenceKey.load(initialValue: nil) ?? persistenceKey.defaultValue(),
+      wrappedValue: persistenceKey.defaultValue(),
       persistenceKey.base,
       fileID: fileID,
       line: line
@@ -297,7 +297,7 @@ extension SharedReader {
     line: UInt = #line
   ) where Key.Value == Value {
     self.init(
-      wrappedValue: persistenceKey.load(initialValue: nil) ?? persistenceKey.defaultValue(),
+      wrappedValue: persistenceKey.defaultValue(),
       persistenceKey.base,
       fileID: fileID,
       line: line

--- a/Tests/ComposableArchitectureTests/SharedTests.swift
+++ b/Tests/ComposableArchitectureTests/SharedTests.swift
@@ -935,7 +935,7 @@ final class SharedTests: XCTestCase {
     XCTAssertEqual(count.wrappedValue, count.wrappedValue)
   }
 
-  func testNotNilInitialValueAndSetToNil() {
+  func testDefaultVersusValueInExternalStorage() {
     @Dependency(\.defaultAppStorage) var userDefaults
     userDefaults.set(true, forKey: "optionalValueWithDefault")
 

--- a/Tests/ComposableArchitectureTests/SharedTests.swift
+++ b/Tests/ComposableArchitectureTests/SharedTests.swift
@@ -934,6 +934,19 @@ final class SharedTests: XCTestCase {
     XCTAssertEqual(count, count)
     XCTAssertEqual(count.wrappedValue, count.wrappedValue)
   }
+
+  func testNotNilInitialValueAndSetToNil() {
+    @Dependency(\.defaultAppStorage) var userDefaults
+    userDefaults.set(true, forKey: "optionalValueWithDefault")
+
+    @Shared(.optionalValueWithDefault) var optionalValueWithDefault
+
+    XCTAssertNotNil(optionalValueWithDefault)
+
+    $optionalValueWithDefault.withLock { $0 = nil }
+
+    XCTAssertNil(optionalValueWithDefault)
+  }
 }
 
 @Reducer


### PR DESCRIPTION
This PR allows deleting elements from an `AppStorageKey` when it loads with a **non-null** value and we attempt to delete that value in persistence.