### PR TITLE
Initial actions

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -159,11 +159,13 @@ public final class Store<State, Action> {
   ///
   /// - Parameters:
   ///   - initialState: The state to start the application in.
+  ///   - initialAction: An action to send the store when it is created.
   ///   - reducer: The reducer that powers the business logic of the application.
   ///   - prepareDependencies: A closure that can be used to override dependencies that will be accessed
   ///     by the reducer.
   public convenience init<R: Reducer<State, Action>>(
-    initialState: @autoclosure () -> R.State,
+    initialState: @autoclosure () -> State,
+    initialAction: @autoclosure () -> Action? = nil,
     @ReducerBuilder<State, Action> reducer: () -> R,
     withDependencies prepareDependencies: ((inout DependencyValues) -> Void)? = nil
   ) {
@@ -175,6 +177,9 @@ public final class Store<State, Action> {
       initialState: initialState,
       reducer: reducer.dependency(\.self, dependencies)
     )
+    if let initialAction = initialAction() {
+      send(initialAction)
+    }
   }
 
   init() {

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -1213,6 +1213,17 @@ final class StoreTests: BaseTCATestCase {
       }
     }
   }
+
+  @MainActor
+  func testInitialAction() async {
+    let store = Store(initialState: 0, initialAction: ()) {
+      Reduce { state, _ in
+        state += 1
+        return .none
+      }
+    }
+    XCTAssertEqual(store.currentState, 1)
+  }
 }
 
 #if canImport(Testing)


### PR DESCRIPTION
It is common to send an action to a store when it is first created to kick off some long-living effects. While many utilize the `onAppear` view modifier for this work, we can simplify things by making the store's initializer a little more powerful.