### PR TITLE
[Building Sync-ups Tutorial] fixes in "Navigating to sync-up detail" chapter

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0001-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0001-previous.swift
@@ -66,7 +66,7 @@ struct CardView: View {
       .font(.caption)
     }
     .padding()
-    .foregroundColor(syncUp.theme.accentColor)
+    .foregroundStyle(syncUp.theme.accentColor)
   }
 }
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0001.swift
@@ -66,7 +66,7 @@ struct CardView: View {
       .font(.caption)
     }
     .padding()
-    .foregroundColor(syncUp.theme.accentColor)
+    .foregroundStyle(syncUp.theme.accentColor)
   }
 }
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0002.swift
@@ -66,7 +66,7 @@ struct CardView: View {
       .font(.caption)
     }
     .padding()
-    .foregroundColor(syncUp.theme.accentColor)
+    .foregroundStyle(syncUp.theme.accentColor)
   }
 }
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0003.swift
@@ -66,7 +66,7 @@ struct CardView: View {
       .font(.caption)
     }
     .padding()
-    .foregroundColor(syncUp.theme.accentColor)
+    .foregroundStyle(syncUp.theme.accentColor)
   }
 }
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0003.swift
@@ -11,7 +11,7 @@ struct SyncUpsListView: View {
 
   var body: some View {
     List {
-      ForEach(store.$syncUps) { $syncUp in
+      ForEach(Array(store.$syncUps)) { $syncUp in
         NavigationLink(
           state: AppFeature.Path.State.detail(SyncUpDetail.State(syncUp: <#Shared<SyncUp>#>))
         ) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0004.swift
@@ -66,7 +66,7 @@ struct CardView: View {
       .font(.caption)
     }
     .padding()
-    .foregroundColor(syncUp.theme.accentColor)
+    .foregroundStyle(syncUp.theme.accentColor)
   }
 }
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation.tutorial
@@ -240,6 +240,10 @@
       @Step {
         Pass the shared collection to the `ForEach` to derive a `Shared<SyncUp>` for each element in
         the `Shared<IdentifiedArrayOf<SyncUp>>`.
+
+        > Note: We need to further encapsulate the shared collection into an `Array` to avoid that the compiler
+        > complains about `ForEach` requiring conformance to `RandomAccessCollection` for its argument.
+        
         @Code(name: "SyncUpsList.swift", file: SyncUpDetailNavigation-03-code-0003.swift)
       }
       

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation.tutorial
@@ -238,11 +238,11 @@
       element in the collection.
       
       @Step {
-        Pass the shared collection to the `ForEach` to derive a `Shared<SyncUp>` for each element in
-        the `Shared<IdentifiedArrayOf<SyncUp>>`.
+        Convert the shared collection of sync-ups into a collection of shared sync-ups and pass it
+        along to `ForEach`.
 
-        > Note: We need to further encapsulate the shared collection into an `Array` to avoid that the compiler
-        > complains about `ForEach` requiring conformance to `RandomAccessCollection` for its argument.
+        > Tip: While we use an `Array` initializer to do this conversion, it is possible to use any range
+        > replaceable collection.
         
         @Code(name: "SyncUpsList.swift", file: SyncUpDetailNavigation-03-code-0003.swift)
       }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/TestingNavigation-01-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/TestingNavigation-01-code-0005.swift
@@ -14,7 +14,7 @@ struct AppFeatureTests {
       AppFeature()
     }
 
-    let sharedSyncUp = try #require($syncUps[id: syncUp.id])
+    let sharedSyncUp = try #require(Shared($syncUps[id: syncUp.id]))
 
     await store.send(\.path.push, (id: 0, .detail(SyncUpDetail.State(syncUp: sharedSyncUp)))) {
       $0.path[id: 0] = .detail(SyncUpDetail.State(syncUp: sharedSyncUp))

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/TestingNavigation-01-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/TestingNavigation-01-code-0006.swift
@@ -14,14 +14,14 @@ struct AppFeatureTests {
       AppFeature()
     }
 
-    let sharedSyncUp = try #require($syncUps[id: syncUp.id])
+    let sharedSyncUp = try #require(Shared($syncUps[id: syncUp.id]))
 
     await store.send(\.path.push, (id: 0, .detail(SyncUpDetail.State(syncUp: sharedSyncUp)))) {
       $0.path[id: 0] = .detail(SyncUpDetail.State(syncUp: sharedSyncUp))
     }
 
     await store.send(\.path[id:0].detail.deleteButtonTapped) {
-      $0.path[id: 0]?.detail?.destination = .alert(.deleteSyncUp)
+      $0.path[id: 0, case: \.detail]?.destination = .alert(.deleteSyncUp)
     }
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/TestingNavigation-01-code-0007.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/TestingNavigation-01-code-0007.swift
@@ -14,19 +14,19 @@ struct AppFeatureTests {
       AppFeature()
     }
 
-    let sharedSyncUp = try #require($syncUps[id: syncUp.id])
+    let sharedSyncUp = try #require(Shared($syncUps[id: syncUp.id]))
 
     await store.send(\.path.push, (id: 0, .detail(SyncUpDetail.State(syncUp: sharedSyncUp)))) {
       $0.path[id: 0] = .detail(SyncUpDetail.State(syncUp: sharedSyncUp))
     }
 
     await store.send(\.path[id:0].detail.deleteButtonTapped) {
-      $0.path[id: 0]?.detail?.destination = .alert(.deleteSyncUp)
+      $0.path[id: 0, case: \.detail]?.destination = .alert(.deleteSyncUp)
     }
 
     await store.send(\.path[id:0].detail.destination.alert.confirmButtonTapped) {
       $0.path[id: 0, case: \.detail]?.destination = nil
-      $0.syncUpsList.syncUps = []
+      $0.syncUpsList.$syncUps.withLock { $0 = [] }
     }
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/TestingNavigation-01-code-0008.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/TestingNavigation-01-code-0008.swift
@@ -14,19 +14,19 @@ struct AppFeatureTests {
       AppFeature()
     }
 
-    let sharedSyncUp = try #require($syncUps[id: syncUp.id])
+    let sharedSyncUp = try #require(Shared($syncUps[id: syncUp.id]))
 
     await store.send(\.path.push, (id: 0, .detail(SyncUpDetail.State(syncUp: sharedSyncUp)))) {
       $0.path[id: 0] = .detail(SyncUpDetail.State(syncUp: sharedSyncUp))
     }
 
     await store.send(\.path[id:0].detail.deleteButtonTapped) {
-      $0.path[id: 0]?.detail?.destination = .alert(.deleteSyncUp)
+      $0.path[id: 0, case: \.detail]?.destination = .alert(.deleteSyncUp)
     }
 
     await store.send(\.path[id:0].detail.destination.alert.confirmButtonTapped) {
       $0.path[id: 0, case: \.detail]?.destination = nil
-      $0.syncUpsList.syncUps = []
+      $0.syncUpsList.$syncUps.withLock { $0 = [] }
     }
 
     await store.receive(\.path.popFrom) {


### PR DESCRIPTION
Hi!

Following my last PR, I'm currently reviewing the "Building Sync-ups" tutorial and so far, there is a lot of changes so I've splitted up into one PR per chapter to ease the review of them, continuing with the "Navigating to sync-up detail" chapter here…

**Changes Made:**

- **CardView Update**: The `CardView` component has been updated to utilize `foregroundStyle` instead of the deprecated `foregroundColor`.
- **Refactoring for Compilation Errors**: 
   - In SyncUps view encapsulate the shared collection within an `Array` in the `ForEach` loop.
   - In navigation tests, encapsulate the `sharedSyncUp` within a `Shared` structure.
   - Path manipulation has been updated to utilize case-based access.
   - Modify `syncUps` list using `withLock`.