### PR TITLE
Fix ephemeral dismissal

### DIFF
--- a/Sources/ComposableArchitecture/Observation/Store+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Store+Observation.swift
@@ -375,8 +375,7 @@
       }
       set {
         if newValue == nil,
-          let childState = self.state[keyPath: state],
-          !isEphemeral(childState),
+          self.state[keyPath: state] != nil,
           !self._isInvalidated()
         {
           self.send(action(.dismiss))

--- a/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
@@ -2653,6 +2653,37 @@ final class PresentationReducerTests: BaseTCATestCase {
       $0.child?.child = nil
     }
   }
+
+  @Reducer
+  struct TestEphemeralBindingDismissalFeature {
+    @ObservableState
+    struct State: Equatable {
+      @Presents var alert: AlertState<Never>?
+    }
+    enum Action: Equatable {
+      case alert(PresentationAction<Never>)
+    }
+    var body: some ReducerOf<Self> {
+      Reduce { state, action in
+        return .none
+      }
+      .ifLet(\.$alert, action: /Action.alert)
+    }
+  }
+  @MainActor
+  func testEphemeralBindingDismissal() async {
+    @Perception.Bindable var store = Store(
+      initialState: TestEphemeralBindingDismissalFeature.State(
+        alert: AlertState { TextState("Oops!") }
+      )
+    ) {
+      TestEphemeralBindingDismissalFeature()
+    }
+
+    XCTAssertNotNil(store.alert)
+    $store.scope(state: \.alert, action: \.alert).wrappedValue = nil
+    XCTAssertNil(store.alert)
+  }
 }
 
 @Reducer

--- a/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
+++ b/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
@@ -324,38 +324,5 @@
           """
       }
     }
-
-    @Reducer
-    struct TestStoreDestination_NotIntegrated_EphemeralState {
-      @Reducer
-      struct Destination {}
-      @ObservableState
-      struct State: Equatable {
-        @Presents var alert: AlertState<Never>?
-      }
-      enum Action {
-        case alert(PresentationAction<Never>)
-      }
-    }
-    @MainActor
-    func testStoreDestination_NotIntegrated_EphemeralState() {
-      let store = Store(
-        initialState: TestStoreDestination_NotIntegrated_EphemeralState.State(
-          alert: .init(title: { TextState("Hi") })
-        )
-      ) {
-        TestStoreDestination_NotIntegrated_EphemeralState()
-      }
-
-      store[
-        state: \.alert,
-        action: \.alert,
-        isInViewBody: false,
-        fileID: "file.swift",
-        filePath: "/file.swift",
-        line: 1,
-        column: 1
-      ] = nil  // NB: Not issue reported
-    }
   }
 #endif


### PR DESCRIPTION
This regression was introduced to fix a UIKit warning, but it causes state to not be `nil`'d out in SwiftUI. Luckily we caught it before a release.