### PR TITLE
Add Pulse from ReactorKit for optimizing state stream observing

### DIFF
--- a/Sources/ComposableArchitecture/Observation/Pulse.swift
+++ b/Sources/ComposableArchitecture/Observation/Pulse.swift
@@ -1,0 +1,98 @@
+//
+//  Pulse.swift
+//  swift-composable-architecture
+//
+//  Created by Jaewook Hwang on 11/13/24.
+//
+
+import Foundation
+import Combine
+
+/**
+ * Example - Reducer
+ **
+```swift
+@Reducer
+struct Feature {
+    @ObservableState
+    struct State {
+        var errorMessage: Pulse<String?> = .init(wrappedValue: nil)
+        // Other properties
+ 
+    }
+   enum Action { /* ... */ }
+
+   var body: some Reducer<State, Action> {
+     Reduce { state, action in
+       switch action {
+       case .setErrorMessage(let errorMessage):
+         state.errorMessage.value = errorMessage
+         return .none
+       }
+     }
+   }
+}
+```
+ **
+ * Example - store publisher
+ **
+ ```swift
+ 
+ store.publisher.pulse(\.errorMessage)
+    .compactMap { $0 }
+    .sink { [weak self] errorMessage in
+       // error message alert or something
+    }
+    .store(in: &cancellable)
+ ```
+ */
+
+/// > Note: This Pulse is from ReactorKit made by Tokijh
+/// https://github.com/ReactorKit/ReactorKit?tab=readme-ov-file#pulse
+/// It is useful for optimizing observation of state. Because Pulse has
+/// ``valueUpdatedCount`` value, we can filter the state stream whenever
+/// the real value is assigned in a Reducer.
+/// so it is helpful to avoid unexpected state-changing stream and
+/// just to get the value whenever the state of real value is assigned
+public struct Pulse<Value: Equatable>: Equatable {
+  public var value: Value {
+    didSet {
+      raiseValueUpdatedCount()
+    }
+  }
+  
+  public internal(set) var valueUpdatedCount = UInt.min
+  
+  public init(wrappedValue: Value) {
+    value = wrappedValue
+  }
+  
+  public var projectedValue: Pulse<Value> {
+    self
+  }
+  
+  private mutating func raiseValueUpdatedCount() {
+    if valueUpdatedCount == UInt.max {
+      valueUpdatedCount = UInt.min
+    } else {
+      valueUpdatedCount += 1
+    }
+  }
+}
+
+/// This function is for using Pulse with Store in a more convenient way.
+/// With this extension function, we can the get the stream of value whenever the state of real value is assigned.
+extension StorePublisher {
+  public func pulse<Value>(_ keyPath: KeyPath<State, Pulse<Value>>) -> AnyPublisher<Value, Never> {
+    map { state in
+      state[keyPath: keyPath]
+    }
+    .removeDuplicates(by: { oldPulse, newPulse in
+      oldPulse.valueUpdatedCount == newPulse.valueUpdatedCount
+    })
+    .map { pulse in
+      pulse.value
+    }
+    .eraseToAnyPublisher()
+  }
+}


### PR DESCRIPTION
## Background

I have been using ReactorKit for my project and recently I found that TCA is a good Redux-like structure architecture with supporting async/await and Combine. So I am applying TCA nowadays. But not with SwiftUI, with UIKit. Because I am still
comfortable with UIKit. 
And then I have been satisfied with the TCA. But I found some uncomfortable aspect. It is about state-observing stream with Combine. I am doing the rendering view or presentation things using Combine state publisher. But even with the operator `removeDuplicate`, I need to optimize the state-observing stream better. Because sometimes I need the duplicate state stream like error message. I know some kind of workaround for this like setting the state optional and setting it to nil or something. 
But what I want is that state stream is on whenever the target state value is assigned by Reducer. Actually there is already
a solution for this in ReactorKit that I used. Because ReactorKit is similar to TCA in terms of state-managing things, It had
the similar problems and thinkings.

## Solution

[Pulse code link](https://github.com/ReactorKit/ReactorKit/blob/master/Sources/ReactorKit/Pulse.swift)
It is the `PULSE`! It is the idea from the developer **Tokijh**. (once again Thanks to **Tokijh**)
[Tokijh - Yoon Joonghyun](https://github.com/tokijh)
It is using the `updateCount` to determine when the value is newly assigned. And I didn't find the better idea for solving my TCA problem. I applied Pulse for my project.
It is just a proposal for my TCA problem and I hope that Pulse is applied in a better code or even with better idea if any.
Actually, Pulse is property wrapper but if I want to use Pulse as a property wrapper in a State, I think I need to change the
macro code of ObservableState. It seems a little complicated so I let it alone.
Anyway, In conclusion, I want something like Pulse in TCA in any form that can solve the state-observing issue with Combine state publisher(maybe mostly TCA with UIKit problem)

## Example

I temporarily added Pulse like this until It can be used as property wrapper or any form of part of TCA

```swift
@Reducer
struct Feature {
    @ObservableState
    struct State {
        var errorMessage: Pulse<String?> = .init(wrappedValue: nil)
        // Other properties
 
    }
   enum Action { /* ... */ }
   var body: some Reducer<State, Action> {
     Reduce { state, action in
       switch action {
       case .setErrorMessage(let errorMessage):
         state.errorMessage.value = errorMessage
         return .none
       }
     }
   }
}
```

```swift
store.publisher.pulse(\.errorMessage)
    .compactMap { $0 }
    .sink { [weak self] errorMessage in
       // error message alert or something
    }
    .store(in: &cancellable)
```

- In this way, errorMessage is send only when a new error messsage is assigned (Even the message is equal)


