### PR TITLE
Improve store scoping in benchmark

### DIFF
--- a/Sources/swift-composable-architecture-benchmark/StoreScope.swift
+++ b/Sources/swift-composable-architecture-benchmark/StoreScope.swift
@@ -22,7 +22,7 @@ let storeScopeSuite = BenchmarkSuite(name: "Store scoping") { suite in
   var store = Store(initialState: 0) { Counter() }
   var viewStores: [ViewStore<Int, Bool>] = [ViewStore(store, observe: { $0 })]
   for _ in 1...4 {
-    store = store.scope(state: { $0 }, action: { $0 })
+    store = store.scope(state: \.self, action: \.self)
     viewStores.append(ViewStore(store, observe: { $0 }))
   }
   let lastViewStore = viewStores.last!


### PR DESCRIPTION
This PR resolves the following warning message:

```
'scope(state:action:)' is deprecated: Pass 'state' a key path to child state and 'action' a case key path to child action, instead. For more information see the following migration guide: https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.5#Store-scoping-with-key-paths
```