### PR TITLE
Performance Article: Sharing logic in child features issue

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -199,8 +199,7 @@ Instead, we recommend invoking the child reducer directly:
 
 ```swift
 case .buttonTapped:
-  return Child().reduce(into: &state.child, action: .refresh)
-    .map(Action.child)
+  return reduce(into: &state, action: .child(.refresh))
 ```
 
 ### CPU intensive calculations


### PR DESCRIPTION
I have found a bug when applying what is described in the Performance Article in the `Sharing logic in child features` section

Calling `Child().reduce` may break cancellation logic, while calling `self.reduce` makes it work perfectly

I have written a sample app to reproduce the issue, you can uncomment the code to fix the issue.

| Child().reduce  | self.reduce |
|-|-|
| ![Simulator Screenshot - iPhone 16 - 2025-03-21 at 01 40 15](https://github.com/user-attachments/assets/b588ddd5-e721-481c-849d-6135788fc4ed) | ![simulator_screenshot_4D98112C-F707-49F6-906A-0BBF833E8971](https://github.com/user-attachments/assets/84fefb28-705c-4bfa-972d-1a4c5e57032b) |

But I am not sure about the performances of `self.reduce` against `.send(.child)` tho

<details>
<summary>Full app code</summary>

```swift
import SwiftUI
import ComposableArchitecture

@main
struct TCABugApp: App {
    static let store: StoreOf<Feature> = .init(initialState: .init(), reducer: { Feature() })

    var body: some Scene {
        WindowGroup {
            FeatureView(store: Self.store)
        }
    }
}

@ViewAction(for: Feature.self)
struct FeatureView: View {
    let store: StoreOf<Feature>

    var body: some View {
        VStack {
            ForEach(store.scope(state: \.sub, action: \.sub)) {
                SubFeatureView(store: $0)
            }
        }
        .onAppear {
            send(.onAppear)
        }
    }
}

struct SubFeatureView: View {
    let store: StoreOf<SubFeature>
    
    var body: some View {
        if store.isLoaded {
            Text("OK")
        } else {
            ProgressView()
        }
    }
}

@Reducer
struct Feature {
    @ObservableState
    struct State {
        var sub: IdentifiedArrayOf<SubFeature.State> = [
            .init(id: 1),
            .init(id: 2),
            .init(id: 3)
        ]
    }

    enum Action: ViewAction {
        case sub(IdentifiedActionOf<SubFeature>)
        case view(ViewAction)
        
        enum ViewAction {
            case onAppear
        }
    }

    var body: some Reducer<State, Action> {
        Reduce { state, action in
            switch action {
            case .view(.onAppear):
//                return .merge(
//                    state.sub.map {
//                        reduce(into: &state, action: .sub(.element(id: $0.id, action: .fetch)))
//                    }
//                )
                return .merge(state.sub.indices.map { index in
                    let id = state.sub[index].id
                    return SubFeature().reduce(into: &state.sub[index], action: .fetch).map {
                        Action.sub(.element(id: id, action: $0))
                    }
                })
            case .sub:
                return .none
            }
        }
        .forEach(\.sub, action: \.sub) {
            SubFeature()
        }
    }
}

@Reducer
struct SubFeature {
    @ObservableState
    struct State: Identifiable {
        let id: Int
        fileprivate(set) var isLoaded: Bool = false
    }
    
    enum Action {
        case fetch
        case fetchResponse(Result<Void, Error>)
    }
    
    enum CancelID {
        case fetch
    }
    
    @Dependency(\.continuousClock) var clock
    
    var body: some ReducerOf<Self> {
        Reduce { state, action in
            switch action {
            case .fetch:
                return .run { send in
                    try await clock.sleep(for: .seconds(1))
                    await send(.fetchResponse(.success(())))
                } catch: { error, send in
                    await send(.fetchResponse(.failure(error)))
                }
                .cancellable(id: CancelID.fetch, cancelInFlight: true)
            case let .fetchResponse(result):
                switch result {
                case .success:
                    state.isLoaded = true
                case .failure:
                    break
                }
                return .none
            }
        }
    }
}
```

</details>