### PR TITLE
Add `@ViewBuilder` to `NavigationStack` root view

### DIFF
--- a/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
@@ -136,7 +136,7 @@ extension NavigationStack {
   /// this view.
   public init<State, Action, Destination: View, R>(
     path: Binding<Store<StackState<State>, StackAction<State, Action>>>,
-    root: () -> R,
+    @ViewBuilder root: () -> R,
     @ViewBuilder destination: @escaping (Store<State, Action>) -> Destination,
     fileID: StaticString = #fileID,
     filePath: StaticString = #filePath,


### PR DESCRIPTION
Adding view builder annotation to `NavigiationStack. init`. This matches the functionality of the built in initializer's root view. See #3483 

Note that I'm not sure if there is a way to add a test for this exactly, but what I did to confirm was to modify `NavigationDemoView` in SwiftUICaseStudies locally (not checked in) like so: 

```
  var body: some View {
    NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
      Text("Fred")
      Form {
        Section { Text(template: readMe) }
      ...
``` 
<img width="463" alt="Screenshot 2024-11-13 at 9 24 19 PM" src="https://github.com/user-attachments/assets/de1d4774-192e-4803-b3af-bf607cd99595">


