### PR TITLE
Address `Reducer._printChanges()` sendability

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
@@ -1,7 +1,7 @@
 import Combine
 import Dispatch
 
-extension Reducer {
+extension Reducer where State: Sendable, Action: Sendable {
   /// Enhances a reducer with debug logging of received actions and state mutations for the given
   /// printer.
   ///
@@ -21,13 +21,21 @@ extension Reducer {
 
 private let printQueue = DispatchQueue(label: "co.pointfree.swift-composable-architecture.printer")
 
-public struct _ReducerPrinter<State, Action> {
-  private let _printChange: (_ receivedAction: Action, _ oldState: State, _ newState: State) -> Void
+public struct _ReducerPrinter<State, Action>: Sendable {
+  private let _printChange: @Sendable (
+    _ receivedAction: Action,
+    _ oldState: State,
+    _ newState: State
+  ) -> Void
   @usableFromInline
   let queue: DispatchQueue
 
   public init(
-    printChange: @escaping (_ receivedAction: Action, _ oldState: State, _ newState: State) -> Void,
+    printChange: @escaping @Sendable (
+      _ receivedAction: Action,
+      _ oldState: State,
+      _ newState: State
+    ) -> Void,
     queue: DispatchQueue? = nil
   ) {
     self._printChange = printChange
@@ -58,7 +66,8 @@ extension _ReducerPrinter {
   }
 }
 
-public struct _PrintChangesReducer<Base: Reducer>: Reducer {
+public struct _PrintChangesReducer<Base: Reducer>: Reducer
+where Base.State: Sendable, Base.Action: Sendable {
   @usableFromInline
   let base: Base
 


### PR DESCRIPTION
Because printing is done on a queue, both `State` and `Action` must be sendable. While `State` is easy enough to make sendable, it might be a pain to do so in a large, modularized application. Actions are not always so easy, but are in simple cases.

Alternately, since this is a debugging affordance:

1. We could forego sendability since all we're doing is hitting it with a `Mirror` at the end of the day, and traffic the state/action along in a `nonisolated(unsafe)`.

2. We could ditch the queue...but that could affect the performance pretty negatively in some cases.