### PR TITLE
Record state access when constructing _StoreCollection.

### DIFF
--- a/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
@@ -100,6 +100,7 @@ public struct _StoreCollection<ID: Hashable & Sendable, State, Action>: RandomAc
   #endif
   fileprivate init(_ store: Store<IdentifiedArray<ID, State>, IdentifiedAction<ID, Action>>) {
     self.store = store
+    store._$observationRegistrar.access(store, keyPath: \.currentState)
     self.data = store.withState { $0 }
   }
 


### PR DESCRIPTION
This fixes an issue brought up in https://github.com/pointfreeco/swift-composable-architecture/discussions/3518. When constructing a `_StoreCollection`, like for a `ForEach`, we should record a state access with the registrar. Currently we use `withState`, which silently accesses state, and so one will not get perception warnings if they forget to use `WithPerceptionTracking`.