### PR TITLE
Remove hashable requirement from `UIPushAction`

### DIFF
--- a/Sources/ComposableArchitecture/UIKit/NavigationStackControllerUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/NavigationStackControllerUIKit.swift
@@ -91,7 +91,7 @@
     ///   - filePath: The source `#filePath` associated with the push.
     ///   - line: The source `#line` associated with the push.
     ///   - column: The source `#column` associated with the push.
-    public func callAsFunction<Element: Hashable>(
+    public func callAsFunction<Element>(
       state: Element,
       fileID: StaticString = #fileID,
       filePath: StaticString = #filePath,


### PR DESCRIPTION
This requirement isn't needed, since the hashability occurs in the internals of `StackState`.