### PR TITLE
Document README update for incorrect RIBs repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,7 +673,7 @@ particular [Elm](https://elm-lang.org) and [Redux](https://redux.js.org/).
 There are also many architecture libraries in the Swift and iOS community. Each one of these has 
 their own set of priorities and trade-offs that differ from the Composable Architecture.
 
-* [RIBs](https://github.com/uber/RIBs)
+* [RIBs](https://github.com/uber/RIBs-iOS)
 * [Loop](https://github.com/ReactiveCocoa/Loop)
 * [ReSwift](https://github.com/ReSwift/ReSwift)
 * [Workflow](https://github.com/square/workflow)


### PR DESCRIPTION
### Changes
- Updated the RIBs repository link in the README.  
- The iOS implementation has been split from the original multi-platform repository ([RIBs](https://github.com/uber/RIBs)) and is now maintained separately at [RIBs-iOS](https://github.com/uber/RIBs-ios).