### PR TITLE
Replace deprecated `viewStore` with `store`

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
@@ -211,13 +211,13 @@ class FeatureViewController: UIViewController {
   }
 
   @objc private func incrementButtonTapped() {
-    self.viewStore.send(.incrementButtonTapped)
+    self.store.send(.incrementButtonTapped)
   }
   @objc private func decrementButtonTapped() {
-    self.viewStore.send(.decrementButtonTapped)
+    self.store.send(.decrementButtonTapped)
   }
   @objc private func factButtonTapped() {
-    self.viewStore.send(.numberFactButtonTapped)
+    self.store.send(.numberFactButtonTapped)
   }
 }
 ```

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -308,10 +308,10 @@ This greatly reduces the bandwidth of actions being sent into the system so that
 incurring unnecessary costs for sending actions.
 
 Another example that comes up often is sliders. If done in the most direct way, by deriving a 
-binding from the view store to hand to a `Slider`:
+binding from the store to hand to a `Slider`:
 
 ```swift
-Slider(value: viewStore.$opacity, in: 0...1)
+Slider(value: store.$opacity, in: 0...1)
 ```
 
 This will send an action into the system for every little change to the slider, which can be dozens

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-MultipleDestinations.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-MultipleDestinations.tutorial
@@ -86,7 +86,7 @@
       
       @Step {
         Add a button to each row of the contacts list in order to send the `deleteButtonTapped`
-        action to the view store.
+        action to the store.
         
         @Code(name: "ContactsFeatures.swift", file: 02-02-01-code-0007.swift)
       }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -293,7 +293,7 @@ public struct _ForEachReducer<
         associated effect before an element is removed, especially if it is a long-living effect.
 
         • This action was sent to the store while its state contained no element at this ID. To \
-        fix this make sure that actions for this reducer can only be sent from a view store when \
+        fix this make sure that actions for this reducer can only be sent from a store when \
         its state contains an element at this id. In SwiftUI applications, use "ForEachStore".
         """,
         fileID: fileID,

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
@@ -230,7 +230,7 @@ public struct _IfCaseLetReducer<Parent: Reducer, Child: Reducer>: Reducer {
         before child state changes to another case, especially if it is a long-living effect.
 
         • This action was sent to the store while state was another case. Make sure that actions \
-        for this reducer can only be sent from a view store when state is set to the appropriate \
+        for this reducer can only be sent from a store when state is set to the appropriate \
         case. In SwiftUI applications, use "SwitchStore".
         """,
         fileID: fileID,

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
@@ -299,7 +299,7 @@ public struct _IfLetReducer<Parent: Reducer, Child: Reducer>: Reducer {
         before child state becomes "nil", especially if it is a long-living effect.
 
         • This action was sent to the store while state was "nil". Make sure that actions for this \
-        reducer can only be sent from a view store when state is non-"nil". In SwiftUI \
+        reducer can only be sent from a store when state is non-"nil". In SwiftUI \
         applications, use "IfLetStore".
         """,
         fileID: fileID,

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -639,7 +639,7 @@ public struct _PresentationReducer<Base: Reducer, Destination: Reducer>: Reducer
         destination reducers can handle their actions while their state is still present.
 
         • This action was sent to the store while destination state was "nil". Make sure that \
-        actions for this reducer can only be sent from a view store when state is present, or \
+        actions for this reducer can only be sent from a store when state is present, or \
         from effects that start from this reducer. In SwiftUI applications, use a Composable \
         Architecture view modifier like "sheet(store:…)".
         """,

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
@@ -365,7 +365,7 @@ public struct Scope<ParentState, ParentAction, Child: Reducer>: Reducer {
           before child state changes to another case, especially if it is a long-living effect.
 
           • This action was sent to the store while state was another case. Make sure that actions \
-          for this reducer can only be sent from a view store when state is set to the appropriate \
+          for this reducer can only be sent from a store when state is set to the appropriate \
           case. In SwiftUI applications, use "SwitchStore".
           """,
           fileID: fileID,

--- a/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
@@ -538,7 +538,7 @@ public struct _StackReducer<Base: Reducer, Destination: Reducer>: Reducer {
           associated effect before an element is removed, especially if it is a long-living effect.
 
           • This action was sent to the store while its state contained no element at this ID. To \
-          fix this make sure that actions for this reducer can only be sent from a view store when \
+          fix this make sure that actions for this reducer can only be sent from a store when \
           its state contains an element at this id. In SwiftUI applications, use \
           "NavigationStack.init(path:)" with a binding to a store.
           """,

--- a/Tests/ComposableArchitectureTests/Reducers/ForEachReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/ForEachReducerTests.swift
@@ -59,7 +59,7 @@ final class ForEachReducerTests: BaseTCATestCase {
         associated effect before an element is removed, especially if it is a long-living effect.
 
         • This action was sent to the store while its state contained no element at this ID. To \
-        fix this make sure that actions for this reducer can only be sent from a view store when \
+        fix this make sure that actions for this reducer can only be sent from a store when \
         its state contains an element at this id. In SwiftUI applications, use "ForEachStore".
         """
     }

--- a/Tests/ComposableArchitectureTests/Reducers/IfCaseLetReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/IfCaseLetReducerTests.swift
@@ -59,7 +59,7 @@ final class IfCaseLetReducerTests: BaseTCATestCase {
         before child state changes to another case, especially if it is a long-living effect.
 
         • This action was sent to the store while state was another case. Make sure that actions \
-        for this reducer can only be sent from a view store when state is set to the appropriate \
+        for this reducer can only be sent from a store when state is set to the appropriate \
         case. In SwiftUI applications, use "SwitchStore".
         """
     }

--- a/Tests/ComposableArchitectureTests/Reducers/IfLetReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/IfLetReducerTests.swift
@@ -29,7 +29,7 @@ final class IfLetReducerTests: BaseTCATestCase {
         before child state becomes "nil", especially if it is a long-living effect.
 
         • This action was sent to the store while state was "nil". Make sure that actions for \
-        this reducer can only be sent from a view store when state is non-"nil". In SwiftUI \
+        this reducer can only be sent from a store when state is non-"nil". In SwiftUI \
         applications, use "IfLetStore".
         """
     }

--- a/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
@@ -1739,7 +1739,7 @@ final class PresentationReducerTests: BaseTCATestCase {
         destination reducers can handle their actions while their state is still present.
 
         • This action was sent to the store while destination state was "nil". Make sure that \
-        actions for this reducer can only be sent from a view store when state is present, or \
+        actions for this reducer can only be sent from a store when state is present, or \
         from effects that start from this reducer. In SwiftUI applications, use a Composable \
         Architecture view modifier like "sheet(store:…)".
         """
@@ -1796,7 +1796,7 @@ final class PresentationReducerTests: BaseTCATestCase {
         destination reducers can handle their actions while their state is still present.
 
         • This action was sent to the store while destination state was "nil". Make sure that \
-        actions for this reducer can only be sent from a view store when state is present, or \
+        actions for this reducer can only be sent from a store when state is present, or \
         from effects that start from this reducer. In SwiftUI applications, use a Composable \
         Architecture view modifier like "sheet(store:…)".
         """

--- a/Tests/ComposableArchitectureTests/Reducers/StackReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/StackReducerTests.swift
@@ -792,7 +792,7 @@ final class StackReducerTests: BaseTCATestCase {
         associated effect before an element is removed, especially if it is a long-living effect.
 
         • This action was sent to the store while its state contained no element at this ID. To \
-        fix this make sure that actions for this reducer can only be sent from a view store when \
+        fix this make sure that actions for this reducer can only be sent from a store when \
         its state contains an element at this id. In SwiftUI applications, use \
         "NavigationStack.init(path:)" with a binding to a store.
         """

--- a/Tests/ComposableArchitectureTests/ScopeTests.swift
+++ b/Tests/ComposableArchitectureTests/ScopeTests.swift
@@ -67,7 +67,7 @@ final class ScopeTests: BaseTCATestCase {
         before child state changes to another case, especially if it is a long-living effect.
 
         • This action was sent to the store while state was another case. Make sure that actions \
-        for this reducer can only be sent from a view store when state is set to the appropriate \
+        for this reducer can only be sent from a store when state is set to the appropriate \
         case. In SwiftUI applications, use "SwitchStore".
         """
     }


### PR DESCRIPTION
Found and fixed spots where the viewStore name was unnecessarily used in runtimeWarning sections and docs.
Since viewStore is deprecated, I think keeping it around might cause some confusion.