### PR TITLE
Change Counter to CounterFeature in StackBasedNavigation docs

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
@@ -404,10 +404,10 @@ struct Feature {
 
   @Reducer  
   struct Path {
-    enum State: Equatable { case counter(Counter.State) }
-    enum Action { case counter(Counter.Action) }
+    enum State: Equatable { case counter(CounterFeature.State) }
+    enum Action { case counter(CounterFeature.Action) }
     var body: some ReducerOf<Self> {
-      Scope(state: \.counter, action: \.counter) { Counter() }
+      Scope(state: \.counter, action: \.counter) { CounterFeature() }
     }
   }
 


### PR DESCRIPTION
I believe this was just a small typo, but I may be mistaken.
The example code in `StackBasedNavigation.md` referred to a `Counter` type, which I think was supposed to be the `CounterFeature` type created in the previous code block. 

---

The reducer `CounterFeature` was declared
```swift
@Reducer
struct CounterFeature {
  // ...
}
```
and the main `Feature` was supposed to contain it in a `StackState`, to show testing stack-based navigation.
```swift
@Reducer
struct Feature {
  @ObservableState
  struct State: Equatable {
    var path = StackState<Path.State>()
  }
  enum Action {
    case path(StackActionOf<Path>)
  }

  @Reducer  
  struct Path {
    enum State: Equatable { case counter(Counter.State) }
    enum Action { case counter(Counter.Action) }
    var body: some ReducerOf<Self> {
      Scope(state: \.counter, action: \.counter) { Counter() }
    }
  }

  // ...
}
```

However, the `Counter` type referenced was not declared anywhere else, and the future examples of testing construct the `Path` using a `CounterFeature`.
```swift
@Test
func dismissal() {
  let store = TestStore(
    initialState: Feature.State(
      path: StackState([
        CounterFeature.State(count: 3)
      ])
    )
  ) {
    CounterFeature()
  }
}
```