### PR TITLE
Fix build error when using SwiftSyntax 601.0.0

### DIFF
--- a/Sources/ComposableArchitectureMacros/ReducerMacro.swift
+++ b/Sources/ComposableArchitectureMacros/ReducerMacro.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftSyntax


### PR DESCRIPTION
Adds a Foundation import to get access to String's `capitalized`.  This fixes an error when building with SwiftSyntax 601.0.0:

```
Sources/ComposableArchitectureMacros/ReducerMacro.swift:271:85: error: value of type 'String' has no member 'capitalized'
269 |           conformances.append(
270 |             contentsOf: arguments[startIndex..<endIndex].compactMap {
271 |               $0.expression.as(MemberAccessExprSyntax.self)?.declName.baseName.text.capitalized
    |                                                                                     `- error: value of type 'String' has no member 'capitalized'
272 |             }
273 |           )
```

Presumably `Foundation` was coming in transitively but that changed in 601?