### PR TITLE
Annotate `Store._StoreCollection` with `@MainActor`

### DIFF
--- a/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
@@ -86,6 +86,7 @@
     }
   }
 
+  @MainActor
   public struct _StoreCollection<ID: Hashable & Sendable, State, Action>: RandomAccessCollection {
     private let store: Store<IdentifiedArray<ID, State>, IdentifiedAction<ID, Action>>
     private let data: IdentifiedArray<ID, State>


### PR DESCRIPTION
Fixes these compiler errors with Xcode 15.4:

```
Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift:95:25: error: call to main actor-isolated instance method 'withState' in a synchronous nonisolated context
      self.data = store.withState { $0 }
                        ^
Sources/ComposableArchitecture/Store.swift:213:15: note: calls to instance method 'withState' from outside of its actor context are implicitly asynchronous
  public func withState<R>(_ body: (_ state: State) -> R) -> R {
              ^
Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift:103:16: error: call to main actor-isolated initializer 'init()' in a synchronous nonisolated context
        return Store()
               ^
Sources/ComposableArchitecture/Store.swift:188:3: note: calls to initializer 'init()' from outside of its actor context are implicitly asynchronous
  init() {
  ^
Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift:107:25: error: call to main actor-isolated instance method 'scope(id:state:action:isInvalid:)' in a synchronous nonisolated context
      return self.store.scope(
                        ^
Sources/ComposableArchitecture/Store.swift:347:10: note: calls to instance method 'scope(id:state:action:isInvalid:)' from outside of its actor context are implicitly asynchronous
    func scope<ChildState, ChildAction>(
         ^
Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift:108:24: error: call to main actor-isolated instance method 'id(state:action:)' in a synchronous nonisolated context
        id: self.store.id(state: \.[id:id]!, action: \.[id:id]),
                       ^
Sources/ComposableArchitecture/Store.swift:456:32: note: calls to instance method 'id(state:action:)' from outside of its actor context are implicitly asynchronous
  @_spi(Internals) public func id<ChildState, ChildAction>(
                               ^
```
