### PR TITLE
Existential `any` to protocol for Swift 6

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/02-SharedState-Notifications.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-SharedState-Notifications.swift
@@ -24,7 +24,7 @@ struct SharedStateNotifications {
     @SharedReader(.screenshotCount) var screenshotCount = 0
   }
   enum Action {
-    case factResponse(Result<String, Error>)
+    case factResponse(Result<String, any Error>)
     case onAppear
   }
   @Dependency(\.factClient) var factClient

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-Basics.swift
@@ -32,7 +32,7 @@ struct EffectsBasics {
     case decrementDelayResponse
     case incrementButtonTapped
     case numberFactButtonTapped
-    case numberFactResponse(Result<String, Error>)
+    case numberFactResponse(Result<String, any Error>)
   }
 
   @Dependency(\.continuousClock) var clock

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-Cancellation.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-Cancellation.swift
@@ -25,7 +25,7 @@ struct EffectsCancellation {
     case cancelButtonTapped
     case stepperChanged(Int)
     case factButtonTapped
-    case factResponse(Result<String, Error>)
+    case factResponse(Result<String, any Error>)
   }
 
   @Dependency(\.factClient) var factClient

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-Refreshable.swift
@@ -23,7 +23,7 @@ struct Refreshable {
   enum Action {
     case cancelButtonTapped
     case decrementButtonTapped
-    case factResponse(Result<String, Error>)
+    case factResponse(Result<String, any Error>)
     case incrementButtonTapped
     case refresh
   }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-WebSocket.swift
@@ -29,7 +29,7 @@ struct WebSocket {
     case alert(PresentationAction<Alert>)
     case connectButtonTapped
     case messageToSendChanged(String)
-    case receivedSocketMessage(Result<WebSocketClient.Message, Error>)
+    case receivedSocketMessage(Result<WebSocketClient.Message, any Error>)
     case sendButtonTapped
     case sendResponse(didSucceed: Bool)
     case webSocket(WebSocketClient.Action)
@@ -227,7 +227,7 @@ struct WebSocketClient {
   var open: @Sendable (_ id: ID, _ url: URL, _ protocols: [String]) async -> AsyncStream<Action> = {
     _, _, _ in .finished
   }
-  var receive: @Sendable (_ id: ID) async throws -> AsyncStream<Result<Message, Error>>
+  var receive: @Sendable (_ id: ID) async throws -> AsyncStream<Result<Message, any Error>>
   var send: @Sendable (_ id: ID, _ message: URLSessionWebSocketTask.Message) async throws -> Void
   var sendPing: @Sendable (_ id: ID) async throws -> Void
 }
@@ -295,7 +295,7 @@ extension WebSocketClient: DependencyKey {
         try self.socket(id: id).cancel(with: closeCode, reason: reason)
       }
 
-      func receive(id: ID) throws -> AsyncStream<Result<Message, Error>> {
+      func receive(id: ID) throws -> AsyncStream<Result<Message, any Error>> {
         let socket = try self.socket(id: id)
         return AsyncStream { continuation in
           let task = Task {

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-NavigationStack.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-NavigationStack.swift
@@ -190,7 +190,7 @@ struct ScreenA {
     case dismissButtonTapped
     case incrementButtonTapped
     case factButtonTapped
-    case factResponse(Result<String, Error>)
+    case factResponse(Result<String, any Error>)
   }
 
   @Dependency(\.dismiss) var dismiss

--- a/Examples/CaseStudies/SwiftUICaseStudies/05-HigherOrderReducers-ResuableOfflineDownloads/DownloadClient.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/05-HigherOrderReducers-ResuableOfflineDownloads/DownloadClient.swift
@@ -3,7 +3,7 @@ import Foundation
 
 @DependencyClient
 struct DownloadClient {
-  var download: @Sendable (_ url: URL) -> AsyncThrowingStream<Event, Error> = { _ in .finished() }
+  var download: @Sendable (_ url: URL) -> AsyncThrowingStream<Event, any Error> = { _ in .finished() }
 
   @CasePathable
   enum Event: Equatable {

--- a/Examples/CaseStudies/SwiftUICaseStudies/05-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/05-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
@@ -14,7 +14,7 @@ struct DownloadComponent {
   enum Action {
     case alert(PresentationAction<Alert>)
     case buttonTapped
-    case downloadClient(Result<DownloadClient.Event, Error>)
+    case downloadClient(Result<DownloadClient.Event, any Error>)
 
     @CasePathable
     enum Alert {

--- a/Examples/CaseStudies/SwiftUICaseStudies/05-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/05-HigherOrderReducers-ReusableFavoriting.swift
@@ -28,7 +28,7 @@ struct FavoritingState<ID: Hashable & Sendable>: Equatable {
 enum FavoritingAction {
   case alert(PresentationAction<Alert>)
   case buttonTapped
-  case response(Result<Bool, Error>)
+  case response(Result<Bool, any Error>)
 
   enum Alert: Equatable {}
 }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/03-Effects-WebSocketTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/03-Effects-WebSocketTests.swift
@@ -6,7 +6,7 @@ import XCTest
 final class WebSocketTests: XCTestCase {
   func testWebSocketHappyPath() async {
     let actions = AsyncStream.makeStream(of: WebSocketClient.Action.self)
-    let messages = AsyncStream.makeStream(of: Result<WebSocketClient.Message, Error>.self)
+    let messages = AsyncStream.makeStream(of: Result<WebSocketClient.Message, any Error>.self)
 
     let store = await TestStore(initialState: WebSocket.State()) {
       WebSocket()
@@ -57,7 +57,7 @@ final class WebSocketTests: XCTestCase {
 
   func testWebSocketSendFailure() async {
     let actions = AsyncStream.makeStream(of: WebSocketClient.Action.self)
-    let messages = AsyncStream.makeStream(of: Result<WebSocketClient.Message, Error>.self)
+    let messages = AsyncStream.makeStream(of: Result<WebSocketClient.Message, any Error>.self)
 
     let store = await TestStore(initialState: WebSocket.State()) {
       WebSocket()

--- a/Examples/Search/Search/SearchView.swift
+++ b/Examples/Search/Search/SearchView.swift
@@ -31,10 +31,10 @@ struct Search {
   }
 
   enum Action {
-    case forecastResponse(GeocodingSearch.Result.ID, Result<Forecast, Error>)
+    case forecastResponse(GeocodingSearch.Result.ID, Result<Forecast, any Error>)
     case searchQueryChanged(String)
     case searchQueryChangeDebounced
-    case searchResponse(Result<GeocodingSearch, Error>)
+    case searchResponse(Result<GeocodingSearch, any Error>)
     case searchResultTapped(GeocodingSearch.Result)
   }
 

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Live.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechClient/Live.swift
@@ -26,7 +26,7 @@ extension SpeechClient: DependencyKey {
 private actor Speech {
   var audioEngine: AVAudioEngine? = nil
   var recognitionTask: SFSpeechRecognitionTask? = nil
-  var recognitionContinuation: AsyncThrowingStream<SpeechRecognitionResult, Error>.Continuation?
+  var recognitionContinuation: AsyncThrowingStream<SpeechRecognitionResult, any Error>.Continuation?
 
   func finishTask() {
     self.audioEngine?.stop()
@@ -37,7 +37,7 @@ private actor Speech {
 
   func startTask(
     request: UncheckedSendable<SFSpeechAudioBufferRecognitionRequest>
-  ) -> AsyncThrowingStream<SpeechRecognitionResult, Error> {
+  ) -> AsyncThrowingStream<SpeechRecognitionResult, any Error> {
     let request = request.wrappedValue
 
     return AsyncThrowingStream { continuation in

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
@@ -20,7 +20,7 @@ struct SpeechRecognition {
   enum Action {
     case alert(PresentationAction<Alert>)
     case recordButtonTapped
-    case speech(Result<String, Error>)
+    case speech(Result<String, any Error>)
     case speechRecognizerAuthorizationStatusResponse(SFSpeechRecognizerAuthorizationStatus)
 
     enum Alert: Equatable {}

--- a/Examples/SyncUps/SyncUps/Dependencies/SpeechRecognizer.swift
+++ b/Examples/SyncUps/SyncUps/Dependencies/SpeechRecognizer.swift
@@ -137,11 +137,11 @@ private actor Speech {
   private var audioEngine: AVAudioEngine? = nil
   private var recognitionTask: SFSpeechRecognitionTask? = nil
   private var recognitionContinuation:
-    AsyncThrowingStream<SpeechRecognitionResult, Error>.Continuation?
+    AsyncThrowingStream<SpeechRecognitionResult, any Error>.Continuation?
 
   func startTask(
     request: SFSpeechAudioBufferRecognitionRequest
-  ) -> AsyncThrowingStream<SpeechRecognitionResult, Error> {
+  ) -> AsyncThrowingStream<SpeechRecognitionResult, any Error> {
     AsyncThrowingStream { continuation in
       self.recognitionContinuation = continuation
       let audioSession = AVAudioSession.sharedInstance()

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginCore/LoginCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginCore/LoginCore.swift
@@ -19,7 +19,7 @@ public struct Login: Sendable {
 
   public enum Action: Sendable, ViewAction {
     case alert(PresentationAction<Alert>)
-    case loginResponse(Result<AuthenticationResponse, Error>)
+    case loginResponse(Result<AuthenticationResponse, any Error>)
     case twoFactor(PresentationAction<TwoFactor.Action>)
     case view(View)
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
@@ -20,7 +20,7 @@ public struct TwoFactor: Sendable {
 
   public enum Action: Sendable, ViewAction {
     case alert(PresentationAction<Alert>)
-    case twoFactorResponse(Result<AuthenticationResponse, Error>)
+    case twoFactorResponse(Result<AuthenticationResponse, any Error>)
     case view(View)
 
     public enum Alert: Equatable, Sendable {}

--- a/Examples/VoiceMemos/VoiceMemos/AudioPlayerClient/LiveAudioPlayerClient.swift
+++ b/Examples/VoiceMemos/VoiceMemos/AudioPlayerClient/LiveAudioPlayerClient.swift
@@ -3,7 +3,7 @@ import Dependencies
 
 extension AudioPlayerClient: DependencyKey {
   static let liveValue = Self { url in
-    let stream = AsyncThrowingStream<Bool, Error> { continuation in
+    let stream = AsyncThrowingStream<Bool, any Error> { continuation in
       do {
         let delegate = try Delegate(
           url: url,
@@ -48,7 +48,7 @@ private final class Delegate: NSObject, AVAudioPlayerDelegate, Sendable {
     self.didFinishPlaying(flag)
   }
 
-  func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: Error?) {
+  func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: (any Error)?) {
     self.decodeErrorDidOccur(error)
   }
 }

--- a/Examples/VoiceMemos/VoiceMemos/AudioRecorderClient/LiveAudioRecorderClient.swift
+++ b/Examples/VoiceMemos/VoiceMemos/AudioRecorderClient/LiveAudioRecorderClient.swift
@@ -37,7 +37,7 @@ private actor AudioRecorder {
   func start(url: URL) async throws -> Bool {
     self.stop()
 
-    let stream = AsyncThrowingStream<Bool, Error> { continuation in
+    let stream = AsyncThrowingStream<Bool, any Error> { continuation in
       do {
         self.delegate = Delegate(
           didFinishRecording: { flag in
@@ -83,11 +83,11 @@ private actor AudioRecorder {
 
 private final class Delegate: NSObject, AVAudioRecorderDelegate, Sendable {
   let didFinishRecording: @Sendable (Bool) -> Void
-  let encodeErrorDidOccur: @Sendable (Error?) -> Void
+  let encodeErrorDidOccur: @Sendable ((any Error)?) -> Void
 
   init(
     didFinishRecording: @escaping @Sendable (Bool) -> Void,
-    encodeErrorDidOccur: @escaping @Sendable (Error?) -> Void
+    encodeErrorDidOccur: @escaping @Sendable ((any Error)?) -> Void
   ) {
     self.didFinishRecording = didFinishRecording
     self.encodeErrorDidOccur = encodeErrorDidOccur
@@ -97,7 +97,7 @@ private final class Delegate: NSObject, AVAudioRecorderDelegate, Sendable {
     self.didFinishRecording(flag)
   }
 
-  func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: Error?) {
+  func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: (any Error)?) {
     self.encodeErrorDidOccur(error)
   }
 }

--- a/Examples/VoiceMemos/VoiceMemos/RecordingMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/RecordingMemo.swift
@@ -17,7 +17,7 @@ struct RecordingMemo {
   }
 
   enum Action: Sendable {
-    case audioRecorderDidFinish(Result<Bool, Error>)
+    case audioRecorderDidFinish(Result<Bool, any Error>)
     case delegate(Delegate)
     case finalRecordingTime(TimeInterval)
     case onTask
@@ -26,7 +26,7 @@ struct RecordingMemo {
 
     @CasePathable
     enum Delegate: Sendable {
-      case didFinish(Result<State, Error>)
+      case didFinish(Result<State, any Error>)
     }
   }
 

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
@@ -22,7 +22,7 @@ struct VoiceMemo {
   }
 
   enum Action {
-    case audioPlayerClient(Result<Bool, Error>)
+    case audioPlayerClient(Result<Bool, any Error>)
     case delegate(Delegate)
     case playButtonTapped
     case timerUpdated(TimeInterval)

--- a/Package.swift
+++ b/Package.swift
@@ -91,6 +91,7 @@ let package = Package(
     target.swiftSettings = target.swiftSettings ?? []
     target.swiftSettings?.append(contentsOf: [
       .enableExperimentalFeature("StrictConcurrency"),
+      .enableUpcomingFeature("ExistentialAny"),
       .enableUpcomingFeature("InferSendableFromCaptures"),
     ])
   }

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -87,8 +87,14 @@ let package = Package(
   swiftLanguageModes: [.v6]
 )
 
-for target in package.targets where target.type == .system || target.type == .test {
+for target in package.targets {
   target.swiftSettings = target.swiftSettings ?? []
+  target.swiftSettings?.append(contentsOf: [
+    .enableUpcomingFeature("ExistentialAny"),
+  ])
+}
+
+for target in package.targets where target.type == .system || target.type == .test {
   target.swiftSettings?.append(contentsOf: [
     .swiftLanguageMode(.v5),
     .enableExperimentalFeature("StrictConcurrency"),

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -83,7 +83,7 @@ extension Effect {
   public static func run(
     priority: TaskPriority? = nil,
     operation: @escaping @Sendable (_ send: Send<Action>) async throws -> Void,
-    catch handler: (@Sendable (_ error: Error, _ send: Send<Action>) async -> Void)? = nil,
+    catch handler: (@Sendable (_ error: any Error, _ send: Send<Action>) async -> Void)? = nil,
     fileID: StaticString = #fileID,
     filePath: StaticString = #filePath,
     line: UInt = #line,

--- a/Sources/ComposableArchitecture/Effects/Animation.swift
+++ b/Sources/ComposableArchitecture/Effects/Animation.swift
@@ -83,7 +83,7 @@ private struct TransactionPublisher<Upstream: Publisher>: Publisher {
       self.transaction = transaction
     }
 
-    func receive(subscription: Subscription) {
+    func receive(subscription: any Subscription) {
       self.downstream.receive(subscription: subscription)
     }
 

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -172,7 +172,7 @@ extension Effect {
   ) async rethrows -> T {
     @Dependency(\.navigationIDPath) var navigationIDPath
 
-    let (cancellable, task): (AnyCancellable, Task<T, Error>) =
+    let (cancellable, task): (AnyCancellable, Task<T, any Error>) =
       _cancellationCancellables
       .withValue {
         if cancelInFlight {
@@ -191,7 +191,7 @@ extension Effect {
     do {
       return try await task.cancellableValue
     } catch {
-      return try Result<T, Error>.failure(error)._rethrowGet()
+      return try Result<T, any Error>.failure(error)._rethrowGet()
     }
   }
 #else
@@ -203,7 +203,7 @@ extension Effect {
   ) async rethrows -> T {
     @Dependency(\.navigationIDPath) var navigationIDPath
 
-    let (cancellable, task): (AnyCancellable, Task<T, Error>) =
+    let (cancellable, task): (AnyCancellable, Task<T, any Error>) =
       _cancellationCancellables
       .withValue {
         if cancelInFlight {
@@ -222,7 +222,7 @@ extension Effect {
     do {
       return try await task.cancellableValue
     } catch {
-      return try Result<T, Error>.failure(error)._rethrowGet()
+      return try Result<T, any Error>.failure(error)._rethrowGet()
     }
   }
 #endif

--- a/Sources/ComposableArchitecture/Effects/TaskResult.swift
+++ b/Sources/ComposableArchitecture/Effects/TaskResult.swift
@@ -4,7 +4,7 @@
 ///
 /// This type is needed because Swift's concurrency tools can only express untyped errors, such as
 /// `async` functions and `AsyncSequence`, and so their output can realistically only be bridged to
-/// `Result<_, Error>`. However, `Result<_, Error>` is never `Equatable` since `Error` is not
+/// `Result<_, any Error>`. However, `Result<_, any Error>` is never `Equatable` since `Error` is not
 /// `Equatable`, and equatability is very important for testing in the Composable Architecture. By
 /// defining our own type we get the ability to recover equatability in most situations.
 ///
@@ -129,7 +129,7 @@ public enum TaskResult<Success: Sendable>: Sendable {
   case success(Success)
 
   /// A failure, storing an error.
-  case failure(Error)
+  case failure(any Error)
 
   /// Creates a new task result by evaluating an async throwing closure, capturing the returned
   /// value as a success, or any thrown error as a failure.
@@ -226,7 +226,7 @@ extension TaskResult: CasePathable {
       )
     }
 
-    public var failure: AnyCasePath<TaskResult, Error> {
+    public var failure: AnyCasePath<TaskResult, any Error> {
       AnyCasePath(
         embed: { .failure($0) },
         extract: {
@@ -238,7 +238,7 @@ extension TaskResult: CasePathable {
   }
 }
 
-extension Result where Success: Sendable, Failure == Error {
+extension Result where Success: Sendable, Failure == any Error {
   /// Transforms a `TaskResult` into a `Result`.
   ///
   /// - Parameter result: A task result.

--- a/Sources/ComposableArchitecture/Internal/Create.swift
+++ b/Sources/ComposableArchitecture/Internal/Create.swift
@@ -105,13 +105,13 @@ final class DemandBuffer<S: Subscriber>: @unchecked Sendable {
 
 extension AnyPublisher where Failure == Never {
   private init(
-    _ callback: @escaping @Sendable (Effect<Output>.Subscriber) -> Cancellable
+    _ callback: @escaping @Sendable (Effect<Output>.Subscriber) -> any Cancellable
   ) {
     self = Publishers.Create(callback: callback).eraseToAnyPublisher()
   }
 
   static func create(
-    _ factory: @escaping @Sendable (Effect<Output>.Subscriber) -> Cancellable
+    _ factory: @escaping @Sendable (Effect<Output>.Subscriber) -> any Cancellable
   ) -> AnyPublisher<Output, Failure> {
     AnyPublisher(factory)
   }
@@ -121,9 +121,9 @@ extension Publishers {
   fileprivate final class Create<Output>: Publisher, Sendable {
     typealias Failure = Never
 
-    private let callback: @Sendable (Effect<Output>.Subscriber) -> Cancellable
+    private let callback: @Sendable (Effect<Output>.Subscriber) -> any Cancellable
 
-    init(callback: @escaping @Sendable (Effect<Output>.Subscriber) -> Cancellable) {
+    init(callback: @escaping @Sendable (Effect<Output>.Subscriber) -> any Cancellable) {
       self.callback = callback
     }
 
@@ -137,10 +137,10 @@ extension Publishers.Create {
   fileprivate final class Subscription<Downstream: Subscriber>: Combine.Subscription, Sendable
   where Downstream.Input == Output, Downstream.Failure == Never {
     private let buffer: DemandBuffer<Downstream>
-    private let cancellable = LockIsolated<Cancellable?>(nil)
+    private let cancellable = LockIsolated<(any Cancellable)?>(nil)
 
     init(
-      callback: @escaping @Sendable (Effect<Output>.Subscriber) -> Cancellable,
+      callback: @escaping @Sendable (Effect<Output>.Subscriber) -> any Cancellable,
       downstream: Downstream
     ) {
       self.buffer = DemandBuffer(subscriber: downstream)

--- a/Sources/ComposableArchitecture/Internal/KeyPath+Sendable.swift
+++ b/Sources/ComposableArchitecture/Internal/KeyPath+Sendable.swift
@@ -1,12 +1,12 @@
 #if compiler(>=6)
-  public typealias _AnyKeyPath = AnyKeyPath & Sendable
-  public typealias _PartialKeyPath<Root> = PartialKeyPath<Root> & Sendable
-  public typealias _KeyPath<Root, Value> = KeyPath<Root, Value> & Sendable
-  public typealias _WritableKeyPath<Root, Value> = WritableKeyPath<Root, Value> & Sendable
-  public typealias _ReferenceWritableKeyPath<Root, Value> = ReferenceWritableKeyPath<Root, Value>
+  public typealias _AnyKeyPath = any AnyKeyPath & Sendable
+  public typealias _PartialKeyPath<Root> = any PartialKeyPath<Root> & Sendable
+  public typealias _KeyPath<Root, Value> = any KeyPath<Root, Value> & Sendable
+  public typealias _WritableKeyPath<Root, Value> = any WritableKeyPath<Root, Value> & Sendable
+  public typealias _ReferenceWritableKeyPath<Root, Value> = any ReferenceWritableKeyPath<Root, Value>
     & Sendable
-  public typealias _PartialCaseKeyPath<Root> = PartialCaseKeyPath<Root> & Sendable
-  public typealias _CaseKeyPath<Root, Value> = CaseKeyPath<Root, Value> & Sendable
+  public typealias _PartialCaseKeyPath<Root> = any PartialCaseKeyPath<Root> & Sendable
+  public typealias _CaseKeyPath<Root, Value> = any CaseKeyPath<Root, Value> & Sendable
 #else
   public typealias _AnyKeyPath = AnyKeyPath
   public typealias _PartialKeyPath<Root> = PartialKeyPath<Root>

--- a/Sources/ComposableArchitecture/Observation/Binding+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Binding+Observation.swift
@@ -59,7 +59,7 @@
 
   extension BindingAction {
     public static func set<Value: Equatable & Sendable>(
-      _ keyPath: any _WritableKeyPath<Root, Value>,
+      _ keyPath: _WritableKeyPath<Root, Value>,
       _ value: Value
     ) -> Self where Root: ObservableState {
       .init(
@@ -117,7 +117,7 @@
 
   extension BindableAction where State: ObservableState {
     fileprivate static func set<Value: Equatable & Sendable>(
-      _ keyPath: any _WritableKeyPath<State, Value>,
+      _ keyPath: _WritableKeyPath<State, Value>,
       _ value: Value,
       isInvalidated: (@MainActor @Sendable () -> Bool)?
     ) -> Self {
@@ -151,7 +151,7 @@
     }
 
     public static func set<Value: Equatable & Sendable>(
-      _ keyPath: any _WritableKeyPath<State, Value>,
+      _ keyPath: _WritableKeyPath<State, Value>,
       _ value: Value
     ) -> Self {
       self.set(keyPath, value, isInvalidated: nil)
@@ -160,7 +160,7 @@
 
   extension Store where State: ObservableState, Action: BindableAction, Action.State == State {
     public subscript<Value: Equatable & Sendable>(
-      dynamicMember keyPath: any _WritableKeyPath<State, Value>
+      dynamicMember keyPath: _WritableKeyPath<State, Value>
     ) -> Value {
       get { self.state[keyPath: keyPath] }
       set {
@@ -196,7 +196,7 @@
     Action.ViewAction.State == State
   {
     public subscript<Value: Equatable & Sendable>(
-      dynamicMember keyPath: any _WritableKeyPath<State, Value>
+      dynamicMember keyPath: _WritableKeyPath<State, Value>
     ) -> Value {
       get { self.state[keyPath: keyPath] }
       set {

--- a/Sources/ComposableArchitecture/Observation/Binding+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Binding+Observation.swift
@@ -59,7 +59,7 @@
 
   extension BindingAction {
     public static func set<Value: Equatable & Sendable>(
-      _ keyPath: _WritableKeyPath<Root, Value>,
+      _ keyPath: any _WritableKeyPath<Root, Value>,
       _ value: Value
     ) -> Self where Root: ObservableState {
       .init(
@@ -117,7 +117,7 @@
 
   extension BindableAction where State: ObservableState {
     fileprivate static func set<Value: Equatable & Sendable>(
-      _ keyPath: _WritableKeyPath<State, Value>,
+      _ keyPath: any _WritableKeyPath<State, Value>,
       _ value: Value,
       isInvalidated: (@MainActor @Sendable () -> Bool)?
     ) -> Self {
@@ -151,7 +151,7 @@
     }
 
     public static func set<Value: Equatable & Sendable>(
-      _ keyPath: _WritableKeyPath<State, Value>,
+      _ keyPath: any _WritableKeyPath<State, Value>,
       _ value: Value
     ) -> Self {
       self.set(keyPath, value, isInvalidated: nil)
@@ -160,7 +160,7 @@
 
   extension Store where State: ObservableState, Action: BindableAction, Action.State == State {
     public subscript<Value: Equatable & Sendable>(
-      dynamicMember keyPath: _WritableKeyPath<State, Value>
+      dynamicMember keyPath: any _WritableKeyPath<State, Value>
     ) -> Value {
       get { self.state[keyPath: keyPath] }
       set {
@@ -196,7 +196,7 @@
     Action.ViewAction.State == State
   {
     public subscript<Value: Equatable & Sendable>(
-      dynamicMember keyPath: _WritableKeyPath<State, Value>
+      dynamicMember keyPath: any _WritableKeyPath<State, Value>
     ) -> Value {
       get { self.state[keyPath: keyPath] }
       set {

--- a/Sources/ComposableArchitecture/Observation/ObservableState.swift
+++ b/Sources/ComposableArchitecture/Observation/ObservableState.swift
@@ -154,7 +154,7 @@
     guard !_isPOD(T.self) else { return false }
 
     func openCollection<C: Collection>(_ lhs: C, _ rhs: Any) -> Bool {
-      guard C.Element.self is ObservableState.Type else {
+      guard C.Element.self is any ObservableState.Type else {
         return false
       }
 

--- a/Sources/ComposableArchitecture/Observation/ObservationStateRegistrar.swift
+++ b/Sources/ComposableArchitecture/Observation/ObservationStateRegistrar.swift
@@ -16,8 +16,8 @@
   extension ObservationStateRegistrar: Equatable, Hashable, Codable {
     public static func == (_: Self, _: Self) -> Bool { true }
     public func hash(into hasher: inout Hasher) {}
-    public init(from decoder: Decoder) throws { self.init() }
-    public func encode(to encoder: Encoder) throws {}
+    public init(from decoder: any Decoder) throws { self.init() }
+    public func encode(to encoder: any Encoder) throws {}
   }
 
   #if canImport(Observation)

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -202,7 +202,7 @@ extension PresentationState: Hashable where State: Hashable {
 extension PresentationState: Sendable where State: Sendable {}
 
 extension PresentationState: Decodable where State: Decodable {
-  public init(from decoder: Decoder) throws {
+  public init(from decoder: any Decoder) throws {
     do {
       self.init(wrappedValue: try decoder.singleValueContainer().decode(State.self))
     } catch {
@@ -212,7 +212,7 @@ extension PresentationState: Decodable where State: Decodable {
 }
 
 extension PresentationState: Encodable where State: Encodable {
-  public func encode(to encoder: Encoder) throws {
+  public func encode(to encoder: any Encoder) throws {
     do {
       var container = encoder.singleValueContainer()
       try container.encode(self.wrappedValue)

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -293,7 +293,7 @@ extension PresentationAction: CasePathable {
     }
 
     public subscript<AppendedAction>(
-      dynamicMember keyPath: _CaseKeyPath<Action, AppendedAction>
+      dynamicMember keyPath: any _CaseKeyPath<Action, AppendedAction>
     ) -> AnyCasePath<PresentationAction, AppendedAction>
     where Action: CasePathable {
       AnyCasePath<PresentationAction, AppendedAction>(
@@ -307,7 +307,7 @@ extension PresentationAction: CasePathable {
 
     @_disfavoredOverload
     public subscript<AppendedAction>(
-      dynamicMember keyPath: _CaseKeyPath<Action, AppendedAction>
+      dynamicMember keyPath: any _CaseKeyPath<Action, AppendedAction>
     ) -> AnyCasePath<PresentationAction, PresentationAction<AppendedAction>>
     where Action: CasePathable {
       AnyCasePath<PresentationAction, PresentationAction<AppendedAction>>(

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -293,7 +293,7 @@ extension PresentationAction: CasePathable {
     }
 
     public subscript<AppendedAction>(
-      dynamicMember keyPath: any _CaseKeyPath<Action, AppendedAction>
+      dynamicMember keyPath: _CaseKeyPath<Action, AppendedAction>
     ) -> AnyCasePath<PresentationAction, AppendedAction>
     where Action: CasePathable {
       AnyCasePath<PresentationAction, AppendedAction>(
@@ -307,7 +307,7 @@ extension PresentationAction: CasePathable {
 
     @_disfavoredOverload
     public subscript<AppendedAction>(
-      dynamicMember keyPath: any _CaseKeyPath<Action, AppendedAction>
+      dynamicMember keyPath: _CaseKeyPath<Action, AppendedAction>
     ) -> AnyCasePath<PresentationAction, PresentationAction<AppendedAction>>
     where Action: CasePathable {
       AnyCasePath<PresentationAction, PresentationAction<AppendedAction>>(

--- a/Sources/ComposableArchitecture/Reducer/Reducers/SignpostReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/SignpostReducer.swift
@@ -166,7 +166,7 @@ func debugCaseOutput(
     }
   }
 
-  return (value as? CustomDebugStringConvertible)?.debugDescription
+  return (value as? any CustomDebugStringConvertible)?.debugDescription
     ?? "\(abbreviated ? "" : typeName(type(of: value)))\(debugCaseOutputHelp(value))"
 }
 

--- a/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
@@ -507,7 +507,7 @@ public struct _StackReducer<Base: Reducer, Destination: Reducer>: Reducer {
             \.dismiss,
             DismissEffect { @MainActor in
               Task._cancel(
-                id: NavigationDismissID(elementID: StackElementID(generation: 0)),
+                id: NavigationDismissID(elementID: elementID),
                 navigationID: elementNavigationIDPath
               )
             }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
@@ -507,7 +507,7 @@ public struct _StackReducer<Base: Reducer, Destination: Reducer>: Reducer {
             \.dismiss,
             DismissEffect { @MainActor in
               Task._cancel(
-                id: NavigationDismissID(elementID: elementID),
+                id: NavigationDismissID(elementID: StackElementID(generation: 0)),
                 navigationID: elementNavigationIDPath
               )
             }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
@@ -210,14 +210,14 @@ extension StackState: Hashable where Element: Hashable {
 extension StackState: Sendable where Element: Sendable {}
 
 extension StackState: Decodable where Element: Decodable {
-  public init(from decoder: Decoder) throws {
+  public init(from decoder: any Decoder) throws {
     let elements = try [Element](from: decoder)
     self.init(elements)
   }
 }
 
 extension StackState: Encodable where Element: Encodable {
-  public func encode(to encoder: Encoder) throws {
+  public func encode(to encoder: any Encoder) throws {
     try [Element](self).encode(to: encoder)
   }
 }

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKeyPathKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKeyPathKey.swift
@@ -15,7 +15,7 @@ extension PersistenceReaderKey {
   /// - Parameter key: A string key identifying a value to share in memory.
   /// - Returns: A persistence key.
   public static func appStorage<Value>(
-    _ keyPath: any _ReferenceWritableKeyPath<UserDefaults, Value>
+    _ keyPath: _ReferenceWritableKeyPath<UserDefaults, Value>
   ) -> Self where Self == AppStorageKeyPathKey<Value> {
     AppStorageKeyPathKey(keyPath)
   }
@@ -25,10 +25,10 @@ extension PersistenceReaderKey {
 ///
 /// See ``PersistenceReaderKey/appStorage(_:)-5jsie`` to create values of this type.
 public struct AppStorageKeyPathKey<Value: Sendable>: Sendable {
-  private let keyPath: any _ReferenceWritableKeyPath<UserDefaults, Value>
+  private let keyPath: _ReferenceWritableKeyPath<UserDefaults, Value>
   private let store: UncheckedSendable<UserDefaults>
 
-  public init(_ keyPath: any _ReferenceWritableKeyPath<UserDefaults, Value>) {
+  public init(_ keyPath: _ReferenceWritableKeyPath<UserDefaults, Value>) {
     @Dependency(\.defaultAppStorage) var store
     self.keyPath = keyPath
     self.store = UncheckedSendable(store)

--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKeyPathKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey/AppStorageKeyPathKey.swift
@@ -15,7 +15,7 @@ extension PersistenceReaderKey {
   /// - Parameter key: A string key identifying a value to share in memory.
   /// - Returns: A persistence key.
   public static func appStorage<Value>(
-    _ keyPath: _ReferenceWritableKeyPath<UserDefaults, Value>
+    _ keyPath: any _ReferenceWritableKeyPath<UserDefaults, Value>
   ) -> Self where Self == AppStorageKeyPathKey<Value> {
     AppStorageKeyPathKey(keyPath)
   }
@@ -25,10 +25,10 @@ extension PersistenceReaderKey {
 ///
 /// See ``PersistenceReaderKey/appStorage(_:)-5jsie`` to create values of this type.
 public struct AppStorageKeyPathKey<Value: Sendable>: Sendable {
-  private let keyPath: _ReferenceWritableKeyPath<UserDefaults, Value>
+  private let keyPath: any _ReferenceWritableKeyPath<UserDefaults, Value>
   private let store: UncheckedSendable<UserDefaults>
 
-  public init(_ keyPath: _ReferenceWritableKeyPath<UserDefaults, Value>) {
+  public init(_ keyPath: any _ReferenceWritableKeyPath<UserDefaults, Value>) {
     @Dependency(\.defaultAppStorage) var store
     self.keyPath = keyPath
     self.store = UncheckedSendable(store)

--- a/Sources/ComposableArchitecture/SharedState/Shared.swift
+++ b/Sources/ComposableArchitecture/SharedState/Shared.swift
@@ -14,9 +14,9 @@ import IssueReporting
 @propertyWrapper
 public struct Shared<Value: Sendable>: Sendable {
   private let reference: any Reference
-  private let keyPath: any _AnyKeyPath
+  private let keyPath: _AnyKeyPath
 
-  init(reference: any Reference, keyPath: any _AnyKeyPath) {
+  init(reference: any Reference, keyPath: _AnyKeyPath) {
     self.reference = reference
     self.keyPath = keyPath
   }
@@ -67,7 +67,7 @@ public struct Shared<Value: Sendable>: Sendable {
       keyPath: unsafeBitCast(
         (base.keyPath as AnyKeyPath)
           .appending(path: \Value?.[default:DefaultSubscript(initialValue)])!,
-        to: (any _AnyKeyPath).self
+        to: _AnyKeyPath.self
       )
     )
   }
@@ -182,7 +182,7 @@ public struct Shared<Value: Sendable>: Sendable {
       //     https://github.com/swiftlang/swift/issues/75531
       keyPath: unsafeBitCast(
         (self.keyPath as AnyKeyPath).appending(path: keyPath)!,
-        to: (any _AnyKeyPath).self
+        to: _AnyKeyPath.self
       )
     )
   }
@@ -465,7 +465,7 @@ extension Shared {
       //     https://github.com/swiftlang/swift/issues/75531
       keyPath: unsafeBitCast(
         (self.keyPath as AnyKeyPath).appending(path: keyPath)!,
-        to: (any _AnyKeyPath).self
+        to: _AnyKeyPath.self
       )
     )
   }

--- a/Sources/ComposableArchitecture/SharedState/Shared.swift
+++ b/Sources/ComposableArchitecture/SharedState/Shared.swift
@@ -14,9 +14,9 @@ import IssueReporting
 @propertyWrapper
 public struct Shared<Value: Sendable>: Sendable {
   private let reference: any Reference
-  private let keyPath: _AnyKeyPath
+  private let keyPath: any _AnyKeyPath
 
-  init(reference: any Reference, keyPath: _AnyKeyPath) {
+  init(reference: any Reference, keyPath: any _AnyKeyPath) {
     self.reference = reference
     self.keyPath = keyPath
   }
@@ -67,7 +67,7 @@ public struct Shared<Value: Sendable>: Sendable {
       keyPath: unsafeBitCast(
         (base.keyPath as AnyKeyPath)
           .appending(path: \Value?.[default:DefaultSubscript(initialValue)])!,
-        to: _AnyKeyPath.self
+        to: (any _AnyKeyPath).self
       )
     )
   }
@@ -182,7 +182,7 @@ public struct Shared<Value: Sendable>: Sendable {
       //     https://github.com/swiftlang/swift/issues/75531
       keyPath: unsafeBitCast(
         (self.keyPath as AnyKeyPath).appending(path: keyPath)!,
-        to: _AnyKeyPath.self
+        to: (any _AnyKeyPath).self
       )
     )
   }
@@ -465,7 +465,7 @@ extension Shared {
       //     https://github.com/swiftlang/swift/issues/75531
       keyPath: unsafeBitCast(
         (self.keyPath as AnyKeyPath).appending(path: keyPath)!,
-        to: _AnyKeyPath.self
+        to: (any _AnyKeyPath).self
       )
     )
   }

--- a/Sources/ComposableArchitecture/SharedState/SharedReader.swift
+++ b/Sources/ComposableArchitecture/SharedState/SharedReader.swift
@@ -166,7 +166,7 @@ extension SharedReader: Identifiable where Value: Identifiable {
 }
 
 extension SharedReader: Encodable where Value: Encodable {
-  public func encode(to encoder: Encoder) throws {
+  public func encode(to encoder: any Encoder) throws {
     do {
       var container = encoder.singleValueContainer()
       try container.encode(self.wrappedValue)

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -416,7 +416,7 @@ public final class Store<State, Action> {
           }
       }
 
-      if let stateType = State.self as? ObservableState.Type {
+      if let stateType = State.self as? any ObservableState.Type {
         self.parentCancellable = subscribeToDidSet(stateType)
       }
     #endif

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -144,7 +144,7 @@ extension BindingState: Sendable where Value: Sendable {}
 ///
 /// Read <doc:Bindings> for more information.
 public struct BindingAction<Root>: CasePathable, Equatable, Sendable {
-  public let keyPath: _PartialKeyPath<Root>
+  public let keyPath: any _PartialKeyPath<Root>
 
   @usableFromInline
   let set: @Sendable (inout Root) -> Void
@@ -152,7 +152,7 @@ public struct BindingAction<Root>: CasePathable, Equatable, Sendable {
   let valueIsEqualTo: @Sendable (Any) -> Bool
 
   init(
-    keyPath: _PartialKeyPath<Root>,
+    keyPath: any _PartialKeyPath<Root>,
     set: @escaping @Sendable (inout Root) -> Void,
     value: any Sendable,
     valueIsEqualTo: @escaping @Sendable (Any) -> Bool
@@ -175,7 +175,7 @@ public struct BindingAction<Root>: CasePathable, Equatable, Sendable {
   public struct AllCasePaths {
     #if canImport(Perception)
       public subscript<Value: Equatable & Sendable>(
-        dynamicMember keyPath: _WritableKeyPath<Root, Value>
+        dynamicMember keyPath: any _WritableKeyPath<Root, Value>
       ) -> AnyCasePath<BindingAction, Value> where Root: ObservableState {
         AnyCasePath(
           embed: { .set(keyPath, $0) },
@@ -185,7 +185,7 @@ public struct BindingAction<Root>: CasePathable, Equatable, Sendable {
     #endif
 
     public subscript<Value: Equatable & Sendable>(
-      dynamicMember keyPath: _WritableKeyPath<Root, BindingState<Value>>
+      dynamicMember keyPath: any _WritableKeyPath<Root, BindingState<Value>>
     ) -> AnyCasePath<BindingAction, Value> {
       AnyCasePath(
         embed: { .set(keyPath, $0) },
@@ -206,7 +206,7 @@ extension BindingAction {
   /// - Returns: An action that describes simple mutations to some root state at a writable key
   ///   path.
   public static func set<Value: Equatable & Sendable>(
-    _ keyPath: _WritableKeyPath<Root, BindingState<Value>>,
+    _ keyPath: any _WritableKeyPath<Root, BindingState<Value>>,
     _ value: Value
   ) -> Self {
     return .init(
@@ -236,7 +236,7 @@ extension BindingAction {
   }
 
   init<Value: Equatable & Sendable>(
-    keyPath: _WritableKeyPath<Root, BindingState<Value>>,
+    keyPath: any _WritableKeyPath<Root, BindingState<Value>>,
     set: @escaping @Sendable (_ state: inout Root) -> Void,
     value: Value
   ) {
@@ -292,7 +292,7 @@ extension BindableAction {
   ///
   /// - Returns: A binding action.
   public static func set<Value: Equatable & Sendable>(
-    _ keyPath: _WritableKeyPath<State, BindingState<Value>>,
+    _ keyPath: any _WritableKeyPath<State, BindingState<Value>>,
     _ value: Value
   ) -> Self {
     self.binding(.set(keyPath, value))
@@ -301,7 +301,7 @@ extension BindableAction {
 
 extension ViewStore where ViewAction: BindableAction, ViewAction.State == ViewState {
   public subscript<Value: Equatable & Sendable>(
-    dynamicMember keyPath: _WritableKeyPath<ViewState, BindingState<Value>>
+    dynamicMember keyPath: any _WritableKeyPath<ViewState, BindingState<Value>>
   ) -> Binding<Value> {
     self.binding(
       get: { $0[keyPath: keyPath].wrappedValue },
@@ -456,7 +456,7 @@ public struct BindingViewStore<State> {
   }
 
   public subscript<Value: Equatable & Sendable>(
-    dynamicMember keyPath: _WritableKeyPath<State, BindingState<Value>>
+    dynamicMember keyPath: any _WritableKeyPath<State, BindingState<Value>>
   ) -> BindingViewState<Value> {
     BindingViewState(
       binding: ViewStore(self.store, observe: { $0[keyPath: keyPath].wrappedValue })

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -96,7 +96,7 @@ extension BindingState: Hashable where Value: Hashable {
 }
 
 extension BindingState: Decodable where Value: Decodable {
-  public init(from decoder: Decoder) throws {
+  public init(from decoder: any Decoder) throws {
     do {
       let container = try decoder.singleValueContainer()
       self.init(wrappedValue: try container.decode(Value.self))
@@ -107,7 +107,7 @@ extension BindingState: Decodable where Value: Decodable {
 }
 
 extension BindingState: Encodable where Value: Encodable {
-  public func encode(to encoder: Encoder) throws {
+  public func encode(to encoder: any Encoder) throws {
     do {
       var container = encoder.singleValueContainer()
       try container.encode(self.wrappedValue)

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -144,7 +144,7 @@ extension BindingState: Sendable where Value: Sendable {}
 ///
 /// Read <doc:Bindings> for more information.
 public struct BindingAction<Root>: CasePathable, Equatable, Sendable {
-  public let keyPath: any _PartialKeyPath<Root>
+  public let keyPath: _PartialKeyPath<Root>
 
   @usableFromInline
   let set: @Sendable (inout Root) -> Void
@@ -152,7 +152,7 @@ public struct BindingAction<Root>: CasePathable, Equatable, Sendable {
   let valueIsEqualTo: @Sendable (Any) -> Bool
 
   init(
-    keyPath: any _PartialKeyPath<Root>,
+    keyPath: _PartialKeyPath<Root>,
     set: @escaping @Sendable (inout Root) -> Void,
     value: any Sendable,
     valueIsEqualTo: @escaping @Sendable (Any) -> Bool
@@ -175,7 +175,7 @@ public struct BindingAction<Root>: CasePathable, Equatable, Sendable {
   public struct AllCasePaths {
     #if canImport(Perception)
       public subscript<Value: Equatable & Sendable>(
-        dynamicMember keyPath: any _WritableKeyPath<Root, Value>
+        dynamicMember keyPath: _WritableKeyPath<Root, Value>
       ) -> AnyCasePath<BindingAction, Value> where Root: ObservableState {
         AnyCasePath(
           embed: { .set(keyPath, $0) },
@@ -185,7 +185,7 @@ public struct BindingAction<Root>: CasePathable, Equatable, Sendable {
     #endif
 
     public subscript<Value: Equatable & Sendable>(
-      dynamicMember keyPath: any _WritableKeyPath<Root, BindingState<Value>>
+      dynamicMember keyPath: _WritableKeyPath<Root, BindingState<Value>>
     ) -> AnyCasePath<BindingAction, Value> {
       AnyCasePath(
         embed: { .set(keyPath, $0) },
@@ -206,7 +206,7 @@ extension BindingAction {
   /// - Returns: An action that describes simple mutations to some root state at a writable key
   ///   path.
   public static func set<Value: Equatable & Sendable>(
-    _ keyPath: any _WritableKeyPath<Root, BindingState<Value>>,
+    _ keyPath: _WritableKeyPath<Root, BindingState<Value>>,
     _ value: Value
   ) -> Self {
     return .init(
@@ -236,7 +236,7 @@ extension BindingAction {
   }
 
   init<Value: Equatable & Sendable>(
-    keyPath: any _WritableKeyPath<Root, BindingState<Value>>,
+    keyPath: _WritableKeyPath<Root, BindingState<Value>>,
     set: @escaping @Sendable (_ state: inout Root) -> Void,
     value: Value
   ) {
@@ -292,7 +292,7 @@ extension BindableAction {
   ///
   /// - Returns: A binding action.
   public static func set<Value: Equatable & Sendable>(
-    _ keyPath: any _WritableKeyPath<State, BindingState<Value>>,
+    _ keyPath: _WritableKeyPath<State, BindingState<Value>>,
     _ value: Value
   ) -> Self {
     self.binding(.set(keyPath, value))
@@ -301,7 +301,7 @@ extension BindableAction {
 
 extension ViewStore where ViewAction: BindableAction, ViewAction.State == ViewState {
   public subscript<Value: Equatable & Sendable>(
-    dynamicMember keyPath: any _WritableKeyPath<ViewState, BindingState<Value>>
+    dynamicMember keyPath: _WritableKeyPath<ViewState, BindingState<Value>>
   ) -> Binding<Value> {
     self.binding(
       get: { $0[keyPath: keyPath].wrappedValue },
@@ -456,7 +456,7 @@ public struct BindingViewStore<State> {
   }
 
   public subscript<Value: Equatable & Sendable>(
-    dynamicMember keyPath: any _WritableKeyPath<State, BindingState<Value>>
+    dynamicMember keyPath: _WritableKeyPath<State, BindingState<Value>>
   ) -> BindingViewState<Value> {
     BindingViewState(
       binding: ViewStore(self.store, observe: { $0[keyPath: keyPath].wrappedValue })

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1918,7 +1918,7 @@ extension TestStore where State: Equatable {
   @_disfavoredOverload
   @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
   public func receive<Value: Equatable & Sendable>(
-    _ actionCase: any _CaseKeyPath<Action, Value>,
+    _ actionCase: _CaseKeyPath<Action, Value>,
     _ value: Value,
     timeout duration: Duration,
     assert updateStateToExpectedResult: ((_ state: inout State) throws -> Void)? = nil,

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -1918,7 +1918,7 @@ extension TestStore where State: Equatable {
   @_disfavoredOverload
   @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
   public func receive<Value: Equatable & Sendable>(
-    _ actionCase: _CaseKeyPath<Action, Value>,
+    _ actionCase: any _CaseKeyPath<Action, Value>,
     _ value: Value,
     timeout duration: Duration,
     assert updateStateToExpectedResult: ((_ state: inout State) throws -> Void)? = nil,

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -131,7 +131,7 @@ import IssueReporting
 ///
 ///   enum Action {
 ///     case queryChanged(String)
-///     case searchResponse(Result<[String], Error>)
+///     case searchResponse(Result<[String], any Error>)
 ///   }
 ///
 ///   @Dependency(\.apiClient) var apiClient

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -48,7 +48,7 @@ extension Store {
   public func ifLet<Wrapped>(
     then unwrap: @escaping (_ store: Store<Wrapped, Action>) -> Void,
     else: @escaping () -> Void = {}
-  ) -> Cancellable where State == Wrapped? {
+  ) -> any Cancellable where State == Wrapped? {
     return self
       .publisher
       .removeDuplicates(by: { ($0 != nil) == ($1 != nil) })

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -301,7 +301,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
   ///   }
   ///   enum Action {
   ///     case pulledToRefresh
-  ///     case receivedResponse(Result<String, Error>)
+  ///     case receivedResponse(Result<String, any Error>)
   ///   }
   ///   @Dependency(\.fetch) var fetch
   ///
@@ -403,7 +403,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
     try? await withTaskCancellationHandler {
       try Task.checkCancellation()
       try await withUnsafeThrowingContinuation {
-        (continuation: UnsafeContinuation<Void, Error>) in
+        (continuation: UnsafeContinuation<Void, any Error>) in
         guard !Task.isCancelled else {
           continuation.resume(throwing: CancellationError())
           return

--- a/Sources/ComposableArchitectureMacros/Extensions.swift
+++ b/Sources/ComposableArchitectureMacros/Extensions.swift
@@ -136,7 +136,7 @@ extension TypeSyntax {
         genericParameters[parameter.name.text] = parameter.inheritedType
       }
     }
-    var iterator = self.asProtocol(TypeSyntaxProtocol.self).tokens(viewMode: .sourceAccurate)
+    var iterator = self.asProtocol((any TypeSyntaxProtocol).self).tokens(viewMode: .sourceAccurate)
       .makeIterator()
     guard let base = iterator.next() else {
       return nil

--- a/Sources/ComposableArchitectureMacros/ObservableStateMacro.swift
+++ b/Sources/ComposableArchitectureMacros/ObservableStateMacro.swift
@@ -230,7 +230,7 @@ extension ObservableStateMacro: MemberMacro {
       return try enumExpansion(of: node, providingMembersOf: declaration, in: context)
     }
 
-    guard let identified = declaration.asProtocol(NamedDeclSyntax.self) else {
+    guard let identified = declaration.asProtocol((any NamedDeclSyntax).self) else {
       return []
     }
 

--- a/Sources/ComposableArchitectureMacros/Plugins.swift
+++ b/Sources/ComposableArchitectureMacros/Plugins.swift
@@ -3,7 +3,7 @@ import SwiftSyntaxMacros
 
 @main
 struct MacrosPlugin: CompilerPlugin {
-  let providingMacros: [Macro.Type] = [
+  let providingMacros: [any Macro.Type] = [
     ObservableStateMacro.self,
     ObservationStateTrackedMacro.self,
     ObservationStateIgnoredMacro.self,

--- a/Sources/swift-composable-architecture-benchmark/Common.swift
+++ b/Sources/swift-composable-architecture-benchmark/Common.swift
@@ -15,7 +15,7 @@ extension BenchmarkSuite {
 
 struct Benchmarking: AnyBenchmark {
   let name: String
-  let settings: [BenchmarkSetting] = []
+  let settings: [any BenchmarkSetting] = []
   private let _run: () throws -> Void
   private let _setUp: () -> Void
   private let _tearDown: () -> Void

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -560,7 +560,7 @@ final class StoreTests: BaseTCATestCase {
   @available(*, deprecated)
   @MainActor
   func testScopeCancellation() async throws {
-    let neverEndingTask = Task<Void, Error> { try await Task.never() }
+    let neverEndingTask = Task<Void, any Error> { try await Task.never() }
 
     let store = Store(initialState: ()) {
       Reduce<Void, Void> { _, _ in


### PR DESCRIPTION
Apply existential any to protocol for Swift 6
- https://github.com/swiftlang/swift-evolution/blob/main/proposals/0335-existential-any.md

  > After any is introduced, warnings will be added to guide programmers toward the new syntax. Finally, these warnings can become errors, or [plain protocol names can be repurposed](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0335-existential-any.md#re-purposing-the-plain-protocol-name), in Swift 6.

- Maybe the requirement has been delayed and will not immediately result in an error in Swift 6, but I think it makes semantic sense as described in the proposal and will eventually take effect.

- Refactored by apply `.enableUpcomingFeature("ExistentialAny")`, 
  and tried running `make test-all` locally with that option enabled, and it worked fine.