### PR TITLE
[Examples] declare store as static to avoid interference with Xcode previews

### DIFF
--- a/Examples/Search/Search/SearchApp.swift
+++ b/Examples/Search/Search/SearchApp.swift
@@ -3,14 +3,20 @@ import SwiftUI
 
 @main
 struct SearchApp: App {
+  
+  @MainActor
+  static let store = Store(initialState: Search.State()) {
+    Search()
+      ._printChanges()
+  }
+  
   var body: some Scene {
     WindowGroup {
-      SearchView(
-        store: Store(initialState: Search.State()) {
-          Search()
-            ._printChanges()
-        }
-      )
+      if isTesting {
+        EmptyView()
+      } else {
+        SearchView(store: Self.store)
+      }
     }
   }
 }

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognitionApp.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognitionApp.swift
@@ -3,13 +3,20 @@ import SwiftUI
 
 @main
 struct SpeechRecognitionApp: App {
+  
+  @MainActor
+  static let store = Store(initialState: SpeechRecognition.State()) {
+    SpeechRecognition()
+      ._printChanges()
+  }
+  
   var body: some Scene {
     WindowGroup {
-      SpeechRecognitionView(
-        store: Store(initialState: SpeechRecognition.State()) {
-          SpeechRecognition()._printChanges()
-        }
-      )
+      if isTesting {
+        EmptyView()
+      } else {
+        SpeechRecognitionView(store: Self.store)
+      }
     }
   }
 }

--- a/Examples/Todos/Todos/TodosApp.swift
+++ b/Examples/Todos/Todos/TodosApp.swift
@@ -3,13 +3,22 @@ import SwiftUI
 
 @main
 struct TodosApp: App {
+  
+  @MainActor
+  static let store = Store(initialState: Todos.State()) {
+    Todos()
+      ._printChange()
+  }
+  
   var body: some Scene {
     WindowGroup {
-      AppView(
-        store: Store(initialState: Todos.State()) {
-          Todos()
-        }
-      )
+      if isTesting {
+        EmptyView()
+      } else {
+        AppView(store: Self.store)
+      }
     }
   }
 }
+
+

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemosApp.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemosApp.swift
@@ -3,13 +3,20 @@ import SwiftUI
 
 @main
 struct VoiceMemosApp: App {
+  
+  @MainActor
+  static let store = Store(initialState: VoiceMemos.State()) {
+    VoiceMemos()
+      ._printChanges()
+  }
+  
   var body: some Scene {
     WindowGroup {
-      VoiceMemosView(
-        store: Store(initialState: VoiceMemos.State()) {
-          VoiceMemos()._printChanges()
-        }
-      )
+      if isTesting {
+        EmptyView()
+      } else {
+        VoiceMemosView(store: Self.store)
+      }
     }
   }
 }


### PR DESCRIPTION
Hi!
I am studying the example apps by referring to the tutorial.
I standardized the App.swift file.

**Changes made:**
- Refactored: Declared the store as static to prevent interference with Xcode previews.
- Added: Added an if isTesting condition to prevent interference between the app and the test.

I hope this change will help developers understand the testing and preview mechanisms better.