### PR TITLE
Subscribe to `@Shared` strategies with async hop

### DIFF
--- a/Sources/ComposableArchitecture/Internal/DispatchQueue.swift
+++ b/Sources/ComposableArchitecture/Internal/DispatchQueue.swift
@@ -14,20 +14,6 @@ func mainActorNow<R: Sendable>(execute block: @MainActor @Sendable () -> R) -> R
   }
 }
 
-func mainActorAsync(execute block: @escaping @MainActor @Sendable () -> Void) {
-  if isTesting {
-    MainActor._assumeIsolated {
-      block()
-    }
-  } else {
-    DispatchQueue.main.async {
-      MainActor._assumeIsolated {
-        block()
-      }
-    }
-  }
-}
-
 private let key: DispatchSpecificKey<UInt8> = {
   let key = DispatchSpecificKey<UInt8>()
   DispatchQueue.main.setSpecific(key: key, value: value)

--- a/Sources/ComposableArchitecture/Internal/DispatchQueue.swift
+++ b/Sources/ComposableArchitecture/Internal/DispatchQueue.swift
@@ -14,8 +14,8 @@ func mainActorNow<R: Sendable>(execute block: @MainActor @Sendable () -> R) -> R
   }
 }
 
-func mainActorASAP(execute block: @escaping @MainActor @Sendable () -> Void) {
-  if DispatchQueue.getSpecific(key: key) == value {
+func mainActorAsync(execute block: @escaping @MainActor @Sendable () -> Void) {
+  if isTesting {
     MainActor._assumeIsolated {
       block()
     }

--- a/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
+++ b/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
@@ -386,7 +386,7 @@ final class ValueReference<Value, Persistence: PersistenceReaderKey<Value>>: Ref
         initialValue: initialValue
       ) { [weak self] value in
         guard let self else { return }
-        mainActorASAP {
+        mainActorAsync {
           self._$perceptionRegistrar.willSet(self, keyPath: \.value)
           defer { self._$perceptionRegistrar.didSet(self, keyPath: \.value) }
           self.lock.withLock {

--- a/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
+++ b/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
@@ -386,7 +386,8 @@ final class ValueReference<Value, Persistence: PersistenceReaderKey<Value>>: Ref
         initialValue: initialValue
       ) { [weak self] value in
         guard let self else { return }
-        mainActorAsync {
+        @Dependency(SchedulerKey.self) var schedule
+        schedule {
           self._$perceptionRegistrar.willSet(self, keyPath: \.value)
           defer { self._$perceptionRegistrar.didSet(self, keyPath: \.value) }
           self.lock.withLock {
@@ -406,6 +407,15 @@ final class ValueReference<Value, Persistence: PersistenceReaderKey<Value>>: Ref
   }
   var description: String {
     "Shared<\(Value.self)>@\(self.fileID):\(self.line)"
+  }
+}
+
+fileprivate enum SchedulerKey: DependencyKey {
+  static var liveValue: @Sendable (@escaping () -> Void) -> Void {
+    DispatchQueue.main.schedule
+  }
+  static var testValue: @Sendable (@escaping () -> Void) -> Void {
+    UIScheduler.shared.schedule
   }
 }
 


### PR DESCRIPTION
I think we're finding that synchronous subscriptions can be problematic depending on the strategy, for example as we're seeing with user defaults notifications being fired by attributed string's internals.

Fixes #3311.