### PR TITLE
Check cancellation for task

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -178,7 +178,11 @@ extension Effect {
         if cancelInFlight {
           $0.cancel(id: id, path: navigationIDPath)
         }
-        let task = Task { try await operation() }
+        let task = Task {
+          let result = try await operation()
+          try Task.checkCancellation()
+          return result
+        }
         let cancellable = AnyCancellable { task.cancel() }
         $0.insert(cancellable, at: id, path: navigationIDPath)
         return (cancellable, task)
@@ -209,7 +213,11 @@ extension Effect {
         if cancelInFlight {
           $0.cancel(id: id, path: navigationIDPath)
         }
-        let task = Task { try await operation() }
+        let task = Task {
+          let result = try await operation()
+          try Task.checkCancellation()
+          return result
+        }
         let cancellable = AnyCancellable { task.cancel() }
         $0.insert(cancellable, at: id, path: navigationIDPath)
         return (cancellable, task)


### PR DESCRIPTION
I think it is necessary to check if a task will be cancelled in a task cancellation scenario. The current code needs to actively check for cancellation at the top level, which I don't think is a reasonable approach.

Before: 

```swift
let content = try await withTaskCancellation(id: CancelID.task, cancelInFlight: true) {
  let result = try await doSomeThing()
  try Task.checkCancellation()
  return result
}
await doSomeThingElse(content)
```

After:

```swift
let content = try await withTaskCancellation(id: CancelID.task, cancelInFlight: true) {
  try await doSomeThing()
}
await doSomeThingElse(content)
```