### PR TITLE
Shared: Simplify internal reference protocol

### DIFF
--- a/Sources/ComposableArchitecture/SharedState/Reference.swift
+++ b/Sources/ComposableArchitecture/SharedState/Reference.swift
@@ -6,11 +6,15 @@ protocol Reference<Value>: AnyObject, CustomStringConvertible, Sendable {
   associatedtype Value: Sendable
   var value: Value { get set }
 
-  func access()
-  func withMutation<T>(_ mutation: () throws -> T) rethrows -> T
   #if canImport(Combine)
     var publisher: AnyPublisher<Value, Never> { get }
   #endif
+}
+
+extension Reference {
+  func touch() {
+    value = value
+  }
 }
 
 extension Reference {

--- a/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
+++ b/Sources/ComposableArchitecture/SharedState/References/ValueReference.swift
@@ -396,14 +396,6 @@ final class ValueReference<Value, Persistence: PersistenceReaderKey<Value>>: Ref
       }
     }
   }
-  func access() {
-    _$perceptionRegistrar.access(self, keyPath: \.value)
-  }
-  func withMutation<T>(_ mutation: () throws -> T) rethrows -> T {
-    self._$perceptionRegistrar.willSet(self, keyPath: \.value)
-    defer { self._$perceptionRegistrar.didSet(self, keyPath: \.value) }
-    return try mutation()
-  }
   var description: String {
     "Shared<\(Value.self)>@\(self.fileID):\(self.line)"
   }

--- a/Sources/ComposableArchitecture/SharedState/Shared.swift
+++ b/Sources/ComposableArchitecture/SharedState/Shared.swift
@@ -123,14 +123,10 @@ public struct Shared<Value: Sendable>: Sendable {
   ///
   /// See <doc:SharingState#Deriving-shared-state> for more details.
   public var projectedValue: Self {
-    get {
-      reference.access()
-      return self
-    }
+    get { self }
     set {
-      reference.withMutation {
-        self = newValue
-      }
+      reference.touch()
+      self = newValue
     }
   }
 

--- a/Sources/ComposableArchitecture/SharedState/SharedReader.swift
+++ b/Sources/ComposableArchitecture/SharedState/SharedReader.swift
@@ -104,14 +104,10 @@ public struct SharedReader<Value: Sendable> {
 
   /// A projection of the read-only shared value that returns a shared reference.
   public var projectedValue: Self {
-    get {
-      reference.access()
-      return self
-    }
+    get { self }
     set {
-      reference.withMutation {
-        self = newValue
-      }
+      reference.touch()
+      self = newValue
     }
   }
 

--- a/Tests/ComposableArchitectureTests/SharedTests.swift
+++ b/Tests/ComposableArchitectureTests/SharedTests.swift
@@ -461,7 +461,7 @@ final class SharedTests: XCTestCase {
     _count = Shared(0)
     let countDidChange = self.expectation(description: "countDidChange")
     withPerceptionTracking {
-      _ = $count
+      _ = $count.wrappedValue
     } onChange: {
       countDidChange.fulfill()
     }


### PR DESCRIPTION
Tackling some small `Shared` refactorings across small PRs. This one simplifies an internal protocol and fixes some potential over-observation.