### PR TITLE
Warn if bindable store binding action isn't processed

### DIFF
--- a/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
+++ b/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
@@ -30,6 +30,32 @@
       }
     }
 
+    @ObservableState
+    struct TestObservableBindingUnhandledActionState: Equatable {
+      var count = 0
+    }
+    @MainActor
+    func testObservableBindingUnhandledAction() {
+      typealias State = TestObservableBindingUnhandledActionState
+      enum Action: BindableAction, Equatable {
+        case binding(BindingAction<State>)
+      }
+      let store = Store<State, Action>(initialState: State()) {}
+
+      XCTExpectFailure {
+        store.count = 42
+      } issueMatcher: {
+        $0.compactDescription == """
+          failed - A binding action sent from a store was not handled. …
+
+            Action:
+              RuntimeWarningTests.Action.binding(.set(_, 42))
+
+          To fix this, invoke "BindingReducer()" from your feature reducer's "body".
+          """
+      }
+    }
+
     @MainActor
     func testBindingUnhandledAction_BindingState() {
       struct State: Equatable {


### PR DESCRIPTION
Looks like the warnings we emit when we detect `BindingReducer` is missing are only applied to view stores, and were not ported over to the newer observable store bindings.

This PR fixes that, though the main caveat is the messages can't seem to point to any good context. These bindings are derived from dynamic member lookup, which can't include source context like file/line.