### PR TITLE
Wrap cases of switch in a closure

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3ebb70e4ef5203d6f8bebecc1bec69837803b880f6f397952a6f49aa1f6fe107",
+  "originHash" : "db98d6ddac14160dacbc01e142642e2f8a4a2d893db3651e8a137ad669ab86a4",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -65,39 +65,12 @@
       }
     },
     {
-      "identity" : "swift-docc-plugin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-docc-plugin",
-      "state" : {
-        "revision" : "85e4bb4e1cd62cec64a4b8e769dcefdf0c5b9d64",
-        "version" : "1.4.3"
-      }
-    },
-    {
-      "identity" : "swift-docc-symbolkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
-      "state" : {
-        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
-        "version" : "1.0.0"
-      }
-    },
-    {
       "identity" : "swift-identified-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",
       "state" : {
         "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
         "version" : "1.1.1"
-      }
-    },
-    {
-      "identity" : "swift-macro-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-macro-testing",
-      "state" : {
-        "revision" : "0b80a098d4805a21c412b65f01ffde7b01aab2fa",
-        "version" : "0.6.0"
       }
     },
     {
@@ -114,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "21811d6230a625fa0f2e6ffa85be857075cc02c4",
-        "version" : "1.5.0"
+        "revision" : "671fa54b279fd73933b4a8b34782ebf6c8869145",
+        "version" : "1.5.1"
       }
     },
     {
@@ -123,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-sharing",
       "state" : {
-        "revision" : "2c840cf2ae0526ad6090e7796c4e13d9a2339f4a",
-        "version" : "2.3.3"
+        "revision" : "732871fabfc6b38fcdff5ad2f7336327dbf78e81",
+        "version" : "2.4.0"
       }
     },
     {

--- a/Sources/ComposableArchitectureMacros/ReducerMacro.swift
+++ b/Sources/ComposableArchitectureMacros/ReducerMacro.swift
@@ -386,6 +386,9 @@ extension ReducerMacro: MemberMacro {
           \(access)static func scope(\
           _ store: ComposableArchitecture.Store<Self.State, Self.Action>\
           ) -> CaseScope {
+          // NB: We are using immediately invoked closures in each case of this switch to work around a Swift
+          //     bug that can cause large switch statements to blow the stack.
+          //     https://forums.swift.org/t/struct-and-enum-accessors-take-a-large-amount-of-stack-space/63251/12
           switch store.state {
           \(raw: storeScopes.joined(separator: "\n"))
           }

--- a/Sources/ComposableArchitectureMacros/ReducerMacro.swift
+++ b/Sources/ComposableArchitectureMacros/ReducerMacro.swift
@@ -627,7 +627,7 @@ private enum ReducerCase {
       {
         return """
           case .\(name):
-          return .\(name)(store.scope(state: \\.\(name), action: \\.\(name))!)
+          return { .\(name)(store.scope(state: \\.\(name), action: \\.\(name))!) }()
           """
       } else if let parameters = element.parameterClause?.parameters {
         let bindingNames = (0..<parameters.count).map { "v\($0)" }.joined(separator: ", ")
@@ -636,12 +636,12 @@ private enum ReducerCase {
           .joined(separator: ", ")
         return """
           case let .\(name)(\(bindingNames)):
-          return .\(name)(\(returnNames))
+          return { .\(name)(\(returnNames)) }()
           """
       } else {
         return """
           case .\(name):
-          return .\(name)
+          return { .\(name) }()
           """
       }
     case let .ifConfig(configs):

--- a/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
@@ -242,6 +242,9 @@
 
             }
             static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
+                // NB: We are using immediately invoked closures in each case of this switch to work around a Swift
+                //     bug that can cause large switch statements to blow the stack.
+                //     https://forums.swift.org/t/struct-and-enum-accessors-take-a-large-amount-of-stack-space/63251/12
                 switch store.state {
 
                 }
@@ -321,6 +324,9 @@
             case alert(AlertState<Alert>)
           }
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
+            // NB: We are using immediately invoked closures in each case of this switch to work around a Swift
+            //     bug that can cause large switch statements to blow the stack.
+            //     https://forums.swift.org/t/struct-and-enum-accessors-take-a-large-amount-of-stack-space/63251/12
             switch store.state {
             case .activity:
               return {
@@ -393,6 +399,9 @@
             case meeting(ComposableArchitecture.StoreOf<Meeting>)
           }
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
+            // NB: We are using immediately invoked closures in each case of this switch to work around a Swift
+            //     bug that can cause large switch statements to blow the stack.
+            //     https://forums.swift.org/t/struct-and-enum-accessors-take-a-large-amount-of-stack-space/63251/12
             switch store.state {
             case .timeline:
               return {
@@ -445,6 +454,9 @@
 
             }
             static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
+                // NB: We are using immediately invoked closures in each case of this switch to work around a Swift
+                //     bug that can cause large switch statements to blow the stack.
+                //     https://forums.swift.org/t/struct-and-enum-accessors-take-a-large-amount-of-stack-space/63251/12
                 switch store.state {
 
                 }
@@ -495,6 +507,9 @@
             }
 
             package static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
+                // NB: We are using immediately invoked closures in each case of this switch to work around a Swift
+                //     bug that can cause large switch statements to blow the stack.
+                //     https://forums.swift.org/t/struct-and-enum-accessors-take-a-large-amount-of-stack-space/63251/12
                 switch store.state {
 
                 }
@@ -545,6 +560,9 @@
             }
 
             public static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
+                // NB: We are using immediately invoked closures in each case of this switch to work around a Swift
+                //     bug that can cause large switch statements to blow the stack.
+                //     https://forums.swift.org/t/struct-and-enum-accessors-take-a-large-amount-of-stack-space/63251/12
                 switch store.state {
 
                 }
@@ -593,6 +611,9 @@
             case alert(AlertState<Never>)
           }
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
+            // NB: We are using immediately invoked closures in each case of this switch to work around a Swift
+            //     bug that can cause large switch statements to blow the stack.
+            //     https://forums.swift.org/t/struct-and-enum-accessors-take-a-large-amount-of-stack-space/63251/12
             switch store.state {
             case let .alert(v0):
               return {
@@ -653,6 +674,9 @@
             case timeline(ComposableArchitecture.StoreOf<Timeline>)
           }
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
+            // NB: We are using immediately invoked closures in each case of this switch to work around a Swift
+            //     bug that can cause large switch statements to blow the stack.
+            //     https://forums.swift.org/t/struct-and-enum-accessors-take-a-large-amount-of-stack-space/63251/12
             switch store.state {
             case .activity:
               return {
@@ -716,6 +740,9 @@
             case meeting(Meeting)
           }
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
+            // NB: We are using immediately invoked closures in each case of this switch to work around a Swift
+            //     bug that can cause large switch statements to blow the stack.
+            //     https://forums.swift.org/t/struct-and-enum-accessors-take-a-large-amount-of-stack-space/63251/12
             switch store.state {
             case .timeline:
               return {
@@ -783,6 +810,9 @@
             case meeting(Meeting, syncUp: SyncUp)
           }
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
+            // NB: We are using immediately invoked closures in each case of this switch to work around a Swift
+            //     bug that can cause large switch statements to blow the stack.
+            //     https://forums.swift.org/t/struct-and-enum-accessors-take-a-large-amount-of-stack-space/63251/12
             switch store.state {
             case let .alert(v0):
               return {
@@ -859,6 +889,9 @@
             case sheet(ComposableArchitecture.StoreOf<Counter>)
           }
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
+            // NB: We are using immediately invoked closures in each case of this switch to work around a Swift
+            //     bug that can cause large switch statements to blow the stack.
+            //     https://forums.swift.org/t/struct-and-enum-accessors-take-a-large-amount-of-stack-space/63251/12
             switch store.state {
             case .drillDown:
               return {
@@ -919,6 +952,9 @@
             case feature(ComposableArchitecture.StoreOf<Nested.Feature>)
           }
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
+            // NB: We are using immediately invoked closures in each case of this switch to work around a Swift
+            //     bug that can cause large switch statements to blow the stack.
+            //     https://forums.swift.org/t/struct-and-enum-accessors-take-a-large-amount-of-stack-space/63251/12
             switch store.state {
             case .feature:
               return {
@@ -1283,6 +1319,9 @@
 
           }
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
+            // NB: We are using immediately invoked closures in each case of this switch to work around a Swift
+            //     bug that can cause large switch statements to blow the stack.
+            //     https://forums.swift.org/t/struct-and-enum-accessors-take-a-large-amount-of-stack-space/63251/12
             switch store.state {
             case .child:
               return {

--- a/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
@@ -6,7 +6,7 @@
   final class ReducerMacroTests: XCTestCase {
     override func invokeTest() {
       withMacroTesting(
-        // record: .failed,
+        record: .failed,
         macros: [ReducerMacro.self]
       ) {
         super.invokeTest()
@@ -323,13 +323,21 @@
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
             case .activity:
-              return .activity(store.scope(state: \.activity, action: \.activity)!)
+              return {
+                .activity(store.scope(state: \.activity, action: \.activity)!)
+              }()
             case .timeline:
-              return .timeline(store.scope(state: \.timeline, action: \.timeline)!)
+              return {
+                .timeline(store.scope(state: \.timeline, action: \.timeline)!)
+              }()
             case .tweet:
-              return .tweet(store.scope(state: \.tweet, action: \.tweet)!)
+              return {
+                .tweet(store.scope(state: \.tweet, action: \.tweet)!)
+              }()
             case let .alert(v0):
-              return .alert(v0)
+              return {
+                .alert(v0)
+              }()
             }
           }
         }
@@ -387,9 +395,13 @@
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
             case .timeline:
-              return .timeline(store.scope(state: \.timeline, action: \.timeline)!)
+              return {
+                .timeline(store.scope(state: \.timeline, action: \.timeline)!)
+              }()
             case .meeting:
-              return .meeting(store.scope(state: \.meeting, action: \.meeting)!)
+              return {
+                .meeting(store.scope(state: \.meeting, action: \.meeting)!)
+              }()
             }
           }
         }
@@ -583,7 +595,9 @@
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
             case let .alert(v0):
-              return .alert(v0)
+              return {
+                .alert(v0)
+              }()
             }
           }
         }
@@ -641,9 +655,13 @@
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
             case .activity:
-              return .activity(store.scope(state: \.activity, action: \.activity)!)
+              return {
+                .activity(store.scope(state: \.activity, action: \.activity)!)
+              }()
             case .timeline:
-              return .timeline(store.scope(state: \.timeline, action: \.timeline)!)
+              return {
+                .timeline(store.scope(state: \.timeline, action: \.timeline)!)
+              }()
             }
           }
         }
@@ -700,9 +718,13 @@
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
             case .timeline:
-              return .timeline(store.scope(state: \.timeline, action: \.timeline)!)
+              return {
+                .timeline(store.scope(state: \.timeline, action: \.timeline)!)
+              }()
             case let .meeting(v0):
-              return .meeting(v0)
+              return {
+                .meeting(v0)
+              }()
             }
           }
         }
