### PR TITLE
Reference IssueReporting symbols instead of XCTestDynamicOverlay

### DIFF
--- a/.github/package.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/.github/package.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-issue-reporting",
       "state" : {
-        "revision" : "926f43898706eaa127db79ac42138e1ad7e85a3f",
-        "version" : "1.2.0"
+        "revision" : "357ca1e5dd31f613a1d43320870ebc219386a495",
+        "version" : "1.2.2"
       }
     },
     {

--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-issue-reporting",
       "state" : {
-        "revision" : "926f43898706eaa127db79ac42138e1ad7e85a3f",
-        "version" : "1.2.0"
+        "revision" : "357ca1e5dd31f613a1d43320870ebc219386a495",
+        "version" : "1.2.2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-issue-reporting",
       "state" : {
-        "revision" : "926f43898706eaa127db79ac42138e1ad7e85a3f",
-        "version" : "1.2.0"
+        "revision" : "357ca1e5dd31f613a1d43320870ebc219386a495",
+        "version" : "1.2.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
     .package(url: "https://github.com/pointfreeco/swift-perception", from: "1.3.3"),
     .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "1.5.2"),
-    .package(url: "https://github.com/pointfreeco/swift-issue-reporting", from: "1.2.0"),
+    .package(url: "https://github.com/pointfreeco/swift-issue-reporting", from: "1.2.2"),
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0-prerelease"),
   ],
   targets: [

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/SharingState.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/SharingState.md
@@ -1133,7 +1133,7 @@ struct MainApp: App {
 
   var body: some Scene {
     WindowGroup {
-      if _XCTIsTesting {
+      if isTesting {
         // NB: Don't run application in tests to avoid interference 
         //     between the app and the test.
         EmptyView()

--- a/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
@@ -46,11 +46,11 @@ public struct StackState<Element> {
     _read { yield self._dictionary[id] }
     _modify { yield &self._dictionary[id] }
     set {
-      switch (self.ids.contains(id), newValue, _XCTIsTesting) {
+      switch (self.ids.contains(id), newValue, isTesting) {
       case (true, _, _), (false, .some, true):
         self._dictionary[id] = newValue
       case (false, .some, false):
-        if !_XCTIsTesting {
+        if !isTesting {
           reportIssue(
             "Can't assign element at missing ID.",
             fileID: fileID.rawValue,
@@ -64,35 +64,6 @@ public struct StackState<Element> {
       }
     }
   }
-
-  //  subscript(
-  //    id id: StackElementID,
-  //    fileID fileID: HashableStaticString,
-  //    filePath filePath: HashableStaticString,
-  //    line line: UInt = #line,
-  //    column column: UInt = #column
-  //  ) -> Element? {
-  //    _read { yield self._dictionary[id] }
-  //    _modify { yield &self._dictionary[id] }
-  //    set {
-  //      switch (self.ids.contains(id), newValue, _XCTIsTesting) {
-  //      case (true, _, _), (false, .some, true):
-  //        self._dictionary[id] = newValue
-  //      case (false, .some, false):
-  //        if !_XCTIsTesting {
-  //          reportIssue(
-  //            "Can't assign element at missing ID.",
-  //            fileID: fileID.rawValue,
-  //            filePath: filePath.rawValue,
-  //            line: line,
-  //            column: column
-  //          )
-  //        }
-  //      case (false, .none, _):
-  //        break
-  //      }
-  //    }
-  //  }
 
   /// Accesses the value associated with the given id and case for reading and writing.
   ///
@@ -755,7 +726,7 @@ extension StackElementID: CustomDumpStringConvertible {
 
 extension StackElementID: ExpressibleByIntegerLiteral {
   public init(integerLiteral value: Int) {
-    if !_XCTIsTesting {
+    if !isTesting {
       fatalError(
         """
         Specifying stack element IDs by integer literal is not allowed outside of tests.


### PR DESCRIPTION
While we should get both dependencies picked up from swift-dependencies' exports, we've heard reports from folks that they're getting linker/symbol errors here:

https://github.com/pointfreeco/swift-issue-reporting/issues/100

We should update these uses regardless!