### PR TITLE
Isolate cancellation in root stores.

### DIFF
--- a/Sources/ComposableArchitecture/Core.swift
+++ b/Sources/ComposableArchitecture/Core.swift
@@ -53,12 +53,21 @@ final class RootCore<Root: Reducer>: Core {
   private var bufferedActions: [Root.Action] = []
   var effectCancellables: [UUID: AnyCancellable] = [:]
   private var isSending = false
-  init(
+  init<Other: Reducer<Root.State, Root.Action>>(
     initialState: Root.State,
-    reducer: Root
-  ) {
+    reducer: Other
+  ) where Root == _DependencyKeyWritingReducer<Other> {
     self.state = initialState
-    self.reducer = reducer
+    self.reducer = reducer.dependency(
+      \.navigationIDPath,
+       NavigationIDPath.init(path: [
+        NavigationID.init(
+          kind: .keyPath(\State.self),
+          identifier: UUID(),
+          tag: nil
+        )
+       ])
+    )
   }
   func send(_ action: Root.Action) -> Task<Void, Never>? {
     _withoutPerceptionChecking {

--- a/Sources/ComposableArchitecture/Core.swift
+++ b/Sources/ComposableArchitecture/Core.swift
@@ -53,21 +53,12 @@ final class RootCore<Root: Reducer>: Core {
   private var bufferedActions: [Root.Action] = []
   var effectCancellables: [UUID: AnyCancellable] = [:]
   private var isSending = false
-  init<Other: Reducer<Root.State, Root.Action>>(
+  init(
     initialState: Root.State,
-    reducer: Other
-  ) where Root == _DependencyKeyWritingReducer<Other> {
+    reducer: Root
+  ) {
     self.state = initialState
-    self.reducer = reducer.dependency(
-      \.navigationIDPath,
-       NavigationIDPath.init(path: [
-        NavigationID.init(
-          kind: .keyPath(\State.self),
-          identifier: UUID(),
-          tag: nil
-        )
-       ])
-    )
+    self.reducer = reducer
   }
   func send(_ action: Root.Action) -> Task<Void, Never>? {
     _withoutPerceptionChecking {

--- a/Sources/ComposableArchitecture/Core.swift
+++ b/Sources/ComposableArchitecture/Core.swift
@@ -61,11 +61,11 @@ final class RootCore<Root: Reducer>: Core {
     self.reducer = reducer
   }
   func send(_ action: Root.Action) -> Task<Void, Never>? {
-    _withoutPerceptionChecking {
-      _send(action)
-    }
+      _withoutPerceptionChecking {
+        _send(action)
+      }
   }
-  func _send(_ action: Root.Action) -> Task<Void, Never>? {
+  private func _send(_ action: Root.Action) -> Task<Void, Never>? {
     self.bufferedActions.append(action)
     guard !self.isSending else { return nil }
 

--- a/Sources/ComposableArchitecture/Internal/NavigationID.swift
+++ b/Sources/ComposableArchitecture/Internal/NavigationID.swift
@@ -38,6 +38,8 @@ struct NavigationID: Hashable, @unchecked Sendable {
   private let identifier: AnyHashable?
   private let tag: UInt32?
 
+
+
   enum Kind: Hashable {
     case casePath(root: Any.Type, value: Any.Type)
     case keyPath(AnyKeyPath)
@@ -109,6 +111,12 @@ struct NavigationID: Hashable, @unchecked Sendable {
     } else {
       self.identifier = nil
     }
+  }
+
+  init(kind: Kind, identifier: AnyHashable?, tag: UInt32?) {
+    self.kind = kind
+    self.identifier = identifier
+    self.tag = tag
   }
 
   static func == (lhs: Self, rhs: Self) -> Bool {

--- a/Sources/ComposableArchitecture/Internal/NavigationID.swift
+++ b/Sources/ComposableArchitecture/Internal/NavigationID.swift
@@ -1,3 +1,4 @@
+import Foundation
 @_spi(Reflection) import CasePaths
 
 extension DependencyValues {
@@ -37,8 +38,6 @@ struct NavigationID: Hashable, @unchecked Sendable {
   private let kind: Kind
   private let identifier: AnyHashable?
   private let tag: UInt32?
-
-
 
   enum Kind: Hashable {
     case casePath(root: Any.Type, value: Any.Type)
@@ -113,10 +112,10 @@ struct NavigationID: Hashable, @unchecked Sendable {
     }
   }
 
-  init(kind: Kind, identifier: AnyHashable?, tag: UInt32?) {
-    self.kind = kind
-    self.identifier = identifier
-    self.tag = tag
+  init() {
+    self.kind = .keyPath(\Void.self)
+    self.identifier = UUID()
+    self.tag = nil
   }
 
   static func == (lhs: Self, rhs: Self) -> Bool {

--- a/Sources/ComposableArchitecture/Internal/NavigationID.swift
+++ b/Sources/ComposableArchitecture/Internal/NavigationID.swift
@@ -23,12 +23,16 @@ struct NavigationIDPath: Hashable, Sendable {
 
   var prefixes: [NavigationIDPath] {
     (0...self.path.count).map { index in
-      NavigationIDPath(path: Array(self.path.dropFirst(index)))
+      NavigationIDPath(path: Array(self.path.prefix(self.path.count - index)))
     }
   }
 
   func appending(_ element: NavigationID) -> Self {
     .init(path: self.path + [element])
+  }
+
+  mutating func append(_ element: NavigationID) {
+    self.path.append(element)
   }
 
   public var id: Self { self }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
@@ -76,7 +76,9 @@ extension Reducer {
     //     specialization defined below from being called, which fuses chained calls.
     -> _DependencyKeyWritingReducer<Self>
   {
-    _DependencyKeyWritingReducer(base: self) { $0[keyPath: keyPath] = value }
+    _DependencyKeyWritingReducer(base: self) {
+      $0[keyPath: keyPath] = value
+    }
   }
 
   /// Places a value in the reducer's dependencies.
@@ -144,7 +146,9 @@ extension Reducer {
     //     specialization defined below from being called, which fuses chained calls.
     -> _DependencyKeyWritingReducer<Self>
   {
-    _DependencyKeyWritingReducer(base: self) { transform(&$0[keyPath: keyPath]) }
+    _DependencyKeyWritingReducer(base: self) {
+      transform(&$0[keyPath: keyPath])
+    }
   }
 }
 

--- a/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
@@ -76,9 +76,7 @@ extension Reducer {
     //     specialization defined below from being called, which fuses chained calls.
     -> _DependencyKeyWritingReducer<Self>
   {
-    _DependencyKeyWritingReducer(base: self) {
-      $0[keyPath: keyPath] = value
-    }
+    _DependencyKeyWritingReducer(base: self) { $0[keyPath: keyPath] = value }
   }
 
   /// Places a value in the reducer's dependencies.
@@ -146,9 +144,7 @@ extension Reducer {
     //     specialization defined below from being called, which fuses chained calls.
     -> _DependencyKeyWritingReducer<Self>
   {
-    _DependencyKeyWritingReducer(base: self) {
-      transform(&$0[keyPath: keyPath])
-    }
+    _DependencyKeyWritingReducer(base: self) { transform(&$0[keyPath: keyPath]) }
   }
 }
 

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -400,9 +400,7 @@ public final class Store<State, Action> {
     initialState: R.State,
     reducer: R
   ) {
-    self.init(
-      core: RootCore(initialState: initialState, reducer: reducer)
-    )
+    self.init(core: RootCore(initialState: initialState, reducer: reducer))
   }
 
   /// A publisher that emits when state changes.

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -174,7 +174,17 @@ public final class Store<State, Action> {
     @ReducerBuilder<State, Action> reducer: () -> R,
     withDependencies prepareDependencies: ((inout DependencyValues) -> Void)? = nil
   ) {
-    let (initialState, reducer, dependencies) = withDependencies(prepareDependencies ?? { _ in }) {
+    let prepDeps: (inout DependencyValues) -> Void = {
+      $0.navigationIDPath = NavigationIDPath(path: [
+        NavigationID(
+          kind: .keyPath(\State.self),
+          identifier: UUID(),
+          tag: nil
+        )
+      ])
+      prepareDependencies?(&$0)
+    }
+    let (initialState, reducer, dependencies) = withDependencies(prepDeps) {
       @Dependency(\.self) var dependencies
       return (initialState(), reducer(), dependencies)
     }
@@ -329,7 +339,8 @@ public final class Store<State, Action> {
   }
 
   @available(
-    *, deprecated,
+    *,
+    deprecated,
     message:
       "Pass 'state' a key path to child state and 'action' a case key path to child action, instead. For more information see the following migration guide: https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.5#Store-scoping-with-key-paths"
   )
@@ -389,7 +400,9 @@ public final class Store<State, Action> {
     initialState: R.State,
     reducer: R
   ) {
-    self.init(core: RootCore(initialState: initialState, reducer: reducer))
+    self.init(
+      core: RootCore(initialState: initialState, reducer: reducer)
+    )
   }
 
   /// A publisher that emits when state changes.

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -174,19 +174,11 @@ public final class Store<State, Action> {
     @ReducerBuilder<State, Action> reducer: () -> R,
     withDependencies prepareDependencies: ((inout DependencyValues) -> Void)? = nil
   ) {
-    let prepDeps: (inout DependencyValues) -> Void = {
-      $0.navigationIDPath = NavigationIDPath(path: [
-        NavigationID(
-          kind: .keyPath(\State.self),
-          identifier: UUID(),
-          tag: nil
-        )
-      ])
-      prepareDependencies?(&$0)
-    }
-    let (initialState, reducer, dependencies) = withDependencies(prepDeps) {
+    let (initialState, reducer, dependencies) = withDependencies(prepareDependencies ?? { _ in }) {
       @Dependency(\.self) var dependencies
-      return (initialState(), reducer(), dependencies)
+      var updatedDependencies = dependencies
+      updatedDependencies.navigationIDPath = NavigationIDPath(path: [NavigationID()])
+      return (initialState(), reducer(), updatedDependencies)
     }
     self.init(
       initialState: initialState,

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -177,7 +177,7 @@ public final class Store<State, Action> {
     let (initialState, reducer, dependencies) = withDependencies(prepareDependencies ?? { _ in }) {
       @Dependency(\.self) var dependencies
       var updatedDependencies = dependencies
-      updatedDependencies.navigationIDPath = NavigationIDPath(path: [NavigationID()])
+      updatedDependencies.navigationIDPath.append(NavigationID())
       return (initialState(), reducer(), updatedDependencies)
     }
     self.init(

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -541,7 +541,7 @@ public final class TestStore<State: Equatable, Action> {
     let reducer = Dependencies.withDependencies {
       prepareDependencies(&$0)
       sharedChangeTracker.track(&$0)
-      $0.navigationIDPath = NavigationIDPath(path: [NavigationID()])
+      $0.navigationIDPath.append(NavigationID())
     } operation: {
       TestReducer(Reduce(reducer()), initialState: initialState())
     }

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -541,6 +541,7 @@ public final class TestStore<State: Equatable, Action> {
     let reducer = Dependencies.withDependencies {
       prepareDependencies(&$0)
       sharedChangeTracker.track(&$0)
+      $0.navigationIDPath = NavigationIDPath(path: [NavigationID()])
     } operation: {
       TestReducer(Reduce(reducer()), initialState: initialState())
     }

--- a/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift
@@ -1109,7 +1109,7 @@ final class PresentationReducerTests: BaseTCATestCase {
     await presentationTask.cancel()
   }
 
-  func testNavigation_cancelID_parentCancellation() async {
+  func testNavigation_cancelID_parentCancellation() async throws {
     struct Grandchild: Reducer {
       struct State: Equatable {}
       enum Action: Equatable {
@@ -1193,17 +1193,15 @@ final class PresentationReducerTests: BaseTCATestCase {
     let store = await TestStore(initialState: Parent.State()) {
       Parent()
     }
-    let childPresentationTask = await store.send(.presentChild) {
+    await store.send(.presentChild) {
       $0.child = Child.State()
     }
-    let grandchildPresentationTask = await store.send(.child(.presented(.presentGrandchild))) {
+    await store.send(.child(.presented(.presentGrandchild))) {
       $0.child?.grandchild = Grandchild.State()
     }
     await store.send(.child(.presented(.startButtonTapped)))
     await store.send(.child(.presented(.grandchild(.presented(.startButtonTapped)))))
     await store.send(.stopButtonTapped)
-    await grandchildPresentationTask.cancel()
-    await childPresentationTask.cancel()
   }
 
   func testNavigation_cancelID_parentCancelTwoChildren() async {

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -1229,9 +1229,9 @@ final class StoreTests: BaseTCATestCase {
     }
     store1.send(.tap)
     store2.send(.tap)
-    try await Task.sleep(nanoseconds: 100_000_000)
+    try await Task.sleep(for: .seconds(1))
     store2.send(.cancelButtonTapped)
-    await clock.run()
+    await clock.run(timeout: .seconds(1))
     XCTAssertEqual(store1.count, 42)
     XCTAssertEqual(store2.count, 0)
   }

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -1251,7 +1251,6 @@ final class StoreTests: BaseTCATestCase {
     }
     await store1.send(.tap)
     await store2.send(.tap)
-    try await Task.sleep(nanoseconds: 100_000_000)
     await store2.send(.cancelButtonTapped)
     await clock.run()
     await store1.receive(\.response) {

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -1213,6 +1213,58 @@ final class StoreTests: BaseTCATestCase {
       }
     }
   }
+
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  @MainActor func testRootStoreCancellationIsolation() async throws {
+    let clock = TestClock()
+    let store1 = Store(initialState: RootStoreCancellationIsolation.State()) {
+      RootStoreCancellationIsolation()
+    } withDependencies: {
+      $0.continuousClock = clock
+    }
+    let store2 = Store(initialState: RootStoreCancellationIsolation.State()) {
+      RootStoreCancellationIsolation()
+    } withDependencies: {
+      $0.continuousClock = clock
+    }
+    store1.send(.tap)
+    store2.send(.tap)
+    try await Task.sleep(nanoseconds: 100_000_000)
+    store2.send(.cancelButtonTapped)
+    await clock.run()
+    XCTAssertEqual(store1.count, 42)
+    XCTAssertEqual(store2.count, 0)
+  }
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  @Reducer struct RootStoreCancellationIsolation {
+    @ObservableState struct State: Equatable {
+      var count = 0
+    }
+    enum Action {
+      case cancelButtonTapped
+      case response(Int)
+      case tap
+    }
+    @Dependency(\.continuousClock) var clock
+    enum CancelID { case effect }
+    var body: some ReducerOf<Self> {
+      Reduce<State, Action> { state, action in
+        switch action {
+        case .cancelButtonTapped:
+          return .cancel(id: CancelID.effect)
+        case .response(let value):
+          state.count = value
+          return .none
+        case .tap:
+          return .run { send in
+            try await clock.sleep(for: .seconds(1))
+            await send(.response(42))
+          }
+          .cancellable(id: CancelID.effect)
+        }
+      }
+    }
+  }
 }
 
 #if canImport(Testing)


### PR DESCRIPTION
It's a little messy right now, but this is a proof-of-concept for isolating cancellation among root stores. I believe more work needs to be done in order for this to work with test stores.

Fixes #3658 