### PR TITLE
Fix Swift <6 warning

### DIFF
--- a/Sources/ComposableArchitecture/Internal/KeyPath+Sendable.swift
+++ b/Sources/ComposableArchitecture/Internal/KeyPath+Sendable.swift
@@ -26,5 +26,9 @@
 func sendableKeyPath(
   _ keyPath: AnyKeyPath
 ) -> _SendableAnyKeyPath {
-  unsafeBitCast(keyPath, to: _SendableAnyKeyPath.self)
+  #if compiler(>=6)
+    unsafeBitCast(keyPath, to: _SendableAnyKeyPath.self)
+  #else
+    keyPath
+  #endif
 }


### PR DESCRIPTION
Bit-casting a type to the type it already is produces a warning.