### PR TITLE
Avoid extra lock when getting `subscriptions` in `CurrentValueRelay.send`

### DIFF
--- a/Sources/ComposableArchitecture/Internal/CurrentValueRelay.swift
+++ b/Sources/ComposableArchitecture/Internal/CurrentValueRelay.swift
@@ -33,10 +33,11 @@ final class CurrentValueRelay<Output>: Publisher {
   }
 
   func send(_ value: Output) {
-    self.lock.sync {
+    let subscriptions = self.lock.sync {
       self.currentValue = value
+      return self.subscriptions
     }
-    for subscription in self.lock.sync({ self.subscriptions }) {
+    for subscription in subscriptions {
       subscription.receive(value)
     }
   }


### PR DESCRIPTION
Minor improvement I forgot to mention while looking at #3447