### PR TITLE
Give `SharedReader` same `Sendable` treatment as `Shared`

### DIFF
--- a/Sources/ComposableArchitecture/Internal/KeyPath+Sendable.swift
+++ b/Sources/ComposableArchitecture/Internal/KeyPath+Sendable.swift
@@ -27,6 +27,8 @@ func sendableKeyPath(
   _ keyPath: AnyKeyPath
 ) -> _SendableAnyKeyPath {
   #if compiler(>=6)
+    // NB: Can get rid of bitcast when this is fixed:
+    //     https://github.com/swiftlang/swift/issues/75531
     unsafeBitCast(keyPath, to: _SendableAnyKeyPath.self)
   #else
     keyPath

--- a/Sources/ComposableArchitecture/SharedState/Shared.swift
+++ b/Sources/ComposableArchitecture/SharedState/Shared.swift
@@ -62,8 +62,6 @@ public struct Shared<Value: Sendable>: Sendable {
     else { return nil }
     self.init(
       reference: base.reference,
-      // NB: Can get rid of bitcast when this is fixed:
-      //     https://github.com/swiftlang/swift/issues/75531
       keyPath: sendableKeyPath(
         (base.keyPath as AnyKeyPath)
           .appending(path: \Value?.[default: DefaultSubscript(initialValue)])!
@@ -177,11 +175,7 @@ public struct Shared<Value: Sendable>: Sendable {
   ) -> Shared<Member> {
     Shared<Member>(
       reference: self.reference,
-      // NB: Can get rid of bitcast when this is fixed:
-      //     https://github.com/swiftlang/swift/issues/75531
-      keyPath: sendableKeyPath(
-        (self.keyPath as AnyKeyPath).appending(path: keyPath)!
-      )
+      keyPath: sendableKeyPath((self.keyPath as AnyKeyPath).appending(path: keyPath)!)
     )
   }
 
@@ -459,11 +453,7 @@ extension Shared {
   ) -> SharedReader<Member> {
     SharedReader<Member>(
       reference: self.reference,
-      // NB: Can get rid of bitcast when this is fixed:
-      //     https://github.com/swiftlang/swift/issues/75531
-      keyPath: sendableKeyPath(
-        (self.keyPath as AnyKeyPath).appending(path: keyPath)!
-      )
+      keyPath: sendableKeyPath((self.keyPath as AnyKeyPath).appending(path: keyPath)!)
     )
   }
 


### PR DESCRIPTION
Some changes made to `Shared` weren't brought over to `SharedReader`.

Would be nice to figure out how to better unify these types to avoid duplication and fragmentation.