### PR TITLE
Make PresentsMacro's wrapped value non-private

### DIFF
--- a/Sources/ComposableArchitectureMacros/PresentsMacro.swift
+++ b/Sources/ComposableArchitectureMacros/PresentsMacro.swift
@@ -97,7 +97,7 @@ extension VariableDeclSyntax {
     return VariableDeclSyntax(
       leadingTrivia: leadingTrivia,
       attributes: newAttributes,
-      modifiers: modifiers.privatePrefixed("_"),
+      modifiers: modifiers,
       bindingSpecifier: TokenSyntax(
         bindingSpecifier.tokenKind,
         trailingTrivia: .space,

--- a/Tests/ComposableArchitectureMacrosTests/PresentsMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/PresentsMacroTests.swift
@@ -49,7 +49,7 @@
             }
           }
 
-          @ObservationStateIgnored private var _destination = ComposableArchitecture.PresentationState<Destination.State>(wrappedValue: nil)
+          @ObservationStateIgnored var _destination = ComposableArchitecture.PresentationState<Destination.State>(wrappedValue: nil)
         }
         """#
       }
@@ -89,7 +89,7 @@
             }
           }
 
-          @ObservationStateIgnored private var _destination = ComposableArchitecture.PresentationState<Destination.State>(wrappedValue: nil)
+          @ObservationStateIgnored public var _destination = ComposableArchitecture.PresentationState<Destination.State>(wrappedValue: nil)
         }
         """#
       }
@@ -126,7 +126,7 @@
             }
           }
 
-          @ObservationStateIgnored private var _destination = ComposableArchitecture.PresentationState<Destination.State>(wrappedValue: nil)
+          @ObservationStateIgnored package var _destination = ComposableArchitecture.PresentationState<Destination.State>(wrappedValue: nil)
         }
         """#
       }
@@ -189,7 +189,7 @@
             }
           }
 
-          private var _destination = ComposableArchitecture.PresentationState<Destination.State>(wrappedValue: nil)
+          var _destination = ComposableArchitecture.PresentationState<Destination.State>(wrappedValue: nil)
 
           var _$observationRegistrar = ComposableArchitecture.ObservationStateRegistrar()
 


### PR DESCRIPTION
## Rationales
1. `PresentsMacro` mimics the `propertyWrapper` and conventionally, we should expect the underlying variable `_alert` to be of the same visibility as the `$alert` and `alert`. The private visibility is contrary to the convention.

2. More importantly, this blocks the kind of usage that **requires referencing the underlying variable outside the class**. The below snippet illustrates the need.

### Problem statement

We explicitly want to avoid [@Shared](https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/sharingstate/) macro usage, and keep the states pure value (the rationale is separate topic). 

Thus we designate the states that a reducer truly owns as `OwnedState`, distinguished from states that are shared from the parent.

Parent `ChatList` reducer owns `Chat.OwnedState`. `chat` state is a computed property with getter and setter. The getter pieces some of the shared states in the parent with its owned states. Inversely, when the child state is updated, the setter is triggered and writes changed shared states back to its parents.

When child has a `@Presents var alert`, and if the child owns it, we want to explicitly store it, thus the requirement of accessing `_alert` variable.

- Child `Chat` reducer.
```
@Reducer
public struct Chat {
    public struct OwnedState: Equatable {
        var messageText: String = ""
        var _alert: PresentationState<AlertState<Action.Alert>> = .init(wrappedValue: nil)
        
        init() {}
        
        init(_ state: State) {
            messageText = state.messageText
            _alert = state._alert // <<< '_alert' is inaccessible due to 'private' protection level
        }
    }
    
    @ObservableState
    public struct State: Equatable {
        var convoId: ConvoId
        var messages: [Message]
        var messageText: String = ""
        @Presents var alert: AlertState<Action.Alert>?
        
        public init(ownedState: OwnedState, convoId: ConvoId, profile: UserProfile, otherUserProfile: UserProfile?, messages: [Message]) {
            self.convoId = convoId
            self.profile = profile
            self.otherUserProfile = otherUserProfile
            self.messages = messages
            self.messageText = ownedState.messageText
            self._alert = ownedState._alert
        }
    }

    // Action
}
```
- Parent `ChatList` reducer.
```
@Reducer
public struct ChatList {
    @ObservableState
    public struct State: Equatable {
        var profile: UserProfile
        var conversations: [Conversation]
        var messagesByConvo: [ConvoId: [Message]]
        var selectedConvoId: ConvoId?
        var chatState: Chat.OwnedState // We 
        
        var chat: Chat.State? {
            get {
                guard let selectedConvoId else {
                    return nil
                }
                return Chat.State(
                    ownedState: chatState,
                    convoId: selectedConvoId,
                    profile: profile,
                    messages: messagesByConvo[selectedConvoId] ?? [],
                )
            }
            set {
                guard let newValue else {
                    return
                }
                chatState = Chat.OwnedState(newValue)
            }
        }
    ...
}
```