### PR TITLE
Fix race conditions in CurrentValueRelay

### DIFF
--- a/Sources/ComposableArchitecture/Internal/CurrentValueRelay.swift
+++ b/Sources/ComposableArchitecture/Internal/CurrentValueRelay.swift
@@ -55,7 +55,7 @@ extension CurrentValueRelay {
     private var demand = Subscribers.Demand.none
 
     private var _downstream: (any Subscriber<Output, Never>)?
-    var downstream: (any Subscriber<Output, Never>)? {
+    private var downstream: (any Subscriber<Output, Never>)? {
       var downstream: (any Subscriber<Output, Never>)?
       self.lock.sync { downstream = _downstream }
       return downstream

--- a/Tests/ComposableArchitectureTests/CurrentValueRelayTests.swift
+++ b/Tests/ComposableArchitectureTests/CurrentValueRelayTests.swift
@@ -26,6 +26,7 @@
       _ = cancellable
     }
 
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testConcurrentSendAndReceive() async {
       nonisolated(unsafe) let subject = CurrentValueRelay(0)
       let values = LockIsolated<Set<Int>>([])


### PR DESCRIPTION
As it's currently written, `CurrentValueRelay` seems to have several race conditions. These are infrequent enough to make them rather elusive in typical usage, but we believe that these are the root cause behind 0.X% of Ramp iOS sessions crashing.

This PR includes a test case that fails on `main`, as well as a fix that solves it, but is slow. It's probably worth you folks writing a fix yourself (without needing the lock to be recursive) to resolve the issue, but I hope that the test case helps. FWIW you should also be able to trip up TSAN when running the failing test case pre-fix; it catches a number of the ways in which the race can be triggered.