### PR TITLE
Enum reducers: generate direct action cases for ephemeral state

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "9085501f168b08f5205b68f1b8a0d56bb52b8c1a",
-        "version" : "1.3.2"
+        "revision" : "d80613633e76d1ef86f41926e72fbef6a2f77d9c",
+        "version" : "1.3.3"
       }
     },
     {

--- a/Sources/ComposableArchitectureMacros/ReducerMacro.swift
+++ b/Sources/ComposableArchitectureMacros/ReducerMacro.swift
@@ -498,7 +498,17 @@ private enum ReducerCase {
         let parameter = parameterClause.parameters.first,
         parameter.type.is(IdentifierTypeSyntax.self) || parameter.type.is(MemberTypeSyntax.self)
       {
-        return "case \(element.suffixed("Action").type.trimmedDescription)"
+        if
+          let type = parameter.type.as(IdentifierTypeSyntax.self),
+          type.isEphemeral,
+          let generics = type.genericArgumentClause?.arguments,
+          generics.count == 1,
+          let generic = generics.first?.argument.trimmedDescription
+        {
+          return "case \(element.name)(\(generic))"
+        } else {
+          return "case \(element.suffixed("Action").type.trimmedDescription)"
+        }
       } else {
         return "case \(element.name)(Swift.Never)"
       }

--- a/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
@@ -246,7 +246,8 @@
                 switch store.state {
 
                 }
-            }}
+            }
+        }
 
         extension Destination: ComposableArchitecture.CaseReducer, ComposableArchitecture.Reducer {
         }
@@ -298,11 +299,11 @@
             case activity(Activity.Action)
             case timeline(Timeline.Action)
             case tweet(Tweet.Action)
-            case alert(AlertState<Alert> .Action)
+            case alert(Alert)
           }
 
           @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
-          static var body: ComposableArchitecture.ReducerBuilder<Self.State, Self.Action> ._Sequence<ComposableArchitecture.ReducerBuilder<Self.State, Self.Action> ._Sequence<ComposableArchitecture.Scope<Self.State, Self.Action, Activity>, ComposableArchitecture.Scope<Self.State, Self.Action, Timeline>>, ComposableArchitecture.Scope<Self.State, Self.Action, Tweet>> {
+          static var body: ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>._Sequence<ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>._Sequence<ComposableArchitecture.Scope<Self.State, Self.Action, Activity>, ComposableArchitecture.Scope<Self.State, Self.Action, Timeline>>, ComposableArchitecture.Scope<Self.State, Self.Action, Tweet>> {
             ComposableArchitecture.Scope(state: \Self.State.Cases.activity, action: \Self.Action.Cases.activity) {
               Activity()
             }
@@ -372,7 +373,7 @@
           }
 
           @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
-          static var body: ComposableArchitecture.ReducerBuilder<Self.State, Self.Action> ._Sequence<ComposableArchitecture.Scope<Self.State, Self.Action, Timeline>, ComposableArchitecture.Scope<Self.State, Self.Action, Meeting>> {
+          static var body: ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>._Sequence<ComposableArchitecture.Scope<Self.State, Self.Action, Timeline>, ComposableArchitecture.Scope<Self.State, Self.Action, Meeting>> {
             ComposableArchitecture.Scope(state: \Self.State.Cases.timeline, action: \Self.Action.Cases.timeline) {
               Timeline()
             }
@@ -572,7 +573,7 @@
 
           @CasePathable
           enum Action {
-            case alert(AlertState<Never> .Action)
+            case alert(Never)
           }
 
           @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
@@ -629,7 +630,7 @@
           }
 
           @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
-          static var body: ComposableArchitecture.ReducerBuilder<Self.State, Self.Action> ._Sequence<ComposableArchitecture.Scope<Self.State, Self.Action, Activity>, ComposableArchitecture.Scope<Self.State, Self.Action, Timeline>> {
+          static var body: ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>._Sequence<ComposableArchitecture.Scope<Self.State, Self.Action, Activity>, ComposableArchitecture.Scope<Self.State, Self.Action, Timeline>> {
             ComposableArchitecture.Scope(state: \Self.State.Cases.activity, action: \Self.Action.Cases.activity) {
               Activity()
             }
@@ -751,8 +752,8 @@
 
           @CasePathable
           enum Action {
-            case alert(AlertState<Alert> .Action)
-            case dialog(ConfirmationDialogState<Dialog> .Action)
+            case alert(Alert)
+            case dialog(Dialog)
             case meeting(Swift.Never)
           }
 
@@ -820,7 +821,7 @@
           }
 
           @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
-          static var body: ComposableArchitecture.ReducerBuilder<Self.State, Self.Action> ._Sequence<ComposableArchitecture.ReducerBuilder<Self.State, Self.Action> ._Sequence<ComposableArchitecture.Scope<Self.State, Self.Action, Counter>, ComposableArchitecture.Scope<Self.State, Self.Action, Counter>>, ComposableArchitecture.Scope<Self.State, Self.Action, Counter>> {
+          static var body: ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>._Sequence<ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>._Sequence<ComposableArchitecture.Scope<Self.State, Self.Action, Counter>, ComposableArchitecture.Scope<Self.State, Self.Action, Counter>>, ComposableArchitecture.Scope<Self.State, Self.Action, Counter>> {
             ComposableArchitecture.Scope(state: \Self.State.Cases.drillDown, action: \Self.Action.Cases.drillDown) {
               Counter()
             }
@@ -1098,7 +1099,8 @@
             enum Action: Equatable, Hashable, Sendable {
             }
 
-            let body = ComposableArchitecture.EmptyReducer<State, Action>()}
+            let body = ComposableArchitecture.EmptyReducer<State, Action>()
+        }
 
         @available(iOS, unavailable) extension Feature: ComposableArchitecture.Reducer {
         }
@@ -1183,7 +1185,7 @@
             case child(ChildFeature.Action)
             #if os(macOS)
             case mac(MacFeature.Action)
-            case macAlert(AlertState<MacAlert> .Action)
+            case macAlert(MacAlert)
             #elseif os(iOS)
             case phone(PhoneFeature.Action)
             #else
@@ -1194,7 +1196,7 @@
             #if DEBUG
             #if INNER
             case inner(InnerFeature.Action)
-            case innerDialog(ConfirmationDialogState<InnerDialog> .Action)
+            case innerDialog(InnerDialog)
             #endif
             #endif
 


### PR DESCRIPTION
Currently, the following reducer enum:

```swift
@Reducer
enum Destination {
  case alert(AlertState<Never>)
}
```

Generates the following action:

```swift
@CasePathable
enum Action {
  case alert(AlertState<Never>.Action)
}
```

And this produces a warning in Case Paths 1.5 due to the nested `Never` not being referenced directly.

This PR plucks the action type out and embeds it directly, instead:

```diff
-case alert(AlertState<Never>.Action)
+case alert(Never)
```

Which will allow us to better suppress warnings Swift emits for uninhabited types.