### PR TITLE
Fix typos in Store.swift

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -331,8 +331,7 @@ public final class Store<State, Action> {
   }
 
   @_spi(Internals)
-  public
-    func scope<ChildState, ChildAction>(
+  public func scope<ChildState, ChildAction>(
       id: ScopeID<State, Action>?,
       state: ToState<State, ChildState>,
       action fromChildAction: @escaping (ChildAction) -> Action,


### PR DESCRIPTION
Hello, I modified the code for the readability of the function.
Please review the changes, Thanks! 😄

Detail: Fix formatting by removing extra space before 'public'. (#Line: 335)

- origin code
  ```swift
  public
      func scope<ChildState, ChildAction>(
  ```

- changed code
  ```swift
  public func scope<ChildState, ChildAction>(
  ```