### PR TITLE
Fix a typo in Tutorial

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0004.swift
@@ -30,7 +30,7 @@ struct CounterFeature {
         return .run { [count = state.count] send in
           let (data, _) = try await URLSession.shared
             .data(from: URL(string: "http://numbersapi.com/\(count)")!)
-          let fact = String(decoding: data, as: UTF8.self)!
+          let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }
         


### PR DESCRIPTION
This PR fixes a typo in Tutorial. According to the documentation for [String.init(decoding:as:)](https://developer.apple.com/documentation/swift/string/init(decoding:as:)), this initializer never returns `nil`.