### PR TITLE
Add nonisolated `Shared.withLock`

### DIFF
--- a/Sources/ComposableArchitecture/SharedState/Shared.swift
+++ b/Sources/ComposableArchitecture/SharedState/Shared.swift
@@ -72,6 +72,11 @@ public struct Shared<Value> {
     try transform(&self._wrappedValue)
   }
 
+  /// Perform a non-mutating operation on shared state with nonisolated access to the underlying value.
+  public func withLock<R>(_ transform: @Sendable (Value) throws -> R) rethrows -> R {
+    try transform(self._wrappedValue)
+  }
+
   /// The underlying value referenced by the shared variable.
   ///
   /// This property provides primary access to the value's data. However, you don't access


### PR DESCRIPTION
Recently `Shared`'s `withLock` had `@MainActor` added due to the need to isolate mutations of the internal value to the main actor. However, composing `Shared` into other APIs may require locked access to the shared state without such a requirement.

This PR adds an additional overload of `withLock` that doesn't allow mutation of the stored `Value`, allowing it to not be isolated to the main actor.