### PR TITLE
Add missing parameter in NavigationLink docs

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
@@ -380,9 +380,8 @@ extension NavigationLink {
       isActive: Binding(
         get: { item.wrappedValue != nil },
         set: { isActive, transaction in
-          if isActive {
-            onNavigate()  
-          } else {
+          onNavigate(isActive)
+          if !isActive {
             item.transaction(transaction).wrappedValue = nil
           }
         }


### PR DESCRIPTION
I found that the `onNavigate` closure isn’t being passed a parameter and is only being called when `isActive` is true.
I believe the `onNavigate` closure should also be called when isActive becomes false 🤔