### PR TITLE
Identifiable

### DIFF
--- a/Sources/ComposableArchitecture/Macros.swift
+++ b/Sources/ComposableArchitecture/Macros.swift
@@ -83,6 +83,9 @@ extension _SynthesizedConformance {
   /// Extends the `State` or `Action` types that ``Reducer()`` creates with the `Sendable`
   /// protocol.
   public static let sendable = Self()
+  /// Extends the `State` or `Action` types that ``Reducer()`` creates with the `Identifiable`
+  /// protocol.
+  public static let identifiable = Self()
 }
 
 /// Marks the case of an enum reducer as holding onto "ephemeral" state.


### PR DESCRIPTION
Hello.
Thank you for swift-composable-architecture.
For some Swift 5 projects `State` or `Action` should be `Identifiable` (please check `LogInScreen` [here](https://github.com/johnpatrickmorgan/TCACoordinators/blob/0.12.1/TCACoordinatorsExample/TCACoordinatorsExample/Game/LogInCoordinator.swift)), that's why I added it.