### PR TITLE
[Building Sync-ups Tutorial] fixes in "Lists of sync-ups" chapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /*.swiftinterface
 /*.xcodeproj
 xcuserdata/
+.docc-build/

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-02-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-02-code-0006.swift
@@ -23,7 +23,7 @@ struct CardView: View {
       .font(.caption)
     }
     .padding()
-    .foregroundColor(syncUp.theme.accentColor)
+    .foregroundStyle(syncUp.theme.accentColor)
   }
 }
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-02-code-0007.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-02-code-0007.swift
@@ -30,7 +30,7 @@ struct CardView: View {
       .font(.caption)
     }
     .padding()
-    .foregroundColor(syncUp.theme.accentColor)
+    .foregroundStyle(syncUp.theme.accentColor)
   }
 }
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-02-code-0008.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-02-code-0008.swift
@@ -51,7 +51,7 @@ struct CardView: View {
       .font(.caption)
     }
     .padding()
-    .foregroundColor(syncUp.theme.accentColor)
+    .foregroundStyle(syncUp.theme.accentColor)
   }
 }
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-02-code-0009.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-02-code-0009.swift
@@ -51,7 +51,7 @@ struct CardView: View {
       .font(.caption)
     }
     .padding()
-    .foregroundColor(syncUp.theme.accentColor)
+    .foregroundStyle(syncUp.theme.accentColor)
   }
 }
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-03-code-0001-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-03-code-0001-previous.swift
@@ -51,7 +51,7 @@ struct CardView: View {
       .font(.caption)
     }
     .padding()
-    .foregroundColor(syncUp.theme.accentColor)
+    .foregroundStyle(syncUp.theme.accentColor)
   }
 }
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-03-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/02-ListsOfSyncUps/ListsOfSyncUps-03-code-0001.swift
@@ -51,7 +51,7 @@ struct CardView: View {
       .font(.caption)
     }
     .padding()
-    .foregroundColor(syncUp.theme.accentColor)
+    .foregroundStyle(syncUp.theme.accentColor)
   }
 }
 


### PR DESCRIPTION
Hi!

   Following my last PR, I'm currently reviewing the "Building Sync-ups" tutorial and so far, there is a lot of changes so I've splitted up into one PR per chapter to ease the review of them, starting with the "Lists of sync-ups" chapter here…

**Changes Made:**
- Replaced all instances of the deprecated `foregroundColor` with `foregroundStyle` in the `CardView` implementation.