### PR TITLE
SyncUps speech client preview

### DIFF
--- a/Examples/SyncUps/SyncUps/Dependencies/SpeechRecognizer.swift
+++ b/Examples/SyncUps/SyncUps/Dependencies/SpeechRecognizer.swift
@@ -48,7 +48,7 @@ extension SpeechClient: DependencyKey {
               officia deserunt mollit anim id est laborum.
               """
             var text = ""
-            while true {
+            while !finalText.isEmpty {
               let word = finalText.prefix { $0 != " " }
               try await Task.sleep(for: .milliseconds(word.count * 50 + .random(in: 0...200)))
               finalText.removeFirst(word.count)

--- a/Examples/SyncUps/SyncUps/Dependencies/SpeechRecognizer.swift
+++ b/Examples/SyncUps/SyncUps/Dependencies/SpeechRecognizer.swift
@@ -33,14 +33,12 @@ extension SpeechClient: DependencyKey {
   }
 
   static var previewValue: SpeechClient {
-    let isRecording = LockIsolated(false)
-    return Self(
+    Self(
       authorizationStatus: { .authorized },
       requestAuthorization: { .authorized },
       startTask: { _ in
         AsyncThrowingStream { continuation in
           Task { @MainActor in
-            isRecording.setValue(true)
             var finalText = """
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor \
               incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud \
@@ -50,7 +48,7 @@ extension SpeechClient: DependencyKey {
               officia deserunt mollit anim id est laborum.
               """
             var text = ""
-            while isRecording.value {
+            while true {
               let word = finalText.prefix { $0 != " " }
               try await Task.sleep(for: .milliseconds(word.count * 50 + .random(in: 0...200)))
               finalText.removeFirst(word.count)


### PR DESCRIPTION
I've noticed that there is some unnecessary state in the preview implementation of the `SpeechClient` which is used in the _SyncUps_ example.

However in the _SpeechRecognition_ example, which also contains a `SpeechClient`, the `isRecording` state is used. But i'm wondering why there is an explicit `finishTask` endpoint instead of making use of cancellation.
