### PR TITLE
Invalidate child store subscriptions

### DIFF
--- a/Examples/Integration/Integration/iOS 17/ObservableSharedStateTestCase.swift
+++ b/Examples/Integration/Integration/iOS 17/ObservableSharedStateTestCase.swift
@@ -112,12 +112,12 @@ private struct Feature {
           defaults.removeObject(forKey: "isOn")
         }
       case .resetButtonTapped:
-        state.isAppStorageOn1 = false
-        state.isAppStorageOn2 = false
-        state.fileStorage1.isOn = false
-        state.fileStorage2.isOn = false
-        state.isInMemoryOn1 = false
-        state.isInMemoryOn2 = false
+        state.$isAppStorageOn1.withLock { $0 = false }
+        state.$isAppStorageOn2.withLock { $0 = false }
+        state.$fileStorage1.withLock { $0.isOn = false }
+        state.$fileStorage2.withLock { $0.isOn = false }
+        state.$isInMemoryOn1.withLock { $0 = false }
+        state.$isInMemoryOn2.withLock { $0 = false }
         return .none
       case .writeToFileStorageButtonTapped:
         return .run { [isOn = state.fileStorage1.isOn] _ in

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -372,12 +372,8 @@ public final class Store<State, Action> {
     if let stateType = State.self as? any ObservableState.Type {
       func subscribeToDidSet<T: ObservableState>(_ type: T.Type) -> AnyCancellable {
         return core.didSet
-          .prefix { [weak self] _ in
-            self?.core.isInvalid != true
-          }
-          .compactMap { [weak self] in
-            (self?.currentState as? T)?._$id
-          }
+          .prefix { [weak self] _ in self?.core.isInvalid != true }
+          .compactMap { [weak self] in (self?.currentState as? T)?._$id }
           .removeDuplicates()
           .dropFirst()
           .sink { [weak self] _ in

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -371,8 +371,13 @@ public final class Store<State, Action> {
 
     if let stateType = State.self as? any ObservableState.Type {
       func subscribeToDidSet<T: ObservableState>(_ type: T.Type) -> AnyCancellable {
-        core.didSet
-          .compactMap { [weak self] in (self?.currentState as? T)?._$id }
+        return core.didSet
+          .prefix { [weak self] _ in
+            self?.core.isInvalid != true
+          }
+          .compactMap { [weak self] in
+            (self?.currentState as? T)?._$id
+          }
           .removeDuplicates()
           .dropFirst()
           .sink { [weak self] _ in

--- a/Tests/ComposableArchitectureTests/StorePerceptionTests.swift
+++ b/Tests/ComposableArchitectureTests/StorePerceptionTests.swift
@@ -32,6 +32,7 @@ final class StorePerceptionTests: BaseTCATestCase {
   }
 
   @MainActor
+  @available(*, deprecated)
   func testPerceptionCheck_AccessStateWithoutTracking() {
     @MainActor
     struct FeatureView: View {


### PR DESCRIPTION
In the current design of TCA, child stores must subscribe via the root store firehose of updates, and these subscriptions can grow over time and eventually lead to a performance issue. This branch attempts to mitigate the problem by terminating subscriptions on invalidated stores, _i.e._ after an optional store is dismissed.

Fixes #3634.