### PR TITLE
Avoid unsafe extraction in `BindingReducer`

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -28,7 +28,7 @@ struct BindingForm {
   }
 
   var body: some Reducer<State, Action> {
-    BindingReducer()
+    BindingReducer(action: \.binding)
     Reduce { state, action in
       switch action {
       case .binding(\.stepCount):

--- a/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
@@ -18,7 +18,7 @@ import SwiftUI
 ///   }
 ///
 ///   var body: some ReducerOf<Self> {
-///     BindingReducer()
+///     BindingReducer(action: \.binding)
 ///     Reduce { state, action in
 ///       // Your feature's logic...
 ///     }
@@ -35,44 +35,67 @@ import SwiftUI
 ///   Reduce { state, action in
 ///     // Your feature's logic...
 ///   }
-///   BindingReducer()
+///   BindingReducer(action: \.binding)
 /// }
 /// ```
 ///
 /// If you forget to compose the ``BindingReducer`` into your feature's reducer, then when a binding
 /// is written to it will cause a runtime purple Xcode warning letting you know what needs to be
 /// fixed.
-public struct BindingReducer<State, Action, ViewAction: BindableAction>: Reducer
-where State == ViewAction.State {
+public struct BindingReducer<State, Action>: Reducer {
   @usableFromInline
-  let toViewAction: (Action) -> ViewAction?
+  let toBindingAction: AnyCasePath<Action, BindingAction<State>>
 
   /// Initializes a reducer that updates bindable state when it receives binding actions.
+  ///
+  /// - Parameter toBindingAction: A case key path to the binding action case.
   @inlinable
-  public init() where Action == ViewAction {
-    self.init(internal: { $0 })
+  public init(action toBindingAction: CaseKeyPath<Action, BindingAction<State>>) {
+    self.init(internal: AnyCasePath(toBindingAction))
   }
 
+  @available(
+    *, deprecated,
+    message: "Pass an explicit case key path, for example: 'BindingReducer(action: \\.binding)'"
+  )
   @inlinable
-  public init(action toViewAction: CaseKeyPath<Action, ViewAction>) where Action: CasePathable {
-    self.init(internal: { $0[case: toViewAction] })
+  public init() where Action: BindableAction<State> {
+    self.init(internal: AnyCasePath(unsafe: { .binding($0) }))
   }
 
+  @available(
+    *, deprecated,
+    message: "Pass an explicit case key path, for example: 'BindingReducer(action: \\.binding)'"
+  )
   @inlinable
-  public init(action toViewAction: @escaping (_ action: Action) -> ViewAction?) {
-    self.init(internal: toViewAction)
+  public init<ViewAction: BindableAction<State>>(
+    action toViewAction: CaseKeyPath<Action, ViewAction>
+  ) {
+    self.init(
+      internal: AnyCasePath(toViewAction)
+        .appending(path: AnyCasePath(unsafe: { .binding($0) }))
+    )
+  }
+
+  @available(*, deprecated)
+  @inlinable
+  public init<ViewAction: BindableAction<State>>(
+    action toViewAction: @escaping (_ action: Action) -> ViewAction?
+  ) {
+    self.init(
+      internal: AnyCasePath(embed: { _ in fatalError() }, extract: { toViewAction($0) })
+        .appending(path: AnyCasePath(unsafe: { .binding($0) }))
+    )
   }
 
   @usableFromInline
-  init(internal toViewAction: @escaping (_ action: Action) -> ViewAction?) {
-    self.toViewAction = toViewAction
+  init(internal toBindingAction: AnyCasePath<Action, BindingAction<State>>) {
+    self.toBindingAction = toBindingAction
   }
 
   @inlinable
   public func reduce(into state: inout State, action: Action) -> Effect<Action> {
-    // NB: Using a closure and not a `\.binding` key path literal to avoid a bug with archives:
-    //     https://github.com/pointfreeco/swift-composable-architecture/pull/2641
-    guard let bindingAction = self.toViewAction(action).flatMap({ $0.binding })
+    guard let bindingAction = toBindingAction.extract(from: action)
     else { return .none }
 
     bindingAction.set(&state)

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -274,15 +274,6 @@ public protocol BindableAction<State> {
   ///
   /// - Returns: A binding action.
   static func binding(_ action: BindingAction<State>) -> Self
-
-  /// Extracts a binding action from this action type.
-  var binding: BindingAction<State>? { get }
-}
-
-extension BindableAction {
-  public var binding: BindingAction<State>? {
-    AnyCasePath(unsafe: { .binding($0) }).extract(from: self)
-  }
 }
 
 extension BindableAction {


### PR DESCRIPTION
We currently have a single case of `AnyCasePath(unsafe:)` in the code base, which uses reflection for extraction, and is something we would like to remove in a future major version of Case Paths.

This explores a refactoring of `BindingReducer` that takes an explicit case key path toe the binding action case, instead:

```swift
BindingReducer(action: \.binding)
```

`BindableAction` as a protocol is still necessary for bindable stores to know how to embed binding actions in a short syntax, _e.g._ `$store.text`.

It's a slight bummer that the reducer gets slightly more verbose, especially when there _is_ something abstractable here, I'm just not sure Swift provides the tools yet to truly abstract over a case path in an ergonomic fashion.

The alternative would be to introduce a special protocol (`BindableCasePath`?) that the `@Reducer` macro would need to apply correctly when detecting a `BindableAction`, but this is one-off logic that seems to take things in the wrong direction.

This is a draft for now that does not clean up all the existing occurrences, as I'm not sure we want to complete and merge it.