### PR TITLE
Fix unit tests for Xcode 16 and older iOS destinations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        command: ['']
+        command: [test, '']
         platform: [IOS, MACOS]
         xcode: ['16.0']
     steps:

--- a/Tests/ComposableArchitectureTests/Reducers/OnChangeReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/OnChangeReducerTests.swift
@@ -208,7 +208,7 @@ final class OnChangeReducerTests: BaseTCATestCase {
         Reduce { state, action in
           switch action {
           case .incrementButtonTapped:
-            state.count.value += 1
+            state.$count.withLock { $0.value += 1 }
             return .none
           }
         }
@@ -222,11 +222,11 @@ final class OnChangeReducerTests: BaseTCATestCase {
     }
     let store = await TestStore(initialState: Feature.State()) { Feature() }
     await store.send(.incrementButtonTapped) {
-      $0.count.value = 1
+      $0.$count.withLock { $0.value = 1 }
       $0.description = "old: 0, new: 1"
     }
     await store.send(.incrementButtonTapped) {
-      $0.count.value = 2
+      $0.$count.withLock { $0.value = 2 }
       $0.description = "old: 1, new: 2"
     }
   }

--- a/Tests/ComposableArchitectureTests/StorePerceptionTests.swift
+++ b/Tests/ComposableArchitectureTests/StorePerceptionTests.swift
@@ -4,6 +4,10 @@ import XCTest
 
 @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
 final class StorePerceptionTests: BaseTCATestCase {
+  override func setUpWithError() throws {
+    try checkAvailability()
+  }
+
   @MainActor
   func testPerceptionCheck_SkipWhenOutsideView() {
     let store = Store(initialState: Feature.State()) {
@@ -43,8 +47,10 @@ final class StorePerceptionTests: BaseTCATestCase {
         render(FeatureView())
       } issueMatcher: {
         $0.compactDescription == """
-          Perceptible state was accessed but is not being tracked. Track changes to state by \
-          wrapping your view in a 'WithPerceptionTracking' view.
+          failed - Perceptible state was accessed but is not being tracked. Track changes to state by \
+          wrapping your view in a 'WithPerceptionTracking' view. This must also be done for any \
+          escaping, trailing closures, such as 'GeometryReader', `LazyVStack` (and all lazy \
+          views), navigation APIs ('sheet', 'popover', 'fullScreenCover', etc.), and others.
           """
       }
     }
@@ -85,5 +91,12 @@ private struct Feature {
       state.count += 1
       return .none
     }
+  }
+}
+
+// NB: Workaround to XCTest ignoring `@available(...)` attributes.
+private func checkAvailability() throws {
+  guard #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) else {
+    throw XCTSkip("Requires iOS 16, macOS 13, tvOS 16, or watchOS 9")
   }
 }

--- a/Tests/ComposableArchitectureTests/StorePerceptionTests.swift
+++ b/Tests/ComposableArchitectureTests/StorePerceptionTests.swift
@@ -33,27 +33,30 @@ final class StorePerceptionTests: BaseTCATestCase {
 
   @MainActor
   func testPerceptionCheck_AccessStateWithoutTracking() {
-    if #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10) {
-      @MainActor
-      struct FeatureView: View {
-        let store = Store(initialState: Feature.State()) {
-          Feature()
-        }
-        var body: some View {
-          Text(store.count.description)
-        }
+    @MainActor
+    struct FeatureView: View {
+      let store = Store(initialState: Feature.State()) {
+        Feature()
       }
-      XCTExpectFailure {
-        render(FeatureView())
-      } issueMatcher: {
-        $0.compactDescription == """
-          failed - Perceptible state was accessed but is not being tracked. Track changes to state by \
-          wrapping your view in a 'WithPerceptionTracking' view. This must also be done for any \
-          escaping, trailing closures, such as 'GeometryReader', `LazyVStack` (and all lazy \
-          views), navigation APIs ('sheet', 'popover', 'fullScreenCover', etc.), and others.
-          """
+      var body: some View {
+        Text(store.count.description)
       }
     }
+#if DEBUG && !os(visionOS)
+    let previous = Perception.isPerceptionCheckingEnabled
+    Perception.isPerceptionCheckingEnabled = true
+    defer { Perception.isPerceptionCheckingEnabled = previous }
+    XCTExpectFailure {
+      render(FeatureView())
+    } issueMatcher: {
+      $0.compactDescription == """
+        failed - Perceptible state was accessed but is not being tracked. Track changes to state by \
+        wrapping your view in a 'WithPerceptionTracking' view. This must also be done for any \
+        escaping, trailing closures, such as 'GeometryReader', `LazyVStack` (and all lazy \
+        views), navigation APIs ('sheet', 'popover', 'fullScreenCover', etc.), and others.
+        """
+    }
+#endif
   }
 
   @MainActor

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -1179,6 +1179,7 @@ final class StoreTests: BaseTCATestCase {
 #if canImport(Testing)
   @Suite
   struct ModernStoreTests {
+    @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
     @Reducer
     fileprivate struct TaskTreeFeature {
       let clock: TestClock<Duration>
@@ -1206,6 +1207,7 @@ final class StoreTests: BaseTCATestCase {
       }
     }
 
+    @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
     @MainActor
     @Test
     func cancellation() async throws {


### PR DESCRIPTION
This PR makes the necessary changes to make the test suite build and pass on Xcode 16 (tested on 16.2) on at least the following destinations:
- macOS 15.2
- iPhone 16 simulator running iOS 18.2
- iPhone 15 simulator running iOS 17.5
- iPhone 14 simulator running iOS 16.4

(Unfortunately I can't seem to pass the test suite on iPhone 13 simulator running iOS 15.5, as several test cases seem to crash with `EXC_BAD_ACCESS` at `static Shared<A>.== infix(_:_:)`. 🤷‍♂️)

Code coverage on the perception checking logic is slightly improved by not skipping the test even if running on iOS 17+.

I think these changes should be enough to enable running adding `test` to `matrix.strategy` on the `xcodebuild-latest` job in `ci.yml`.