### PR TITLE
Bump minimum sharing version to allow  DebugReducer compilation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
     .package(url: "https://github.com/pointfreeco/swift-navigation", from: "2.2.2"),
     .package(url: "https://github.com/pointfreeco/swift-perception", from: "1.3.4"),
-    .package(url: "https://github.com/pointfreeco/swift-sharing", "0.1.2"..<"3.0.0"),
+    .package(url: "https://github.com/pointfreeco/swift-sharing", "1.0.4"..<"3.0.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.3.0"),
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0"),


### PR DESCRIPTION
Changes introduced in [1.17.1](https://github.com/pointfreeco/swift-composable-architecture/compare/1.17.0...1.17.1) include change of `SharedChangeTracker` initialisation  in [DebugReducer](https://github.com/pointfreeco/swift-composable-architecture/blob/2ebda6ae2b155a5c3d75aff5f6d25c024bc91311/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift)

### Before ###
```
let changeTracker = SharedChangeTracker()
```

### Now ###
```
let changeTracker = SharedChangeTracker(reportUnassertedChanges: false)
```

This change won't allow compilation with swift-sharing dependency of version lower than [1.0.4](https://github.com/pointfreeco/swift-sharing/compare/1.0.3...1.0.4), since it introduced that form of initialisation for [SharedChangeTracker](https://github.com/pointfreeco/swift-sharing/blob/524e1a6868f0c9eebe8002e3f604912865521beb/Sources/Sharing/Internal/SharedChangeTracker.swift)

Therefore, there is a need now to bump minimum version of swift-sharing to 1.0.4
