### PR TITLE
UIKit: Skip `UIBindable` perception checks

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "658be5678358d678b69ea40e4be4814633be8197318d5ac54b97fb40cfb2152b",
+  "originHash" : "9e30691675e494f8d62a6fee1540bdd1399c73ceefda0cfe638103df9a271e71",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "4c90d6b2b9bf0911af87b103bb40f41771891596",
-        "version" : "1.9.2"
+        "revision" : "eefcdaa88d2e2fd82e3405dfb6eb45872011a0b5",
+        "version" : "1.9.3"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "f4f57cac7d273cddf0161293d47adbb5a6ba3aed",
-        "version" : "2.0.0"
+        "revision" : "328a0b49e2690135c4c2660661f0ed83f16853e3",
+        "version" : "2.0.4"
       }
     },
     {

--- a/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
@@ -484,7 +484,7 @@ extension Store {
 @_spi(Internals)
 public var _isInPerceptionTracking: Bool {
   #if DEBUG && !os(visionOS)
-    return _PerceptionLocals.isInPerceptionTracking
+    return _PerceptionLocals.isInPerceptionTracking || _PerceptionLocals.skipPerceptionChecking
   #else
     return false
   #endif

--- a/Sources/ComposableArchitecture/Observation/Store+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Store+Observation.swift
@@ -403,11 +403,18 @@ extension UIBindable {
     column: UInt = #column
   ) -> UIBinding<Store<ChildState, ChildAction>?>
   where Value == Store<State, Action> {
-    self[
-      id: wrappedValue.currentState[keyPath: state].flatMap(_identifiableID),
+    #if DEBUG && canImport(SwiftUI)
+      let id = _PerceptionLocals.$skipPerceptionChecking.withValue(true) {
+        wrappedValue.currentState[keyPath: state].flatMap(_identifiableID)
+      }
+    #else
+      let id = wrappedValue.currentState[keyPath: state].flatMap(_identifiableID)
+    #endif
+    return self[
+      id: id,
       state: state,
       action: action,
-      isInViewBody: _isInPerceptionTracking,
+      isInViewBody: true,
       fileID: _HashableStaticString(rawValue: fileID),
       filePath: _HashableStaticString(rawValue: filePath),
       line: line,


### PR DESCRIPTION
View controllers embedded in SwiftUI views can lead to errant perception checks when constructing UIBindings, so let's disable perception checks entirely when projecting a UIBinding.