### PR TITLE
Fix: Crash when writing to user defaults in background thread

### DIFF
--- a/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
+++ b/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
@@ -395,11 +395,11 @@ final class ValueReference<Value, Persistence: PersistenceReaderKey<Value>>: Ref
         initialValue: initialValue
       ) { [weak self] value in
         guard let self else { return }
-        #if canImport(Perception)
-          self._$perceptionRegistrar.willSet(self, keyPath: \.value)
-          defer { self._$perceptionRegistrar.didSet(self, keyPath: \.value) }
-        #endif
         mainActorASAP {
+          #if canImport(Perception)
+            self._$perceptionRegistrar.willSet(self, keyPath: \.value)
+            defer { self._$perceptionRegistrar.didSet(self, keyPath: \.value) }
+          #endif
           self.lock.withLock {
             self._value = value ?? initialValue
           }

--- a/Tests/ComposableArchitectureTests/AppStorageTests.swift
+++ b/Tests/ComposableArchitectureTests/AppStorageTests.swift
@@ -261,7 +261,7 @@ final class AppStorageTests: XCTestCase {
   func testWillEnterForegroundFromBackgroundThread() async throws {
     @Shared(.appStorage("count")) var count = 0
 
-    let publisherExpectation: XCTestExpectation = expectation(description: "publisher")
+    let publisherExpectation = expectation(description: "publisher")
     let cancellable = $count.publisher.sink { _ in
       XCTAssertTrue(Thread.isMainThread)
       publisherExpectation.fulfill()

--- a/Tests/ComposableArchitectureTests/AppStorageTests.swift
+++ b/Tests/ComposableArchitectureTests/AppStorageTests.swift
@@ -213,6 +213,14 @@ final class AppStorageTests: XCTestCase {
     }
     defer { _ = cancellable }
 
+    let perceptionExpectation = self.expectation(description: "perception")
+    withPerceptionTracking {
+      _ = count
+    } onChange: {
+      XCTAssertTrue(Thread.isMainThread)
+      perceptionExpectation.fulfill()
+    }
+
     await withUnsafeContinuation { continuation in
       DispatchQueue.global().async { [store = UncheckedSendable(store)] in
         XCTAssertFalse(Thread.isMainThread)
@@ -221,7 +229,7 @@ final class AppStorageTests: XCTestCase {
       }
     }
 
-    await fulfillment(of: [publisherExpectation], timeout: 0)
+    await fulfillment(of: [perceptionExpectation, publisherExpectation], timeout: 0)
   }
 
   @MainActor
@@ -253,12 +261,20 @@ final class AppStorageTests: XCTestCase {
   func testWillEnterForegroundFromBackgroundThread() async throws {
     @Shared(.appStorage("count")) var count = 0
 
-    let publisherExpectation = expectation(description: "publisher")
+    let publisherExpectation: XCTestExpectation = expectation(description: "publisher")
     let cancellable = $count.publisher.sink { _ in
       XCTAssertTrue(Thread.isMainThread)
       publisherExpectation.fulfill()
     }
     defer { _ = cancellable }
+
+    let perceptionExpectation = self.expectation(description: "perception")
+    withPerceptionTracking {
+      _ = count
+    } onChange: {
+      XCTAssertTrue(Thread.isMainThread)
+      perceptionExpectation.fulfill()
+    }
 
     await withUnsafeContinuation { continuation in
       DispatchQueue.global().async {
@@ -268,7 +284,7 @@ final class AppStorageTests: XCTestCase {
       }
     }
 
-    await fulfillment(of: [publisherExpectation], timeout: 0)
+    await fulfillment(of: [perceptionExpectation, publisherExpectation], timeout: 0)
   }
 
   @MainActor
@@ -284,6 +300,14 @@ final class AppStorageTests: XCTestCase {
     }
     defer { _ = cancellable }
 
+    let perceptionExpectation = self.expectation(description: "perception")
+    withPerceptionTracking {
+      _ = count
+    } onChange: {
+      XCTAssertTrue(Thread.isMainThread)
+      perceptionExpectation.fulfill()
+    }
+
     await withUnsafeContinuation { continuation in
       DispatchQueue.global().async { [store = UncheckedSendable(store)] in
         XCTAssertFalse(Thread.isMainThread)
@@ -292,7 +316,7 @@ final class AppStorageTests: XCTestCase {
       }
     }
 
-    await fulfillment(of: [publisherExpectation], timeout: 0)
+    await fulfillment(of: [perceptionExpectation, publisherExpectation], timeout: 0)
   }
 }
 


### PR DESCRIPTION
Potential fix for the issue https://github.com/pointfreeco/swift-composable-architecture/issues/3247