### PR TITLE
Fix for "Your first feature" tutorial Store type mismatch in #Preview

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-02-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-02-code-0005.swift
@@ -1,6 +1,6 @@
 #Preview {
   CounterView(
-    store: Store(initialState: CounterFeature.State()) {
+    store: StoreOf<CounterFeature>(initialState: CounterFeature.State()) {
       CounterFeature()
     }
   )

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-02-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-02-code-0006.swift
@@ -1,6 +1,6 @@
 #Preview {
   CounterView(
-    store: Store(initialState: CounterFeature.State()) {
+    store: StoreOf<CounterFeature>(initialState: CounterFeature.State()) {
       // CounterFeature()
     }
   )

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-02-code-0007.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-02-code-0007.swift
@@ -1,6 +1,6 @@
 #Preview {
   CounterView(
-    store: Store(initialState: CounterFeature.State()) {
+    store: StoreOf<CounterFeature>(initialState: CounterFeature.State()) {
       CounterFeature()
     }
   )

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-03-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/01-YourFirstFeature/01-01-03-code-0002.swift
@@ -6,7 +6,7 @@ struct MyApp: App {
   var body: some Scene {
     WindowGroup {
       CounterView(
-        store: Store(initialState: CounterFeature.State()) {
+        store: StoreOf<CounterFeature>(initialState: CounterFeature.State()) {
           CounterFeature()
         }
       )


### PR DESCRIPTION
The tutorial uses `Store(...)` to initialize the `CounterFeature` store, which leads to a type mismatch error in the latest versions of TCA.

<img width="787" alt="Screenshot 2025-05-17 at 19 15 02" src="https://github.com/user-attachments/assets/d497edfd-bf1f-4b17-aea7-e96af553fe6d" />

This commit updates the tutorial code to use the explicit generic form `StoreOf<CounterFeature>(...)`