### PR TITLE
Fix the infinite loop issue when WebSocket returns an error message in the example case.

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-WebSocket.swift
@@ -301,10 +301,10 @@ extension WebSocketClient: DependencyKey {
           let task = Task {
             while !Task.isCancelled {
               do {
-                let socketMessage = try await socket.receive()
+                let socketMessage = try await Message(socket.receive())
                 continuation.yield(.success(socketMessage))
               } catch {
-                continuation.yield(with: .failure(error))
+                continuation.yield(.failure(error))
               }
             }
             continuation.finish()

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-WebSocket.swift
@@ -300,8 +300,12 @@ extension WebSocketClient: DependencyKey {
         return AsyncStream { continuation in
           let task = Task {
             while !Task.isCancelled {
-              let socketMessage = try await socket.receive()
-              continuation.yield(Result { try Message(socketMessage) })
+              do {
+                let socketMessage = try await socket.receive()
+                continuation.yield(.success(socketMessage))
+              } catch {
+                continuation.yield(with: .failure(error))
+              }
             }
             continuation.finish()
           }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-WebSocket.swift
@@ -300,7 +300,8 @@ extension WebSocketClient: DependencyKey {
         return AsyncStream { continuation in
           let task = Task {
             while !Task.isCancelled {
-              continuation.yield(await Result { try await Message(socket.receive()) })
+              let socketMessage = try await socket.receive()
+              continuation.yield(Result { try Message(socketMessage) })
             }
             continuation.finish()
           }


### PR DESCRIPTION
When websocket.receive() encounters an error, it cannot be properly thrown, resulting in an infinite loop within AsyncStream, which negatively impacts performance.
Writing this way allows the error to be handled properly, avoiding the issue mentioned earlier.

socket.receive() is a throwing function.
```swift
extension URLSessionWebSocketTask {
    // ...
    public func receive() async throws -> URLSessionWebSocketTask.Message
}
```

In the case of SwiftUICaseStudies: `03-Effects-WebSocket.swift`
```swift
func receive(id: ID) throws -> AsyncStream<Result<Message, any Error>> {
  let socket = try self.socket(id: id)
  return AsyncStream { continuation in
    let task = Task {
      while !Task.isCancelled {
        continuation.yield(await Result { try await Message(socket.receive()) }) // 🚨throw error indefinitely
      }
      continuation.finish()
    }
    continuation.onTermination = { _ in task.cancel() }
  }
}
```
The error throwing form `Message(socket.receive())` will be caught by `Result<Success, Failure>`
This will cause the AsyncStream to continuously unexpectedly throw errors indefinitely.

It would be better to handle the Success and Failure cases separately.
```swift
do {
  let socketMessage = try await Message(socket.receive())
  continuation.yield(.success(socketMessage))
} catch {
  continuation.yield(.failure(error))
}
```