### PR TITLE
Fix variable naming in StackBasedNavigation.md

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
@@ -122,7 +122,7 @@ struct RootView: View {
       path: $store.scope(state: \.path, action: \.path)
     ) {
       // Root view of the navigation stack
-    } destination: { state in
+    } destination: { store in
       // A view for each case of the Path.State enum
     }
   }


### PR DESCRIPTION
Considering the context, this should be named `store`.

![CleanShot 2024-06-27 at 12 28 54@2x](https://github.com/pointfreeco/swift-composable-architecture/assets/31601805/dd25dbff-0949-4760-a61a-42d3241ea838)
