### PR TITLE
Require main actor isolation in store collection

### DIFF
--- a/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
@@ -90,7 +90,11 @@
     private let store: Store<IdentifiedArray<ID, State>, IdentifiedAction<ID, Action>>
     private let data: IdentifiedArray<ID, State>
 
-    @MainActor
+    #if swift(<5.10)
+      @MainActor(unsafe)
+    #else
+      @preconcurrency@MainActor
+    #endif
     fileprivate init(_ store: Store<IdentifiedArray<ID, State>, IdentifiedAction<ID, Action>>) {
       self.store = store
       self.data = store.withState { $0 }

--- a/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
@@ -99,7 +99,8 @@
     public var startIndex: Int { self.data.startIndex }
     public var endIndex: Int { self.data.endIndex }
     public subscript(position: Int) -> Store<State, Action> {
-      MainActor.preconditionIsolated(
+      precondition(
+        Thread.isMainThread,
         #"""
         Store collections must be interacted with on the main actor.
 

--- a/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
@@ -90,6 +90,7 @@
     private let store: Store<IdentifiedArray<ID, State>, IdentifiedAction<ID, Action>>
     private let data: IdentifiedArray<ID, State>
 
+    @MainActor
     fileprivate init(_ store: Store<IdentifiedArray<ID, State>, IdentifiedAction<ID, Action>>) {
       self.store = store
       self.data = store.withState { $0 }
@@ -98,21 +99,34 @@
     public var startIndex: Int { self.data.startIndex }
     public var endIndex: Int { self.data.endIndex }
     public subscript(position: Int) -> Store<State, Action> {
-      guard self.data.indices.contains(position)
-      else {
-        return Store()
-      }
-      let id = self.data.ids[position]
-      var element = self.data[position]
-      return self.store.scope(
-        id: self.store.id(state: \.[id:id]!, action: \.[id:id]),
-        state: ToState {
-          element = $0[id: id] ?? element
-          return element
-        },
-        action: { .element(id: id, action: $0) },
-        isInvalid: { !$0.ids.contains(id) }
+      MainActor.preconditionIsolated(
+        #"""
+        Store collections must be interacted with on the main actor.
+
+        When passing a scoped store to a 'ForEach' in a lazy view (for example, 'LazyVStack'), it \
+        must be eagerly transformed into a collection to avoid access off the main actor:
+
+            Array(store.scope(state: \.elements, action: \.elements))
+        """#
       )
+      return MainActor._assumeIsolated { [uncheckedSelf = UncheckedSendable(self)] in
+        let `self` = uncheckedSelf.wrappedValue
+        guard self.data.indices.contains(position)
+        else {
+          return Store()
+        }
+        let id = self.data.ids[position]
+        var element = self.data[position]
+        return self.store.scope(
+          id: self.store.id(state: \.[id:id]!, action: \.[id:id]),
+          state: ToState {
+            element = $0[id: id] ?? element
+            return element
+          },
+          action: { .element(id: id, action: $0) },
+          isInvalid: { !$0.ids.contains(id) }
+        )
+      }
     }
   }
 #endif


### PR DESCRIPTION
We can eliminate sendable warnings and improve the error handling via `MainActor.preconditionIsolated`.