### PR TITLE
Add `final` to `UIViewController`s in UIKit CaseStudies

### DIFF
--- a/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
@@ -52,7 +52,7 @@ struct LazyNavigation {
   }
 }
 
-class LazyNavigationViewController: UIViewController {
+final class LazyNavigationViewController: UIViewController {
   let store: StoreOf<LazyNavigation>
 
   init(store: StoreOf<LazyNavigation>) {

--- a/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
@@ -48,7 +48,7 @@ struct EagerNavigation {
   }
 }
 
-class EagerNavigationViewController: UIViewController {
+final class EagerNavigationViewController: UIViewController {
   let store: StoreOf<EagerNavigation>
 
   init(store: StoreOf<EagerNavigation>) {


### PR DESCRIPTION
While checking out the UIKit CaseStudies, I noticed that a couple of ViewControllers were missing the `final` keyword.
I didn't see any subclassing, and all the other ViewControllers seem to have `final`, so I assumed it was an oversight. Let me know if I'm missing something 👍