@@ -763,11 +785,17 @@
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
             case let .alert(v0):
-              return .alert(v0)
+              return {
+                .alert(v0)
+              }()
             case let .dialog(v0):
-              return .dialog(v0)
+              return {
+                .dialog(v0)
+              }()
             case let .meeting(v0, v1):
-              return .meeting(v0, syncUp: v1)
+              return {
+                .meeting(v0, syncUp: v1)
+              }()
             }
           }
         }
@@ -833,11 +861,17 @@
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
             case .drillDown:
-              return .drillDown(store.scope(state: \.drillDown, action: \.drillDown)!)
+              return {
+                .drillDown(store.scope(state: \.drillDown, action: \.drillDown)!)
+              }()
             case .popover:
-              return .popover(store.scope(state: \.popover, action: \.popover)!)
+              return {
+                .popover(store.scope(state: \.popover, action: \.popover)!)
+              }()
             case .sheet:
-              return .sheet(store.scope(state: \.sheet, action: \.sheet)!)
+              return {
+                .sheet(store.scope(state: \.sheet, action: \.sheet)!)
+              }()
             }
           }
         }
@@ -887,7 +921,9 @@
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
             case .feature:
-              return .feature(store.scope(state: \.feature, action: \.feature)!)
+              return {
+                .feature(store.scope(state: \.feature, action: \.feature)!)
+              }()
             }
           }
         }
