### PR TITLE
Add a test to document how 'task tree' cancellation  happens.

### DIFF
--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -1176,50 +1176,52 @@ final class StoreTests: BaseTCATestCase {
   }
 }
 
-@Suite
-struct ModernStoreTests {
-  @Reducer
-  fileprivate struct TaskTreeFeature {
-    let clock: TestClock<Duration>
-    @ObservableState
-    struct State { var count = 0 }
-    enum Action { case tap, response1, response2 }
-    var body: some ReducerOf<Self> {
-      Reduce { state, action in
-        switch action {
-        case .tap:
-          return Effect.run { send in
-            await send(.response1)
+#if canImport(Testing)
+  @Suite
+  struct ModernStoreTests {
+    @Reducer
+    fileprivate struct TaskTreeFeature {
+      let clock: TestClock<Duration>
+      @ObservableState
+      struct State { var count = 0 }
+      enum Action { case tap, response1, response2 }
+      var body: some ReducerOf<Self> {
+        Reduce { state, action in
+          switch action {
+          case .tap:
+            return Effect.run { send in
+              await send(.response1)
+            }
+          case .response1:
+            state.count = 42
+            return Effect.run { send in
+              try await clock.sleep(for: .seconds(1))
+              await send(.response2)
+            }
+          case .response2:
+            state.count = 1729
+            return .none
           }
-        case .response1:
-          state.count = 42
-          return Effect.run { send in
-            try await clock.sleep(for: .seconds(1))
-            await send(.response2)
-          }
-        case .response2:
-          state.count = 1729
-          return .none
         }
       }
     }
-  }
 
-  @MainActor
-  @Test
-  func cancellation() async throws {
-    let clock = TestClock()
-    let store = Store(initialState: TaskTreeFeature.State()) { TaskTreeFeature(clock: clock) }
-    let task = store.send(.tap)
-    try await Task.sleep(for: .seconds(0.1))
-    #expect(store.count == 42)
-    task.cancel()
-    await clock.run()
-    withKnownIssue("Cancelling the root effect should not cancel the child effects.") {
-      #expect(store.count == 1729)
+    @MainActor
+    @Test
+    func cancellation() async throws {
+      let clock = TestClock()
+      let store = Store(initialState: TaskTreeFeature.State()) { TaskTreeFeature(clock: clock) }
+      let task = store.send(.tap)
+      try await Task.sleep(for: .seconds(0.1))
+      #expect(store.count == 42)
+      task.cancel()
+      await clock.run()
+      withKnownIssue("Cancelling the root effect should not cancel the child effects.") {
+        #expect(store.count == 1729)
+      }
     }
   }
-}
+#endif
 
 private struct Count: TestDependencyKey {
   var value: Int

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -2,6 +2,10 @@
 @_spi(Internals) import ComposableArchitecture
 import XCTest
 
+#if canImport(Testing)
+  import Testing
+#endif
+
 final class StoreTests: BaseTCATestCase {
   var cancellables: Set<AnyCancellable> = []
 
@@ -1169,6 +1173,51 @@ final class StoreTests: BaseTCATestCase {
     XCTAssertNotNil(weakStore)
     cancellable.cancel()
     XCTAssertNil(weakStore)
+  }
+}
+
+@Suite
+struct ModernStoreTests {
+  @Reducer
+  fileprivate struct TaskTreeFeature {
+    let clock: TestClock<Duration>
+    @ObservableState
+    struct State { var count = 0 }
+    enum Action { case tap, response1, response2 }
+    var body: some ReducerOf<Self> {
+      Reduce { state, action in
+        switch action {
+        case .tap:
+          return Effect.run { send in
+            await send(.response1)
+          }
+        case .response1:
+          state.count = 42
+          return Effect.run { send in
+            try await clock.sleep(for: .seconds(1))
+            await send(.response2)
+          }
+        case .response2:
+          state.count = 1729
+          return .none
+        }
+      }
+    }
+  }
+
+  @MainActor
+  @Test
+  func cancellation() async throws {
+    let clock = TestClock()
+    let store = Store(initialState: TaskTreeFeature.State()) { TaskTreeFeature(clock: clock) }
+    let task = store.send(.tap)
+    try await Task.sleep(for: .seconds(0.1))
+    #expect(store.count == 42)
+    task.cancel()
+    await clock.run()
+    withKnownIssue("Cancelling the root effect should not cancel the child effects.") {
+      #expect(store.count == 1729)
+    }
   }
 }
 


### PR DESCRIPTION
This was inspired by #3497. We've known for a long time that cancelling a root effect will cancel its child effects too. We've investigate fixes for this, but sadly we do think it's just how things have to be right now. Fortunately we do have some changes coming to the library that will allow us to improve this behavior. But for the time being let's at least document this behavior in a test.