### PR TITLE
Add ability to send actions / return effects using `UITransaction`

### DIFF
--- a/Sources/ComposableArchitecture/UIKit/Animation+UIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/Animation+UIKit.swift
@@ -1,0 +1,107 @@
+#if canImport(UIKit) && !os(watchOS)
+  import Combine
+  import UIKitNavigation
+  
+  extension Effect {
+    /// Wraps the emission of each element with `withUIKitAnimation`.
+    ///
+    /// ```swift
+    /// case .buttonTapped:
+    ///   return .run { send in
+    ///     await send(.activityResponse(self.apiClient.fetchActivity()))
+    ///   }
+    ///   .uiKitAnimation()
+    /// ```
+    ///
+    /// - Parameter animation: An animation.
+    /// - Returns: A publisher.
+    public func uiKitAnimation(_ animation: UIKitAnimation? = .default) -> Self {
+      self.transaction(UITransaction(animation: animation))
+    }
+    
+    /// Wraps the emission of each element with `withUITransaction`.
+    ///
+    /// ```swift
+    /// case .buttonTapped:
+    ///   var transaction = UITransaction(animation: .default)
+    ///   transaction.uiKit.disablesAnimations = true
+    ///   return .run { send in
+    ///     await send(.activityResponse(self.apiClient.fetchActivity()))
+    ///   }
+    ///   .transaction(transaction)
+    /// ```
+    ///
+    /// - Parameter transaction: A transaction.
+    /// - Returns: A publisher.
+    public func transaction(_ transaction: UITransaction) -> Self {
+      switch self.operation {
+      case .none:
+        return .none
+      case let .publisher(publisher):
+        return Self(
+          operation: .publisher(
+            UITransactionPublisher(
+              upstream: publisher,
+              transaction: transaction
+            )
+            .eraseToAnyPublisher()
+          )
+        )
+      case let .run(priority, operation):
+        return Self(
+          operation: .run(priority) { send in
+            await operation(
+              Send { value in
+                withUITransaction(transaction) {
+                  send(value)
+                }
+              }
+            )
+          }
+        )
+      }
+    }
+  }
+
+  private struct UITransactionPublisher<Upstream: Publisher>: Publisher {
+    typealias Output = Upstream.Output
+    typealias Failure = Upstream.Failure
+    
+    var upstream: Upstream
+    var transaction: UITransaction
+    
+    func receive(subscriber: some Combine.Subscriber<Upstream.Output, Upstream.Failure>) {
+      let conduit = Subscriber(downstream: subscriber, transaction: self.transaction)
+      self.upstream.receive(subscriber: conduit)
+    }
+    
+    private final class Subscriber<Downstream: Combine.Subscriber>: Combine.Subscriber {
+      typealias Input = Downstream.Input
+      typealias Failure = Downstream.Failure
+      
+      let downstream: Downstream
+      let transaction: UITransaction
+      
+      init(downstream: Downstream, transaction: UITransaction) {
+        self.downstream = downstream
+        self.transaction = transaction
+      }
+      
+      func receive(subscription: Subscription) {
+        self.downstream.receive(subscription: subscription)
+      }
+      
+      func receive(_ input: Input) -> Subscribers.Demand {
+        withUITransaction(self.transaction) {
+          self.downstream.receive(input)
+        }
+      }
+      
+      func receive(completion: Subscribers.Completion<Failure>) {
+        self.downstream.receive(completion: completion)
+      }
+    }
+  }
+#endif
+
+

--- a/Sources/ComposableArchitecture/UIKit/Effect+UIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/Effect+UIKit.swift
@@ -1,0 +1,26 @@
+#if canImport(UIKit) && !os(watchOS)
+  import UIKitNavigation
+
+  extension Send {
+    /// Sends an action back into the system from an effect with animation.
+    ///
+    /// - Parameters:
+    ///   - action: An action.
+    ///   - animation: An animation.
+    public func callAsFunction(_ action: Action, uiKitAnimation: UIKitAnimation?) {
+      callAsFunction(action, transaction: UITransaction(animation: uiKitAnimation))
+    }
+    
+    /// Sends an action back into the system from an effect with transaction.
+    ///
+    /// - Parameters:
+    ///   - action: An action.
+    ///   - transaction: A transaction.
+    public func callAsFunction(_ action: Action, transaction: UITransaction) {
+      guard !Task.isCancelled else { return }
+      withUITransaction(transaction) {
+        self(action)
+      }
+    }
+  }
+#endif

--- a/Sources/ComposableArchitecture/UIKit/Store+UIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/Store+UIKit.swift
@@ -1,0 +1,31 @@
+#if canImport(UIKit) && !os(watchOS)
+  import UIKitNavigation
+
+  extension Store {
+    /// Sends an action to the store with a given animation.
+    ///
+    /// See ``Store/send(_:)`` for more info.
+    ///
+    /// - Parameters:
+    ///   - action: An action.
+    ///   - animation: An animation.
+    @discardableResult
+    public func send(_ action: Action, uiKitAnimation: UIKitAnimation?) -> StoreTask {
+      send(action, transaction: UITransaction(animation: uiKitAnimation))
+    }
+    
+    /// Sends an action to the store with a given transaction.
+    ///
+    /// See ``Store/send(_:)`` for more info.
+    ///
+    /// - Parameters:
+    ///   - action: An action.
+    ///   - transaction: A transaction.
+    @discardableResult
+    public func send(_ action: Action, transaction: UITransaction) -> StoreTask {
+      withUITransaction(transaction) {
+        .init(rawValue: self.send(action, originatingFrom: nil))
+      }
+    }
+  }
+#endif


### PR DESCRIPTION
Adds methods to send actions and return effects using `UITransaction`:

```swift
return .run { send in
   await send(.buttonTapped, uiKitAnimation: .easeInOut)
}
```

```swift
return .run { send in
   await send(.buttonTapped)
}
.uiKitAnimation(.easeInOut)
```

```swift
return .run { send in
  await send(.buttonTapped, transaction: UITransaction(animation: .easeInOut))
}
```

```swift
var transaction = UITransaction()
transaction.uiKit.disablesAnimations = true

return .run { send in
  await send(.buttonTapped)
}
.transaction(transaction)
```

```swift
store.send(.buttonTapped, uiKitAnimation: .easeInOut)
store.send(.buttonTapped, transaction: UITransaction())

// ViewActionSending
send(.buttonTapped, uiKitAnimation: .easeInOut)
send(.buttonTapped, transaction: UITransaction())
```