### PR TITLE
Call same `receive` method as receiver on wrapped `Publisher`

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Publisher.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher.swift
@@ -21,7 +21,7 @@ public struct _EffectPublisher<Action>: Publisher {
   }
 
   public func receive(subscriber: some Combine.Subscriber<Action, Failure>) {
-    publisher.subscribe(subscriber)
+    publisher.receive(subscriber: subscriber)
   }
 
   private var publisher: AnyPublisher<Action, Failure> {


### PR DESCRIPTION
Our company is seeing this line cited in a stack overflow. This is ~ a guess, but it would make sense that if the contained `Publisher` is the one being subscribed to that we should pass that along using the same API we are called with.