### PR TITLE
Fix document in WhatIsNavigation.md

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/WhatIsNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/WhatIsNavigation.md
@@ -258,7 +258,7 @@ navigation, and so it can be important to be aware of their differences when mod
     let path: [Path] = [
       .movie(/* ... */),
       .actors(/* ... */),
-      .actor(/* ... */)
+      .actor(/* ... */),
       .movies(/* ... */),
       .movie(/* ... */),
     ]


### PR DESCRIPTION
While working through the documentation, I noticed that the items in the array were missing commas, so I fixed that.