### PR TITLE
Add Shared AppStorage support for [Bool], [Int], [Double] and [String]

### DIFF
--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
@@ -76,6 +76,42 @@ extension PersistenceReaderKey {
     AppStorageKey(key)
   }
 
+  /// Creates a persistence key that can read and write to a string array user default.
+  ///
+  /// - Parameter key: The key to read and write the value to in the user defaults store.
+  /// - Returns: A user defaults persistence key.
+  public static func appStorage(_ key: String) -> Self
+  where Self == AppStorageKey<[Bool]> {
+    AppStorageKey(key)
+  }
+  
+  /// Creates a persistence key that can read and write to a string array user default.
+  ///
+  /// - Parameter key: The key to read and write the value to in the user defaults store.
+  /// - Returns: A user defaults persistence key.
+  public static func appStorage(_ key: String) -> Self
+  where Self == AppStorageKey<[Int]> {
+    AppStorageKey(key)
+  }
+  
+  /// Creates a persistence key that can read and write to a string array user default.
+  ///
+  /// - Parameter key: The key to read and write the value to in the user defaults store.
+  /// - Returns: A user defaults persistence key.
+  public static func appStorage(_ key: String) -> Self
+  where Self == AppStorageKey<[Double]> {
+    AppStorageKey(key)
+  }
+  
+  /// Creates a persistence key that can read and write to a string array user default.
+  ///
+  /// - Parameter key: The key to read and write the value to in the user defaults store.
+  /// - Returns: A user defaults persistence key.
+  public static func appStorage(_ key: String) -> Self
+  where Self == AppStorageKey<[String]> {
+    AppStorageKey(key)
+  }
+  
   /// Creates a persistence key that can read and write to an optional boolean user default.
   ///
   /// - Parameter key: The key to read and write the value to in the user defaults store.
@@ -149,6 +185,42 @@ extension PersistenceReaderKey {
   where Value.RawValue == String, Self == AppStorageKey<Value?> {
     AppStorageKey(key)
   }
+  
+  /// Creates a persistence key that can read and write to an optional string array user default.
+  ///
+  /// - Parameter key: The key to read and write the value to in the user defaults store.
+  /// - Returns: A user defaults persistence key.
+  public static func appStorage(_ key: String) -> Self
+  where Self == AppStorageKey<[Bool]?> {
+    AppStorageKey(key)
+  }
+  
+  /// Creates a persistence key that can read and write to an optional string array user default.
+  ///
+  /// - Parameter key: The key to read and write the value to in the user defaults store.
+  /// - Returns: A user defaults persistence key.
+  public static func appStorage(_ key: String) -> Self
+  where Self == AppStorageKey<[Int]?> {
+    AppStorageKey(key)
+  }
+  
+  /// Creates a persistence key that can read and write to an optional string array user default.
+  ///
+  /// - Parameter key: The key to read and write the value to in the user defaults store.
+  /// - Returns: A user defaults persistence key.
+  public static func appStorage(_ key: String) -> Self
+  where Self == AppStorageKey<[Double]?> {
+    AppStorageKey(key)
+  }
+  
+  /// Creates a persistence key that can read and write to an optional string array user default.
+  ///
+  /// - Parameter key: The key to read and write the value to in the user defaults store.
+  /// - Returns: A user defaults persistence key.
+  public static func appStorage(_ key: String) -> Self
+  where Self == AppStorageKey<[String]?> {
+    AppStorageKey(key)
+  }
 }
 
 /// A type defining a user defaults persistence strategy.
@@ -219,6 +291,34 @@ public struct AppStorageKey<Value> {
     self.store = store
   }
 
