### PR TITLE
fix typos in on `alert`

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
 extension View {
-  /// Displays an alert when then store's state becomes non-`nil`, and dismisses it when it becomes
+  /// Displays an alert when the store's state becomes non-`nil`, and dismisses it when it becomes
   /// `nil`.
   ///
   /// - Parameters:
@@ -14,7 +14,7 @@ extension View {
     self._alert(store: store, state: { $0 }, action: { $0 })
   }
 
-  /// Displays an alert when then store's state becomes non-`nil`, and dismisses it when it becomes
+  /// Displays an alert when the store's state becomes non-`nil`, and dismisses it when it becomes
   /// `nil`.
   ///
   /// - Parameters:

--- a/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
 extension View {
-  /// Displays a dialog when then store's state becomes non-`nil`, and dismisses it when it becomes
+  /// Displays a dialog when the store's state becomes non-`nil`, and dismisses it when it becomes
   /// `nil`.
   ///
   /// - Parameters:

--- a/Sources/ComposableArchitecture/SwiftUI/Deprecated/ActionSheet.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Deprecated/ActionSheet.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 extension View {
-  /// Displays an action sheet when then store's state becomes non-`nil`, and dismisses it when it
+  /// Displays an action sheet when the store's state becomes non-`nil`, and dismisses it when it
   /// becomes `nil`.
   ///
   /// - Parameters:
@@ -37,7 +37,7 @@ extension View {
     self.actionSheet(store: store, state: { $0 }, action: { $0 })
   }
 
-  /// Displays an alert when then store's state becomes non-`nil`, and dismisses it when it becomes
+  /// Displays an alert when the store's state becomes non-`nil`, and dismisses it when it becomes
   /// `nil`.
   ///
   /// - Parameters:

--- a/Sources/ComposableArchitecture/SwiftUI/Deprecated/LegacyAlert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Deprecated/LegacyAlert.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 extension View {
-  /// Displays a legacy alert when then store's state becomes non-`nil`, and dismisses it when it
+  /// Displays a legacy alert when the store's state becomes non-`nil`, and dismisses it when it
   /// becomes `nil`.
   ///
   /// - Parameters:
@@ -21,7 +21,7 @@ extension View {
     self.legacyAlert(store: store, state: { $0 }, action: { $0 })
   }
 
-  /// Displays a legacy alert when then store's state becomes non-`nil`, and dismisses it when it
+  /// Displays a legacy alert when the store's state becomes non-`nil`, and dismisses it when it
   /// becomes `nil`.
   ///
   /// - Parameters:


### PR DESCRIPTION
fixes small typos on `alert` and `confirmationDialog`