### PR TITLE
Hide UIViewController method/properties in UIKit Example code

### DIFF
--- a/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
@@ -29,7 +29,7 @@ struct Counter {
 }
 
 final class CounterViewController: UIViewController {
-  let store: StoreOf<Counter>
+  private let store: StoreOf<Counter>
 
   init(store: StoreOf<Counter>) {
     self.store = store

--- a/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
@@ -75,7 +75,7 @@ final class CounterViewController: UIViewController {
     }
   }
 
-  @objc func decrementButtonTapped() {
+  @objc private func decrementButtonTapped() {
     store.send(.decrementButtonTapped)
   }
 

--- a/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
@@ -79,7 +79,7 @@ final class CounterViewController: UIViewController {
     store.send(.decrementButtonTapped)
   }
 
-  @objc func incrementButtonTapped() {
+  @objc private func incrementButtonTapped() {
     store.send(.incrementButtonTapped)
   }
 }

--- a/Examples/CaseStudies/UIKitCaseStudies/Internal/IfLetStoreController.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/Internal/IfLetStoreController.swift
@@ -3,9 +3,9 @@ import ComposableArchitecture
 import UIKit
 
 final class IfLetStoreController<State, Action>: UIViewController {
-  let store: Store<State?, Action>
-  let ifDestination: (Store<State, Action>) -> UIViewController
-  let elseDestination: () -> UIViewController
+  private let store: Store<State?, Action>
+  private let ifDestination: (Store<State, Action>) -> UIViewController
+  private let elseDestination: () -> UIViewController
 
   private var cancellables: Set<AnyCancellable> = []
   private var viewController = UIViewController() {

--- a/Examples/CaseStudies/UIKitCaseStudies/ListsOfState.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/ListsOfState.swift
@@ -23,7 +23,7 @@ struct CounterList {
 let cellIdentifier = "Cell"
 
 final class CountersTableViewController: UITableViewController {
-  let store: StoreOf<CounterList>
+  private let store: StoreOf<CounterList>
 
   var observations: [IndexPath: ObservationToken] = [:]
 

--- a/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
@@ -53,7 +53,7 @@ struct LazyNavigation {
 }
 
 final class LazyNavigationViewController: UIViewController {
-  let store: StoreOf<LazyNavigation>
+  private let store: StoreOf<LazyNavigation>
 
   init(store: StoreOf<LazyNavigation>) {
     self.store = store

--- a/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
@@ -49,7 +49,7 @@ struct EagerNavigation {
 }
 
 final class EagerNavigationViewController: UIViewController {
-  let store: StoreOf<EagerNavigation>
+  private let store: StoreOf<EagerNavigation>
 
   init(store: StoreOf<EagerNavigation>) {
     self.store = store


### PR DESCRIPTION
I noticed that a few ViewControllers in the UIKit example code had some methods and properties that could be hidden. 
I also thought the stores would be better off hidden as well. (Please give me your thoughts if you think they should be left alone. )
Cheers🙂