@@ -1249,28 +1285,44 @@
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
             case .child:
-              return .child(store.scope(state: \.child, action: \.child)!)
+              return {
+                .child(store.scope(state: \.child, action: \.child)!)
+              }()
             #if os(macOS)
             case .mac:
-              return .mac(store.scope(state: \.mac, action: \.mac)!)
+              return {
+                .mac(store.scope(state: \.mac, action: \.mac)!)
+              }()
             case let .macAlert(v0):
-              return .macAlert(v0)
+              return {
+                .macAlert(v0)
+              }()
             #elseif os(iOS)
             case .phone:
-              return .phone(store.scope(state: \.phone, action: \.phone)!)
+              return {
+                .phone(store.scope(state: \.phone, action: \.phone)!)
+              }()
             #else
             case .other:
-              return .other(store.scope(state: \.other, action: \.other)!)
+              return {
+                .other(store.scope(state: \.other, action: \.other)!)
+              }()
             case .another:
-              return .another
+              return {
+                .another
+              }()
             #endif
 
             #if DEBUG
             #if INNER
             case .inner:
-              return .inner(store.scope(state: \.inner, action: \.inner)!)
+              return {
+                .inner(store.scope(state: \.inner, action: \.inner)!)
+              }()
             case let .innerDialog(v0):
