### PR TITLE
Improve UIKit case studies: ListsOfState

### DIFF
--- a/Examples/CaseStudies/UIKitCaseStudies/ListsOfState.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/ListsOfState.swift
@@ -25,6 +25,8 @@ let cellIdentifier = "Cell"
 final class CountersTableViewController: UITableViewController {
   let store: StoreOf<CounterList>
 
+  var observations: [IndexPath: ObservationToken] = [:]
+
   init(store: StoreOf<CounterList>) {
     self.store = store
     super.init(nibName: nil, bundle: nil)
@@ -51,7 +53,8 @@ final class CountersTableViewController: UITableViewController {
   {
     let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
     cell.accessoryType = .disclosureIndicator
-    observe { [weak self] in
+    observations[indexPath]?.cancel()
+    observations[indexPath] = observe { [weak self] in
       guard let self else { return }
       cell.textLabel?.text = "\(store.counters[indexPath.row].count)"
     }


### PR DESCRIPTION
I have improved the ListsOfState example.
The `tableView(_:cellForRowAt:)` delegate method can be called multiple times for the same indexPath, and in the current code, the `observe(_:)` method is executed multiple times for the same indexPath.
When the `observe(_:)` method is executed multiple times, the closure is called unnecessarily many times when the Counter model at the corresponding index is changed.
To prevent this, I have added the observation cancellation logic.