### PR TITLE
Fix build issue related to isolated(any)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -91,6 +91,7 @@ let package = Package(
     target.swiftSettings = target.swiftSettings ?? []
     target.swiftSettings?.append(contentsOf: [
       .enableExperimentalFeature("StrictConcurrency"),
+      .enableExperimentalFeature("IsolatedAny")
     ])
   }
 #endif


### PR DESCRIPTION
Enable experimental feature `IsolatedAny`

In some environments (at least Xcode 16 beta (16A5171c)) the lack of this flag caused compilation error 😔

`Attribute requires '-enable-experimental-feature IsolatedAny'`

<img width="951" alt="Screenshot 2024-09-07 at 11 54 27 PM" src="https://github.com/user-attachments/assets/4c996e0d-672f-4808-8c62-53436751a18c">

<img width="268" alt="Screenshot 2024-09-08 at 12 14 21 AM" src="https://github.com/user-attachments/assets/68c52183-6c34-40d1-8d18-8b1bcb311e06">

> Issue was present even in standalone swift-tca package build, I didn't check it as a dependency yet, but now local build is successful c:
