### PR TITLE
expose navigation stack helper behind SPI

### DIFF
--- a/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
@@ -202,14 +202,22 @@ public struct _NavigationDestinationViewModifier<
     content
       .environment(\.navigationDestinationType, State.self)
       .navigationDestination(for: StackState<State>.Component.self) { component in
-        navigationDestination(component: component)
+        destination(store.scope(component: component, fileID: fileID, filePath: filePath, line: line, column: column))
           .environment(\.navigationDestinationType, State.self)
       }
   }
+}
 
-  @MainActor
-  private func navigationDestination(component: StackState<State>.Component) -> Destination {
-    let id = store.id(
+@_spi(Internals)
+public extension Store {
+  func scope<ChildState, ChildAction>(
+    component: StackState<ChildState>.Component,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) -> Store<ChildState, ChildAction> where State == StackState<ChildState>, Action == StackAction<ChildState, ChildAction> {
+    let id = self.id(
       state:
         \.[
           id: component.id,
@@ -222,8 +230,8 @@ public struct _NavigationDestinationViewModifier<
     )
     @MainActor
     func open(
-      _ core: some Core<StackState<State>, StackAction<State, Action>>
-    ) -> any Core<State, Action> {
+      _ core: some Core<StackState<ChildState>, StackAction<ChildState, ChildAction>>
+    ) -> any Core<ChildState, ChildAction> {
       IfLetCore(
         base: core,
         cachedState: component.element,
@@ -238,7 +246,7 @@ public struct _NavigationDestinationViewModifier<
         actionKeyPath: \.[id: component.id]
       )
     }
-    return destination(store.scope(id: id, childCore: open(store.core)))
+    return self.scope(id: id, childCore: open(self.core))
   }
 }
 


### PR DESCRIPTION
Hi,

The latest release with Core refactoring broke our back port of the NavigationStack.init(path:) you provide. At first I tried to expose enough to make the same thing but it's far easier and maybe better to only expose a helper method that get the job done. What do you think ?