### PR TITLE
Fix obsolete detail on StackElementID documentation

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
@@ -686,10 +686,8 @@ public struct _StackReducer<Base: Reducer, Destination: Reducer>: Reducer {
 /// resorting to positional indices, which can be error prone, especially when dealing with async
 /// effects.
 ///
-/// In production environments (e.g. in Xcode previews, simulators and on devices) the identifier
-/// is backed by a randomly generated UUID, but in tests a deterministic, generational ID is used.
-/// This allows you to predict how IDs will be created and allows you to write tests for how
-/// features behave in the stack.
+/// The identifier is backed by a deterministic, generational ID. This allows you to predict how
+/// IDs will be created and allows you to write tests for how features behave in the stack.
 ///
 /// ```swift
 /// @Test


### PR DESCRIPTION
Looks like `StackElementID` [was once backed by a UUID](https://github.com/pointfreeco/swift-composable-architecture/commit/341b09bb4f5eb18a841722599c31ad6f127b3207#diff-41bfac62990a3b8f3c78d97ce4eac2d1a9f94a4a3dab24d797edb0c407d3d021R452), but later on in #1945 the implementation was simplified down to just a wrapped `Int`. This change fixes the confusing documentation accordingly.