### PR TITLE
[Building Sync-ups Tutorial] fixes in "Record meeting" chapter

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0001-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0001-previous.swift
@@ -48,7 +48,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0001.swift
@@ -49,7 +49,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0002.swift
@@ -64,7 +64,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0003.swift
@@ -65,7 +65,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0004.swift
@@ -68,7 +68,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0005.swift
@@ -69,7 +69,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0006.swift
@@ -73,7 +73,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0007.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0007.swift
@@ -74,7 +74,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0008.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0008.swift
@@ -78,7 +78,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0009.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0009.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import Foundation
 
 @Reducer
 struct RecordMeeting {
@@ -43,10 +44,12 @@ struct RecordMeeting {
         let secondsPerAttendee = Int(state.syncUp.durationPerAttendee.components.seconds)
         if state.secondsElapsed.isMultiple(of: secondsPerAttendee) {
           if state.secondsElapsed == state.syncUp.duration.components.seconds {
-            state.syncUp.meetings.insert(
-              Meeting(id: Meeting.ID(), date: Date(), transcript: state.transcript),
-              at: 0
-            )
+            state.$syncUp.withLock {
+              $0.meetings.insert(
+                Meeting(id: Meeting.ID(), date: Date(), transcript: state.transcript),
+                at: 0
+              )
+            }
           }
           state.speakerIndex += 1
         }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0009.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0009.swift
@@ -84,7 +84,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0009.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0009.swift
@@ -45,7 +45,7 @@ struct RecordMeeting {
         if state.secondsElapsed.isMultiple(of: secondsPerAttendee) {
           if state.secondsElapsed == state.syncUp.duration.components.seconds {
             state.$syncUp.withLock {
-              $0.meetings.insert(
+              _ = $0.meetings.insert(
                 Meeting(id: Meeting.ID(), date: Date(), transcript: state.transcript),
                 at: 0
               )

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0010.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0010.swift
@@ -87,7 +87,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0010.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0010.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import Foundation
 
 @Reducer
 struct RecordMeeting {
@@ -45,10 +46,12 @@ struct RecordMeeting {
         let secondsPerAttendee = Int(state.syncUp.durationPerAttendee.components.seconds)
         if state.secondsElapsed.isMultiple(of: secondsPerAttendee) {
           if state.secondsElapsed == state.syncUp.duration.components.seconds {
-            state.syncUp.meetings.insert(
-              Meeting(id: Meeting.ID(), date: Date(), transcript: state.transcript),
-              at: 0
-            )
+            state.$syncUp.withLock {
+              $0.meetings.insert(
+                Meeting(id: Meeting.ID(), date: Date(), transcript: state.transcript),
+                at: 0
+              )
+            }
             return .run { _ in await dismiss() }
           }
           state.speakerIndex += 1

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0010.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-01-code-0010.swift
@@ -47,7 +47,7 @@ struct RecordMeeting {
         if state.secondsElapsed.isMultiple(of: secondsPerAttendee) {
           if state.secondsElapsed == state.syncUp.duration.components.seconds {
             state.$syncUp.withLock {
-              $0.meetings.insert(
+              _ = $0.meetings.insert(
                 Meeting(id: Meeting.ID(), date: Date(), transcript: state.transcript),
                 at: 0
               )

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0001-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0001-previous.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import Foundation
 
 @Reducer
 struct RecordMeeting {
@@ -45,10 +46,12 @@ struct RecordMeeting {
         let secondsPerAttendee = Int(state.syncUp.durationPerAttendee.components.seconds)
         if state.secondsElapsed.isMultiple(of: secondsPerAttendee) {
           if state.secondsElapsed == state.syncUp.duration.components.seconds {
-            state.syncUp.meetings.insert(
-              Meeting(id: Meeting.ID(), date: Date(), transcript: state.transcript),
-              at: 0
-            )
+            state.$syncUp.withLock {
+              _ = $0.meetings.insert(
+                Meeting(id: Meeting.ID(), date: Date(), transcript: state.transcript),
+                at: 0
+              )
+            }
             return .run { _ in await dismiss() }
           }
           state.speakerIndex += 1

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0001-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0001-previous.swift
@@ -87,7 +87,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0001.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import Foundation
 
 @Reducer
 struct RecordMeeting {
@@ -47,10 +48,12 @@ struct RecordMeeting {
         let secondsPerAttendee = Int(state.syncUp.durationPerAttendee.components.seconds)
         if state.secondsElapsed.isMultiple(of: secondsPerAttendee) {
           if state.secondsElapsed == state.syncUp.duration.components.seconds {
-            state.syncUp.meetings.insert(
-              Meeting(id: Meeting.ID(), date: Date(), transcript: state.transcript),
-              at: 0
-            )
+            state.$syncUp.withLock {
+              _ = $0.meetings.insert(
+                Meeting(id: Meeting.ID(), date: Date(), transcript: state.transcript),
+                at: 0
+              )
+            }
             return .run { _ in await dismiss() }
           }
           state.speakerIndex += 1

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0001.swift
@@ -89,7 +89,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0002.swift
@@ -47,10 +47,12 @@ struct RecordMeeting {
         let secondsPerAttendee = Int(state.syncUp.durationPerAttendee.components.seconds)
         if state.secondsElapsed.isMultiple(of: secondsPerAttendee) {
           if state.secondsElapsed == state.syncUp.duration.components.seconds {
-            state.syncUp.meetings.insert(
-              Meeting(id: uuid(), date: now, transcript: state.transcript),
-              at: 0
-            )
+            state.$syncUp.withLock {
+              _ = $0.meetings.insert(
+                Meeting(id: uuid(), date: now, transcript: state.transcript),
+                at: 0
+              )
+            }
             return .run { _ in await dismiss() }
           }
           state.speakerIndex += 1

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0002.swift
@@ -89,7 +89,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0003.swift
@@ -90,7 +90,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0003.swift
@@ -48,10 +48,12 @@ struct RecordMeeting {
         let secondsPerAttendee = Int(state.syncUp.durationPerAttendee.components.seconds)
         if state.secondsElapsed.isMultiple(of: secondsPerAttendee) {
           if state.secondsElapsed == state.syncUp.duration.components.seconds {
-            state.syncUp.meetings.insert(
-              Meeting(id: uuid(), date: now, transcript: state.transcript),
-              at: 0
-            )
+            state.$syncUp.withLock {
+              _ = $0.meetings.insert(
+                Meeting(id: uuid(), date: now, transcript: state.transcript),
+                at: 0
+              )
+            }
             return .run { _ in await dismiss() }
           }
           state.speakerIndex += 1

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0004.swift
@@ -47,10 +47,12 @@ struct RecordMeeting {
         let secondsPerAttendee = Int(state.syncUp.durationPerAttendee.components.seconds)
         if state.secondsElapsed.isMultiple(of: secondsPerAttendee) {
           if state.secondsElapsed == state.syncUp.duration.components.seconds {
-            state.syncUp.meetings.insert(
-              Meeting(id: uuid(), date: now, transcript: state.transcript),
-              at: 0
-            )
+            state.$syncUp.withLock {
+              _ = $0.meetings.insert(
+                Meeting(id: uuid(), date: now, transcript: state.transcript),
+                at: 0
+              )
+            }
             return .run { _ in await dismiss() }
           }
           state.speakerIndex += 1

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-02-code-0004.swift
@@ -89,7 +89,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0001-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0001-previous.swift
@@ -47,10 +47,12 @@ struct RecordMeeting {
         let secondsPerAttendee = Int(state.syncUp.durationPerAttendee.components.seconds)
         if state.secondsElapsed.isMultiple(of: secondsPerAttendee) {
           if state.secondsElapsed == state.syncUp.duration.components.seconds {
-            state.syncUp.meetings.insert(
-              Meeting(id: uuid(), date: now, transcript: state.transcript),
-              at: 0
-            )
+            state.$syncUp.withLock {
+              _ = $0.meetings.insert(
+                Meeting(id: uuid(), date: now, transcript: state.transcript),
+                at: 0
+              )
+            }
             return .run { _ in await dismiss() }
           }
           state.speakerIndex += 1

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0001-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0001-previous.swift
@@ -89,7 +89,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0001.swift
@@ -97,7 +97,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0001.swift
@@ -55,10 +55,12 @@ struct RecordMeeting {
         let secondsPerAttendee = Int(state.syncUp.durationPerAttendee.components.seconds)
         if state.secondsElapsed.isMultiple(of: secondsPerAttendee) {
           if state.secondsElapsed == state.syncUp.duration.components.seconds {
-            state.syncUp.meetings.insert(
-              Meeting(id: uuid(), date: now, transcript: state.transcript),
-              at: 0
-            )
+            state.$syncUp.withLock {
+              _ = $0.meetings.insert(
+                Meeting(id: uuid(), date: now, transcript: state.transcript),
+                at: 0
+              )
+            }
             return .run { _ in await dismiss() }
           }
           state.speakerIndex += 1

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0002.swift
@@ -56,10 +56,12 @@ struct RecordMeeting {
         let secondsPerAttendee = Int(state.syncUp.durationPerAttendee.components.seconds)
         if state.secondsElapsed.isMultiple(of: secondsPerAttendee) {
           if state.secondsElapsed == state.syncUp.duration.components.seconds {
-            state.syncUp.meetings.insert(
-              Meeting(id: uuid(), date: now, transcript: state.transcript),
-              at: 0
-            )
+            state.$syncUp.withLock {
+              _ = $0.meetings.insert(
+                Meeting(id: uuid(), date: now, transcript: state.transcript),
+                at: 0
+              )
+            }
             return .run { _ in await dismiss() }
           }
           state.speakerIndex += 1

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0002.swift
@@ -98,7 +98,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0003.swift
@@ -62,10 +62,12 @@ struct RecordMeeting {
         let secondsPerAttendee = Int(state.syncUp.durationPerAttendee.components.seconds)
         if state.secondsElapsed.isMultiple(of: secondsPerAttendee) {
           if state.secondsElapsed == state.syncUp.duration.components.seconds {
-            state.syncUp.meetings.insert(
-              Meeting(id: uuid(), date: now, transcript: state.transcript),
-              at: 0
-            )
+            state.$syncUp.withLock {
+              _ = $0.meetings.insert(
+                Meeting(id: uuid(), date: now, transcript: state.transcript),
+                at: 0
+              )
+            }
             return .run { _ in await dismiss() }
           }
           state.speakerIndex += 1

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0003.swift
@@ -104,7 +104,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0004.swift
@@ -105,7 +105,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0004.swift
@@ -62,10 +62,12 @@ struct RecordMeeting {
         let secondsPerAttendee = Int(state.syncUp.durationPerAttendee.components.seconds)
         if state.secondsElapsed.isMultiple(of: secondsPerAttendee) {
           if state.secondsElapsed == state.syncUp.duration.components.seconds {
-            state.syncUp.meetings.insert(
-              Meeting(id: uuid(), date: now, transcript: state.transcript),
-              at: 0
-            )
+            state.$syncUp.withLock {
+              _ = $0.meetings.insert(
+                Meeting(id: uuid(), date: now, transcript: state.transcript),
+                at: 0
+              )
+            }
             return .run { _ in await dismiss() }
           }
           state.speakerIndex += 1

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0005.swift
@@ -105,7 +105,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0005.swift
@@ -62,10 +62,12 @@ struct RecordMeeting {
         let secondsPerAttendee = Int(state.syncUp.durationPerAttendee.components.seconds)
         if state.secondsElapsed.isMultiple(of: secondsPerAttendee) {
           if state.secondsElapsed == state.syncUp.duration.components.seconds {
-            state.syncUp.meetings.insert(
-              Meeting(id: uuid(), date: now, transcript: state.transcript),
-              at: 0
-            )
+            state.$syncUp.withLock {
+              _ = $0.meetings.insert(
+                Meeting(id: uuid(), date: now, transcript: state.transcript),
+                at: 0
+              )
+            }
             return .run { _ in await dismiss() }
           }
           state.speakerIndex += 1

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0006.swift
@@ -125,7 +125,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0006.swift
@@ -62,10 +62,12 @@ struct RecordMeeting {
         let secondsPerAttendee = Int(state.syncUp.durationPerAttendee.components.seconds)
         if state.secondsElapsed.isMultiple(of: secondsPerAttendee) {
           if state.secondsElapsed == state.syncUp.duration.components.seconds {
-            state.syncUp.meetings.insert(
-              Meeting(id: uuid(), date: now, transcript: state.transcript),
-              at: 0
-            )
+            state.$syncUp.withLock {
+              _ = $0.meetings.insert(
+                Meeting(id: uuid(), date: now, transcript: state.transcript),
+                at: 0
+              )
+            }
             return .run { _ in await dismiss() }
           }
           state.speakerIndex += 1

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0007.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0007.swift
@@ -40,10 +40,12 @@ struct RecordMeeting {
         return .run { _ in await dismiss() }
 
       case .alert(.presented(.saveMeeting)):
-        state.syncUp.meetings.insert(
-          Meeting(id: uuid(), date: now, transcript: state.transcript),
-          at: 0
-        )
+        state.$syncUp.withLock {
+          _ = $0.meetings.insert(
+            Meeting(id: uuid(), date: now, transcript: state.transcript),
+            at: 0
+          )
+        }
         return .run { _ in await dismiss() }
 
       case .alert:
@@ -75,10 +77,12 @@ struct RecordMeeting {
         let secondsPerAttendee = Int(state.syncUp.durationPerAttendee.components.seconds)
         if state.secondsElapsed.isMultiple(of: secondsPerAttendee) {
           if state.secondsElapsed == state.syncUp.duration.components.seconds {
-            state.syncUp.meetings.insert(
-              Meeting(id: uuid(), date: now, transcript: state.transcript),
-              at: 0
-            )
+            state.$syncUp.withLock {
+              _ = $0.meetings.insert(
+                Meeting(id: uuid(), date: now, transcript: state.transcript),
+                at: 0
+              )
+            }
             return .run { _ in await dismiss() }
           }
           state.speakerIndex += 1

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0007.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0007.swift
@@ -138,7 +138,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0008.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0008.swift
@@ -40,10 +40,12 @@ struct RecordMeeting {
         return .run { _ in await dismiss() }
 
       case .alert(.presented(.saveMeeting)):
-        state.syncUp.meetings.insert(
-          Meeting(id: uuid(), date: now, transcript: state.transcript),
-          at: 0
-        )
+        state.$syncUp.withLock {
+          _ = $0.meetings.insert(
+            Meeting(id: uuid(), date: now, transcript: state.transcript),
+            at: 0
+          )
+        }
         return .run { _ in await dismiss() }
 
       case .alert:
@@ -78,10 +80,12 @@ struct RecordMeeting {
         let secondsPerAttendee = Int(state.syncUp.durationPerAttendee.components.seconds)
         if state.secondsElapsed.isMultiple(of: secondsPerAttendee) {
           if state.secondsElapsed == state.syncUp.duration.components.seconds {
-            state.syncUp.meetings.insert(
-              Meeting(id: uuid(), date: now, transcript: state.transcript),
-              at: 0
-            )
+            state.$syncUp.withLock {
+              _ = $0.meetings.insert(
+                Meeting(id: uuid(), date: now, transcript: state.transcript),
+                at: 0
+              )
+            }
             return .run { _ in await dismiss() }
           }
           state.speakerIndex += 1

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0008.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0008.swift
@@ -141,7 +141,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-04-code-0011.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-04-code-0011.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import Foundation
 import Testing
 
 @testable import SyncUps
@@ -45,14 +46,15 @@ struct RecordMeetingTests {
     await clock.advance(by: .seconds(1))
     await store.receive(\.timerTick) {
       $0.secondsElapsed = 4
-      $0.syncUp.meetings.insert(
-        Meeting(
-          id: UUID(0),
-          date: Date(timeIntervalSince1970: 1234567890),
-          transcript: ""
-        ),
-        at: 0
-      )
+      $0.$syncUp.withLock {
+        $0.meetings = [
+          Meeting(
+            id: UUID(0),
+            date: Date(timeIntervalSince1970: 1234567890),
+            transcript: ""
+          )
+        ]
+      }
     }
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-04-code-0012.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-04-code-0012.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import Foundation
 import Testing
 
 @testable import SyncUps
@@ -45,14 +46,15 @@ struct RecordMeetingTests {
     await clock.advance(by: .seconds(1))
     await store.receive(\.timerTick) {
       $0.secondsElapsed = 4
-      $0.syncUp.meetings.insert(
-        Meeting(
-          id: UUID(0),
-          date: Date(timeIntervalSince1970: 1234567890),
-          transcript: ""
-        ),
-        at: 0
-      )
+      $0.$syncUp.withLock {
+        $0.meetings = [
+          Meeting(
+            id: UUID(0),
+            date: Date(timeIntervalSince1970: 1234567890),
+            transcript: ""
+          )
+        ]
+      }
     }
     // ❌ An effect returned for this action is still running. It must complete before the end of the test. …
     // ❌ Unimplemented: @Dependency(\.date) …

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-04-code-0013.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-04-code-0013.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import Foundation
 import Testing
 
 @testable import SyncUps
@@ -47,14 +48,15 @@ struct RecordMeetingTests {
     await clock.advance(by: .seconds(1))
     await store.receive(\.timerTick) {
       $0.secondsElapsed = 4
-      $0.syncUp.meetings.insert(
-        Meeting(
-          id: UUID(0),
-          date: Date(timeIntervalSince1970: 1234567890),
-          transcript: ""
-        ),
-        at: 0
-      )
+      $0.$syncUp.withLock {
+        $0.meetings = [
+          Meeting(
+            id: UUID(0),
+            date: Date(timeIntervalSince1970: 1234567890),
+            transcript: ""
+          )
+        ]
+      }
     }
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-04-code-0014.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-04-code-0014.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import Foundation
 import Testing
 
 @testable import SyncUps
@@ -47,14 +48,15 @@ struct RecordMeetingTests {
     await clock.advance(by: .seconds(1))
     await store.receive(\.timerTick) {
       $0.secondsElapsed = 4
-      $0.syncUp.meetings.insert(
-        Meeting(
-          id: UUID(0),
-          date: Date(timeIntervalSince1970: 1234567890),
-          transcript: ""
-        ),
-        at: 0
-      )
+      $0.$syncUp.withLock {
+        $0.meetings = [
+          Meeting(
+            id: UUID(0),
+            date: Date(timeIntervalSince1970: 1234567890),
+            transcript: ""
+          )
+        ]
+      }
     }
     // ❌ An effect returned for this action is still running. It must complete before the end of the test. …
   }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-04-code-0015.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-04-code-0015.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import Foundation
 import Testing
 
 @testable import SyncUps
@@ -47,14 +48,15 @@ struct RecordMeetingTests {
     await clock.advance(by: .seconds(1))
     await store.receive(\.timerTick) {
       $0.secondsElapsed = 4
-      $0.syncUp.meetings.insert(
-        Meeting(
-          id: UUID(0),
-          date: Date(timeIntervalSince1970: 1234567890),
-          transcript: ""
-        ),
-        at: 0
-      )
+      $0.$syncUp.withLock {
+        $0.meetings = [
+          Meeting(
+            id: UUID(0),
+            date: Date(timeIntervalSince1970: 1234567890),
+            transcript: ""
+          )
+        ]
+      }
     }
 
     await onAppearTask.cancel()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-04-code-0016.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-04-code-0016.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import Foundation
 import Testing
 
 @testable import SyncUps
@@ -48,14 +49,15 @@ struct RecordMeetingTests {
     await clock.advance(by: .seconds(1))
     await store.receive(\.timerTick) {
       $0.secondsElapsed = 4
-      $0.syncUp.meetings.insert(
-        Meeting(
-          id: UUID(0),
-          date: Date(timeIntervalSince1970: 1234567890),
-          transcript: ""
-        ),
-        at: 0
-      )
+      $0.$syncUp.withLock {
+        $0.meetings = [
+          Meeting(
+            id: UUID(0),
+            date: Date(timeIntervalSince1970: 1234567890),
+            transcript: ""
+          )
+        ]
+      }
     }
 
     await onAppearTask.cancel()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-04-code-0017.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-04-code-0017.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import Foundation
 import Testing
 
 @testable import SyncUps
@@ -47,14 +48,15 @@ struct RecordMeetingTests {
     await clock.advance(by: .seconds(1))
     await store.receive(\.timerTick) {
       $0.secondsElapsed = 4
-      $0.syncUp.meetings.insert(
-        Meeting(
-          id: UUID(0),
-          date: Date(timeIntervalSince1970: 1234567890),
-          transcript: ""
-        ),
-        at: 0
-      )
+      $0.$syncUp.withLock {
+        $0.meetings = [
+          Meeting(
+            id: UUID(0),
+            date: Date(timeIntervalSince1970: 1234567890),
+            transcript: ""
+          )
+        ]
+      }
     }
 
     await onAppearTask.cancel()

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-01-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-01-code-0003.swift
@@ -48,7 +48,7 @@ struct RecordMeetingView: View {
       }
     }
     .padding()
-    .foregroundColor(store.syncUp.theme.accentColor)
+    .foregroundStyle(store.syncUp.theme.accentColor)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-02-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-02-code-0002.swift
@@ -28,15 +28,3 @@ struct AppView: View {
     }
   }
 }
-
-#Preview {
-  AppView(
-    store: Store(
-      initialState: App.State(
-        syncUpsList: SyncUpsList.State()
-      )
-    ) {
-      App()
-    }
-  )
-}

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-02-code-0003-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-02-code-0003-previous.swift
@@ -16,7 +16,7 @@ struct SyncUpDetailView: View {
         } label: {
           Label("Start Meeting", systemImage: "timer")
             .font(.headline)
-            .foregroundColor(.accentColor)
+            .foregroundStyle(Color.accentColor)
         }
         HStack {
           Label("Length", systemImage: "clock")
@@ -29,7 +29,7 @@ struct SyncUpDetailView: View {
           Spacer()
           Text(store.syncUp.theme.name)
             .padding(4)
-            .foregroundColor(store.syncUp.theme.accentColor)
+            .foregroundStyle(store.syncUp.theme.accentColor)
             .background(store.syncUp.theme.mainColor)
             .cornerRadius(4)
         }
@@ -64,10 +64,9 @@ struct SyncUpDetailView: View {
       }
 
       Section {
-        Button("Delete") {
+        Button("Delete", role: .destructive) {
           store.send(.deleteButtonTapped)
         }
-        .foregroundColor(.red)
         .frame(maxWidth: .infinity)
       }
     }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-02-code-0003.swift
@@ -17,7 +17,7 @@ struct SyncUpDetailView: View {
         ) {
           Label("Start Meeting", systemImage: "timer")
             .font(.headline)
-            .foregroundColor(.accentColor)
+            .foregroundStyle(Color.accentColor)
         }
         HStack {
           Label("Length", systemImage: "clock")
@@ -30,7 +30,7 @@ struct SyncUpDetailView: View {
           Spacer()
           Text(store.syncUp.theme.name)
             .padding(4)
-            .foregroundColor(store.syncUp.theme.accentColor)
+            .foregroundStyle(store.syncUp.theme.accentColor)
             .background(store.syncUp.theme.mainColor)
             .cornerRadius(4)
         }
@@ -65,10 +65,9 @@ struct SyncUpDetailView: View {
       }
 
       Section {
-        Button("Delete") {
+        Button("Delete", role: .destructive) {
           store.send(.deleteButtonTapped)
         }
-        .foregroundColor(.red)
         .frame(maxWidth: .infinity)
       }
     }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature.tutorial
@@ -2,8 +2,6 @@
   @Intro(title: "The RecordMeeting feature") {
     Let's get the basics of a new feature into place that we can navigate to, and then we will 
     slowly layer on its complex logic and behavior, such as the timer and speech recognizer.
-    
-<!--    @Image(source: <#file#>, alt: "<#accessible description#>")-->
   }
   
   @Section(title: "Create a new feature") {
@@ -11,8 +9,6 @@
       We will create a brand new feature to hold the logic, behavior and view of the record 
       meeting feature. We won't actually implement any of the logic yet, but we will get the 
       basics of the domain modeling and view into place.
-      
-<!--      @Image(source: <#file#>, alt: "<#accessible description#>")-->
     }
     
     @Steps {


### PR DESCRIPTION
Hi!

Following my last PR, I'm currently reviewing the "Building Sync-ups" tutorial and so far, there is a lot of changes so I've splitted up into one PR per chapter to ease the review of them, **finishing** with the "Record meeting" chapter here…

**Changes Made:**

- Removed unused preview and comments in the tutorial.
- Updated the usage of `foregroundColor` to `foregroundStyle`. Additionally, modified the delete button to utilize a destructive role to match previous changes.
- Implemented `withLock` for modifying shared syncUp instances. 
- Add a missing Foundation import for Date usage.

And this should conclude this review… Thanks for your review of all these changes! 🙏 

**Note**: When trying the last steps of the tests where we cancel the long living timer effect, my test was already passing without the cancel call. It seems to be useless now or maybe the production code had a regression on this part ? Anyway, I left it as an insightful example of how to deal with these problem which tends to occurs sometimes…