### PR TITLE
Enable binding workaround in release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,21 +132,21 @@ jobs:
       - name: Update mtime for incremental builds
         uses: chetan/git-restore-mtime-action@v2
       - name: CaseStudies (SwiftUI)
-        run: make DERIVED_DATA_PATH=~/.derivedData SCHEME="CaseStudies (SwiftUI)" xcodebuild
+        run: make DERIVED_DATA_PATH=~/.derivedData SCHEME="CaseStudies (SwiftUI)" xcodebuild-raw
       - name: CaseStudies (UIKit)
-        run: make DERIVED_DATA_PATH=~/.derivedData SCHEME="CaseStudies (UIKit)" xcodebuild
+        run: make DERIVED_DATA_PATH=~/.derivedData SCHEME="CaseStudies (UIKit)" xcodebuild-raw
       - name: Search
-        run: make DERIVED_DATA_PATH=~/.derivedData SCHEME="Search" xcodebuild
+        run: make DERIVED_DATA_PATH=~/.derivedData SCHEME="Search" xcodebuild-raw
       - name: SyncUps
-        run: make DERIVED_DATA_PATH=~/.derivedData SCHEME="SyncUps" xcodebuild
+        run: make DERIVED_DATA_PATH=~/.derivedData SCHEME="SyncUps" xcodebuild-raw
       - name: SpeechRecognition
-        run: make DERIVED_DATA_PATH=~/.derivedData SCHEME="SpeechRecognition" xcodebuild
+        run: make DERIVED_DATA_PATH=~/.derivedData SCHEME="SpeechRecognition" xcodebuild-raw
       - name: TicTacToe
-        run: make DERIVED_DATA_PATH=~/.derivedData SCHEME="TicTacToe" xcodebuild
+        run: make DERIVED_DATA_PATH=~/.derivedData SCHEME="TicTacToe" xcodebuild-raw
       - name: Todos
-        run: make DERIVED_DATA_PATH=~/.derivedData SCHEME="Todos" xcodebuild
+        run: make DERIVED_DATA_PATH=~/.derivedData SCHEME="Todos" xcodebuild-raw
       - name: VoiceMemos
-        run: make DERIVED_DATA_PATH=~/.derivedData SCHEME="VoiceMemos" xcodebuild
+        run: make DERIVED_DATA_PATH=~/.derivedData SCHEME="VoiceMemos" xcodebuild-raw
 
   check-macro-compatibility:
     name: Check Macro Compatibility

--- a/Sources/ComposableArchitecture/Core.swift
+++ b/Sources/ComposableArchitecture/Core.swift
@@ -268,11 +268,9 @@ final class IfLetCore<Base: Core, State, Action>: Core {
   @inlinable
   @inline(__always)
   func send(_ action: Action) -> Task<Void, Never>? {
-    #if DEBUG
-      if BindingLocal.isActive && isInvalid {
-        return nil
-      }
-    #endif
+    if BindingLocal.isActive && isInvalid {
+      return nil
+    }
     return base.send(actionKeyPath(action))
   }
   @inlinable

--- a/Tests/ComposableArchitectureTests/EffectRunTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectRunTests.swift
@@ -166,6 +166,6 @@ final class EffectRunTests: BaseTCATestCase {
     await store.send(.tap).finish()
     await queue.advance(by: .seconds(1))
 
-    try await Task.sleep(nanoseconds: 100_000_000)
+    try await Task.sleep(nanoseconds: 1_000_000_000)
   }
 }


### PR DESCRIPTION
The store will suppress warnings for invalid actions emitted by bindings to workaround a SwiftUI issue of bindings firing on dismissal when focussed, but only in debug builds.

We capture issues in release builds in Sentry so this can still be noisy and there doesn't seem to be any need to restrict this to just debug builds.