### PR TITLE
RootCore crash

### DIFF
--- a/Sources/ComposableArchitecture/Core.swift
+++ b/Sources/ComposableArchitecture/Core.swift
@@ -128,9 +128,7 @@ final class RootCore<Root: Reducer>: Core {
           }
           boxedTask.wrappedValue = task
           tasks.withValue { $0.append(task) }
-          self.effectCancellables[uuid] = AnyCancellable {
-            task.cancel()
-          }
+          self.effectCancellables[uuid] = self.effectCancellable(task: task)
         }
       case let .run(priority, operation):
         withEscapedDependencies { continuation in
@@ -169,9 +167,7 @@ final class RootCore<Root: Reducer>: Core {
             self?.effectCancellables[uuid] = nil
           }
           tasks.withValue { $0.append(task) }
-          self.effectCancellables[uuid] = AnyCancellable {
-            task.cancel()
-          }
+          self.effectCancellables[uuid] = self.effectCancellable(task: task)
         }
       }
     }
@@ -193,6 +189,11 @@ final class RootCore<Root: Reducer>: Core {
       }
     }
   }
+
+  nonisolated private func effectCancellable<Success, Failure>(task: Task<Success, Failure>) -> AnyCancellable {
+    AnyCancellable { task.cancel() }
+  }
+
   private actor DefaultIsolation {}
 }
 

--- a/Sources/ComposableArchitecture/Core.swift
+++ b/Sources/ComposableArchitecture/Core.swift
@@ -128,7 +128,9 @@ final class RootCore<Root: Reducer>: Core {
           }
           boxedTask.wrappedValue = task
           tasks.withValue { $0.append(task) }
-          self.effectCancellables[uuid] = self.effectCancellable(task: task)
+          self.effectCancellables[uuid] = AnyCancellable { @Sendable in
+            task.cancel()
+          }
         }
       case let .run(priority, operation):
         withEscapedDependencies { continuation in
@@ -167,7 +169,9 @@ final class RootCore<Root: Reducer>: Core {
             self?.effectCancellables[uuid] = nil
           }
           tasks.withValue { $0.append(task) }
-          self.effectCancellables[uuid] = self.effectCancellable(task: task)
+          self.effectCancellables[uuid] = AnyCancellable { @Sendable in
+            task.cancel()
+          }
         }
       }
     }
@@ -189,11 +193,6 @@ final class RootCore<Root: Reducer>: Core {
       }
     }
   }
-
-  nonisolated private func effectCancellable<Success, Failure>(task: Task<Success, Failure>) -> AnyCancellable {
-    AnyCancellable { task.cancel() }
-  }
-
   private actor DefaultIsolation {}
 }
 

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -58,7 +58,7 @@ extension Effect {
 
               let cancellable = LockIsolated<AnyCancellable?>(nil)
               cancellable.setValue(
-                AnyCancellable {
+                AnyCancellable { @Sendable in
                   _cancellationCancellables.withValue {
                     cancellationSubject.send(())
                     cancellationSubject.send(completion: .finished)
@@ -179,7 +179,7 @@ extension Effect {
           $0.cancel(id: id, path: navigationIDPath)
         }
         let task = Task { try await operation() }
-        let cancellable = AnyCancellable { task.cancel() }
+        let cancellable = AnyCancellable { @Sendable in task.cancel() }
         $0.insert(cancellable, at: id, path: navigationIDPath)
         return (cancellable, task)
       }

--- a/Sources/ComposableArchitecture/Effects/Publisher.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher.swift
@@ -36,7 +36,7 @@ public struct _EffectPublisher<Action>: Publisher {
           defer { subscriber.send(completion: .finished) }
           await operation(Send { subscriber.send($0) })
         }
-        return AnyCancellable {
+        return AnyCancellable { @Sendable in
           task.cancel()
         }
       }

--- a/Tests/ComposableArchitectureTests/StoreLifetimeTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreLifetimeTests.swift
@@ -69,7 +69,7 @@ final class StoreLifetimeTests: BaseTCATestCase {
     }
 
     @MainActor
-    func testStoreDeinit_RunningEffect() async {
+    func testStoreDeinit_RunningEffect_MainActor() async {
       Logger.shared.isEnabled = true
       let effectFinished = self.expectation(description: "Effect finished")
       do {
@@ -94,6 +94,24 @@ final class StoreLifetimeTests: BaseTCATestCase {
       )
       await self.fulfillment(of: [effectFinished], timeout: 0.5)
     }
+
+  func testStoreDeinit_RunningEffect() async {
+    let effectFinished = self.expectation(description: "Effect finished")
+    do {
+      let store = await Store<Void, Void>(initialState: ()) {
+        Reduce { state, _ in
+          .run { _ in
+            try? await Task.never()
+            effectFinished.fulfill()
+          }
+        }
+      }
+      await store.send(())
+      _ = store
+    }
+
+    await self.fulfillment(of: [effectFinished], timeout: 0.5)
+  }
 
     @MainActor
     func testStoreDeinit_RunningCombineEffect() async {


### PR DESCRIPTION
Fix RootCore crash when released with effects outside of the MainActor

Because RootCore is a MainActor, every closure is expected to be called on MainActor, so when RootCore deinits outside of the MainActor the AnyCancellable closure is called and makes the app crash

<img width="1499" alt="Screenshot 2025-03-27 at 16 27 30" src="https://github.com/user-attachments/assets/2b89cdc0-89fd-4692-a553-54d9b8d244b3" />

Note: The crash also occurs on the latest release in RootStore