+  fileprivate init(_ key: String) where Value == [Bool] {
+    @Dependency(\.defaultAppStorage) var store
+    self.lookup = CastableLookup()
+    self.key = key
+    self.store = store
+  }
+  
+  fileprivate init(_ key: String) where Value == [Int] {
+    @Dependency(\.defaultAppStorage) var store
+    self.lookup = CastableLookup()
+    self.key = key
+    self.store = store
+  }
+  
+  fileprivate init(_ key: String) where Value == [Double] {
+    @Dependency(\.defaultAppStorage) var store
+    self.lookup = CastableLookup()
+    self.key = key
+    self.store = store
+  }
+  
+  fileprivate init(_ key: String) where Value == [String] {
+    @Dependency(\.defaultAppStorage) var store
+    self.lookup = CastableLookup()
+    self.key = key
+    self.store = store
+  }
+  
   fileprivate init(_ key: String) where Value == Bool? {
     @Dependency(\.defaultAppStorage) var store
     self.lookup = OptionalLookup(base: CastableLookup())
@@ -271,6 +371,34 @@ public struct AppStorageKey<Value> {
   fileprivate init<R: RawRepresentable<String>>(_ key: String) where Value == R? {
     @Dependency(\.defaultAppStorage) var store
     self.lookup = OptionalLookup(base: RawRepresentableLookup(base: CastableLookup()))
+    self.key = key
+    self.store = store
+  }
+
+  fileprivate init(_ key: String) where Value == [Bool]? {
+    @Dependency(\.defaultAppStorage) var store
+    self.lookup = OptionalLookup(base: CastableLookup())
+    self.key = key
+    self.store = store
+  }
+  
+  fileprivate init(_ key: String) where Value == [Int]? {
+    @Dependency(\.defaultAppStorage) var store
+    self.lookup = OptionalLookup(base: CastableLookup())
+    self.key = key
+    self.store = store
+  }
+  
+  fileprivate init(_ key: String) where Value == [Double]? {
+    @Dependency(\.defaultAppStorage) var store
+    self.lookup = OptionalLookup(base: CastableLookup())
+    self.key = key
+    self.store = store
+  }
+  
+  fileprivate init(_ key: String) where Value == [String]? {
+    @Dependency(\.defaultAppStorage) var store
+    self.lookup = OptionalLookup(base: CastableLookup())
     self.key = key
     self.store = store
   }

--- a/Tests/ComposableArchitectureTests/AppStorageTests.swift
+++ b/Tests/ComposableArchitectureTests/AppStorageTests.swift
@@ -85,6 +85,40 @@ final class AppStorageTests: XCTestCase {
     XCTAssertEqual(defaults.string(forKey: "direction"), "south")
   }
 
+  func testDefaultsRead_StringArray() {
+    @Dependency(\.defaultAppStorage) var defaults
+    defaults.set(["Blob, Jr.", "Blob, Sr"], forKey: "stringArray")
+    @Shared(.appStorage("stringArray")) var array: [String]?
+    XCTAssertEqual(array, ["Blob, Jr.", "Blob, Sr"])
+  }
+
+  func testDefaultsRegistered_StringArray() {
+    @Dependency(\.defaultAppStorage) var defaults
+    @Shared(.appStorage("stringArray")) var array: [String] = ["Blob, Jr.", "Blob, Sr"]
+    XCTAssertEqual(defaults.stringArray(forKey: "stringArray"), ["Blob, Jr.", "Blob, Sr"])
+
+    array = ["Hello", "World"]
+    XCTAssertEqual(array, ["Hello", "World"])
+    XCTAssertEqual(defaults.stringArray(forKey: "stringArray"), ["Hello", "World"])
+  }
+  
+  func testDefaultsRead_IntArray() {
+    @Dependency(\.defaultAppStorage) var defaults
+    defaults.set([42, 43, 44], forKey: "intArray")
+    @Shared(.appStorage("intArray")) var array: [Int]?
+    XCTAssertEqual(array, [42, 43, 44])
+  }
+
+  func testDefaultsRegistered_IntArray() {
+    @Dependency(\.defaultAppStorage) var defaults
+    @Shared(.appStorage("intArray")) var array: [Int] = [42, 43, 44]
+    XCTAssertEqual(defaults.array(forKey: "intArray") as! [Int], [42, 43, 44])
+
+    array = [1, 2, 3]
+    XCTAssertEqual(array, [1, 2, 3])
+    XCTAssertEqual(defaults.array(forKey: "intArray") as! [Int], [1, 2, 3])
+  }
+  
   func testDefaultAppStorageOverride() {
     let defaults = UserDefaults(suiteName: "tests")!
     defaults.removePersistentDomain(forName: "tests")


### PR DESCRIPTION
My project needed to access an array of integers from user defaults.