### PR TITLE
Prevent reduce function from being optimized

### DIFF
--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -82,6 +82,7 @@ extension Reducer where Body == Never {
 extension Reducer where Body: Reducer<State, Action> {
   /// Invokes the ``Body-40qdd``'s implementation of ``reduce(into:action:)-1t2ri``.
   @inlinable
+  @_optimize(none)
   public func reduce(
     into state: inout Body.State, action: Body.Action
   ) -> Effect<Body.Action> {


### PR DESCRIPTION
## Description

Ever since Swift 6 (i.e. TCA 1.15.0) there exists an issue in the Swift compiler that can lead to crashes only when the app has been archived for release. Greater detail was documented in [this discussion](https://github.com/pointfreeco/swift-composable-architecture/discussions/3606).

Unfortunately, we have still been unable to identify the conditions in which the crash occurs so it makes reproducing the issue prohibitively difficult in a sample app (making testing this PR difficult for someone not experiencing the crash). 

**However, we were able to pare down our production application considerably and share this with Apple developer support who were also able to reproduce the issue. They've acknowledged this to be an issue rooted in the Swift compiler.** 

Below is the latest response from the internal email thread we've had open with developer support:

> Engineering has identified the specific point of failure in this code. It appears to be a compiler bug. To mitigate this issue, you can disable optimizations for the problematic function by using the following code:

```swift
extension Reducer where Body: Reducer<State, Action> {
  /// Invokes the ``Body-40qdd``'s implementation of ``reduce(into:action:)-1t2ri``.
  @inlinable
  @_optimize(none)
  public func reduce(
    into state: inout Body.State, action: Body.Action
  ) -> Effect<Body.Action> {
    self.body.reduce(into: &state, action: action)
  }
}
```
> At Apple, we are unable to disclose any information regarding upcoming releases. However, we can assure you that the bug will be addressed in future releases. We recommend that you monitor your FB number for updates regarding the bug’s resolution.

## Changes:
- Adds `@_optimize(none)` to `reduce(into:action:)` per Apple's guidance to mitigate crashes.

## Testing: 
As mentioned, testing this can be rather difficult if you don't already have an app that exhibits the issue. We were able to clone the latest TCA release, add it as a _local_ dependency, make the change, and verify that the crashes no longer occurred on archived release builds.