-              return .innerDialog(v0)
+              return {
+                .innerDialog(v0)
+              }()
             #endif
             #endif
 

--- a/Tests/ComposableArchitectureTests/Internal/BaseTCATestCase.swift
+++ b/Tests/ComposableArchitectureTests/Internal/BaseTCATestCase.swift
@@ -4,7 +4,8 @@ import XCTest
 class BaseTCATestCase: XCTestCase {
   override func tearDown() async throws {
     try await super.tearDown()
-    _cancellationCancellables.withValue { [description = "\(self)"] in
+    let description = "\(self)"
+    _cancellationCancellables.withValue {
       XCTAssertEqual($0.count, 0, description)
       $0.removeAll()
     }

--- a/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import SwiftUI
 import XCTest
 
 @available(*, deprecated, message: "TODO: Update to use case pathable syntax with Swift 5.9")
@@ -2636,7 +2637,7 @@ final class PresentationReducerTests: BaseTCATestCase {
     }
     @MainActor
     func testEphemeralBindingDismissal() async {
-      @Perception.Bindable var store = Store(
+      @Bindable var store = Store(
         initialState: TestEphemeralBindingDismissalFeature.State(
           alert: AlertState { TextState("Oops!") }
         )

--- a/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
@@ -2639,7 +2639,7 @@ final class PresentationReducerTests: BaseTCATestCase {
     }
     @MainActor
     func testEphemeralBindingDismissal() async {
-      @Bindable var store = Store(
+      @Perception.Bindable var store = Store(
         initialState: TestEphemeralBindingDismissalFeature.State(
           alert: AlertState { TextState("Oops!") }
         )

--- a/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
@@ -2109,7 +2109,8 @@ final class PresentationReducerTests: BaseTCATestCase {
                 ConfirmationDialogState {
                   TextState("Hello!")
                 } actions: {
-                })
+                }
+              )
               return .none
             case .destination(.presented(.dialog(.showAlert))):
               state.destination = .alert(AlertState { TextState("Hello!") })
@@ -2155,7 +2156,8 @@ final class PresentationReducerTests: BaseTCATestCase {
           ConfirmationDialogState {
             TextState("Hello!")
           } actions: {
-          })
+          }
+        )
       }
       await store.send(.destination(.dismiss)) {
         $0.destination = nil
@@ -2618,7 +2620,7 @@ final class PresentationReducerTests: BaseTCATestCase {
     }
   }
 
-  #if !os(visionOS)
+  #if !os(visionOS) && compiler(<6.1)
     @Reducer
     struct TestEphemeralBindingDismissalFeature {
       @ObservableState

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -525,7 +525,8 @@ final class StoreTests: BaseTCATestCase {
       [
         .button,
         .child(2),
-      ])
+      ]
+    )
   }
 
   func testCascadingTaskCancellation() async {
@@ -936,7 +937,8 @@ final class StoreTests: BaseTCATestCase {
   func testPresentationScope() async {
     let store = Store(
       initialState: Feature_testPresentationScope.State(
-        child: .init(child: .init()))
+        child: .init(child: .init())
+      )
     ) {
       Feature_testPresentationScope()
     }
@@ -1104,10 +1106,10 @@ final class StoreTests: BaseTCATestCase {
     var body: some ReducerOf<Self> { EmptyReducer() }
   }
 
-  #if !os(visionOS)
+  #if !os(visionOS) && compiler(<6.1)
     @MainActor
     func testInvalidatedStoreScope() async throws {
-      @Bindable var store = Store(
+      @Perception.Bindable var store = Store(
         initialState: InvalidatedStoreScopeParentFeature.State(
           child: InvalidatedStoreScopeChildFeature.State(
             grandchild: InvalidatedStoreScopeGrandchildFeature.State()

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -1120,7 +1120,7 @@ final class StoreTests: BaseTCATestCase {
       }
       store.send(.tap)
 
-      @Bindable var childStore = store.scope(state: \.child, action: \.child)!
+      @Perception.Bindable var childStore = store.scope(state: \.child, action: \.child)!
       let grandchildStoreBinding = $childStore.scope(state: \.grandchild, action: \.grandchild)
 
       store.send(.child(.dismiss))

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -1,5 +1,6 @@
 @preconcurrency import Combine
 @_spi(Internals) import ComposableArchitecture
+import SwiftUI
 import XCTest
 
 #if canImport(Testing)
@@ -1106,7 +1107,7 @@ final class StoreTests: BaseTCATestCase {
   #if !os(visionOS)
     @MainActor
     func testInvalidatedStoreScope() async throws {
-      @Perception.Bindable var store = Store(
+      @Bindable var store = Store(
         initialState: InvalidatedStoreScopeParentFeature.State(
           child: InvalidatedStoreScopeChildFeature.State(
             grandchild: InvalidatedStoreScopeGrandchildFeature.State()
@@ -1117,7 +1118,7 @@ final class StoreTests: BaseTCATestCase {
       }
       store.send(.tap)
 
-      @Perception.Bindable var childStore = store.scope(state: \.child, action: \.child)!
+      @Bindable var childStore = store.scope(state: \.child, action: \.child)!
       let grandchildStoreBinding = $childStore.scope(state: \.grandchild, action: \.grandchild)
 
       store.send(.child(.dismiss))


### PR DESCRIPTION
There is a known, and longstanding, issues in Swift where large switch statements can blow the stack. Indirect enums can help with this, but there is also a trick described [here](https://forums.swift.org/t/struct-and-enum-accessors-take-a-large-amount-of-stack-space/63251/12) of wrapping each case in an immediately invoked closure. 