### PR TITLE
Shared state shows test change in the wrong action

### DIFF
--- a/Tests/ComposableArchitectureTests/SharedTests.swift
+++ b/Tests/ComposableArchitectureTests/SharedTests.swift
@@ -51,6 +51,25 @@ final class SharedTests: XCTestCase {
   }
 
   @MainActor
+  func testSharingWithDelegateAction_EagerActionProcessing() async {
+    let store = TestStore(
+      initialState: SharedFeature.State(
+        profile: Shared(Profile(stats: Shared(Stats()))),
+        sharedCount: Shared(0),
+        stats: Shared(Stats())
+      )
+    ) {
+      SharedFeature()
+    }
+    await store.send(.incrementSharedInDelegate) {
+      $0.stats.count = 1
+    }
+    await store.receive(\.delegate.didIncrement) {
+      $0.count = 1
+    }
+  }
+
+  @MainActor
   func testSharing_Failure() async {
     let store = TestStore(
       initialState: SharedFeature.State(

--- a/Tests/ComposableArchitectureTests/SharedTests.swift
+++ b/Tests/ComposableArchitectureTests/SharedTests.swift
@@ -27,6 +27,13 @@ final class SharedTests: XCTestCase {
 
   @MainActor
   func testSharingWithDelegateAction() async {
+    XCTTODO(
+      """
+      Ideally this test would pass but is a known, but also expected, issue with shared state and
+      the test store. The fix is to have the test store not eagerly process actions from effects,
+      but unfortunately that would be a breaking change in 1.0.
+      """)
+
     let store = TestStore(
       initialState: SharedFeature.State(
         profile: Shared(Profile(stats: Shared(Stats()))),


### PR DESCRIPTION
When modifying a `@Shared` value in a delegate action, the `TestStore` shows the state change in the original action, not the delegate. 

This PR is a failing test only. In reality this would be a parent feature responding to the delegate, but the test works within a single reducer.