### PR TITLE
Adjust documentation for binding action

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -222,10 +222,10 @@ extension BindingAction {
   /// action directly to do further work:
   ///
   /// ```swift
-  /// case .binding(\.$displayName): // Invokes the `~=` operator.
+  /// case .binding(\.displayName): // Invokes the `~=` operator.
   ///   // Validate display name
   ///
-  /// case .binding(\.$enableNotifications):
+  /// case .binding(\.enableNotifications):
   ///   // Return an authorization request effect
   /// ```
   public static func ~= <Value>(


### PR DESCRIPTION
Afaict the $ sign shouldn't used to match on a binding as was done in this documentation snippet.