### PR TITLE
Propagate current navigation path to cancellable publisher effects

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -42,7 +42,7 @@ extension Effect {
     case let .publisher(publisher):
       return Self(
         operation: .publisher(
-          Deferred {
+          Deferred { [navigationIDPath]
             ()
               -> Publishers.HandleEvents<
                 Publishers.PrefixUntilOutput<

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -434,7 +434,7 @@ final class EffectCancellationTests: BaseTCATestCase {
     }
 
     func testCancellablePath() async throws {
-      let navigationIDPath = dump(NavigationIDPath(path: [NavigationID()]))
+      let navigationIDPath = NavigationIDPath(path: [NavigationID()])
       let effect = withDependencies {
         $0.navigationIDPath = navigationIDPath
       } operation: {
@@ -449,7 +449,7 @@ final class EffectCancellationTests: BaseTCATestCase {
           await withDependencies {
             $0.navigationIDPath = NavigationIDPath(path: [NavigationID()])
           } operation: {
-            for await action in effect.actions {
+            for await _ in effect.actions {
               XCTFail()
             }
           }

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -432,5 +432,37 @@ final class EffectCancellationTests: BaseTCATestCase {
       //     structs in Swift have the same hash value.
       XCTAssertNotEqual(id1.hashValue, id2.hashValue)
     }
+
+    func testCancellablePath() async throws {
+      let navigationIDPath = dump(NavigationIDPath(path: [NavigationID()]))
+      let effect = withDependencies {
+        $0.navigationIDPath = navigationIDPath
+      } operation: {
+        Effect
+          .publisher {
+            Just(()).delay(for: .seconds(1), scheduler: DispatchQueue(label: #function))
+          }
+          .cancellable(id: 1)
+      }
+      await withThrowingTaskGroup(of: Void.self) { taskGroup in
+        taskGroup.addTask {
+          await withDependencies {
+            $0.navigationIDPath = NavigationIDPath(path: [NavigationID()])
+          } operation: {
+            for await action in effect.actions {
+              XCTFail()
+            }
+          }
+        }
+        taskGroup.addTask {
+          try await withDependencies {
+            $0.navigationIDPath = navigationIDPath
+          } operation: {
+            try await Task.sleep(for: .seconds(0.5))
+            Task.cancel(id: 1)
+          }
+        }
+      }
+    }
   }
 #endif

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -458,7 +458,7 @@ final class EffectCancellationTests: BaseTCATestCase {
           try await withDependencies {
             $0.navigationIDPath = navigationIDPath
           } operation: {
-            try await Task.sleep(for: .seconds(0.5))
+            try await Task.sleep(nanoseconds: NSEC_PER_SEC / 2)
             Task.cancel(id: 1)
           }
         }


### PR DESCRIPTION
Fixes #3727.