### PR TITLE
Require sendable IDs in cancellation/reducers

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -33,7 +33,7 @@ extension Effect {
   ///   - cancelInFlight: Determines if any in-flight effect with the same identifier should be
   ///     canceled before starting this new one.
   /// - Returns: A new effect that is capable of being canceled by an identifier.
-  public func cancellable<ID: Hashable>(id: ID, cancelInFlight: Bool = false) -> Self {
+  public func cancellable(id: some Hashable & Sendable, cancelInFlight: Bool = false) -> Self {
     @Dependency(\.navigationIDPath) var navigationIDPath
 
     switch self.operation {

--- a/Sources/ComposableArchitecture/Effects/Debounce.swift
+++ b/Sources/ComposableArchitecture/Effects/Debounce.swift
@@ -28,8 +28,8 @@ extension Effect {
   ///   - scheduler: The scheduler you want to deliver the debounced output to.
   ///   - options: Scheduler options that customize the effect's delivery of elements.
   /// - Returns: An effect that publishes events only after a specified time elapses.
-  public func debounce<ID: Hashable, S: Scheduler>(
-    id: ID,
+  public func debounce<S: Scheduler>(
+    id: some Hashable & Sendable,
     for dueTime: S.SchedulerTimeType.Stride,
     scheduler: S,
     options: S.SchedulerOptions? = nil

--- a/Sources/ComposableArchitecture/Effects/Throttle.swift
+++ b/Sources/ComposableArchitecture/Effects/Throttle.swift
@@ -23,8 +23,8 @@ extension Effect {
   ///     `false`, the publisher emits the first element received during the interval.
   /// - Returns: An effect that emits either the most-recent or first element received during the
   ///   specified interval.
-  public func throttle<ID: Hashable, S: Scheduler>(
-    id: ID,
+  public func throttle<S: Scheduler>(
+    id: some Hashable & Sendable,
     for interval: S.SchedulerTimeType.Stride,
     scheduler: S,
     latest: Bool

--- a/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
@@ -86,7 +86,7 @@
     }
   }
 
-  public struct _StoreCollection<ID: Hashable, State, Action>: RandomAccessCollection {
+  public struct _StoreCollection<ID: Hashable & Sendable, State, Action>: RandomAccessCollection {
     private let store: Store<IdentifiedArray<ID, State>, IdentifiedAction<ID, Action>>
     private let data: IdentifiedArray<ID, State>
 

--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -4,7 +4,7 @@ import OrderedCollections
 ///
 /// Use this type for modeling a feature's domain that needs to present child features using
 /// ``Reducer/forEach(_:action:element:fileID:filePath:line:column:)-3dw7i``.
-public enum IdentifiedAction<ID: Hashable, Action>: CasePathable {
+public enum IdentifiedAction<ID: Hashable & Sendable, Action>: CasePathable {
   /// An action sent to the element at a given identifier.
   case element(id: ID, action: Action)
 
@@ -163,7 +163,10 @@ extension Reducer {
   @inlinable
   @warn_unqualified_access
   public func forEach<
-    ElementState, ElementAction, ID: Hashable, Element: Reducer<ElementState, ElementAction>
+    ElementState,
+    ElementAction,
+    ID: Hashable & Sendable,
+    Element: Reducer<ElementState, ElementAction>
   >(
     _ toElementsState: WritableKeyPath<State, IdentifiedArray<ID, ElementState>>,
     action toElementAction: AnyCasePath<Action, (ID, ElementAction)>,
@@ -190,7 +193,7 @@ extension Reducer {
 }
 
 public struct _ForEachReducer<
-  Parent: Reducer, ID: Hashable, Element: Reducer
+  Parent: Reducer, ID: Hashable & Sendable, Element: Reducer
 >: Reducer {
   @usableFromInline
   let parent: Parent

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -742,8 +742,8 @@ extension Task<Never, Never> {
 }
 
 extension Effect {
-  internal func _cancellable<ID: Hashable>(
-    id: ID = _PresentedID(),
+  internal func _cancellable(
+    id: some Hashable & Sendable = _PresentedID(),
     navigationIDPath: NavigationIDPath,
     cancelInFlight: Bool = false
   ) -> Self {
@@ -753,8 +753,8 @@ extension Effect {
       self.cancellable(id: id, cancelInFlight: cancelInFlight)
     }
   }
-  internal static func _cancel<ID: Hashable>(
-    id: ID = _PresentedID(),
+  internal static func _cancel(
+    id: some Hashable & Sendable = _PresentedID(),
     navigationID: NavigationIDPath
   ) -> Self {
     withDependencies {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -714,11 +714,11 @@ struct PresentationDismissID: Hashable {
   @usableFromInline init() {}
 }
 @usableFromInline
-struct OnFirstAppearID: Hashable {
+struct OnFirstAppearID: Hashable, Sendable {
   @usableFromInline init() {}
 }
 
-public struct _PresentedID: Hashable {
+public struct _PresentedID: Hashable, Sendable {
   @inlinable
   public init() {
     self.init(internal: ())
@@ -729,8 +729,8 @@ public struct _PresentedID: Hashable {
 }
 
 extension Task<Never, Never> {
-  internal static func _cancel<ID: Hashable>(
-    id: ID,
+  internal static func _cancel(
+    id: some Hashable,
     navigationID: NavigationIDPath
   ) {
     withDependencies {
@@ -754,7 +754,7 @@ extension Effect {
     }
   }
   internal static func _cancel(
-    id: some Hashable & Sendable = _PresentedID(),
+    id: some Hashable = _PresentedID(),
     navigationID: NavigationIDPath
   ) -> Self {
     withDependencies {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -710,7 +710,7 @@ public struct _PresentationReducer<Base: Reducer, Destination: Reducer>: Reducer
 }
 
 @usableFromInline
-struct PresentationDismissID: Hashable {
+struct PresentationDismissID: Hashable, Sendable {
   @usableFromInline init() {}
 }
 @usableFromInline

--- a/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
@@ -742,5 +742,9 @@ extension StackElementID: ExpressibleByIntegerLiteral {
 }
 
 private struct NavigationDismissID: Hashable, Sendable {
-  let elementID: AnyHashable
+  private let elementID: AnyHashableSendable
+
+  init(elementID: some Hashable & Sendable) {
+    self.elementID = AnyHashableSendable(elementID)
+  }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
@@ -741,6 +741,6 @@ extension StackElementID: ExpressibleByIntegerLiteral {
   }
 }
 
-private struct NavigationDismissID: Hashable {
+private struct NavigationDismissID: Hashable, Sendable {
   let elementID: AnyHashable
 }

--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -105,7 +105,7 @@ import SwiftUI
     "Pass 'ForEach' a store scoped to an identified array and identified action, instead. For more information, see the following article: https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.7#Replacing-ForEachStore-with-ForEach]"
 )
 public struct ForEachStore<
-  EachState, EachAction, Data: Collection, ID: Hashable, Content: View
+  EachState, EachAction, Data: Collection, ID: Hashable & Sendable, Content: View
 >: View {
   public let data: Data
   let content: Content
@@ -232,7 +232,7 @@ public struct ForEachStore<
 #endif
 
 extension Case {
-  fileprivate subscript<ID: Hashable, Action>(id id: ID) -> Case<Action>
+  fileprivate subscript<ID: Hashable & Sendable, Action>(id id: ID) -> Case<Action>
   where Value == (id: ID, action: Action) {
     Case<Action>(
       embed: { (id: id, action: $0) },


### PR DESCRIPTION
Many of our APIs warn that we are passing hashable identifiers across concurrency boundaries, so we should require that they're sendable.