### PR TITLE
Make 'didSet' main actor.

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.11.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.11.md
@@ -15,7 +15,6 @@ APIs and deprecated 1 API.
 * [Mutating shared state concurrently](#Mutating-shared-state-concurrently)
 * [Supplying mock read-only state to previews](#Supplying-mock-read-only-state-to-previews)
 * [Migrating to 1.11.2](#Migrating-to-1112)
-* [Migrating to 1.11.3](#Migrating-to-1113)
 
 ## Mutating shared state concurrently
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.11.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.11.md
@@ -12,6 +12,11 @@ APIs and deprecated 1 API.
 > Important: Before following this migration guide be sure you have fully migrated to the newest
 > tools of version 1.10. See <doc:MigrationGuides> for more information.
 
+* [Mutating shared state concurrently](#Mutating-shared-state-concurrently)
+* [Supplying mock read-only state to previews](#Supplying-mock-read-only-state-to-previews)
+* [Migrating to 1.11.2](#Migrating-to-1112)
+* [Migrating to 1.11.3](#Migrating-to-1113)
+
 ## Mutating shared state concurrently
 
 Version 1.10 of the Composable Architecture introduced a powerful tool for 

--- a/Sources/ComposableArchitecture/Internal/DispatchQueue.swift
+++ b/Sources/ComposableArchitecture/Internal/DispatchQueue.swift
@@ -1,0 +1,20 @@
+import Dispatch
+
+func mainActorASAP(execute block: @escaping @MainActor @Sendable () -> Void) {
+  if DispatchQueue.main.getSpecific(key: key) == nil {
+    DispatchQueue.main.setSpecific(key: key, value: value)
+  }
+
+  if DispatchQueue.getSpecific(key: key) == value {
+    MainActor.assumeIsolated { block() }
+  } else {
+    DispatchQueue.main.async {
+      MainActor.assumeIsolated {
+        block()
+      }
+    }
+  }
+}
+
+private let key = DispatchSpecificKey<UInt8>()
+private let value: UInt8 = 0

--- a/Sources/ComposableArchitecture/Internal/DispatchQueue.swift
+++ b/Sources/ComposableArchitecture/Internal/DispatchQueue.swift
@@ -2,7 +2,7 @@ import Dispatch
 
 func mainActorASAP(execute block: @escaping @MainActor @Sendable () -> Void) {
   if DispatchQueue.getSpecific(key: key) == value {
-    MainActor.assumeIsolated {
+    assumeMainActorIsolated {
       block()
     }
   } else {
@@ -18,3 +18,8 @@ private let key: DispatchSpecificKey<UInt8> = {
   return key
 }()
 private let value: UInt8 = 0
+
+@MainActor(unsafe)
+private func assumeMainActorIsolated(_ block: @escaping @MainActor @Sendable () -> Void) {
+  block()
+}

--- a/Sources/ComposableArchitecture/Internal/DispatchQueue.swift
+++ b/Sources/ComposableArchitecture/Internal/DispatchQueue.swift
@@ -19,6 +19,8 @@ private let key: DispatchSpecificKey<UInt8> = {
 }()
 private let value: UInt8 = 0
 
+// NB: Currently we can't use 'MainActor.assumeIsolated' on CI, but we can approximate this in
+//     the meantime.
 @MainActor(unsafe)
 private func assumeMainActorIsolated(_ block: @escaping @MainActor @Sendable () -> Void) {
   block()

--- a/Sources/ComposableArchitecture/Internal/DispatchQueue.swift
+++ b/Sources/ComposableArchitecture/Internal/DispatchQueue.swift
@@ -1,20 +1,20 @@
 import Dispatch
 
 func mainActorASAP(execute block: @escaping @MainActor @Sendable () -> Void) {
-  if DispatchQueue.main.getSpecific(key: key) == nil {
-    DispatchQueue.main.setSpecific(key: key, value: value)
-  }
-
   if DispatchQueue.getSpecific(key: key) == value {
-    MainActor.assumeIsolated { block() }
+    MainActor.assumeIsolated {
+      block()
+    }
   } else {
     DispatchQueue.main.async {
-      MainActor.assumeIsolated {
-        block()
-      }
+      block()
     }
   }
 }
 
-private let key = DispatchSpecificKey<UInt8>()
+private let key: DispatchSpecificKey<UInt8> = {
+  let key = DispatchSpecificKey<UInt8>()
+  DispatchQueue.main.setSpecific(key: key, value: value)
+  return key
+}()
 private let value: UInt8 = 0

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
@@ -35,7 +35,7 @@ public protocol PersistenceReaderKey<Value> {
   ///   deinitialized, the `didSet` closure will no longer be invoked.
   func subscribe(
     initialValue: Value?,
-    didSet: @Sendable @escaping (_ newValue: Value?) -> Void
+    didSet: @escaping @MainActor @Sendable (_ newValue: Value?) -> Void
   ) -> Shared<Value>.Subscription
 }
 
@@ -46,7 +46,7 @@ extension PersistenceReaderKey where ID == Self {
 extension PersistenceReaderKey {
   public func subscribe(
     initialValue: Value?,
-    didSet: @Sendable @escaping (_ newValue: Value?) -> Void
+    didSet: @escaping @MainActor @Sendable (_ newValue: Value?) -> Void
   ) -> Shared<Value>.Subscription {
     Shared.Subscription {}
   }

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
@@ -35,7 +35,7 @@ public protocol PersistenceReaderKey<Value> {
   ///   deinitialized, the `didSet` closure will no longer be invoked.
   func subscribe(
     initialValue: Value?,
-    didSet: @escaping @MainActor @Sendable (_ newValue: Value?) -> Void
+    didSet: @escaping @Sendable (_ newValue: Value?) -> Void
   ) -> Shared<Value>.Subscription
 }
 
@@ -46,7 +46,7 @@ extension PersistenceReaderKey where ID == Self {
 extension PersistenceReaderKey {
   public func subscribe(
     initialValue: Value?,
-    didSet: @escaping @MainActor @Sendable (_ newValue: Value?) -> Void
+    didSet: @escaping @Sendable (_ newValue: Value?) -> Void
   ) -> Shared<Value>.Subscription {
     Shared.Subscription {}
   }

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
@@ -293,7 +293,7 @@ extension AppStorageKey: PersistenceKey {
     let userDefaultsDidChange = NotificationCenter.default.addObserver(
       forName: UserDefaults.didChangeNotification,
       object: self.store,
-      queue: OperationQueue.main
+      queue: nil
     ) { _ in
       let newValue = load(initialValue: initialValue)
       defer { previousValue.withValue { $0 = newValue } }
@@ -305,7 +305,7 @@ extension AppStorageKey: PersistenceKey {
       }
       guard !SharedAppStorageLocals.isSetting
       else { return }
-      MainActor.assumeIsolated {
+      mainActorASAP {
         _ = didSet(newValue)
       }
     }
@@ -314,9 +314,9 @@ extension AppStorageKey: PersistenceKey {
       willEnterForeground = NotificationCenter.default.addObserver(
         forName: willEnterForegroundNotificationName,
         object: nil,
-        queue: OperationQueue.main
+        queue: nil
       ) { _ in
-        MainActor.assumeIsolated {
+        mainActorASAP {
           _ = didSet(load(initialValue: initialValue))
         }
       }

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
@@ -287,7 +287,7 @@ extension AppStorageKey: PersistenceKey {
 
   public func subscribe(
     initialValue: Value?,
-    didSet: @escaping @MainActor @Sendable (_ newValue: Value?) -> Void
+    didSet: @escaping @Sendable (_ newValue: Value?) -> Void
   ) -> Shared<Value>.Subscription {
     let previousValue = LockIsolated(initialValue)
     let userDefaultsDidChange = NotificationCenter.default.addObserver(
@@ -305,9 +305,7 @@ extension AppStorageKey: PersistenceKey {
       }
       guard !SharedAppStorageLocals.isSetting
       else { return }
-      mainActorASAP {
-        _ = didSet(newValue)
-      }
+      didSet(newValue)
     }
     let willEnterForeground: (any NSObjectProtocol)?
     if let willEnterForegroundNotificationName {
@@ -316,9 +314,7 @@ extension AppStorageKey: PersistenceKey {
         object: nil,
         queue: nil
       ) { _ in
-        mainActorASAP {
-          _ = didSet(load(initialValue: initialValue))
-        }
+        didSet(load(initialValue: initialValue))
       }
     } else {
       willEnterForeground = nil

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKey.swift
@@ -287,7 +287,7 @@ extension AppStorageKey: PersistenceKey {
 
   public func subscribe(
     initialValue: Value?,
-    didSet: @escaping @Sendable @MainActor (_ newValue: Value?) -> Void
+    didSet: @escaping @MainActor @Sendable (_ newValue: Value?) -> Void
   ) -> Shared<Value>.Subscription {
     let previousValue = LockIsolated(initialValue)
     let userDefaultsDidChange = NotificationCenter.default.addObserver(

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKeyPathKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKeyPathKey.swift
@@ -48,7 +48,7 @@ extension AppStorageKeyPathKey: PersistenceKey, Hashable {
 
   public func subscribe(
     initialValue: Value?,
-    didSet: @escaping @Sendable @MainActor (_ newValue: Value?) -> Void
+    didSet: @escaping @MainActor @Sendable (_ newValue: Value?) -> Void
   ) -> Shared<Value>.Subscription {
     let observer = self.store.observe(self.keyPath, options: .new) { _, change in
       guard

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKeyPathKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKeyPathKey.swift
@@ -48,13 +48,15 @@ extension AppStorageKeyPathKey: PersistenceKey, Hashable {
 
   public func subscribe(
     initialValue: Value?,
-    didSet: @Sendable @escaping (_ newValue: Value?) -> Void
+    didSet: @escaping @Sendable @MainActor (_ newValue: Value?) -> Void
   ) -> Shared<Value>.Subscription {
     let observer = self.store.observe(self.keyPath, options: .new) { _, change in
       guard
         !SharedAppStorageLocals.isSetting
       else { return }
-      didSet(change.newValue ?? initialValue)
+      mainActorASAP {
+        _ = didSet(change.newValue ?? initialValue)
+      }
     }
     return Shared.Subscription {
       observer.invalidate()

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKeyPathKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKeyPathKey.swift
@@ -48,15 +48,13 @@ extension AppStorageKeyPathKey: PersistenceKey, Hashable {
 
   public func subscribe(
     initialValue: Value?,
-    didSet: @escaping @MainActor @Sendable (_ newValue: Value?) -> Void
+    didSet: @escaping @Sendable (_ newValue: Value?) -> Void
   ) -> Shared<Value>.Subscription {
     let observer = self.store.observe(self.keyPath, options: .new) { _, change in
       guard
         !SharedAppStorageLocals.isSetting
       else { return }
-      mainActorASAP {
-        _ = didSet(change.newValue ?? initialValue)
-      }
+      didSet(change.newValue ?? initialValue)
     }
     return Shared.Subscription {
       observer.invalidate()

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/FileStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/FileStorageKey.swift
@@ -98,7 +98,7 @@ public final class FileStorageKey<Value: Codable & Sendable>: PersistenceKey, Se
             } else {
               state.workItem?.cancel()
               state.workItem = nil
-              MainActor.assumeIsolated {
+              mainActorASAP {
                 _ = didSet(self.load(initialValue: initialValue))
               }
             }
@@ -109,7 +109,7 @@ public final class FileStorageKey<Value: Codable & Sendable>: PersistenceKey, Se
             state.workItem?.cancel()
             state.workItem = nil
           }
-          MainActor.assumeIsolated {
+          mainActorASAP {
             `didSet`(self.load(initialValue: initialValue))
           }
           setUpSources()
@@ -265,7 +265,7 @@ public struct FileStorage: Hashable, Sendable {
         let source = DispatchSource.makeFileSystemObjectSource(
           fileDescriptor: open($0.path, O_EVTONLY),
           eventMask: $1,
-          queue: DispatchQueue.main
+          queue: queue
         )
         source.setEventHandler(handler: $2)
         source.resume()

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/FileStorageKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/FileStorageKey.swift
@@ -79,7 +79,7 @@ public final class FileStorageKey<Value: Codable & Sendable>: PersistenceKey, Se
 
   public func subscribe(
     initialValue: Value?,
-    didSet: @escaping @MainActor @Sendable (_ newValue: Value?) -> Void
+    didSet: @escaping @Sendable (_ newValue: Value?) -> Void
   ) -> Shared<Value>.Subscription {
     let cancellable = LockIsolated<AnyCancellable?>(nil)
     @Sendable func setUpSources() {
@@ -98,9 +98,7 @@ public final class FileStorageKey<Value: Codable & Sendable>: PersistenceKey, Se
             } else {
               state.workItem?.cancel()
               state.workItem = nil
-              mainActorASAP {
-                _ = didSet(self.load(initialValue: initialValue))
-              }
+              didSet(self.load(initialValue: initialValue))
             }
           }
         }
@@ -109,9 +107,7 @@ public final class FileStorageKey<Value: Codable & Sendable>: PersistenceKey, Se
             state.workItem?.cancel()
             state.workItem = nil
           }
-          mainActorASAP {
-            `didSet`(self.load(initialValue: initialValue))
-          }
+          `didSet`(self.load(initialValue: initialValue))
           setUpSources()
         }
         $0 = AnyCancellable {

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/PersistenceKeyDefault.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/PersistenceKeyDefault.swift
@@ -41,7 +41,7 @@ public struct PersistenceKeyDefault<Base: PersistenceReaderKey>: PersistenceRead
 
   public func subscribe(
     initialValue: Base.Value?,
-    didSet: @escaping @MainActor @Sendable (Base.Value?) -> Void
+    didSet: @escaping @Sendable (Base.Value?) -> Void
   ) -> Shared<Base.Value>.Subscription {
     self.base.subscribe(initialValue: initialValue, didSet: didSet)
   }

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/PersistenceKeyDefault.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/PersistenceKeyDefault.swift
@@ -41,7 +41,7 @@ public struct PersistenceKeyDefault<Base: PersistenceReaderKey>: PersistenceRead
 
   public func subscribe(
     initialValue: Base.Value?,
-    didSet: @Sendable @escaping (Base.Value?) -> Void
+    didSet: @escaping @MainActor @Sendable (Base.Value?) -> Void
   ) -> Shared<Base.Value>.Subscription {
     self.base.subscribe(initialValue: initialValue, didSet: didSet)
   }

--- a/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
+++ b/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
@@ -399,8 +399,10 @@ final class ValueReference<Value, Persistence: PersistenceReaderKey<Value>>: Ref
           self._$perceptionRegistrar.willSet(self, keyPath: \.value)
           defer { self._$perceptionRegistrar.didSet(self, keyPath: \.value) }
         #endif
-        self.lock.withLock {
-          self._value = value ?? initialValue
+        mainActorASAP {
+          self.lock.withLock {
+            self._value = value ?? initialValue
+          }
         }
       }
     }

--- a/Tests/ComposableArchitectureTests/AppStorageTests.swift
+++ b/Tests/ComposableArchitectureTests/AppStorageTests.swift
@@ -294,8 +294,6 @@ final class AppStorageTests: XCTestCase {
 
     await fulfillment(of: [publisherExpectation], timeout: 0)
   }
-
-  // TODO: confirm this is called sync when on main actor
 }
 
 extension UserDefaults {

--- a/Tests/ComposableArchitectureTests/FileStorageTests.swift
+++ b/Tests/ComposableArchitectureTests/FileStorageTests.swift
@@ -459,7 +459,7 @@ final class FileStorageTests: XCTestCase {
         }
       }
 
-      await fulfillment(of: [publisherExpectation], timeout: 0)
+      await fulfillment(of: [publisherExpectation], timeout: 0.1)
     }
   }
 }

--- a/Tests/ComposableArchitectureTests/FileStorageTests.swift
+++ b/Tests/ComposableArchitectureTests/FileStorageTests.swift
@@ -434,6 +434,64 @@ final class FileStorageTests: XCTestCase {
       XCTAssertEqual(count, max * (max + 1) / 2)
     }
   }
+
+  @MainActor
+  func testUpdateFileSystemFromBackgroundThread() async throws {
+    await withDependencies {
+      $0.defaultFileStorage = .fileSystem
+    } operation: {
+      try? FileManager.default.removeItem(at: .fileURL)
+
+      @Shared(.fileStorage(.fileURL)) var count = 0
+
+      let publisherExpectation = expectation(description: "publisher")
+      let cancellable = $count.publisher.sink { _ in
+        XCTAssertTrue(Thread.isMainThread)
+        publisherExpectation.fulfill()
+      }
+      defer { _ = cancellable }
+
+      await withUnsafeContinuation { continuation in
+        DispatchQueue.global().async {
+          XCTAssertFalse(Thread.isMainThread)
+          try! Data("1".utf8).write(to: .fileURL)
+          continuation.resume()
+        }
+      }
+
+      await fulfillment(of: [publisherExpectation], timeout: 0)
+    }
+  }
+
+  @MainActor
+  func testUpdateFileSystemFromMainThreadASAP() async throws {
+    await withDependencies {
+      $0.defaultFileStorage = .fileSystem
+    } operation: {
+      try? FileManager.default.removeItem(at: .fileURL)
+
+      @Shared(.fileStorage(.fileURL)) var count = 0
+      let isInStackFrame = LockIsolated(false)
+
+      let publisherExpectation = expectation(description: "publisher")
+      let cancellable = $count.publisher.sink { _ in
+        XCTAssertTrue(Thread.isMainThread)
+        XCTAssertTrue(isInStackFrame.value)
+        publisherExpectation.fulfill()
+      }
+      defer { _ = cancellable }
+
+      await withUnsafeContinuation { continuation in
+        XCTAssertTrue(Thread.isMainThread)
+        isInStackFrame.withValue { $0 = true }
+        try! Data("1".utf8).write(to: .fileURL)
+        isInStackFrame.withValue { $0 = false }
+        continuation.resume()
+      }
+
+      await fulfillment(of: [publisherExpectation], timeout: 0)
+    }
+  }
 }
 
 extension URL {

--- a/Tests/ComposableArchitectureTests/FileStorageTests.swift
+++ b/Tests/ComposableArchitectureTests/FileStorageTests.swift
@@ -462,36 +462,6 @@ final class FileStorageTests: XCTestCase {
       await fulfillment(of: [publisherExpectation], timeout: 0)
     }
   }
-
-  @MainActor
-  func testUpdateFileSystemFromMainThreadASAP() async throws {
-    await withDependencies {
-      $0.defaultFileStorage = .fileSystem
-    } operation: {
-      try? FileManager.default.removeItem(at: .fileURL)
-
-      @Shared(.fileStorage(.fileURL)) var count = 0
-      let isInStackFrame = LockIsolated(false)
-
-      let publisherExpectation = expectation(description: "publisher")
-      let cancellable = $count.publisher.sink { _ in
-        XCTAssertTrue(Thread.isMainThread)
-        XCTAssertTrue(isInStackFrame.value)
-        publisherExpectation.fulfill()
-      }
-      defer { _ = cancellable }
-
-      await withUnsafeContinuation { continuation in
-        XCTAssertTrue(Thread.isMainThread)
-        isInStackFrame.withValue { $0 = true }
-        try! Data("1".utf8).write(to: .fileURL)
-        isInStackFrame.withValue { $0 = false }
-        continuation.resume()
-      }
-
-      await fulfillment(of: [publisherExpectation], timeout: 0)
-    }
-  }
 }
 
 extension URL {


### PR DESCRIPTION
This fixes an issue brought up here: https://github.com/pointfreeco/swift-composable-architecture/discussions/3182#discussioncomment-9841265

In order for a `@Shared` value to subscribe to changes to an external system (e.g. file system, user defaults, etc.), one uses the `subscribe` endpoint and feeds data to `didSet`. Sending data to `didSet` ultimately mutates the `@Shared` value and triggers SwiftUI re-renders, and so that should take place on the main thread.

This enforces that contract by making the `didSet` argument `@MainActor`. It is _technically_ a breaking change, but really it's a bug fix. This is a problem people may have in their custom persistence strategies right now, and they may want to investigate how to fix them.