### PR TITLE
[Building Sync-ups Tutorial] fixes in "Sync-up form" chapter

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-01-code-0009.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-01-code-0009.swift
@@ -54,7 +54,7 @@ struct ThemePicker: View {
           Label(theme.name, systemImage: "paintpalette")
             .padding(4)
         }
-        .foregroundColor(theme.accentColor)
+        .foregroundStyle(theme.accentColor)
         .fixedSize(horizontal: false, vertical: true)
         .tag(theme)
       }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-02-code-0001-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-02-code-0001-previous.swift
@@ -54,7 +54,7 @@ struct ThemePicker: View {
           Label(theme.name, systemImage: "paintpalette")
             .padding(4)
         }
-        .foregroundColor(theme.accentColor)
+        .foregroundStyle(theme.accentColor)
         .fixedSize(horizontal: false, vertical: true)
         .tag(theme)
       }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-02-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-02-code-0001.swift
@@ -60,7 +60,7 @@ struct ThemePicker: View {
           Label(theme.name, systemImage: "paintpalette")
             .padding(4)
         }
-        .foregroundColor(theme.accentColor)
+        .foregroundStyle(theme.accentColor)
         .fixedSize(horizontal: false, vertical: true)
         .tag(theme)
       }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-02-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-02-code-0002.swift
@@ -62,7 +62,7 @@ struct ThemePicker: View {
           Label(theme.name, systemImage: "paintpalette")
             .padding(4)
         }
-        .foregroundColor(theme.accentColor)
+        .foregroundStyle(theme.accentColor)
         .fixedSize(horizontal: false, vertical: true)
         .tag(theme)
       }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-02-code-0003.swift
@@ -63,7 +63,7 @@ struct ThemePicker: View {
           Label(theme.name, systemImage: "paintpalette")
             .padding(4)
         }
-        .foregroundColor(theme.accentColor)
+        .foregroundStyle(theme.accentColor)
         .fixedSize(horizontal: false, vertical: true)
         .tag(theme)
       }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-02-code-0004.swift
@@ -64,7 +64,7 @@ struct ThemePicker: View {
           Label(theme.name, systemImage: "paintpalette")
             .padding(4)
         }
-        .foregroundColor(theme.accentColor)
+        .foregroundStyle(theme.accentColor)
         .fixedSize(horizontal: false, vertical: true)
         .tag(theme)
       }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-02-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-02-code-0005.swift
@@ -70,7 +70,7 @@ struct ThemePicker: View {
           Label(theme.name, systemImage: "paintpalette")
             .padding(4)
         }
-        .foregroundColor(theme.accentColor)
+        .foregroundStyle(theme.accentColor)
         .fixedSize(horizontal: false, vertical: true)
         .tag(theme)
       }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-02-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm-02-code-0006.swift
@@ -70,7 +70,7 @@ struct ThemePicker: View {
           Label(theme.name, systemImage: "paintpalette")
             .padding(4)
         }
-        .foregroundColor(theme.accentColor)
+        .foregroundStyle(theme.accentColor)
         .fixedSize(horizontal: false, vertical: true)
         .tag(theme)
       }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/SyncUpForm.tutorial
@@ -254,7 +254,7 @@
       
       @Step {
         Implement the logic of focusing a new added attendee. Now that we have immediate access
-        to the reducer's logic we no longer to do any force unwrapping or defensive programming
+        to the reducer's logic we no longer have to do any force unwrapping or defensive programming
         with `guard`s.
         
         @Code(name: "SyncUpForm.swift", file: SyncUpForm-03-code-0002.swift)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/TestingSyncUpForm.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/03-SyncUpForm/TestingSyncUpForm.tutorial
@@ -43,10 +43,10 @@
       
       @Step {
         Add a new test method for testing what happens when we delete a focused attendee. This time
-        the initial state with start with two attendees, which have been pulled out into variables
+        the initial state will start with two attendees, which have been pulled out into variables
         so that we can reference them. The first attendee will also be focused.
         
-        > Note: We have collapsed the `testRemoveAttendee` method in the code snippet.
+        > Note: We have collapsed the `removeAttendee` test method in the code snippet.
         
         @Code(name: "SyncUpFormTests.swift", file: TestingSyncUpForm-01-code-0004.swift, previousFile: TestingSyncUpForm-01-code-0004-previous.swift)
       }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/TestingSyncUpFormPresentation-01-code-0013.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/TestingSyncUpFormPresentation-01-code-0013.swift
@@ -8,7 +8,6 @@ struct SyncUpsListTests {
   @Test
   func addSyncUp() async {
     let store = TestStore(initialState: SyncUpsList.State()) {
-    let store = await TestStore(initialState: SyncUpsList.State()) {
       SyncUpsList()
     } withDependencies: {
       $0.uuid = .incrementing

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/TestingSyncUpFormPresentation.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/TestingSyncUpFormPresentation.tutorial
@@ -173,7 +173,7 @@
     
     @Steps {
       @Step {
-        Add a new test method for testing the "Add sync-up" flow, but this time in an exhaustive 
+        Add a new test method for testing the "Add sync-up" flow, but this time in an non-exhaustive 
         manner.
         
         @Code(name: "SyncUpsListTests.swift", file: TestingSyncUpFormPresentation-02-code-0001.swift, previousFile: TestingSyncUpFormPresentation-02-code-0001-previous.swift)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/TestingSyncUpFormPresentation.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/TestingSyncUpFormPresentation.tutorial
@@ -173,7 +173,7 @@
     
     @Steps {
       @Step {
-        Add a new test method for testing the "Add sync-up" flow, but this time in an non-exhaustive 
+        Add a new test method for testing the "Add sync-up" flow, but this time in a non-exhaustive 
         manner.
         
         @Code(name: "SyncUpsListTests.swift", file: TestingSyncUpFormPresentation-02-code-0001.swift, previousFile: TestingSyncUpFormPresentation-02-code-0001-previous.swift)


### PR DESCRIPTION
Hi!

   Following my last PR, I'm currently reviewing the "Building Sync-ups" tutorial and so far, there is a lot of changes so I've splitted up into one PR per chapter to ease the review of them, continuing with the "Sync-up form" chapter here…
   
   
**Changes Made:**

- **Update ThemePicker**: The `ThemePicker` component has been updated to utilize `foregroundStyle` instead of the deprecated `foregroundColor`.
- **Fix Typos in Documentation**: Minor grammatical and spelling errors have been corrected in the tutorial documentation for `SyncUpForm`, `TestingSyncUpForm` and `TestingSyncUpFormPresentation`.
- **Remove Duplicate TestStore Initialization**: The tutorial code has been cleaned up by removing a duplicate initialization of `TestStore` with a useless `await` keyword.