### PR TITLE
Remove `#if` Perception branching

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Exports.swift
+++ b/Sources/ComposableArchitecture/Internal/Exports.swift
@@ -4,16 +4,9 @@
 @_exported import ConcurrencyExtras
 @_exported import CustomDump
 @_exported import Dependencies
+@_exported import DependenciesMacros
 @_exported import IdentifiedCollections
+@_exported import Observation
+@_exported import Perception
 @_exported import SwiftUINavigation
 @_exported import UIKitNavigation
-
-#if canImport(DependenciesMacros)
-  @_exported import DependenciesMacros
-#endif
-#if canImport(Observation)
-  @_exported import Observation
-#endif
-#if canImport(Perception)
-  @_exported import Perception
-#endif

--- a/Sources/ComposableArchitecture/Observation/Binding+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Binding+Observation.swift
@@ -1,378 +1,376 @@
-#if canImport(Perception)
-  import SwiftUI
+import SwiftUI
 
-  extension Binding {
-    @_disfavoredOverload
-    public subscript<State: ObservableState, Action, Member>(
-      dynamicMember keyPath: KeyPath<State, Member>
-    ) -> _StoreBinding<State, Action, Member>
-    where Value == Store<State, Action> {
-      _StoreBinding(binding: self, keyPath: keyPath)
-    }
+extension Binding {
+  @_disfavoredOverload
+  public subscript<State: ObservableState, Action, Member>(
+    dynamicMember keyPath: KeyPath<State, Member>
+  ) -> _StoreBinding<State, Action, Member>
+  where Value == Store<State, Action> {
+    _StoreBinding(binding: self, keyPath: keyPath)
+  }
+}
+
+extension UIBinding {
+  @_disfavoredOverload
+  public subscript<State: ObservableState, Action, Member>(
+    dynamicMember keyPath: KeyPath<State, Member>
+  ) -> _StoreUIBinding<State, Action, Member>
+  where Value == Store<State, Action> {
+    _StoreUIBinding(binding: self, keyPath: keyPath)
+  }
+}
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+extension SwiftUI.Bindable {
+  @_disfavoredOverload
+  public subscript<State: ObservableState, Action, Member>(
+    dynamicMember keyPath: KeyPath<State, Member>
+  ) -> _StoreBindable_SwiftUI<State, Action, Member>
+  where Value == Store<State, Action> {
+    _StoreBindable_SwiftUI(bindable: self, keyPath: keyPath)
+  }
+}
+
+@available(iOS, introduced: 13, obsoleted: 17)
+@available(macOS, introduced: 10.15, obsoleted: 14)
+@available(tvOS, introduced: 13, obsoleted: 17)
+@available(watchOS, introduced: 6, obsoleted: 10)
+@available(visionOS, unavailable)
+extension Perception.Bindable {
+  @_disfavoredOverload
+  public subscript<State: ObservableState, Action, Member>(
+    dynamicMember keyPath: KeyPath<State, Member>
+  ) -> _StoreBindable_Perception<State, Action, Member>
+  where Value == Store<State, Action> {
+    _StoreBindable_Perception(bindable: self, keyPath: keyPath)
+  }
+}
+
+extension UIBindable {
+  @_disfavoredOverload
+  public subscript<State: ObservableState, Action, Member>(
+    dynamicMember keyPath: KeyPath<State, Member>
+  ) -> _StoreUIBindable<State, Action, Member>
+  where Value == Store<State, Action> {
+    _StoreUIBindable(bindable: self, keyPath: keyPath)
+  }
+}
+
+extension BindingAction {
+  public static func set<Value: Equatable & Sendable>(
+    _ keyPath: _WritableKeyPath<Root, Value>,
+    _ value: Value
+  ) -> Self where Root: ObservableState {
+    .init(
+      keyPath: keyPath,
+      set: { $0[keyPath: keyPath] = value },
+      value: value,
+      valueIsEqualTo: { $0 as? Value == value }
+    )
   }
 
-  extension UIBinding {
-    @_disfavoredOverload
-    public subscript<State: ObservableState, Action, Member>(
-      dynamicMember keyPath: KeyPath<State, Member>
-    ) -> _StoreUIBinding<State, Action, Member>
-    where Value == Store<State, Action> {
-      _StoreUIBinding(binding: self, keyPath: keyPath)
+  public static func ~= <Value>(
+    keyPath: WritableKeyPath<Root, Value>,
+    bindingAction: Self
+  ) -> Bool where Root: ObservableState {
+    keyPath == bindingAction.keyPath
+  }
+}
+
+#if DEBUG
+  private final class BindableActionDebugger<Action>: Sendable {
+    let isInvalidated: @MainActor @Sendable () -> Bool
+    let value: any Sendable
+    let wasCalled = LockIsolated(false)
+    init(
+      value: some Sendable,
+      isInvalidated: @escaping @MainActor @Sendable () -> Bool
+    ) {
+      self.value = value
+      self.isInvalidated = isInvalidated
+    }
+    deinit {
+      let isInvalidated = mainActorNow(execute: isInvalidated)
+      guard !isInvalidated else { return }
+      guard wasCalled.value else {
+        var valueDump: String {
+          var valueDump = ""
+          customDump(self.value, to: &valueDump, maxDepth: 0)
+          return valueDump
+        }
+        reportIssue(
+          """
+          A binding action sent from a store was not handled. …
+
+            Action:
+              \(typeName(Action.self)).binding(.set(_, \(valueDump)))
+
+          To fix this, invoke "BindingReducer()" from your feature reducer's "body".
+          """
+        )
+        return
+      }
     }
   }
+#endif
 
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  extension SwiftUI.Bindable {
-    @_disfavoredOverload
-    public subscript<State: ObservableState, Action, Member>(
-      dynamicMember keyPath: KeyPath<State, Member>
-    ) -> _StoreBindable_SwiftUI<State, Action, Member>
-    where Value == Store<State, Action> {
-      _StoreBindable_SwiftUI(bindable: self, keyPath: keyPath)
-    }
-  }
-
-  @available(iOS, introduced: 13, obsoleted: 17)
-  @available(macOS, introduced: 10.15, obsoleted: 14)
-  @available(tvOS, introduced: 13, obsoleted: 17)
-  @available(watchOS, introduced: 6, obsoleted: 10)
-  @available(visionOS, unavailable)
-  extension Perception.Bindable {
-    @_disfavoredOverload
-    public subscript<State: ObservableState, Action, Member>(
-      dynamicMember keyPath: KeyPath<State, Member>
-    ) -> _StoreBindable_Perception<State, Action, Member>
-    where Value == Store<State, Action> {
-      _StoreBindable_Perception(bindable: self, keyPath: keyPath)
-    }
-  }
-
-  extension UIBindable {
-    @_disfavoredOverload
-    public subscript<State: ObservableState, Action, Member>(
-      dynamicMember keyPath: KeyPath<State, Member>
-    ) -> _StoreUIBindable<State, Action, Member>
-    where Value == Store<State, Action> {
-      _StoreUIBindable(bindable: self, keyPath: keyPath)
-    }
-  }
-
-  extension BindingAction {
-    public static func set<Value: Equatable & Sendable>(
-      _ keyPath: _WritableKeyPath<Root, Value>,
-      _ value: Value
-    ) -> Self where Root: ObservableState {
+extension BindableAction where State: ObservableState {
+  fileprivate static func set<Value: Equatable & Sendable>(
+    _ keyPath: _WritableKeyPath<State, Value>,
+    _ value: Value,
+    isInvalidated: (@MainActor @Sendable () -> Bool)?
+  ) -> Self {
+    #if DEBUG
+      if let isInvalidated {
+        let debugger = BindableActionDebugger<Self>(
+          value: value,
+          isInvalidated: isInvalidated
+        )
+        return Self.binding(
+          .init(
+            keyPath: keyPath,
+            set: {
+              debugger.wasCalled.setValue(true)
+              $0[keyPath: keyPath] = value
+            },
+            value: value,
+            valueIsEqualTo: { $0 as? Value == value }
+          )
+        )
+      }
+    #endif
+    return Self.binding(
       .init(
         keyPath: keyPath,
         set: { $0[keyPath: keyPath] = value },
         value: value,
         valueIsEqualTo: { $0 as? Value == value }
       )
-    }
-
-    public static func ~= <Value>(
-      keyPath: WritableKeyPath<Root, Value>,
-      bindingAction: Self
-    ) -> Bool where Root: ObservableState {
-      keyPath == bindingAction.keyPath
-    }
+    )
   }
 
-  #if DEBUG
-    private final class BindableActionDebugger<Action>: Sendable {
-      let isInvalidated: @MainActor @Sendable () -> Bool
-      let value: any Sendable
-      let wasCalled = LockIsolated(false)
-      init(
-        value: some Sendable,
-        isInvalidated: @escaping @MainActor @Sendable () -> Bool
-      ) {
-        self.value = value
-        self.isInvalidated = isInvalidated
-      }
-      deinit {
-        let isInvalidated = mainActorNow(execute: isInvalidated)
-        guard !isInvalidated else { return }
-        guard wasCalled.value else {
-          var valueDump: String {
-            var valueDump = ""
-            customDump(self.value, to: &valueDump, maxDepth: 0)
-            return valueDump
-          }
-          reportIssue(
-            """
-            A binding action sent from a store was not handled. …
+  public static func set<Value: Equatable & Sendable>(
+    _ keyPath: _WritableKeyPath<State, Value>,
+    _ value: Value
+  ) -> Self {
+    self.set(keyPath, value, isInvalidated: nil)
+  }
+}
 
-              Action:
-                \(typeName(Action.self)).binding(.set(_, \(valueDump)))
-
-            To fix this, invoke "BindingReducer()" from your feature reducer's "body".
-            """
-          )
-          return
-        }
+extension Store where State: ObservableState, Action: BindableAction, Action.State == State {
+  public subscript<Value: Equatable & Sendable>(
+    dynamicMember keyPath: _WritableKeyPath<State, Value>
+  ) -> Value {
+    get { self.state[keyPath: keyPath] }
+    set {
+      BindingLocal.$isActive.withValue(true) {
+        self.send(.set(keyPath, newValue, isInvalidated: _isInvalidated))
       }
     }
+  }
+}
+
+extension Store
+where
+  State: Equatable & Sendable,
+  State: ObservableState,
+  Action: BindableAction,
+  Action.State == State
+{
+  public var state: State {
+    get { self.observableState }
+    set {
+      BindingLocal.$isActive.withValue(true) {
+        self.send(.set(\.self, newValue, isInvalidated: _isInvalidated))
+      }
+    }
+  }
+}
+
+extension Store
+where
+  State: ObservableState,
+  Action: ViewAction,
+  Action.ViewAction: BindableAction,
+  Action.ViewAction.State == State
+{
+  public subscript<Value: Equatable & Sendable>(
+    dynamicMember keyPath: _WritableKeyPath<State, Value>
+  ) -> Value {
+    get { self.state[keyPath: keyPath] }
+    set {
+      BindingLocal.$isActive.withValue(true) {
+        self.send(.view(.set(keyPath, newValue, isInvalidated: _isInvalidated)))
+      }
+    }
+  }
+}
+
+extension Store
+where
+  State: Equatable & Sendable,
+  State: ObservableState,
+  Action: ViewAction,
+  Action.ViewAction: BindableAction,
+  Action.ViewAction.State == State
+{
+  public var state: State {
+    get { self.observableState }
+    set {
+      BindingLocal.$isActive.withValue(true) {
+        self.send(.view(.set(\.self, newValue, isInvalidated: _isInvalidated)))
+      }
+    }
+  }
+}
+
+@dynamicMemberLookup
+public struct _StoreBinding<State: ObservableState, Action, Value> {
+  fileprivate let binding: Binding<Store<State, Action>>
+  fileprivate let keyPath: KeyPath<State, Value>
+
+  public subscript<Member>(
+    dynamicMember keyPath: KeyPath<Value, Member>
+  ) -> _StoreBinding<State, Action, Member> {
+    _StoreBinding<State, Action, Member>(
+      binding: self.binding,
+      keyPath: self.keyPath.appending(path: keyPath)
+    )
+  }
+
+  /// Creates a binding to the value by sending new values through the given action.
+  ///
+  /// - Parameter action: An action for the binding to send values through.
+  /// - Returns: A binding.
+  #if swift(<5.10)
+    @MainActor(unsafe)
+  #else
+    @preconcurrency@MainActor
   #endif
+  public func sending(_ action: CaseKeyPath<Action, Value>) -> Binding<Value> {
+    self.binding[state: self.keyPath, action: action]
+  }
+}
 
-  extension BindableAction where State: ObservableState {
-    fileprivate static func set<Value: Equatable & Sendable>(
-      _ keyPath: _WritableKeyPath<State, Value>,
-      _ value: Value,
-      isInvalidated: (@MainActor @Sendable () -> Bool)?
-    ) -> Self {
-      #if DEBUG
-        if let isInvalidated {
-          let debugger = BindableActionDebugger<Self>(
-            value: value,
-            isInvalidated: isInvalidated
-          )
-          return Self.binding(
-            .init(
-              keyPath: keyPath,
-              set: {
-                debugger.wasCalled.setValue(true)
-                $0[keyPath: keyPath] = value
-              },
-              value: value,
-              valueIsEqualTo: { $0 as? Value == value }
-            )
-          )
-        }
-      #endif
-      return Self.binding(
-        .init(
-          keyPath: keyPath,
-          set: { $0[keyPath: keyPath] = value },
-          value: value,
-          valueIsEqualTo: { $0 as? Value == value }
-        )
-      )
-    }
+@dynamicMemberLookup
+public struct _StoreUIBinding<State: ObservableState, Action, Value> {
+  fileprivate let binding: UIBinding<Store<State, Action>>
+  fileprivate let keyPath: KeyPath<State, Value>
 
-    public static func set<Value: Equatable & Sendable>(
-      _ keyPath: _WritableKeyPath<State, Value>,
-      _ value: Value
-    ) -> Self {
-      self.set(keyPath, value, isInvalidated: nil)
-    }
+  public subscript<Member>(
+    dynamicMember keyPath: KeyPath<Value, Member>
+  ) -> _StoreUIBinding<State, Action, Member> {
+    _StoreUIBinding<State, Action, Member>(
+      binding: self.binding,
+      keyPath: self.keyPath.appending(path: keyPath)
+    )
   }
 
-  extension Store where State: ObservableState, Action: BindableAction, Action.State == State {
-    public subscript<Value: Equatable & Sendable>(
-      dynamicMember keyPath: _WritableKeyPath<State, Value>
-    ) -> Value {
-      get { self.state[keyPath: keyPath] }
-      set {
-        BindingLocal.$isActive.withValue(true) {
-          self.send(.set(keyPath, newValue, isInvalidated: _isInvalidated))
-        }
+  /// Creates a binding to the value by sending new values through the given action.
+  ///
+  /// - Parameter action: An action for the binding to send values through.
+  /// - Returns: A binding.
+  @MainActor
+  public func sending(_ action: CaseKeyPath<Action, Value>) -> UIBinding<Value> {
+    self.binding[state: self.keyPath, action: action]
+  }
+}
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+@dynamicMemberLookup
+public struct _StoreBindable_SwiftUI<State: ObservableState, Action, Value> {
+  fileprivate let bindable: SwiftUI.Bindable<Store<State, Action>>
+  fileprivate let keyPath: KeyPath<State, Value>
+
+  public subscript<Member>(
+    dynamicMember keyPath: KeyPath<Value, Member>
+  ) -> _StoreBindable_SwiftUI<State, Action, Member> {
+    _StoreBindable_SwiftUI<State, Action, Member>(
+      bindable: self.bindable,
+      keyPath: self.keyPath.appending(path: keyPath)
+    )
+  }
+
+  /// Creates a binding to the value by sending new values through the given action.
+  ///
+  /// - Parameter action: An action for the binding to send values through.
+  /// - Returns: A binding.
+  #if swift(<5.10)
+    @MainActor(unsafe)
+  #else
+    @preconcurrency@MainActor
+  #endif
+  public func sending(_ action: CaseKeyPath<Action, Value>) -> Binding<Value> {
+    self.bindable[state: self.keyPath, action: action]
+  }
+}
+
+@available(iOS, introduced: 13, obsoleted: 17)
+@available(macOS, introduced: 10.15, obsoleted: 14)
+@available(tvOS, introduced: 13, obsoleted: 17)
+@available(watchOS, introduced: 6, obsoleted: 10)
+@available(visionOS, unavailable)
+@dynamicMemberLookup
+public struct _StoreBindable_Perception<State: ObservableState, Action, Value> {
+  fileprivate let bindable: Perception.Bindable<Store<State, Action>>
+  fileprivate let keyPath: KeyPath<State, Value>
+
+  public subscript<Member>(
+    dynamicMember keyPath: KeyPath<Value, Member>
+  ) -> _StoreBindable_Perception<State, Action, Member> {
+    _StoreBindable_Perception<State, Action, Member>(
+      bindable: self.bindable,
+      keyPath: self.keyPath.appending(path: keyPath)
+    )
+  }
+
+  /// Creates a binding to the value by sending new values through the given action.
+  ///
+  /// - Parameter action: An action for the binding to send values through.
+  /// - Returns: A binding.
+  #if swift(<5.10)
+    @MainActor(unsafe)
+  #else
+    @preconcurrency@MainActor
+  #endif
+  public func sending(_ action: CaseKeyPath<Action, Value>) -> Binding<Value> {
+    self.bindable[state: self.keyPath, action: action]
+  }
+}
+
+public struct _StoreUIBindable<State: ObservableState, Action, Value> {
+  fileprivate let bindable: UIBindable<Store<State, Action>>
+  fileprivate let keyPath: KeyPath<State, Value>
+
+  public subscript<Member>(
+    dynamicMember keyPath: KeyPath<Value, Member>
+  ) -> _StoreUIBindable<State, Action, Member> {
+    _StoreUIBindable<State, Action, Member>(
+      bindable: self.bindable,
+      keyPath: self.keyPath.appending(path: keyPath)
+    )
+  }
+
+  /// Creates a binding to the value by sending new values through the given action.
+  ///
+  /// - Parameter action: An action for the binding to send values through.
+  /// - Returns: A binding.
+  @MainActor
+  public func sending(_ action: CaseKeyPath<Action, Value>) -> UIBinding<Value> {
+    self.bindable[state: self.keyPath, action: action]
+  }
+}
+
+extension Store where State: ObservableState {
+  fileprivate subscript<Value>(
+    state state: KeyPath<State, Value>,
+    action action: CaseKeyPath<Action, Value>
+  ) -> Value {
+    get { self.state[keyPath: state] }
+    set {
+      BindingLocal.$isActive.withValue(true) {
+        self.send(action(newValue))
       }
     }
   }
-
-  extension Store
-  where
-    State: Equatable & Sendable,
-    State: ObservableState,
-    Action: BindableAction,
-    Action.State == State
-  {
-    public var state: State {
-      get { self.observableState }
-      set {
-        BindingLocal.$isActive.withValue(true) {
-          self.send(.set(\.self, newValue, isInvalidated: _isInvalidated))
-        }
-      }
-    }
-  }
-
-  extension Store
-  where
-    State: ObservableState,
-    Action: ViewAction,
-    Action.ViewAction: BindableAction,
-    Action.ViewAction.State == State
-  {
-    public subscript<Value: Equatable & Sendable>(
-      dynamicMember keyPath: _WritableKeyPath<State, Value>
-    ) -> Value {
-      get { self.state[keyPath: keyPath] }
-      set {
-        BindingLocal.$isActive.withValue(true) {
-          self.send(.view(.set(keyPath, newValue, isInvalidated: _isInvalidated)))
-        }
-      }
-    }
-  }
-
-  extension Store
-  where
-    State: Equatable & Sendable,
-    State: ObservableState,
-    Action: ViewAction,
-    Action.ViewAction: BindableAction,
-    Action.ViewAction.State == State
-  {
-    public var state: State {
-      get { self.observableState }
-      set {
-        BindingLocal.$isActive.withValue(true) {
-          self.send(.view(.set(\.self, newValue, isInvalidated: _isInvalidated)))
-        }
-      }
-    }
-  }
-
-  @dynamicMemberLookup
-  public struct _StoreBinding<State: ObservableState, Action, Value> {
-    fileprivate let binding: Binding<Store<State, Action>>
-    fileprivate let keyPath: KeyPath<State, Value>
-
-    public subscript<Member>(
-      dynamicMember keyPath: KeyPath<Value, Member>
-    ) -> _StoreBinding<State, Action, Member> {
-      _StoreBinding<State, Action, Member>(
-        binding: self.binding,
-        keyPath: self.keyPath.appending(path: keyPath)
-      )
-    }
-
-    /// Creates a binding to the value by sending new values through the given action.
-    ///
-    /// - Parameter action: An action for the binding to send values through.
-    /// - Returns: A binding.
-    #if swift(<5.10)
-      @MainActor(unsafe)
-    #else
-      @preconcurrency@MainActor
-    #endif
-    public func sending(_ action: CaseKeyPath<Action, Value>) -> Binding<Value> {
-      self.binding[state: self.keyPath, action: action]
-    }
-  }
-
-  @dynamicMemberLookup
-  public struct _StoreUIBinding<State: ObservableState, Action, Value> {
-    fileprivate let binding: UIBinding<Store<State, Action>>
-    fileprivate let keyPath: KeyPath<State, Value>
-
-    public subscript<Member>(
-      dynamicMember keyPath: KeyPath<Value, Member>
-    ) -> _StoreUIBinding<State, Action, Member> {
-      _StoreUIBinding<State, Action, Member>(
-        binding: self.binding,
-        keyPath: self.keyPath.appending(path: keyPath)
-      )
-    }
-
-    /// Creates a binding to the value by sending new values through the given action.
-    ///
-    /// - Parameter action: An action for the binding to send values through.
-    /// - Returns: A binding.
-    @MainActor
-    public func sending(_ action: CaseKeyPath<Action, Value>) -> UIBinding<Value> {
-      self.binding[state: self.keyPath, action: action]
-    }
-  }
-
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  @dynamicMemberLookup
-  public struct _StoreBindable_SwiftUI<State: ObservableState, Action, Value> {
-    fileprivate let bindable: SwiftUI.Bindable<Store<State, Action>>
-    fileprivate let keyPath: KeyPath<State, Value>
-
-    public subscript<Member>(
-      dynamicMember keyPath: KeyPath<Value, Member>
-    ) -> _StoreBindable_SwiftUI<State, Action, Member> {
-      _StoreBindable_SwiftUI<State, Action, Member>(
-        bindable: self.bindable,
-        keyPath: self.keyPath.appending(path: keyPath)
-      )
-    }
-
-    /// Creates a binding to the value by sending new values through the given action.
-    ///
-    /// - Parameter action: An action for the binding to send values through.
-    /// - Returns: A binding.
-    #if swift(<5.10)
-      @MainActor(unsafe)
-    #else
-      @preconcurrency@MainActor
-    #endif
-    public func sending(_ action: CaseKeyPath<Action, Value>) -> Binding<Value> {
-      self.bindable[state: self.keyPath, action: action]
-    }
-  }
-
-  @available(iOS, introduced: 13, obsoleted: 17)
-  @available(macOS, introduced: 10.15, obsoleted: 14)
-  @available(tvOS, introduced: 13, obsoleted: 17)
-  @available(watchOS, introduced: 6, obsoleted: 10)
-  @available(visionOS, unavailable)
-  @dynamicMemberLookup
-  public struct _StoreBindable_Perception<State: ObservableState, Action, Value> {
-    fileprivate let bindable: Perception.Bindable<Store<State, Action>>
-    fileprivate let keyPath: KeyPath<State, Value>
-
-    public subscript<Member>(
-      dynamicMember keyPath: KeyPath<Value, Member>
-    ) -> _StoreBindable_Perception<State, Action, Member> {
-      _StoreBindable_Perception<State, Action, Member>(
-        bindable: self.bindable,
-        keyPath: self.keyPath.appending(path: keyPath)
-      )
-    }
-
-    /// Creates a binding to the value by sending new values through the given action.
-    ///
-    /// - Parameter action: An action for the binding to send values through.
-    /// - Returns: A binding.
-    #if swift(<5.10)
-      @MainActor(unsafe)
-    #else
-      @preconcurrency@MainActor
-    #endif
-    public func sending(_ action: CaseKeyPath<Action, Value>) -> Binding<Value> {
-      self.bindable[state: self.keyPath, action: action]
-    }
-  }
-
-  public struct _StoreUIBindable<State: ObservableState, Action, Value> {
-    fileprivate let bindable: UIBindable<Store<State, Action>>
-    fileprivate let keyPath: KeyPath<State, Value>
-
-    public subscript<Member>(
-      dynamicMember keyPath: KeyPath<Value, Member>
-    ) -> _StoreUIBindable<State, Action, Member> {
-      _StoreUIBindable<State, Action, Member>(
-        bindable: self.bindable,
-        keyPath: self.keyPath.appending(path: keyPath)
-      )
-    }
-
-    /// Creates a binding to the value by sending new values through the given action.
-    ///
-    /// - Parameter action: An action for the binding to send values through.
-    /// - Returns: A binding.
-    @MainActor
-    public func sending(_ action: CaseKeyPath<Action, Value>) -> UIBinding<Value> {
-      self.bindable[state: self.keyPath, action: action]
-    }
-  }
-
-  extension Store where State: ObservableState {
-    fileprivate subscript<Value>(
-      state state: KeyPath<State, Value>,
-      action action: CaseKeyPath<Action, Value>
-    ) -> Value {
-      get { self.state[keyPath: state] }
-      set {
-        BindingLocal.$isActive.withValue(true) {
-          self.send(action(newValue))
-        }
-      }
-    }
-  }
-#endif
+}

--- a/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
@@ -1,137 +1,135 @@
-#if canImport(Perception)
-  import OrderedCollections
-  import SwiftUI
+import OrderedCollections
+import SwiftUI
 
-  extension Store where State: ObservableState {
-    /// Scopes the store of an identified collection to a collection of stores.
-    ///
-    /// This operator is most often used with SwiftUI's `ForEach` view. For example, suppose you
-    /// have a feature that contains an `IdentifiedArray` of child features like so:
-    ///
-    /// ```swift
-    /// @Reducer
-    /// struct Feature {
-    ///   @ObservableState
-    ///   struct State {
-    ///     var rows: IdentifiedArrayOf<Child.State> = []
-    ///   }
-    ///   enum Action {
-    ///     case rows(IdentifiedActionOf<Child>)
-    ///   }
-    ///   var body: some ReducerOf<Self> {
-    ///     Reduce { state, action in
-    ///       // Core feature logic
-    ///     }
-    ///     .forEach(\.rows, action: \.rows) {
-    ///       Child()
-    ///     }
-    ///   }
-    /// }
-    /// ```
-    ///
-    /// Then in the view you can use this operator, with `ForEach`, to derive a store for
-    /// each element in the identified collection:
-    ///
-    /// ```swift
-    /// struct FeatureView: View {
-    ///   let store: StoreOf<Feature>
-    ///
-    ///   var body: some View {
-    ///     List {
-    ///       ForEach(store.scope(state: \.rows, action: \.rows), id: \.state.id) { store in
-    ///         ChildView(store: store)
-    ///       }
-    ///     }
-    ///   }
-    /// }
-    /// ```
-    ///
-    /// > Tip: If you do not depend on the identity of the state of each row (_e.g._, the state's
-    /// > `id` is not associated with a selection binding), you can omit the `id` parameter, as the
-    /// > `Store` type is identifiable by its object identity:
-    /// >
-    /// > ```diff
-    /// >  ForEach(
-    /// > -  store.scope(state: \.rows, action: \.rows),
-    /// > -  id: \.state.id,
-    /// > +  store.scope(state: \.rows, action: \.rows)
-    /// >  ) { childStore in
-    /// >    ChildView(store: childStore)
-    /// >  }
-    /// > ```
-    ///
-    /// - Parameters:
-    ///   - state: A key path to an identified array of child state.
-    ///   - action: A case key path to an identified child action.
-    /// - Returns: An collection of stores of child state.
-    @_disfavoredOverload
-    public func scope<ElementID, ElementState, ElementAction>(
-      state: KeyPath<State, IdentifiedArray<ElementID, ElementState>>,
-      action: CaseKeyPath<Action, IdentifiedAction<ElementID, ElementAction>>,
-      fileID: StaticString = #fileID,
-      filePath: StaticString = #filePath,
-      line: UInt = #line,
-      column: UInt = #column
-    ) -> some RandomAccessCollection<Store<ElementState, ElementAction>> {
-      if !self.canCacheChildren {
-        reportIssue(
-          uncachedStoreWarning(self),
-          fileID: fileID,
-          filePath: filePath,
-          line: line,
-          column: column
-        )
-      }
-      return _StoreCollection(self.scope(state: state, action: action))
-    }
-  }
-
-  public struct _StoreCollection<ID: Hashable & Sendable, State, Action>: RandomAccessCollection {
-    private let store: Store<IdentifiedArray<ID, State>, IdentifiedAction<ID, Action>>
-    private let data: IdentifiedArray<ID, State>
-
-    #if swift(<5.10)
-      @MainActor(unsafe)
-    #else
-      @preconcurrency@MainActor
-    #endif
-    fileprivate init(_ store: Store<IdentifiedArray<ID, State>, IdentifiedAction<ID, Action>>) {
-      self.store = store
-      self.data = store.withState { $0 }
-    }
-
-    public var startIndex: Int { self.data.startIndex }
-    public var endIndex: Int { self.data.endIndex }
-    public subscript(position: Int) -> Store<State, Action> {
-      precondition(
-        Thread.isMainThread,
-        #"""
-        Store collections must be interacted with on the main actor.
-
-        When passing a scoped store to a 'ForEach' in a lazy view (for example, 'LazyVStack'), it \
-        must be eagerly transformed into a collection to avoid access off the main actor:
-
-            Array(store.scope(state: \.elements, action: \.elements))
-        """#
+extension Store where State: ObservableState {
+  /// Scopes the store of an identified collection to a collection of stores.
+  ///
+  /// This operator is most often used with SwiftUI's `ForEach` view. For example, suppose you
+  /// have a feature that contains an `IdentifiedArray` of child features like so:
+  ///
+  /// ```swift
+  /// @Reducer
+  /// struct Feature {
+  ///   @ObservableState
+  ///   struct State {
+  ///     var rows: IdentifiedArrayOf<Child.State> = []
+  ///   }
+  ///   enum Action {
+  ///     case rows(IdentifiedActionOf<Child>)
+  ///   }
+  ///   var body: some ReducerOf<Self> {
+  ///     Reduce { state, action in
+  ///       // Core feature logic
+  ///     }
+  ///     .forEach(\.rows, action: \.rows) {
+  ///       Child()
+  ///     }
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Then in the view you can use this operator, with `ForEach`, to derive a store for
+  /// each element in the identified collection:
+  ///
+  /// ```swift
+  /// struct FeatureView: View {
+  ///   let store: StoreOf<Feature>
+  ///
+  ///   var body: some View {
+  ///     List {
+  ///       ForEach(store.scope(state: \.rows, action: \.rows), id: \.state.id) { store in
+  ///         ChildView(store: store)
+  ///       }
+  ///     }
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// > Tip: If you do not depend on the identity of the state of each row (_e.g._, the state's
+  /// > `id` is not associated with a selection binding), you can omit the `id` parameter, as the
+  /// > `Store` type is identifiable by its object identity:
+  /// >
+  /// > ```diff
+  /// >  ForEach(
+  /// > -  store.scope(state: \.rows, action: \.rows),
+  /// > -  id: \.state.id,
+  /// > +  store.scope(state: \.rows, action: \.rows)
+  /// >  ) { childStore in
+  /// >    ChildView(store: childStore)
+  /// >  }
+  /// > ```
+  ///
+  /// - Parameters:
+  ///   - state: A key path to an identified array of child state.
+  ///   - action: A case key path to an identified child action.
+  /// - Returns: An collection of stores of child state.
+  @_disfavoredOverload
+  public func scope<ElementID, ElementState, ElementAction>(
+    state: KeyPath<State, IdentifiedArray<ElementID, ElementState>>,
+    action: CaseKeyPath<Action, IdentifiedAction<ElementID, ElementAction>>,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) -> some RandomAccessCollection<Store<ElementState, ElementAction>> {
+    if !self.canCacheChildren {
+      reportIssue(
+        uncachedStoreWarning(self),
+        fileID: fileID,
+        filePath: filePath,
+        line: line,
+        column: column
       )
-      return MainActor._assumeIsolated { [uncheckedSelf = UncheckedSendable(self)] in
-        let `self` = uncheckedSelf.wrappedValue
-        guard self.data.indices.contains(position)
-        else {
-          return Store()
-        }
-        let id = self.data.ids[position]
-        var element = self.data[position]
-        return self.store.scope(
-          id: self.store.id(state: \.[id:id]!, action: \.[id:id]),
-          state: ToState {
-            element = $0[id: id] ?? element
-            return element
-          },
-          action: { .element(id: id, action: $0) },
-          isInvalid: { !$0.ids.contains(id) }
-        )
+    }
+    return _StoreCollection(self.scope(state: state, action: action))
+  }
+}
+
+public struct _StoreCollection<ID: Hashable & Sendable, State, Action>: RandomAccessCollection {
+  private let store: Store<IdentifiedArray<ID, State>, IdentifiedAction<ID, Action>>
+  private let data: IdentifiedArray<ID, State>
+
+  #if swift(<5.10)
+    @MainActor(unsafe)
+  #else
+    @preconcurrency@MainActor
+  #endif
+  fileprivate init(_ store: Store<IdentifiedArray<ID, State>, IdentifiedAction<ID, Action>>) {
+    self.store = store
+    self.data = store.withState { $0 }
+  }
+
+  public var startIndex: Int { self.data.startIndex }
+  public var endIndex: Int { self.data.endIndex }
+  public subscript(position: Int) -> Store<State, Action> {
+    precondition(
+      Thread.isMainThread,
+      #"""
+      Store collections must be interacted with on the main actor.
+
+      When passing a scoped store to a 'ForEach' in a lazy view (for example, 'LazyVStack'), it \
+      must be eagerly transformed into a collection to avoid access off the main actor:
+
+          Array(store.scope(state: \.elements, action: \.elements))
+      """#
+    )
+    return MainActor._assumeIsolated { [uncheckedSelf = UncheckedSendable(self)] in
+      let `self` = uncheckedSelf.wrappedValue
+      guard self.data.indices.contains(position)
+      else {
+        return Store()
       }
+      let id = self.data.ids[position]
+      var element = self.data[position]
+      return self.store.scope(
+        id: self.store.id(state: \.[id:id]!, action: \.[id:id]),
+        state: ToState {
+          element = $0[id: id] ?? element
+          return element
+        },
+        action: { .element(id: id, action: $0) },
+        isInvalid: { !$0.ids.contains(id) }
+      )
     }
   }
-#endif
+}

--- a/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
@@ -1,438 +1,436 @@
 import SwiftUI
 
-#if canImport(Perception)
-  extension Binding {
-    /// Derives a binding to a store focused on ``StackState`` and ``StackAction``.
-    ///
-    /// This operator is most used in conjunction with `NavigationStack`, and in particular
-    /// the initializer ``SwiftUI/NavigationStack/init(path:root:destination:fileID:filePath:line:column:)`` that
-    /// ships with this library.
-    ///
-    /// For example, suppose you have a feature that holds onto ``StackState`` in its state in order
-    /// to represent all the screens that can be pushed onto a navigation stack:
-    ///
-    /// ```swift
-    /// @Reducer
-    /// struct Feature {
-    ///   @ObservableState
-    ///   struct State {
-    ///     var path: StackState<Path.State> = []
-    ///   }
-    ///   enum Action {
-    ///     case path(StackActionOf<Path>)
-    ///   }
-    ///   var body: some ReducerOf<Self> {
-    ///     Reduce { state, action in
-    ///       // Core feature logic
-    ///     }
-    ///     .forEach(\.rows, action: \.rows) {
-    ///       Child()
-    ///     }
-    ///   }
-    ///   @Reducer
-    ///   enum Path {
-    ///     // ...
-    ///   }
-    /// }
-    /// ```
-    ///
-    /// > Note: We are using the ``Reducer()`` macro on an enum to compose together all the features
-    /// that can be pushed onto the stack. See <doc:Reducer#Destination-and-path-reducers> for
-    /// more information.
-    ///
-    /// Then in the view you can use this operator, with
-    /// `NavigationStack` ``SwiftUI/NavigationStack/init(path:root:destination:fileID:filePath:line:column:)``, to
-    /// derive a store for each element in the stack:
-    ///
-    /// ```swift
-    /// struct FeatureView: View {
-    ///   @Bindable var store: StoreOf<Feature>
-    ///
-    ///   var body: some View {
-    ///     NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
-    ///       // Root view
-    ///     } destination: {
-    ///       // Destinations
-    ///     }
-    ///   }
-    /// }
-    /// ```
-    #if swift(>=5.10)
-      @preconcurrency@MainActor
-    #else
-      @MainActor(unsafe)
-    #endif
-    public func scope<State: ObservableState, Action, ElementState, ElementAction>(
-      state: KeyPath<State, StackState<ElementState>>,
-      action: CaseKeyPath<Action, StackAction<ElementState, ElementAction>>
-    ) -> Binding<Store<StackState<ElementState>, StackAction<ElementState, ElementAction>>>
-    where Value == Store<State, Action> {
-      self[state: state, action: action]
-    }
+extension Binding {
+  /// Derives a binding to a store focused on ``StackState`` and ``StackAction``.
+  ///
+  /// This operator is most used in conjunction with `NavigationStack`, and in particular
+  /// the initializer ``SwiftUI/NavigationStack/init(path:root:destination:fileID:filePath:line:column:)`` that
+  /// ships with this library.
+  ///
+  /// For example, suppose you have a feature that holds onto ``StackState`` in its state in order
+  /// to represent all the screens that can be pushed onto a navigation stack:
+  ///
+  /// ```swift
+  /// @Reducer
+  /// struct Feature {
+  ///   @ObservableState
+  ///   struct State {
+  ///     var path: StackState<Path.State> = []
+  ///   }
+  ///   enum Action {
+  ///     case path(StackActionOf<Path>)
+  ///   }
+  ///   var body: some ReducerOf<Self> {
+  ///     Reduce { state, action in
+  ///       // Core feature logic
+  ///     }
+  ///     .forEach(\.rows, action: \.rows) {
+  ///       Child()
+  ///     }
+  ///   }
+  ///   @Reducer
+  ///   enum Path {
+  ///     // ...
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// > Note: We are using the ``Reducer()`` macro on an enum to compose together all the features
+  /// that can be pushed onto the stack. See <doc:Reducer#Destination-and-path-reducers> for
+  /// more information.
+  ///
+  /// Then in the view you can use this operator, with
+  /// `NavigationStack` ``SwiftUI/NavigationStack/init(path:root:destination:fileID:filePath:line:column:)``, to
+  /// derive a store for each element in the stack:
+  ///
+  /// ```swift
+  /// struct FeatureView: View {
+  ///   @Bindable var store: StoreOf<Feature>
+  ///
+  ///   var body: some View {
+  ///     NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
+  ///       // Root view
+  ///     } destination: {
+  ///       // Destinations
+  ///     }
+  ///   }
+  /// }
+  /// ```
+  #if swift(>=5.10)
+    @preconcurrency@MainActor
+  #else
+    @MainActor(unsafe)
+  #endif
+  public func scope<State: ObservableState, Action, ElementState, ElementAction>(
+    state: KeyPath<State, StackState<ElementState>>,
+    action: CaseKeyPath<Action, StackAction<ElementState, ElementAction>>
+  ) -> Binding<Store<StackState<ElementState>, StackAction<ElementState, ElementAction>>>
+  where Value == Store<State, Action> {
+    self[state: state, action: action]
   }
+}
 
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  extension SwiftUI.Bindable {
-    /// Derives a binding to a store focused on ``StackState`` and ``StackAction``.
-    ///
-    /// See ``SwiftUI/Binding/scope(state:action:fileID:filePath:line:column:)`` defined on `Binding` for more
-    /// information.
-    #if swift(>=5.10)
-      @preconcurrency@MainActor
-    #else
-      @MainActor(unsafe)
-    #endif
-    public func scope<State: ObservableState, Action, ElementState, ElementAction>(
-      state: KeyPath<State, StackState<ElementState>>,
-      action: CaseKeyPath<Action, StackAction<ElementState, ElementAction>>
-    ) -> Binding<Store<StackState<ElementState>, StackAction<ElementState, ElementAction>>>
-    where Value == Store<State, Action> {
-      self[state: state, action: action]
-    }
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+extension SwiftUI.Bindable {
+  /// Derives a binding to a store focused on ``StackState`` and ``StackAction``.
+  ///
+  /// See ``SwiftUI/Binding/scope(state:action:fileID:filePath:line:column:)`` defined on `Binding` for more
+  /// information.
+  #if swift(>=5.10)
+    @preconcurrency@MainActor
+  #else
+    @MainActor(unsafe)
+  #endif
+  public func scope<State: ObservableState, Action, ElementState, ElementAction>(
+    state: KeyPath<State, StackState<ElementState>>,
+    action: CaseKeyPath<Action, StackAction<ElementState, ElementAction>>
+  ) -> Binding<Store<StackState<ElementState>, StackAction<ElementState, ElementAction>>>
+  where Value == Store<State, Action> {
+    self[state: state, action: action]
   }
+}
 
-  @available(iOS, introduced: 13, obsoleted: 17)
-  @available(macOS, introduced: 10.15, obsoleted: 14)
-  @available(tvOS, introduced: 13, obsoleted: 17)
-  @available(watchOS, introduced: 6, obsoleted: 10)
-  extension Perception.Bindable {
-    /// Derives a binding to a store focused on ``StackState`` and ``StackAction``.
-    ///
-    /// See ``SwiftUI/Binding/scope(state:action:fileID:filePath:line:column:)`` defined on `Binding` for more
-    /// information.
-    public func scope<State: ObservableState, Action, ElementState, ElementAction>(
-      state: KeyPath<State, StackState<ElementState>>,
-      action: CaseKeyPath<Action, StackAction<ElementState, ElementAction>>
-    ) -> Binding<Store<StackState<ElementState>, StackAction<ElementState, ElementAction>>>
-    where Value == Store<State, Action> {
-      self[state: state, action: action]
-    }
+@available(iOS, introduced: 13, obsoleted: 17)
+@available(macOS, introduced: 10.15, obsoleted: 14)
+@available(tvOS, introduced: 13, obsoleted: 17)
+@available(watchOS, introduced: 6, obsoleted: 10)
+extension Perception.Bindable {
+  /// Derives a binding to a store focused on ``StackState`` and ``StackAction``.
+  ///
+  /// See ``SwiftUI/Binding/scope(state:action:fileID:filePath:line:column:)`` defined on `Binding` for more
+  /// information.
+  public func scope<State: ObservableState, Action, ElementState, ElementAction>(
+    state: KeyPath<State, StackState<ElementState>>,
+    action: CaseKeyPath<Action, StackAction<ElementState, ElementAction>>
+  ) -> Binding<Store<StackState<ElementState>, StackAction<ElementState, ElementAction>>>
+  where Value == Store<State, Action> {
+    self[state: state, action: action]
   }
+}
 
-  extension UIBindable {
-    /// Derives a binding to a store focused on ``StackState`` and ``StackAction``.
-    ///
-    /// See ``SwiftUI/Binding/scope(state:action:fileID:filePath:line:column:)`` defined on `Binding` for more
-    /// information.
-    #if swift(>=5.10)
-      @preconcurrency@MainActor
-    #else
-      @MainActor(unsafe)
-    #endif
-    public func scope<State: ObservableState, Action, ElementState, ElementAction>(
-      state: KeyPath<State, StackState<ElementState>>,
-      action: CaseKeyPath<Action, StackAction<ElementState, ElementAction>>
-    ) -> UIBinding<Store<StackState<ElementState>, StackAction<ElementState, ElementAction>>>
-    where Value == Store<State, Action> {
-      self[state: state, action: action]
-    }
+extension UIBindable {
+  /// Derives a binding to a store focused on ``StackState`` and ``StackAction``.
+  ///
+  /// See ``SwiftUI/Binding/scope(state:action:fileID:filePath:line:column:)`` defined on `Binding` for more
+  /// information.
+  #if swift(>=5.10)
+    @preconcurrency@MainActor
+  #else
+    @MainActor(unsafe)
+  #endif
+  public func scope<State: ObservableState, Action, ElementState, ElementAction>(
+    state: KeyPath<State, StackState<ElementState>>,
+    action: CaseKeyPath<Action, StackAction<ElementState, ElementAction>>
+  ) -> UIBinding<Store<StackState<ElementState>, StackAction<ElementState, ElementAction>>>
+  where Value == Store<State, Action> {
+    self[state: state, action: action]
   }
+}
 
-  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
-  extension NavigationStack {
-    /// Drives a navigation stack with a store.
-    ///
-    /// See the dedicated article on <doc:Navigation> for more information on the library's
-    /// navigation tools, and in particular see <doc:StackBasedNavigation> for information on using
-    /// this view.
-    public init<State, Action, Destination: View, R>(
-      path: Binding<Store<StackState<State>, StackAction<State, Action>>>,
-      root: () -> R,
-      @ViewBuilder destination: @escaping (Store<State, Action>) -> Destination,
-      fileID: StaticString = #fileID,
-      filePath: StaticString = #filePath,
-      line: UInt = #line,
-      column: UInt = #column
-    )
-    where
-      Data == StackState<State>.PathView,
-      Root == ModifiedContent<R, _NavigationDestinationViewModifier<State, Action, Destination>>
-    {
-      self.init(
-        path: path[
-          fileID: _HashableStaticString(rawValue: fileID),
-          filePath: _HashableStaticString(rawValue: filePath),
-          line: line,
-          column: column
-        ]
-      ) {
-        root()
-          .modifier(
-            _NavigationDestinationViewModifier(
-              store: path.wrappedValue,
-              destination: destination,
-              fileID: fileID,
-              filePath: filePath,
-              line: line,
-              column: column
-            )
-          )
-      }
-    }
-  }
-
-  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
-  public struct _NavigationDestinationViewModifier<
-    State: ObservableState, Action, Destination: View
-  >:
-    ViewModifier
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+extension NavigationStack {
+  /// Drives a navigation stack with a store.
+  ///
+  /// See the dedicated article on <doc:Navigation> for more information on the library's
+  /// navigation tools, and in particular see <doc:StackBasedNavigation> for information on using
+  /// this view.
+  public init<State, Action, Destination: View, R>(
+    path: Binding<Store<StackState<State>, StackAction<State, Action>>>,
+    root: () -> R,
+    @ViewBuilder destination: @escaping (Store<State, Action>) -> Destination,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  )
+  where
+    Data == StackState<State>.PathView,
+    Root == ModifiedContent<R, _NavigationDestinationViewModifier<State, Action, Destination>>
   {
-    @SwiftUI.State var store: Store<StackState<State>, StackAction<State, Action>>
-    fileprivate let destination: (Store<State, Action>) -> Destination
-    fileprivate let fileID: StaticString
-    fileprivate let filePath: StaticString
-    fileprivate let line: UInt
-    fileprivate let column: UInt
-
-    public func body(content: Content) -> some View {
-      content
-        .environment(\.navigationDestinationType, State.self)
-        .navigationDestination(for: StackState<State>.Component.self) { component in
-          var element = component.element
-          self
-            .destination(
-              self.store.scope(
-                id: self.store.id(
-                  state:
-                    \.[
-                      id:component.id,fileID:_HashableStaticString(
-                        rawValue: fileID),filePath:_HashableStaticString(
-                          rawValue: filePath),line:line,column:column
-                    ],
-                  action: \.[id:component.id]
-                ),
-                state: ToState {
-                  element = $0[id: component.id] ?? element
-                  return element
-                },
-                action: { .element(id: component.id, action: $0) },
-                isInvalid: { !$0.ids.contains(component.id) }
-              )
-            )
-            .environment(\.navigationDestinationType, State.self)
-        }
-    }
-  }
-
-  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
-  extension NavigationLink where Destination == Never {
-    /// Creates a navigation link that presents the view corresponding to an element of
-    /// ``StackState``.
-    ///
-    /// When someone activates the navigation link that this initializer creates, SwiftUI looks for
-    /// a parent `NavigationStack` view with a store of ``StackState`` containing elements that
-    /// matches the type of this initializer's `state` input.
-    ///
-    /// See SwiftUI's documentation for `NavigationLink.init(value:label:)` for more.
-    ///
-    /// - Parameters:
-    ///   - state: An optional value to present. When the user selects the link, SwiftUI stores a
-    ///     copy of the value. Pass a `nil` value to disable the link.
-    ///   - label: A label that describes the view that this link presents.
-    public init<P, L: View>(
-      state: P?,
-      @ViewBuilder label: () -> L,
-      fileID: StaticString = #fileID,
-      filePath: StaticString = #filePath,
-      line: UInt = #line,
-      column: UInt = #column
-    )
-    where Label == _NavigationLinkStoreContent<P, L> {
-      @Dependency(\.stackElementID) var stackElementID
-      self.init(value: state.map { StackState.Component(id: stackElementID(), element: $0) }) {
-        _NavigationLinkStoreContent<P, L>(
-          state: state,
-          label: label,
-          fileID: fileID,
-          filePath: filePath,
-          line: line,
-          column: column
-        )
-      }
-    }
-
-    /// Creates a navigation link that presents the view corresponding to an element of
-    /// ``StackState``, with a text label that the link generates from a localized string key.
-    ///
-    /// When someone activates the navigation link that this initializer creates, SwiftUI looks for
-    /// a parent ``NavigationStackStore`` view with a store of ``StackState`` containing elements
-    /// that matches the type of this initializer's `state` input.
-    ///
-    /// See SwiftUI's documentation for `NavigationLink.init(_:value:)` for more.
-    ///
-    /// - Parameters:
-    ///   - titleKey: A localized string that describes the view that this link
-    ///     presents.
-    ///   - state: An optional value to present. When the user selects the link, SwiftUI stores a
-    ///     copy of the value. Pass a `nil` value to disable the link.
-    public init<P>(
-      _ titleKey: LocalizedStringKey, state: P?, fileID: StaticString = #fileID, line: UInt = #line
-    )
-    where Label == _NavigationLinkStoreContent<P, Text> {
-      self.init(state: state, label: { Text(titleKey) }, fileID: fileID, line: line)
-    }
-
-    /// Creates a navigation link that presents the view corresponding to an element of
-    /// ``StackState``, with a text label that the link generates from a title string.
-    ///
-    /// When someone activates the navigation link that this initializer creates, SwiftUI looks for
-    /// a parent ``NavigationStackStore`` view with a store of ``StackState`` containing elements
-    /// that matches the type of this initializer's `state` input.
-    ///
-    /// See SwiftUI's documentation for `NavigationLink.init(_:value:)` for more.
-    ///
-    /// - Parameters:
-    ///   - title: A string that describes the view that this link presents.
-    ///   - state: An optional value to present. When the user selects the link, SwiftUI stores a
-    ///     copy of the value. Pass a `nil` value to disable the link.
-    @_disfavoredOverload
-    public init<S: StringProtocol, P>(
-      _ title: S, state: P?, fileID: StaticString = #fileID, line: UInt = #line
-    )
-    where Label == _NavigationLinkStoreContent<P, Text> {
-      self.init(state: state, label: { Text(title) }, fileID: fileID, line: line)
-    }
-  }
-
-  public struct _NavigationLinkStoreContent<State, Label: View>: View {
-    let state: State?
-    @ViewBuilder let label: Label
-    let fileID: StaticString
-    let filePath: StaticString
-    let line: UInt
-    let column: UInt
-    @Environment(\.navigationDestinationType) var navigationDestinationType
-
-    @_spi(Internals)
-    public init(
-      state: State?,
-      @ViewBuilder label: () -> Label,
-      fileID: StaticString,
-      filePath: StaticString,
-      line: UInt,
-      column: UInt
+    self.init(
+      path: path[
+        fileID: _HashableStaticString(rawValue: fileID),
+        filePath: _HashableStaticString(rawValue: filePath),
+        line: line,
+        column: column
+      ]
     ) {
-      self.state = state
-      self.label = label()
-      self.fileID = fileID
-      self.filePath = filePath
-      self.line = line
-      self.column = column
-    }
-
-    public var body: some View {
-      #if DEBUG
-        label.onAppear {
-          if navigationDestinationType != State.self {
-            let elementType =
-              navigationDestinationType.map { typeName($0) }
-                ?? """
-                (None found in view hierarchy. Is this link inside a store-powered \
-                'NavigationStack'?)
-                """
-            reportIssue(
-              """
-              A navigation link at "\(fileID):\(line)" is unpresentable. …
-
-                NavigationStack state element type:
-                  \(elementType)
-                NavigationLink state type:
-                  \(typeName(State.self))
-                NavigationLink state value:
-                \(String(customDumping: state).indent(by: 2))
-              """,
-              fileID: fileID,
-              filePath: filePath,
-              line: line,
-              column: column
-            )
-          }
-        }
-      #else
-        label
-      #endif
-    }
-  }
-
-  extension Store where State: ObservableState {
-    fileprivate subscript<ElementState, ElementAction>(
-      state state: KeyPath<State, StackState<ElementState>>,
-      action action: CaseKeyPath<Action, StackAction<ElementState, ElementAction>>,
-      isInViewBody isInViewBody: Bool = _isInPerceptionTracking
-    ) -> Store<StackState<ElementState>, StackAction<ElementState, ElementAction>> {
-      get {
-        #if DEBUG && !os(visionOS)
-          _PerceptionLocals.$isInPerceptionTracking.withValue(isInViewBody) {
-            self.scope(state: state, action: action)
-          }
-        #else
-          self.scope(state: state, action: action)
-        #endif
-      }
-      set {}
-    }
-  }
-
-  extension Store {
-    @_spi(Internals)
-    public subscript<ElementState, ElementAction>(
-      fileID fileID: _HashableStaticString,
-      filePath filePath: _HashableStaticString,
-      line line: UInt,
-      column column: UInt
-    ) -> StackState<ElementState>.PathView
-    where State == StackState<ElementState>, Action == StackAction<ElementState, ElementAction> {
-      get { self.currentState.path }
-      set {
-        let newCount = newValue.count
-        guard newCount != self.currentState.count else {
-          reportIssue(
-            """
-            A navigation stack binding at "\(fileID.rawValue):\(line)" was written to with a \
-            path that has the same number of elements that already exist in the store. A view \
-            should only write to this binding with a path that has pushed a new element onto the \
-            stack, or popped one or more elements from the stack.
-
-            This usually means the "forEach" has not been integrated with the reducer powering the \
-            store, and this reducer is responsible for handling stack actions.
-
-            To fix this, ensure that "forEach" is invoked from the reducer's "body":
-
-                Reduce { state, action in
-                  // ...
-                }
-                .forEach(\\.path, action: \\.path) {
-                  Path()
-                }
-
-            And ensure that every parent reducer is integrated into the root reducer that powers \
-            the store.
-            """,
-            fileID: fileID.rawValue,
-            filePath: filePath.rawValue,
+      root()
+        .modifier(
+          _NavigationDestinationViewModifier(
+            store: path.wrappedValue,
+            destination: destination,
+            fileID: fileID,
+            filePath: filePath,
             line: line,
             column: column
           )
-          return
-        }
-        if newCount > self.currentState.count, let component = newValue.last {
-          self.send(.push(id: component.id, state: component.element))
-        } else {
-          self.send(.popFrom(id: self.currentState.ids[newCount]))
-        }
+        )
+    }
+  }
+}
+
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+public struct _NavigationDestinationViewModifier<
+  State: ObservableState, Action, Destination: View
+>:
+  ViewModifier
+{
+  @SwiftUI.State var store: Store<StackState<State>, StackAction<State, Action>>
+  fileprivate let destination: (Store<State, Action>) -> Destination
+  fileprivate let fileID: StaticString
+  fileprivate let filePath: StaticString
+  fileprivate let line: UInt
+  fileprivate let column: UInt
+
+  public func body(content: Content) -> some View {
+    content
+      .environment(\.navigationDestinationType, State.self)
+      .navigationDestination(for: StackState<State>.Component.self) { component in
+        var element = component.element
+        self
+          .destination(
+            self.store.scope(
+              id: self.store.id(
+                state:
+                  \.[
+                    id:component.id,fileID:_HashableStaticString(
+                      rawValue: fileID),filePath:_HashableStaticString(
+                        rawValue: filePath),line:line,column:column
+                  ],
+                action: \.[id:component.id]
+              ),
+              state: ToState {
+                element = $0[id: component.id] ?? element
+                return element
+              },
+              action: { .element(id: component.id, action: $0) },
+              isInvalid: { !$0.ids.contains(component.id) }
+            )
+          )
+          .environment(\.navigationDestinationType, State.self)
       }
+  }
+}
+
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+extension NavigationLink where Destination == Never {
+  /// Creates a navigation link that presents the view corresponding to an element of
+  /// ``StackState``.
+  ///
+  /// When someone activates the navigation link that this initializer creates, SwiftUI looks for
+  /// a parent `NavigationStack` view with a store of ``StackState`` containing elements that
+  /// matches the type of this initializer's `state` input.
+  ///
+  /// See SwiftUI's documentation for `NavigationLink.init(value:label:)` for more.
+  ///
+  /// - Parameters:
+  ///   - state: An optional value to present. When the user selects the link, SwiftUI stores a
+  ///     copy of the value. Pass a `nil` value to disable the link.
+  ///   - label: A label that describes the view that this link presents.
+  public init<P, L: View>(
+    state: P?,
+    @ViewBuilder label: () -> L,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  )
+  where Label == _NavigationLinkStoreContent<P, L> {
+    @Dependency(\.stackElementID) var stackElementID
+    self.init(value: state.map { StackState.Component(id: stackElementID(), element: $0) }) {
+      _NavigationLinkStoreContent<P, L>(
+        state: state,
+        label: label,
+        fileID: fileID,
+        filePath: filePath,
+        line: line,
+        column: column
+      )
     }
   }
 
+  /// Creates a navigation link that presents the view corresponding to an element of
+  /// ``StackState``, with a text label that the link generates from a localized string key.
+  ///
+  /// When someone activates the navigation link that this initializer creates, SwiftUI looks for
+  /// a parent ``NavigationStackStore`` view with a store of ``StackState`` containing elements
+  /// that matches the type of this initializer's `state` input.
+  ///
+  /// See SwiftUI's documentation for `NavigationLink.init(_:value:)` for more.
+  ///
+  /// - Parameters:
+  ///   - titleKey: A localized string that describes the view that this link
+  ///     presents.
+  ///   - state: An optional value to present. When the user selects the link, SwiftUI stores a
+  ///     copy of the value. Pass a `nil` value to disable the link.
+  public init<P>(
+    _ titleKey: LocalizedStringKey, state: P?, fileID: StaticString = #fileID, line: UInt = #line
+  )
+  where Label == _NavigationLinkStoreContent<P, Text> {
+    self.init(state: state, label: { Text(titleKey) }, fileID: fileID, line: line)
+  }
+
+  /// Creates a navigation link that presents the view corresponding to an element of
+  /// ``StackState``, with a text label that the link generates from a title string.
+  ///
+  /// When someone activates the navigation link that this initializer creates, SwiftUI looks for
+  /// a parent ``NavigationStackStore`` view with a store of ``StackState`` containing elements
+  /// that matches the type of this initializer's `state` input.
+  ///
+  /// See SwiftUI's documentation for `NavigationLink.init(_:value:)` for more.
+  ///
+  /// - Parameters:
+  ///   - title: A string that describes the view that this link presents.
+  ///   - state: An optional value to present. When the user selects the link, SwiftUI stores a
+  ///     copy of the value. Pass a `nil` value to disable the link.
+  @_disfavoredOverload
+  public init<S: StringProtocol, P>(
+    _ title: S, state: P?, fileID: StaticString = #fileID, line: UInt = #line
+  )
+  where Label == _NavigationLinkStoreContent<P, Text> {
+    self.init(state: state, label: { Text(title) }, fileID: fileID, line: line)
+  }
+}
+
+public struct _NavigationLinkStoreContent<State, Label: View>: View {
+  let state: State?
+  @ViewBuilder let label: Label
+  let fileID: StaticString
+  let filePath: StaticString
+  let line: UInt
+  let column: UInt
+  @Environment(\.navigationDestinationType) var navigationDestinationType
+
   @_spi(Internals)
-  public var _isInPerceptionTracking: Bool {
-    #if !os(visionOS)
-      return _PerceptionLocals.isInPerceptionTracking
+  public init(
+    state: State?,
+    @ViewBuilder label: () -> Label,
+    fileID: StaticString,
+    filePath: StaticString,
+    line: UInt,
+    column: UInt
+  ) {
+    self.state = state
+    self.label = label()
+    self.fileID = fileID
+    self.filePath = filePath
+    self.line = line
+    self.column = column
+  }
+
+  public var body: some View {
+    #if DEBUG
+      label.onAppear {
+        if navigationDestinationType != State.self {
+          let elementType =
+            navigationDestinationType.map { typeName($0) }
+              ?? """
+              (None found in view hierarchy. Is this link inside a store-powered \
+              'NavigationStack'?)
+              """
+          reportIssue(
+            """
+            A navigation link at "\(fileID):\(line)" is unpresentable. …
+
+              NavigationStack state element type:
+                \(elementType)
+              NavigationLink state type:
+                \(typeName(State.self))
+              NavigationLink state value:
+              \(String(customDumping: state).indent(by: 2))
+            """,
+            fileID: fileID,
+            filePath: filePath,
+            line: line,
+            column: column
+          )
+        }
+      }
     #else
-      return false
+      label
     #endif
   }
-#endif
+}
+
+extension Store where State: ObservableState {
+  fileprivate subscript<ElementState, ElementAction>(
+    state state: KeyPath<State, StackState<ElementState>>,
+    action action: CaseKeyPath<Action, StackAction<ElementState, ElementAction>>,
+    isInViewBody isInViewBody: Bool = _isInPerceptionTracking
+  ) -> Store<StackState<ElementState>, StackAction<ElementState, ElementAction>> {
+    get {
+      #if DEBUG && !os(visionOS)
+        _PerceptionLocals.$isInPerceptionTracking.withValue(isInViewBody) {
+          self.scope(state: state, action: action)
+        }
+      #else
+        self.scope(state: state, action: action)
+      #endif
+    }
+    set {}
+  }
+}
+
+extension Store {
+  @_spi(Internals)
+  public subscript<ElementState, ElementAction>(
+    fileID fileID: _HashableStaticString,
+    filePath filePath: _HashableStaticString,
+    line line: UInt,
+    column column: UInt
+  ) -> StackState<ElementState>.PathView
+  where State == StackState<ElementState>, Action == StackAction<ElementState, ElementAction> {
+    get { self.currentState.path }
+    set {
+      let newCount = newValue.count
+      guard newCount != self.currentState.count else {
+        reportIssue(
+          """
+          A navigation stack binding at "\(fileID.rawValue):\(line)" was written to with a \
+          path that has the same number of elements that already exist in the store. A view \
+          should only write to this binding with a path that has pushed a new element onto the \
+          stack, or popped one or more elements from the stack.
+
+          This usually means the "forEach" has not been integrated with the reducer powering the \
+          store, and this reducer is responsible for handling stack actions.
+
+          To fix this, ensure that "forEach" is invoked from the reducer's "body":
+
+              Reduce { state, action in
+                // ...
+              }
+              .forEach(\\.path, action: \\.path) {
+                Path()
+              }
+
+          And ensure that every parent reducer is integrated into the root reducer that powers \
+          the store.
+          """,
+          fileID: fileID.rawValue,
+          filePath: filePath.rawValue,
+          line: line,
+          column: column
+        )
+        return
+      }
+      if newCount > self.currentState.count, let component = newValue.last {
+        self.send(.push(id: component.id, state: component.element))
+      } else {
+        self.send(.popFrom(id: self.currentState.ids[newCount]))
+      }
+    }
+  }
+}
+
+@_spi(Internals)
+public var _isInPerceptionTracking: Bool {
+  #if !os(visionOS)
+    return _PerceptionLocals.isInPerceptionTracking
+  #else
+    return false
+  #endif
+}
 
 extension StackState {
   var path: PathView {

--- a/Sources/ComposableArchitecture/Observation/ObservableState.swift
+++ b/Sources/ComposableArchitecture/Observation/ObservableState.swift
@@ -1,197 +1,195 @@
-#if canImport(Perception)
-  import Foundation
+import Foundation
 
-  /// A type that emits notifications to observers when underlying data changes.
-  ///
-  /// Conforming to this protocol signals to other APIs that the value type supports observation.
-  /// However, applying the ``ObservableState`` protocol by itself to a type doesn’t add observation
-  /// functionality to the type. Instead, always use the ``ObservableState()`` macro when adding
-  /// observation support to a type.
-  #if !os(visionOS)
-    public protocol ObservableState: Perceptible {
-      var _$id: ObservableStateID { get }
-      mutating func _$willModify()
-    }
-  #else
-    public protocol ObservableState: Observable {
-      var _$id: ObservableStateID { get }
-      mutating func _$willModify()
-    }
-  #endif
+/// A type that emits notifications to observers when underlying data changes.
+///
+/// Conforming to this protocol signals to other APIs that the value type supports observation.
+/// However, applying the ``ObservableState`` protocol by itself to a type doesn’t add observation
+/// functionality to the type. Instead, always use the ``ObservableState()`` macro when adding
+/// observation support to a type.
+#if !os(visionOS)
+  public protocol ObservableState: Perceptible {
+    var _$id: ObservableStateID { get }
+    mutating func _$willModify()
+  }
+#else
+  public protocol ObservableState: Observable {
+    var _$id: ObservableStateID { get }
+    mutating func _$willModify()
+  }
+#endif
 
-  /// A unique identifier for a observed value.
-  public struct ObservableStateID: Equatable, Hashable, Sendable {
-    @usableFromInline
-    var location: UUID {
-      get { self.storage.id.location }
-      set {
-        if !isKnownUniquelyReferenced(&self.storage) {
-          self.storage = Storage(id: self.storage.id)
-        }
-        self.storage.id.location = newValue
+/// A unique identifier for a observed value.
+public struct ObservableStateID: Equatable, Hashable, Sendable {
+  @usableFromInline
+  var location: UUID {
+    get { self.storage.id.location }
+    set {
+      if !isKnownUniquelyReferenced(&self.storage) {
+        self.storage = Storage(id: self.storage.id)
       }
+      self.storage.id.location = newValue
+    }
+  }
+
+  private var storage: Storage
+
+  private init(storage: Storage) {
+    self.storage = storage
+  }
+
+  public init() {
+    self.init(storage: Storage(id: .location(UUID())))
+  }
+
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.storage === rhs.storage || lhs.storage.id == rhs.storage.id
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(self.storage.id)
+  }
+
+  @inlinable
+  public static func _$id<T>(for value: T) -> Self {
+    (value as? any ObservableState)?._$id ?? Self()
+  }
+
+  @inlinable
+  public static func _$id(for value: some ObservableState) -> Self {
+    value._$id
+  }
+
+  public func _$tag(_ tag: Int) -> Self {
+    Self(storage: Storage(id: .tag(tag, self.storage.id)))
+  }
+
+  @inlinable
+  public mutating func _$willModify() {
+    self.location = UUID()
+  }
+
+  private final class Storage: @unchecked Sendable {
+    fileprivate var id: ID
+
+    init(id: ID = .location(UUID())) {
+      self.id = id
     }
 
-    private var storage: Storage
+    enum ID: Equatable, Hashable, Sendable {
+      case location(UUID)
+      indirect case tag(Int, ID)
 
-    private init(storage: Storage) {
-      self.storage = storage
-    }
-
-    public init() {
-      self.init(storage: Storage(id: .location(UUID())))
-    }
-
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-      lhs.storage === rhs.storage || lhs.storage.id == rhs.storage.id
-    }
-
-    public func hash(into hasher: inout Hasher) {
-      hasher.combine(self.storage.id)
-    }
-
-    @inlinable
-    public static func _$id<T>(for value: T) -> Self {
-      (value as? any ObservableState)?._$id ?? Self()
-    }
-
-    @inlinable
-    public static func _$id(for value: some ObservableState) -> Self {
-      value._$id
-    }
-
-    public func _$tag(_ tag: Int) -> Self {
-      Self(storage: Storage(id: .tag(tag, self.storage.id)))
-    }
-
-    @inlinable
-    public mutating func _$willModify() {
-      self.location = UUID()
-    }
-
-    private final class Storage: @unchecked Sendable {
-      fileprivate var id: ID
-
-      init(id: ID = .location(UUID())) {
-        self.id = id
-      }
-
-      enum ID: Equatable, Hashable, Sendable {
-        case location(UUID)
-        indirect case tag(Int, ID)
-
-        var location: UUID {
-          get {
-            switch self {
-            case let .location(location):
-              return location
-            case let .tag(_, id):
-              return id.location
-            }
+      var location: UUID {
+        get {
+          switch self {
+          case let .location(location):
+            return location
+          case let .tag(_, id):
+            return id.location
           }
-          set {
-            switch self {
-            case .location:
-              self = .location(newValue)
-            case .tag(let tag, var id):
-              id.location = newValue
-              self = .tag(tag, id)
-            }
+        }
+        set {
+          switch self {
+          case .location:
+            self = .location(newValue)
+          case .tag(let tag, var id):
+            id.location = newValue
+            self = .tag(tag, id)
           }
         }
       }
     }
   }
+}
 
-  @inlinable
-  public func _$isIdentityEqual<T: ObservableState>(
-    _ lhs: T, _ rhs: T
-  ) -> Bool {
-    lhs._$id == rhs._$id
-  }
+@inlinable
+public func _$isIdentityEqual<T: ObservableState>(
+  _ lhs: T, _ rhs: T
+) -> Bool {
+  lhs._$id == rhs._$id
+}
 
-  @inlinable
-  public func _$isIdentityEqual<ID: Hashable, T: ObservableState>(
-    _ lhs: IdentifiedArray<ID, T>,
-    _ rhs: IdentifiedArray<ID, T>
-  ) -> Bool {
-    areOrderedSetsDuplicates(lhs.ids, rhs.ids)
-  }
+@inlinable
+public func _$isIdentityEqual<ID: Hashable, T: ObservableState>(
+  _ lhs: IdentifiedArray<ID, T>,
+  _ rhs: IdentifiedArray<ID, T>
+) -> Bool {
+  areOrderedSetsDuplicates(lhs.ids, rhs.ids)
+}
 
-  @inlinable
-  public func _$isIdentityEqual<T: ObservableState>(
-    _ lhs: PresentationState<T>,
-    _ rhs: PresentationState<T>
-  ) -> Bool {
-    lhs.wrappedValue?._$id == rhs.wrappedValue?._$id
-  }
+@inlinable
+public func _$isIdentityEqual<T: ObservableState>(
+  _ lhs: PresentationState<T>,
+  _ rhs: PresentationState<T>
+) -> Bool {
+  lhs.wrappedValue?._$id == rhs.wrappedValue?._$id
+}
 
-  @inlinable
-  public func _$isIdentityEqual<T: ObservableState>(
-    _ lhs: StackState<T>,
-    _ rhs: StackState<T>
-  ) -> Bool {
-    areOrderedSetsDuplicates(lhs.ids, rhs.ids)
-  }
+@inlinable
+public func _$isIdentityEqual<T: ObservableState>(
+  _ lhs: StackState<T>,
+  _ rhs: StackState<T>
+) -> Bool {
+  areOrderedSetsDuplicates(lhs.ids, rhs.ids)
+}
 
-  @inlinable
-  public func _$isIdentityEqual<C: Collection>(
-    _ lhs: C,
-    _ rhs: C
-  ) -> Bool
-  where C.Element: ObservableState {
-    lhs.count == rhs.count && zip(lhs, rhs).allSatisfy { $0._$id == $1._$id }
-  }
+@inlinable
+public func _$isIdentityEqual<C: Collection>(
+  _ lhs: C,
+  _ rhs: C
+) -> Bool
+where C.Element: ObservableState {
+  lhs.count == rhs.count && zip(lhs, rhs).allSatisfy { $0._$id == $1._$id }
+}
 
-  // NB: This is a fast path so that String is not checked as a collection.
-  @inlinable
-  public func _$isIdentityEqual(_ lhs: String, _ rhs: String) -> Bool {
-    false
-  }
+// NB: This is a fast path so that String is not checked as a collection.
+@inlinable
+public func _$isIdentityEqual(_ lhs: String, _ rhs: String) -> Bool {
+  false
+}
 
-  @inlinable
-  public func _$isIdentityEqual<T>(_ lhs: T, _ rhs: T) -> Bool {
-    guard !_isPOD(T.self) else { return false }
+@inlinable
+public func _$isIdentityEqual<T>(_ lhs: T, _ rhs: T) -> Bool {
+  guard !_isPOD(T.self) else { return false }
 
-    func openCollection<C: Collection>(_ lhs: C, _ rhs: Any) -> Bool {
-      guard C.Element.self is any ObservableState.Type else {
-        return false
-      }
-
-      func openIdentifiable<Element: Identifiable>(_: Element.Type) -> Bool? {
-        guard
-          let lhs = lhs as? IdentifiedArrayOf<Element>,
-          let rhs = rhs as? IdentifiedArrayOf<Element>
-        else {
-          return nil
-        }
-        return areOrderedSetsDuplicates(lhs.ids, rhs.ids)
-      }
-
-      if let identifiable = C.Element.self as? any Identifiable.Type,
-        let result = openIdentifiable(identifiable)
-      {
-        return result
-      } else if let rhs = rhs as? C {
-        return lhs.count == rhs.count && zip(lhs, rhs).allSatisfy(_$isIdentityEqual)
-      } else {
-        return false
-      }
+  func openCollection<C: Collection>(_ lhs: C, _ rhs: Any) -> Bool {
+    guard C.Element.self is any ObservableState.Type else {
+      return false
     }
 
-    if let lhs = lhs as? any ObservableState, let rhs = rhs as? any ObservableState {
-      return lhs._$id == rhs._$id
-    } else if let lhs = lhs as? any Collection {
-      return openCollection(lhs, rhs)
+    func openIdentifiable<Element: Identifiable>(_: Element.Type) -> Bool? {
+      guard
+        let lhs = lhs as? IdentifiedArrayOf<Element>,
+        let rhs = rhs as? IdentifiedArrayOf<Element>
+      else {
+        return nil
+      }
+      return areOrderedSetsDuplicates(lhs.ids, rhs.ids)
+    }
+
+    if let identifiable = C.Element.self as? any Identifiable.Type,
+      let result = openIdentifiable(identifiable)
+    {
+      return result
+    } else if let rhs = rhs as? C {
+      return lhs.count == rhs.count && zip(lhs, rhs).allSatisfy(_$isIdentityEqual)
     } else {
       return false
     }
   }
 
-  @inlinable
-  public func _$willModify<T>(_: inout T) {}
-  @inlinable
-  public func _$willModify<T: ObservableState>(_ value: inout T) {
-    value._$willModify()
+  if let lhs = lhs as? any ObservableState, let rhs = rhs as? any ObservableState {
+    return lhs._$id == rhs._$id
+  } else if let lhs = lhs as? any Collection {
+    return openCollection(lhs, rhs)
+  } else {
+    return false
   }
-#endif
+}
+
+@inlinable
+public func _$willModify<T>(_: inout T) {}
+@inlinable
+public func _$willModify<T: ObservableState>(_ value: inout T) {
+  value._$willModify()
+}

--- a/Sources/ComposableArchitecture/Observation/ObservationStateRegistrar.swift
+++ b/Sources/ComposableArchitecture/Observation/ObservationStateRegistrar.swift
@@ -1,183 +1,181 @@
-#if canImport(Perception)
-  /// Provides storage for tracking and access to data changes.
-  public struct ObservationStateRegistrar: Sendable {
-    public private(set) var id = ObservableStateID()
-    #if !os(visionOS)
-      @usableFromInline
-      let registrar = PerceptionRegistrar()
-    #else
-      @usableFromInline
-      let registrar = ObservationRegistrar()
-    #endif
-    public init() {}
-    public mutating func _$willModify() { self.id._$willModify() }
-  }
-
-  extension ObservationStateRegistrar: Equatable, Hashable, Codable {
-    public static func == (_: Self, _: Self) -> Bool { true }
-    public func hash(into hasher: inout Hasher) {}
-    public init(from decoder: any Decoder) throws { self.init() }
-    public func encode(to encoder: any Encoder) throws {}
-  }
-
-  #if canImport(Observation)
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    extension ObservationStateRegistrar {
-      /// Registers access to a specific property for observation.
-      ///
-      /// - Parameters:
-      ///   - subject: An instance of an observable type.
-      ///   - keyPath: The key path of an observed property.
-      @inlinable
-      public func access<Subject: Observable, Member>(
-        _ subject: Subject,
-        keyPath: KeyPath<Subject, Member>
-      ) {
-        self.registrar.access(subject, keyPath: keyPath)
-      }
-
-      /// Mutates a value to a new value, and decided to notify observers based on the identity of
-      /// the value.
-      ///
-      /// - Parameters:
-      ///   - subject: An instance of an observable type.
-      ///   - keyPath: The key path of an observed property.
-      ///   - value: The value being mutated.
-      ///   - newValue: The new value to mutate with.
-      ///   - isIdentityEqual: A comparison function that determines whether two values have the
-      ///     same identity or not.
-      @inlinable
-      public func mutate<Subject: Observable, Member, Value>(
-        _ subject: Subject,
-        keyPath: KeyPath<Subject, Member>,
-        _ value: inout Value,
-        _ newValue: Value,
-        _ isIdentityEqual: (Value, Value) -> Bool
-      ) {
-        if isIdentityEqual(value, newValue) {
-          value = newValue
-        } else {
-          self.registrar.withMutation(of: subject, keyPath: keyPath) {
-            value = newValue
-          }
-        }
-      }
-
-      /// A no-op for non-observable values.
-      ///
-      /// See ``willModify(_:keyPath:_:)-29op6`` info on what this method does when used with
-      /// observable values.
-      @inlinable
-      public func willModify<Subject: Observable, Member>(
-        _ subject: Subject,
-        keyPath: KeyPath<Subject, Member>,
-        _ member: inout Member
-      ) -> Member {
-        member
-      }
-
-      /// A property observation called before setting the value of the subject.
-      ///
-      /// - Parameters:
-      ///   - subject: An instance of an observable type.`
-      ///   - keyPath: The key path of an observed property.
-      ///   - member: The value in the subject that will be set.
-      @inlinable
-      public func willModify<Subject: Observable, Member: ObservableState>(
-        _ subject: Subject,
-        keyPath: KeyPath<Subject, Member>,
-        _ member: inout Member
-      ) -> Member {
-        member._$willModify()
-        return member
-      }
-
-      /// A property observation called after setting the value of the subject.
-      ///
-      /// If the identity of the value changed between ``willModify(_:keyPath:_:)-29op6`` and
-      /// ``didModify(_:keyPath:_:_:_:)-34nhq``, observers are notified.
-      @inlinable
-      public func didModify<Subject: Observable, Member>(
-        _ subject: Subject,
-        keyPath: KeyPath<Subject, Member>,
-        _ member: inout Member,
-        _ oldValue: Member,
-        _ isIdentityEqual: (Member, Member) -> Bool
-      ) {
-        if !isIdentityEqual(oldValue, member) {
-          let newValue = member
-          member = oldValue
-          self.mutate(subject, keyPath: keyPath, &member, newValue, isIdentityEqual)
-        }
-      }
-    }
-  #endif
-
+/// Provides storage for tracking and access to data changes.
+public struct ObservationStateRegistrar: Sendable {
+  public private(set) var id = ObservableStateID()
   #if !os(visionOS)
-    extension ObservationStateRegistrar {
-      @_disfavoredOverload
-      @inlinable
-      public func access<Subject: Perceptible, Member>(
-        _ subject: Subject,
-        keyPath: KeyPath<Subject, Member>
-      ) {
-        self.registrar.access(subject, keyPath: keyPath)
-      }
+    @usableFromInline
+    let registrar = PerceptionRegistrar()
+  #else
+    @usableFromInline
+    let registrar = ObservationRegistrar()
+  #endif
+  public init() {}
+  public mutating func _$willModify() { self.id._$willModify() }
+}
 
-      @_disfavoredOverload
-      @inlinable
-      public func mutate<Subject: Perceptible, Member, Value>(
-        _ subject: Subject,
-        keyPath: KeyPath<Subject, Member>,
-        _ value: inout Value,
-        _ newValue: Value,
-        _ isIdentityEqual: (Value, Value) -> Bool
-      ) {
-        if isIdentityEqual(value, newValue) {
+extension ObservationStateRegistrar: Equatable, Hashable, Codable {
+  public static func == (_: Self, _: Self) -> Bool { true }
+  public func hash(into hasher: inout Hasher) {}
+  public init(from decoder: any Decoder) throws { self.init() }
+  public func encode(to encoder: any Encoder) throws {}
+}
+
+#if canImport(Observation)
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  extension ObservationStateRegistrar {
+    /// Registers access to a specific property for observation.
+    ///
+    /// - Parameters:
+    ///   - subject: An instance of an observable type.
+    ///   - keyPath: The key path of an observed property.
+    @inlinable
+    public func access<Subject: Observable, Member>(
+      _ subject: Subject,
+      keyPath: KeyPath<Subject, Member>
+    ) {
+      self.registrar.access(subject, keyPath: keyPath)
+    }
+
+    /// Mutates a value to a new value, and decided to notify observers based on the identity of
+    /// the value.
+    ///
+    /// - Parameters:
+    ///   - subject: An instance of an observable type.
+    ///   - keyPath: The key path of an observed property.
+    ///   - value: The value being mutated.
+    ///   - newValue: The new value to mutate with.
+    ///   - isIdentityEqual: A comparison function that determines whether two values have the
+    ///     same identity or not.
+    @inlinable
+    public func mutate<Subject: Observable, Member, Value>(
+      _ subject: Subject,
+      keyPath: KeyPath<Subject, Member>,
+      _ value: inout Value,
+      _ newValue: Value,
+      _ isIdentityEqual: (Value, Value) -> Bool
+    ) {
+      if isIdentityEqual(value, newValue) {
+        value = newValue
+      } else {
+        self.registrar.withMutation(of: subject, keyPath: keyPath) {
           value = newValue
-        } else {
-          self.registrar.withMutation(of: subject, keyPath: keyPath) {
-            value = newValue
-          }
-        }
-      }
-
-      @_disfavoredOverload
-      @inlinable
-      public func willModify<Subject: Perceptible, Member>(
-        _ subject: Subject,
-        keyPath: KeyPath<Subject, Member>,
-        _ member: inout Member
-      ) -> Member {
-        return member
-      }
-
-      @_disfavoredOverload
-      @inlinable
-      public func willModify<Subject: Perceptible, Member: ObservableState>(
-        _ subject: Subject,
-        keyPath: KeyPath<Subject, Member>,
-        _ member: inout Member
-      ) -> Member {
-        member._$willModify()
-        return member
-      }
-
-      @_disfavoredOverload
-      @inlinable
-      public func didModify<Subject: Perceptible, Member>(
-        _ subject: Subject,
-        keyPath: KeyPath<Subject, Member>,
-        _ member: inout Member,
-        _ oldValue: Member,
-        _ isIdentityEqual: (Member, Member) -> Bool
-      ) {
-        if !isIdentityEqual(oldValue, member) {
-          let newValue = member
-          member = oldValue
-          self.mutate(subject, keyPath: keyPath, &member, newValue, isIdentityEqual)
         }
       }
     }
-  #endif
+
+    /// A no-op for non-observable values.
+    ///
+    /// See ``willModify(_:keyPath:_:)-29op6`` info on what this method does when used with
+    /// observable values.
+    @inlinable
+    public func willModify<Subject: Observable, Member>(
+      _ subject: Subject,
+      keyPath: KeyPath<Subject, Member>,
+      _ member: inout Member
+    ) -> Member {
+      member
+    }
+
+    /// A property observation called before setting the value of the subject.
+    ///
+    /// - Parameters:
+    ///   - subject: An instance of an observable type.`
+    ///   - keyPath: The key path of an observed property.
+    ///   - member: The value in the subject that will be set.
+    @inlinable
+    public func willModify<Subject: Observable, Member: ObservableState>(
+      _ subject: Subject,
+      keyPath: KeyPath<Subject, Member>,
+      _ member: inout Member
+    ) -> Member {
+      member._$willModify()
+      return member
+    }
+
+    /// A property observation called after setting the value of the subject.
+    ///
+    /// If the identity of the value changed between ``willModify(_:keyPath:_:)-29op6`` and
+    /// ``didModify(_:keyPath:_:_:_:)-34nhq``, observers are notified.
+    @inlinable
+    public func didModify<Subject: Observable, Member>(
+      _ subject: Subject,
+      keyPath: KeyPath<Subject, Member>,
+      _ member: inout Member,
+      _ oldValue: Member,
+      _ isIdentityEqual: (Member, Member) -> Bool
+    ) {
+      if !isIdentityEqual(oldValue, member) {
+        let newValue = member
+        member = oldValue
+        self.mutate(subject, keyPath: keyPath, &member, newValue, isIdentityEqual)
+      }
+    }
+  }
+#endif
+
+#if !os(visionOS)
+  extension ObservationStateRegistrar {
+    @_disfavoredOverload
+    @inlinable
+    public func access<Subject: Perceptible, Member>(
+      _ subject: Subject,
+      keyPath: KeyPath<Subject, Member>
+    ) {
+      self.registrar.access(subject, keyPath: keyPath)
+    }
+
+    @_disfavoredOverload
+    @inlinable
+    public func mutate<Subject: Perceptible, Member, Value>(
+      _ subject: Subject,
+      keyPath: KeyPath<Subject, Member>,
+      _ value: inout Value,
+      _ newValue: Value,
+      _ isIdentityEqual: (Value, Value) -> Bool
+    ) {
+      if isIdentityEqual(value, newValue) {
+        value = newValue
+      } else {
+        self.registrar.withMutation(of: subject, keyPath: keyPath) {
+          value = newValue
+        }
+      }
+    }
+
+    @_disfavoredOverload
+    @inlinable
+    public func willModify<Subject: Perceptible, Member>(
+      _ subject: Subject,
+      keyPath: KeyPath<Subject, Member>,
+      _ member: inout Member
+    ) -> Member {
+      return member
+    }
+
+    @_disfavoredOverload
+    @inlinable
+    public func willModify<Subject: Perceptible, Member: ObservableState>(
+      _ subject: Subject,
+      keyPath: KeyPath<Subject, Member>,
+      _ member: inout Member
+    ) -> Member {
+      member._$willModify()
+      return member
+    }
+
+    @_disfavoredOverload
+    @inlinable
+    public func didModify<Subject: Perceptible, Member>(
+      _ subject: Subject,
+      keyPath: KeyPath<Subject, Member>,
+      _ member: inout Member,
+      _ oldValue: Member,
+      _ isIdentityEqual: (Member, Member) -> Bool
+    ) {
+      if !isIdentityEqual(oldValue, member) {
+        let newValue = member
+        member = oldValue
+        self.mutate(subject, keyPath: keyPath, &member, newValue, isIdentityEqual)
+      }
+    }
+  }
 #endif

--- a/Sources/ComposableArchitecture/Observation/Store+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Store+Observation.swift
@@ -1,388 +1,377 @@
-#if canImport(Perception)
-  import SwiftUI
+import SwiftUI
 
-  #if canImport(Observation)
-    import Observation
-  #endif
+#if canImport(Observation)
+  import Observation
+#endif
 
-  #if !os(visionOS)
-    extension Store: Perceptible {}
-  #endif
+#if !os(visionOS)
+  extension Store: Perceptible {}
+#endif
 
-  extension Store where State: ObservableState {
-    var observableState: State {
-      self._$observationRegistrar.access(self, keyPath: \.currentState)
-      return self.currentState
-    }
-
-    /// Direct access to state in the store when `State` conforms to ``ObservableState``.
-    public var state: State {
-      self.observableState
-    }
-
-    public subscript<Value>(dynamicMember keyPath: KeyPath<State, Value>) -> Value {
-      self.state[keyPath: keyPath]
-    }
+extension Store where State: ObservableState {
+  var observableState: State {
+    self._$observationRegistrar.access(self, keyPath: \.currentState)
+    return self.currentState
   }
 
-  extension Store: Equatable {
-    public static nonisolated func == (lhs: Store, rhs: Store) -> Bool {
-      lhs === rhs
-    }
+  /// Direct access to state in the store when `State` conforms to ``ObservableState``.
+  public var state: State {
+    self.observableState
   }
 
-  extension Store: Hashable {
-    public nonisolated func hash(into hasher: inout Hasher) {
-      hasher.combine(ObjectIdentifier(self))
-    }
+  public subscript<Value>(dynamicMember keyPath: KeyPath<State, Value>) -> Value {
+    self.state[keyPath: keyPath]
   }
+}
 
-  extension Store: Identifiable {}
+extension Store: Equatable {
+  public static nonisolated func == (lhs: Store, rhs: Store) -> Bool {
+    lhs === rhs
+  }
+}
 
-  extension Store where State: ObservableState {
-    /// Scopes the store to optional child state and actions.
-    ///
-    /// If your feature holds onto a child feature as an optional:
-    ///
-    /// ```swift
-    /// @Reducer
-    /// struct Feature {
-    ///   @ObservableState
-    ///   struct State {
-    ///     var child: Child.State?
-    ///     // ...
-    ///   }
-    ///   enum Action {
-    ///     case child(Child.Action)
-    ///     // ...
-    ///   }
-    ///   // ...
-    /// }
-    /// ```
-    ///
-    /// …then you can use this `scope` operator in order to transform a store of your feature into
-    /// a non-optional store of the child domain:
-    ///
-    /// ```swift
-    /// if let childStore = store.scope(state: \.child, action: \.child) {
-    ///   ChildView(store: childStore)
-    /// }
-    /// ```
-    ///
-    /// > Important: This operation should only be used from within a SwiftUI view or within
-    /// > `withPerceptionTracking` in order for changes of the optional state to be properly
-    /// > observed.
-    ///
-    /// - Parameters:
-    ///   - state: A key path to optional child state.
-    ///   - action: A case key path to child actions.
-    /// - Returns: An optional store of non-optional child state and actions.
-    public func scope<ChildState, ChildAction>(
-      state: KeyPath<State, ChildState?>,
-      action: CaseKeyPath<Action, ChildAction>,
-      fileID: StaticString = #fileID,
-      filePath: StaticString = #filePath,
-      line: UInt = #line,
-      column: UInt = #column
-    ) -> Store<ChildState, ChildAction>? {
-      if !self.canCacheChildren {
-        reportIssue(
-          uncachedStoreWarning(self),
-          fileID: fileID,
-          filePath: filePath,
-          line: line,
-          column: column
-        )
-      }
-      guard var childState = self.state[keyPath: state]
-      else { return nil }
-      return self.scope(
-        id: self.id(state: state.appending(path: \.!), action: action),
-        state: ToState {
-          childState = $0[keyPath: state] ?? childState
-          return childState
-        },
-        action: { action($0) },
-        isInvalid: { $0[keyPath: state] == nil }
+extension Store: Hashable {
+  public nonisolated func hash(into hasher: inout Hasher) {
+    hasher.combine(ObjectIdentifier(self))
+  }
+}
+
+extension Store: Identifiable {}
+
+extension Store where State: ObservableState {
+  /// Scopes the store to optional child state and actions.
+  ///
+  /// If your feature holds onto a child feature as an optional:
+  ///
+  /// ```swift
+  /// @Reducer
+  /// struct Feature {
+  ///   @ObservableState
+  ///   struct State {
+  ///     var child: Child.State?
+  ///     // ...
+  ///   }
+  ///   enum Action {
+  ///     case child(Child.Action)
+  ///     // ...
+  ///   }
+  ///   // ...
+  /// }
+  /// ```
+  ///
+  /// …then you can use this `scope` operator in order to transform a store of your feature into
+  /// a non-optional store of the child domain:
+  ///
+  /// ```swift
+  /// if let childStore = store.scope(state: \.child, action: \.child) {
+  ///   ChildView(store: childStore)
+  /// }
+  /// ```
+  ///
+  /// > Important: This operation should only be used from within a SwiftUI view or within
+  /// > `withPerceptionTracking` in order for changes of the optional state to be properly
+  /// > observed.
+  ///
+  /// - Parameters:
+  ///   - state: A key path to optional child state.
+  ///   - action: A case key path to child actions.
+  /// - Returns: An optional store of non-optional child state and actions.
+  public func scope<ChildState, ChildAction>(
+    state: KeyPath<State, ChildState?>,
+    action: CaseKeyPath<Action, ChildAction>,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) -> Store<ChildState, ChildAction>? {
+    if !self.canCacheChildren {
+      reportIssue(
+        uncachedStoreWarning(self),
+        fileID: fileID,
+        filePath: filePath,
+        line: line,
+        column: column
       )
     }
+    guard var childState = self.state[keyPath: state]
+    else { return nil }
+    return self.scope(
+      id: self.id(state: state.appending(path: \.!), action: action),
+      state: ToState {
+        childState = $0[keyPath: state] ?? childState
+        return childState
+      },
+      action: { action($0) },
+      isInvalid: { $0[keyPath: state] == nil }
+    )
   }
+}
 
-  extension Binding {
-    /// Scopes the binding of a store to a binding of an optional presentation store.
-    ///
-    /// Use this operator to derive a binding that can be handed to SwiftUI's various navigation
-    /// view modifiers, such as `sheet(item:)`, `popover(item:)`, etc.
-    ///
-    ///
-    /// For example, suppose your feature can present a child feature in a sheet. Then your feature's
-    /// domain would hold onto the child's domain using the library's presentation tools (see
-    /// <doc:TreeBasedNavigation> for more information on these tools):
-    ///
-    /// ```swift
-    /// @Reducer
-    /// struct Feature {
-    ///   @ObservableState
-    ///   struct State {
-    ///     @Presents var child: Child.State?
-    ///     // ...
-    ///   }
-    ///   enum Action {
-    ///     case child(PresentationActionOf<Child>)
-    ///     // ...
-    ///   }
-    ///   // ...
-    /// }
-    /// ```
-    ///
-    /// Then you can derive a binding to the child domain that can be handed to the `sheet(item:)`
-    /// view modifier:
-    ///
-    /// ```swift
-    /// struct FeatureView: View {
-    ///   @Bindable var store: StoreOf<Feature>
-    ///
-    ///   var body: some View {
-    ///     // ...
-    ///     .sheet(item: $store.scope(state: \.child, action: \.child)) { store in
-    ///       ChildView(store: store)
-    ///     }
-    ///   }
-    /// }
-    /// ```
-    ///
-    /// - Parameters:
-    ///   - state: A key path to optional child state.
-    ///   - action: A case key path to presentation child actions.
-    /// - Returns: A binding of an optional child store.
-    #if swift(>=5.10)
-      @preconcurrency@MainActor
-    #else
-      @MainActor(unsafe)
-    #endif
-    public func scope<State: ObservableState, Action, ChildState, ChildAction>(
-      state: KeyPath<State, ChildState?>,
-      action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
-      fileID: StaticString = #fileID,
-      filePath: StaticString = #fileID,
-      line: UInt = #line,
-      column: UInt = #column
-    ) -> Binding<Store<ChildState, ChildAction>?>
-    where Value == Store<State, Action> {
-      self[
-        id: wrappedValue.currentState[keyPath: state].flatMap(_identifiableID),
-        state: state,
-        action: action,
-        isInViewBody: _isInPerceptionTracking,
-        fileID: _HashableStaticString(rawValue: fileID),
-        filePath: _HashableStaticString(rawValue: filePath),
-        line: line,
-        column: column
-      ]
-    }
+extension Binding {
+  /// Scopes the binding of a store to a binding of an optional presentation store.
+  ///
+  /// Use this operator to derive a binding that can be handed to SwiftUI's various navigation
+  /// view modifiers, such as `sheet(item:)`, `popover(item:)`, etc.
+  ///
+  ///
+  /// For example, suppose your feature can present a child feature in a sheet. Then your feature's
+  /// domain would hold onto the child's domain using the library's presentation tools (see
+  /// <doc:TreeBasedNavigation> for more information on these tools):
+  ///
+  /// ```swift
+  /// @Reducer
+  /// struct Feature {
+  ///   @ObservableState
+  ///   struct State {
+  ///     @Presents var child: Child.State?
+  ///     // ...
+  ///   }
+  ///   enum Action {
+  ///     case child(PresentationActionOf<Child>)
+  ///     // ...
+  ///   }
+  ///   // ...
+  /// }
+  /// ```
+  ///
+  /// Then you can derive a binding to the child domain that can be handed to the `sheet(item:)`
+  /// view modifier:
+  ///
+  /// ```swift
+  /// struct FeatureView: View {
+  ///   @Bindable var store: StoreOf<Feature>
+  ///
+  ///   var body: some View {
+  ///     // ...
+  ///     .sheet(item: $store.scope(state: \.child, action: \.child)) { store in
+  ///       ChildView(store: store)
+  ///     }
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - state: A key path to optional child state.
+  ///   - action: A case key path to presentation child actions.
+  /// - Returns: A binding of an optional child store.
+  #if swift(>=5.10)
+    @preconcurrency@MainActor
+  #else
+    @MainActor(unsafe)
+  #endif
+  public func scope<State: ObservableState, Action, ChildState, ChildAction>(
+    state: KeyPath<State, ChildState?>,
+    action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #fileID,
+    line: UInt = #line,
+    column: UInt = #column
+  ) -> Binding<Store<ChildState, ChildAction>?>
+  where Value == Store<State, Action> {
+    self[
+      id: wrappedValue.currentState[keyPath: state].flatMap(_identifiableID),
+      state: state,
+      action: action,
+      isInViewBody: _isInPerceptionTracking,
+      fileID: _HashableStaticString(rawValue: fileID),
+      filePath: _HashableStaticString(rawValue: filePath),
+      line: line,
+      column: column
+    ]
   }
+}
 
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  extension SwiftUI.Bindable {
-    /// Scopes the binding of a store to a binding of an optional presentation store.
-    ///
-    /// Use this operator to derive a binding that can be handed to SwiftUI's various navigation
-    /// view modifiers, such as `sheet(item:)`, `popover(item:)`, etc.
-    ///
-    ///
-    /// For example, suppose your feature can present a child feature in a sheet. Then your
-    /// feature's domain would hold onto the child's domain using the library's presentation tools
-    /// (see <doc:TreeBasedNavigation> for more information on these tools):
-    ///
-    /// ```swift
-    /// @Reducer
-    /// struct Feature {
-    ///   @ObservableState
-    ///   struct State {
-    ///     @Presents var child: Child.State?
-    ///     // ...
-    ///   }
-    ///   enum Action {
-    ///     case child(PresentationActionOf<Child>)
-    ///     // ...
-    ///   }
-    ///   // ...
-    /// }
-    /// ```
-    ///
-    /// Then you can derive a binding to the child domain that can be handed to the `sheet(item:)`
-    /// view modifier:
-    ///
-    /// ```swift
-    /// struct FeatureView: View {
-    ///   @Bindable var store: StoreOf<Feature>
-    ///
-    ///   var body: some View {
-    ///     // ...
-    ///     .sheet(item: $store.scope(state: \.child, action: \.child)) { store in
-    ///       ChildView(store: store)
-    ///     }
-    ///   }
-    /// }
-    /// ```
-    ///
-    /// - Parameters:
-    ///   - state: A key path to optional child state.
-    ///   - action: A case key path to presentation child actions.
-    /// - Returns: A binding of an optional child store.
-    #if swift(>=5.10)
-      @preconcurrency@MainActor
-    #else
-      @MainActor(unsafe)
-    #endif
-    public func scope<State: ObservableState, Action, ChildState, ChildAction>(
-      state: KeyPath<State, ChildState?>,
-      action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
-      fileID: StaticString = #fileID,
-      filePath: StaticString = #fileID,
-      line: UInt = #line,
-      column: UInt = #column
-    ) -> Binding<Store<ChildState, ChildAction>?>
-    where Value == Store<State, Action> {
-      self[
-        id: wrappedValue.currentState[keyPath: state].flatMap(_identifiableID),
-        state: state,
-        action: action,
-        isInViewBody: _isInPerceptionTracking,
-        fileID: _HashableStaticString(rawValue: fileID),
-        filePath: _HashableStaticString(rawValue: filePath),
-        line: line,
-        column: column
-      ]
-    }
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+extension SwiftUI.Bindable {
+  /// Scopes the binding of a store to a binding of an optional presentation store.
+  ///
+  /// Use this operator to derive a binding that can be handed to SwiftUI's various navigation
+  /// view modifiers, such as `sheet(item:)`, `popover(item:)`, etc.
+  ///
+  ///
+  /// For example, suppose your feature can present a child feature in a sheet. Then your
+  /// feature's domain would hold onto the child's domain using the library's presentation tools
+  /// (see <doc:TreeBasedNavigation> for more information on these tools):
+  ///
+  /// ```swift
+  /// @Reducer
+  /// struct Feature {
+  ///   @ObservableState
+  ///   struct State {
+  ///     @Presents var child: Child.State?
+  ///     // ...
+  ///   }
+  ///   enum Action {
+  ///     case child(PresentationActionOf<Child>)
+  ///     // ...
+  ///   }
+  ///   // ...
+  /// }
+  /// ```
+  ///
+  /// Then you can derive a binding to the child domain that can be handed to the `sheet(item:)`
+  /// view modifier:
+  ///
+  /// ```swift
+  /// struct FeatureView: View {
+  ///   @Bindable var store: StoreOf<Feature>
+  ///
+  ///   var body: some View {
+  ///     // ...
+  ///     .sheet(item: $store.scope(state: \.child, action: \.child)) { store in
+  ///       ChildView(store: store)
+  ///     }
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - state: A key path to optional child state.
+  ///   - action: A case key path to presentation child actions.
+  /// - Returns: A binding of an optional child store.
+  #if swift(>=5.10)
+    @preconcurrency@MainActor
+  #else
+    @MainActor(unsafe)
+  #endif
+  public func scope<State: ObservableState, Action, ChildState, ChildAction>(
+    state: KeyPath<State, ChildState?>,
+    action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #fileID,
+    line: UInt = #line,
+    column: UInt = #column
+  ) -> Binding<Store<ChildState, ChildAction>?>
+  where Value == Store<State, Action> {
+    self[
+      id: wrappedValue.currentState[keyPath: state].flatMap(_identifiableID),
+      state: state,
+      action: action,
+      isInViewBody: _isInPerceptionTracking,
+      fileID: _HashableStaticString(rawValue: fileID),
+      filePath: _HashableStaticString(rawValue: filePath),
+      line: line,
+      column: column
+    ]
   }
+}
 
-  @available(iOS, introduced: 13, obsoleted: 17)
-  @available(macOS, introduced: 10.15, obsoleted: 14)
-  @available(tvOS, introduced: 13, obsoleted: 17)
-  @available(watchOS, introduced: 6, obsoleted: 10)
-  extension Perception.Bindable {
-    /// Scopes the binding of a store to a binding of an optional presentation store.
-    ///
-    /// Use this operator to derive a binding that can be handed to SwiftUI's various navigation
-    /// view modifiers, such as `sheet(item:)`, `popover(item:)`, etc.
-    ///
-    ///
-    /// For example, suppose your feature can present a child feature in a sheet. Then your
-    /// feature's domain would hold onto the child's domain using the library's presentation tools
-    /// (see <doc:TreeBasedNavigation> for more information on these tools):
-    ///
-    /// ```swift
-    /// @Reducer
-    /// struct Feature {
-    ///   @ObservableState
-    ///   struct State {
-    ///     @Presents var child: Child.State?
-    ///     // ...
-    ///   }
-    ///   enum Action {
-    ///     case child(PresentationActionOf<Child>)
-    ///     // ...
-    ///   }
-    ///   // ...
-    /// }
-    /// ```
-    ///
-    /// Then you can derive a binding to the child domain that can be handed to the `sheet(item:)`
-    /// view modifier:
-    ///
-    /// ```swift
-    /// struct FeatureView: View {
-    ///   @Bindable var store: StoreOf<Feature>
-    ///
-    ///   var body: some View {
-    ///     // ...
-    ///     .sheet(item: $store.scope(state: \.child, action: \.child)) { store in
-    ///       ChildView(store: store)
-    ///     }
-    ///   }
-    /// }
-    /// ```
-    ///
-    /// - Parameters:
-    ///   - state: A key path to optional child state.
-    ///   - action: A case key path to presentation child actions.
-    /// - Returns: A binding of an optional child store.
-    public func scope<State: ObservableState, Action, ChildState, ChildAction>(
-      state: KeyPath<State, ChildState?>,
-      action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
-      fileID: StaticString = #fileID,
-      filePath: StaticString = #filePath,
-      line: UInt = #line,
-      column: UInt = #column
-    ) -> Binding<Store<ChildState, ChildAction>?>
-    where Value == Store<State, Action> {
-      self[
-        id: wrappedValue.currentState[keyPath: state].flatMap(_identifiableID),
-        state: state,
-        action: action,
-        isInViewBody: _isInPerceptionTracking,
-        fileID: _HashableStaticString(rawValue: fileID),
-        filePath: _HashableStaticString(rawValue: filePath),
-        line: line,
-        column: column
-      ]
-    }
+@available(iOS, introduced: 13, obsoleted: 17)
+@available(macOS, introduced: 10.15, obsoleted: 14)
+@available(tvOS, introduced: 13, obsoleted: 17)
+@available(watchOS, introduced: 6, obsoleted: 10)
+extension Perception.Bindable {
+  /// Scopes the binding of a store to a binding of an optional presentation store.
+  ///
+  /// Use this operator to derive a binding that can be handed to SwiftUI's various navigation
+  /// view modifiers, such as `sheet(item:)`, `popover(item:)`, etc.
+  ///
+  ///
+  /// For example, suppose your feature can present a child feature in a sheet. Then your
+  /// feature's domain would hold onto the child's domain using the library's presentation tools
+  /// (see <doc:TreeBasedNavigation> for more information on these tools):
+  ///
+  /// ```swift
+  /// @Reducer
+  /// struct Feature {
+  ///   @ObservableState
+  ///   struct State {
+  ///     @Presents var child: Child.State?
+  ///     // ...
+  ///   }
+  ///   enum Action {
+  ///     case child(PresentationActionOf<Child>)
+  ///     // ...
+  ///   }
+  ///   // ...
+  /// }
+  /// ```
+  ///
+  /// Then you can derive a binding to the child domain that can be handed to the `sheet(item:)`
+  /// view modifier:
+  ///
+  /// ```swift
+  /// struct FeatureView: View {
+  ///   @Bindable var store: StoreOf<Feature>
+  ///
+  ///   var body: some View {
+  ///     // ...
+  ///     .sheet(item: $store.scope(state: \.child, action: \.child)) { store in
+  ///       ChildView(store: store)
+  ///     }
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - state: A key path to optional child state.
+  ///   - action: A case key path to presentation child actions.
+  /// - Returns: A binding of an optional child store.
+  public func scope<State: ObservableState, Action, ChildState, ChildAction>(
+    state: KeyPath<State, ChildState?>,
+    action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) -> Binding<Store<ChildState, ChildAction>?>
+  where Value == Store<State, Action> {
+    self[
+      id: wrappedValue.currentState[keyPath: state].flatMap(_identifiableID),
+      state: state,
+      action: action,
+      isInViewBody: _isInPerceptionTracking,
+      fileID: _HashableStaticString(rawValue: fileID),
+      filePath: _HashableStaticString(rawValue: filePath),
+      line: line,
+      column: column
+    ]
   }
+}
 
-  extension UIBindable {
-    #if swift(>=5.10)
-      @preconcurrency@MainActor
-    #else
-      @MainActor(unsafe)
-    #endif
-    public func scope<State: ObservableState, Action, ChildState, ChildAction>(
-      state: KeyPath<State, ChildState?>,
-      action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
-      fileID: StaticString = #fileID,
-      filePath: StaticString = #filePath,
-      line: UInt = #line,
-      column: UInt = #column
-    ) -> UIBinding<Store<ChildState, ChildAction>?>
-    where Value == Store<State, Action> {
-      self[
-        id: wrappedValue.currentState[keyPath: state].flatMap(_identifiableID),
-        state: state,
-        action: action,
-        isInViewBody: _isInPerceptionTracking,
-        fileID: _HashableStaticString(rawValue: fileID),
-        filePath: _HashableStaticString(rawValue: filePath),
-        line: line,
-        column: column
-      ]
-    }
+extension UIBindable {
+  #if swift(>=5.10)
+    @preconcurrency@MainActor
+  #else
+    @MainActor(unsafe)
+  #endif
+  public func scope<State: ObservableState, Action, ChildState, ChildAction>(
+    state: KeyPath<State, ChildState?>,
+    action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) -> UIBinding<Store<ChildState, ChildAction>?>
+  where Value == Store<State, Action> {
+    self[
+      id: wrappedValue.currentState[keyPath: state].flatMap(_identifiableID),
+      state: state,
+      action: action,
+      isInViewBody: _isInPerceptionTracking,
+      fileID: _HashableStaticString(rawValue: fileID),
+      filePath: _HashableStaticString(rawValue: filePath),
+      line: line,
+      column: column
+    ]
   }
+}
 
-  extension Store where State: ObservableState {
-    @_spi(Internals)
-    public subscript<ChildState, ChildAction>(
-      id id: AnyHashable?,
-      state state: KeyPath<State, ChildState?>,
-      action action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
-      isInViewBody isInViewBody: Bool,
-      fileID fileID: _HashableStaticString,
-      filePath filePath: _HashableStaticString,
-      line line: UInt,
-      column column: UInt
-    ) -> Store<ChildState, ChildAction>? {
-      get {
-        #if DEBUG && !os(visionOS)
-          _PerceptionLocals.$isInPerceptionTracking.withValue(isInViewBody) {
-            self.scope(
-              state: state,
-              action: action.appending(path: \.presented),
-              fileID: fileID.rawValue,
-              filePath: filePath.rawValue,
-              line: line,
-              column: column
-            )
-          }
-        #else
+extension Store where State: ObservableState {
+  @_spi(Internals)
+  public subscript<ChildState, ChildAction>(
+    id id: AnyHashable?,
+    state state: KeyPath<State, ChildState?>,
+    action action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
+    isInViewBody isInViewBody: Bool,
+    fileID fileID: _HashableStaticString,
+    filePath filePath: _HashableStaticString,
+    line line: UInt,
+    column column: UInt
+  ) -> Store<ChildState, ChildAction>? {
+    get {
+      #if DEBUG && !os(visionOS)
+        _PerceptionLocals.$isInPerceptionTracking.withValue(isInViewBody) {
           self.scope(
             state: state,
             action: action.appending(path: \.presented),
@@ -391,65 +380,73 @@
             line: line,
             column: column
           )
-        #endif
-      }
-      set {
-        if newValue == nil,
-          let childState = self.state[keyPath: state],
-          id == _identifiableID(childState),
-          !self._isInvalidated()
-        {
-          self.send(action(.dismiss))
-          if self.state[keyPath: state] != nil {
-            reportIssue(
-              """
-              A binding at "\(fileID):\(line)" was set to "nil", but the store destination wasn't \
-              nil'd out.
+        }
+      #else
+        self.scope(
+          state: state,
+          action: action.appending(path: \.presented),
+          fileID: fileID.rawValue,
+          filePath: filePath.rawValue,
+          line: line,
+          column: column
+        )
+      #endif
+    }
+    set {
+      if newValue == nil,
+        let childState = self.state[keyPath: state],
+        id == _identifiableID(childState),
+        !self._isInvalidated()
+      {
+        self.send(action(.dismiss))
+        if self.state[keyPath: state] != nil {
+          reportIssue(
+            """
+            A binding at "\(fileID):\(line)" was set to "nil", but the store destination wasn't \
+            nil'd out.
 
-              This usually means an "ifLet" has not been integrated with the reducer powering the \
-              store, and this reducer is responsible for handling presentation actions.
+            This usually means an "ifLet" has not been integrated with the reducer powering the \
+            store, and this reducer is responsible for handling presentation actions.
 
-              To fix this, ensure that "ifLet" is invoked from the reducer's "body":
+            To fix this, ensure that "ifLet" is invoked from the reducer's "body":
 
-                  Reduce { state, action in
-                    // ...
-                  }
-                  .ifLet(\\.destination, action: \\.destination) {
-                    Destination()
-                  }
+                Reduce { state, action in
+                  // ...
+                }
+                .ifLet(\\.destination, action: \\.destination) {
+                  Destination()
+                }
 
-              And ensure that every parent reducer is integrated into the root reducer that powers \
-              the store.
-              """,
-              fileID: fileID.rawValue,
-              filePath: filePath.rawValue,
-              line: line,
-              column: column
-            )
-            return
-          }
+            And ensure that every parent reducer is integrated into the root reducer that powers \
+            the store.
+            """,
+            fileID: fileID.rawValue,
+            filePath: filePath.rawValue,
+            line: line,
+            column: column
+          )
+          return
         }
       }
     }
   }
+}
 
-  func uncachedStoreWarning<State, Action>(_ store: Store<State, Action>) -> String {
-    """
-    Scoping from uncached \(store) is not compatible with observation.
+func uncachedStoreWarning<State, Action>(_ store: Store<State, Action>) -> String {
+  """
+  Scoping from uncached \(store) is not compatible with observation.
 
-    This can happen for one of two reasons:
+  This can happen for one of two reasons:
 
-    • A parent view scopes on a store using transform functions, which has been \
-    deprecated, instead of with key paths and case paths. Read the migration guide for 1.5 \
-    to update these scopes: https://pointfreeco.github.io/swift-composable-architecture/\
-    main/documentation/composablearchitecture/migratingto1.5
+  • A parent view scopes on a store using transform functions, which has been \
+  deprecated, instead of with key paths and case paths. Read the migration guide for 1.5 \
+  to update these scopes: https://pointfreeco.github.io/swift-composable-architecture/\
+  main/documentation/composablearchitecture/migratingto1.5
 
-    • A parent feature is using deprecated navigation APIs, such as 'IfLetStore', \
-    'SwitchStore', 'ForEachStore', or any navigation view modifiers taking stores instead of \
-    bindings. Read the migration guide for 1.7 to update those APIs: \
-    https://pointfreeco.github.io/swift-composable-architecture/main/documentation/\
-    composablearchitecture/migratingto1.7
-    """
-  }
-
-#endif
+  • A parent feature is using deprecated navigation APIs, such as 'IfLetStore', \
+  'SwitchStore', 'ForEachStore', or any navigation view modifiers taking stores instead of \
+  bindings. Read the migration guide for 1.7 to update those APIs: \
+  https://pointfreeco.github.io/swift-composable-architecture/main/documentation/\
+  composablearchitecture/migratingto1.7
+  """
+}

--- a/Sources/ComposableArchitecture/RootStore.swift
+++ b/Sources/ComposableArchitecture/RootStore.swift
@@ -147,12 +147,8 @@ public final class RootStore {
         }
       }
     }
-    #if canImport(Perception)
-      return _withoutPerceptionChecking {
-        open(reducer: self.reducer)
-      }
-    #else
-      return open(reducer: self.reducer)
-    #endif
+    return _withoutPerceptionChecking {
+      open(reducer: self.reducer)
+    }
   }
 }

--- a/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
+++ b/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
@@ -4,9 +4,6 @@ import Foundation
 #if canImport(Combine)
   import Combine
 #endif
-#if canImport(Perception)
-  import Perception
-#endif
 
 extension Shared {
   /// Creates a shared reference to a value using a persistence key.
@@ -342,25 +339,19 @@ final class ValueReference<Value, Persistence: PersistenceReaderKey<Value>>: Ref
       self.subject.send(newValue)
     }
   }
-  #if canImport(Perception)
-    private let _$perceptionRegistrar = PerceptionRegistrar(
-      isPerceptionCheckingEnabled: _isStorePerceptionCheckingEnabled
-    )
-  #endif
+  private let _$perceptionRegistrar = PerceptionRegistrar(
+    isPerceptionCheckingEnabled: _isStorePerceptionCheckingEnabled
+  )
   private let fileID: StaticString
   private let line: UInt
   var value: Value {
     get {
-      #if canImport(Perception)
-        self._$perceptionRegistrar.access(self, keyPath: \.value)
-      #endif
+      self._$perceptionRegistrar.access(self, keyPath: \.value)
       return self.lock.withLock { self._value }
     }
     set {
-      #if canImport(Perception)
-        self._$perceptionRegistrar.willSet(self, keyPath: \.value)
-        defer { self._$perceptionRegistrar.didSet(self, keyPath: \.value) }
-      #endif
+      self._$perceptionRegistrar.willSet(self, keyPath: \.value)
+      defer { self._$perceptionRegistrar.didSet(self, keyPath: \.value) }
       self.lock.withLock {
         self._value = newValue
         func open<A>(_ key: some PersistenceKey<A>) {
@@ -396,10 +387,8 @@ final class ValueReference<Value, Persistence: PersistenceReaderKey<Value>>: Ref
       ) { [weak self] value in
         guard let self else { return }
         mainActorASAP {
-          #if canImport(Perception)
-            self._$perceptionRegistrar.willSet(self, keyPath: \.value)
-            defer { self._$perceptionRegistrar.didSet(self, keyPath: \.value) }
-          #endif
+          self._$perceptionRegistrar.willSet(self, keyPath: \.value)
+          defer { self._$perceptionRegistrar.didSet(self, keyPath: \.value) }
           self.lock.withLock {
             self._value = value ?? initialValue
           }
@@ -408,15 +397,11 @@ final class ValueReference<Value, Persistence: PersistenceReaderKey<Value>>: Ref
     }
   }
   func access() {
-    #if canImport(Perception)
-      _$perceptionRegistrar.access(self, keyPath: \.value)
-    #endif
+    _$perceptionRegistrar.access(self, keyPath: \.value)
   }
   func withMutation<T>(_ mutation: () throws -> T) rethrows -> T {
-    #if canImport(Perception)
-      self._$perceptionRegistrar.willSet(self, keyPath: \.value)
-      defer { self._$perceptionRegistrar.didSet(self, keyPath: \.value) }
-    #endif
+    self._$perceptionRegistrar.willSet(self, keyPath: \.value)
+    defer { self._$perceptionRegistrar.didSet(self, keyPath: \.value) }
     return try mutation()
   }
   var description: String {
@@ -427,9 +412,8 @@ final class ValueReference<Value, Persistence: PersistenceReaderKey<Value>>: Ref
 #if canImport(Observation)
   extension ValueReference: Observable {}
 #endif
-#if canImport(Perception)
-  extension ValueReference: Perceptible {}
-#endif
+
+extension ValueReference: Perceptible {}
 
 private enum PersistentReferencesKey: DependencyKey {
   static var liveValue: LockIsolated<[AnyHashable: any Reference]> {

--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -173,16 +173,14 @@ public struct BindingAction<Root>: CasePathable, Equatable, Sendable {
 
   @dynamicMemberLookup
   public struct AllCasePaths {
-    #if canImport(Perception)
-      public subscript<Value: Equatable & Sendable>(
-        dynamicMember keyPath: _WritableKeyPath<Root, Value>
-      ) -> AnyCasePath<BindingAction, Value> where Root: ObservableState {
-        AnyCasePath(
-          embed: { .set(keyPath, $0) },
-          extract: { $0.keyPath == keyPath ? $0.value as? Value : nil }
-        )
-      }
-    #endif
+    public subscript<Value: Equatable & Sendable>(
+      dynamicMember keyPath: _WritableKeyPath<Root, Value>
+    ) -> AnyCasePath<BindingAction, Value> where Root: ObservableState {
+      AnyCasePath(
+        embed: { .set(keyPath, $0) },
+        extract: { $0.keyPath == keyPath ? $0.value as? Value : nil }
+      )
+    }
 
     public subscript<Value: Equatable & Sendable>(
       dynamicMember keyPath: _WritableKeyPath<Root, BindingState<Value>>


### PR DESCRIPTION
We originally conditionally branched on Perception availability for Swift <5.9, but we removed support for Swift 5.9 awhile back and these branches should never compile.