### PR TITLE
Remove the outdated unused dependency

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/05-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/05-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -43,10 +43,6 @@ struct CityMap {
     case downloadComponent(DownloadComponent.Action)
   }
 
-  struct CityMapEnvironment {
-    var downloadClient: DownloadClient
-  }
-
   var body: some Reducer<State, Action> {
     Scope(state: \.downloadComponent, action: \.downloadComponent) {
       DownloadComponent()


### PR DESCRIPTION
This PR removes the unused (and old style) dependency from the CityMap Reducer