### PR TITLE
Add import modules on NavigationStack tutorial source code.

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-01-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-01-code-0005.swift
@@ -1,3 +1,4 @@
+import ComposableArchitecture
 import SwiftUI
 
 struct ContactDetailView: View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-01-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-01-code-0006.swift
@@ -1,3 +1,4 @@
+import ComposableArchitecture
 import SwiftUI
 
 struct ContactDetailView: View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-01-code-0007.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-01-code-0007.swift
@@ -1,3 +1,4 @@
+import ComposableArchitecture
 import SwiftUI
 
 struct ContactDetailView: View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0000-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0000-previous.swift
@@ -1,3 +1,5 @@
+import ComposableArchitecture
+
 @Reducer
 struct ContactsFeature {
   @ObservableState

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0000.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0000.swift
@@ -1,3 +1,5 @@
+import ComposableArchitecture
+
 @Reducer
 struct ContactsFeature {
   @ObservableState

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0001.swift
@@ -1,3 +1,5 @@
+import ComposableArchitecture
+
 @Reducer
 struct ContactsFeature {
   @ObservableState

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0002.swift
@@ -1,3 +1,5 @@
+import ComposableArchitecture
+
 @Reducer
 struct ContactsFeature {
   @ObservableState

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003-previous.swift
@@ -1,3 +1,6 @@
+import ComposableArchitecture
+import SwiftUI
+
 struct ContactsView: View {
   @Bindable var store: StoreOf<ContactsFeature>
   

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003.swift
@@ -1,3 +1,6 @@
+import ComposableArchitecture
+import SwiftUI
+
 struct ContactsView: View {
   @Bindable var store: StoreOf<ContactsFeature>
   

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0004.swift
@@ -1,3 +1,6 @@
+import ComposableArchitecture
+import SwiftUI
+
 struct ContactsView: View {
   @Bindable var store: StoreOf<ContactsFeature>
   

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0005-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0005-previous.swift
@@ -1,3 +1,6 @@
+import ComposableArchitecture
+import SwiftUI
+
 struct ContactsView: View {
   @Bindable var store: StoreOf<ContactsFeature>
   

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-03-code-0003-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-03-code-0003-previous.swift
@@ -1,3 +1,4 @@
+import ComposableArchitecture
 import SwiftUI
 
 struct ContactDetailView: View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-03-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-03-code-0003.swift
@@ -1,3 +1,4 @@
+import ComposableArchitecture
 import SwiftUI
 
 struct ContactDetailView: View {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-03-code-0004-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-03-code-0004-previous.swift
@@ -1,3 +1,5 @@
+import ComposableArchitecture
+
 @Reducer
 struct ContactsFeature {
   @ObservableState

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-03-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-03-code-0004.swift
@@ -1,3 +1,5 @@
+import ComposableArchitecture
+
 @Reducer
 struct ContactsFeature {
   @ObservableState


### PR DESCRIPTION
This PR adds import `modules` to the NavigationStacks tutorial's source code. 

This may help with compiling the source code.