### PR TITLE
Fix crash when cancelling subscription for custom PersistenceKey

### DIFF
--- a/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
+++ b/Sources/ComposableArchitecture/SharedState/PersistenceKey.swift
@@ -73,7 +73,7 @@ extension Shared {
   /// This object is returned from ``PersistenceReaderKey/subscribe(initialValue:didSet:)``, which
   /// will feed updates from an external system for its lifetime, or till ``cancel()`` is called.
   public class Subscription {
-    let onCancel: () -> Void
+    var onCancel: (() -> Void)?
 
     /// Initializes the subscription with the given cancel closure.
     ///
@@ -88,7 +88,8 @@ extension Shared {
 
     /// Cancels the subscription.
     public func cancel() {
-      self.onCancel()
+      self.onCancel?()
+      self.onCancel = nil
     }
   }
 }


### PR DESCRIPTION
We have a custom conformance of `PersistenceKey` that called `Shared<Value>.Subscription.cancel()` on the base persistence key in its own `onCancel` closure:

```swift
struct PersistenceKeyProjection<Value: Sendable, Base: PersistenceReaderKey>: PersistenceReaderKey {
  let base: Base

  // ...

  func subscribe(
    initialValue: Value?,
    didSet: @escaping @Sendable (_ newValue: Value?) -> Void
  ) -> Shared<Value>.Subscription {
    let subscription = self.base.subscribe( /* ... */ )
    return Shared.Subscription {
      subscription.cancel()  // ← ⚠️
    }
  }
}
```

When upgrading to 1.16.0, that logic started crashing with `AppStorageKey` because `Shared<Value>.Subscription` also calls `cancel()` from its `deinit` and key-value observing does not allow that:

> [!CAUTION]
> Cannot remove an observer `<_TtCGV22ComposableArchitecture13AppStorageKeyGSqSS__P10$1353d4f8c8Observer 0x6000002848a0>` for the key path `"stringKey"` from `<NSUserDefaults 0x600000dd3cf0>` because it is not registered as an observer.

In our case, the sufficient workaround was to change the call to `subscription.cancel()` into just an extended lifetime `_ = subscription` and call it a day.

But I think it's still a wart that `Shared<Value>.Subscription` allowed this to crash!

This PR reproduces the crash with a (rather artificial) unit test and follows up with a proposed fix.