### PR TITLE
Add failing test using store.publisher in makeUIView

### DIFF
--- a/Tests/ComposableArchitectureTests/StorePerceptionTests.swift
+++ b/Tests/ComposableArchitectureTests/StorePerceptionTests.swift
@@ -69,11 +69,34 @@ final class StorePerceptionTests: BaseTCATestCase {
   }
 
   @MainActor
+  func testPerceptionCheck_ViewRepresentable_publisher() {
+    #if canImport(UIKit)
+      struct ViewRepresentable: UIViewRepresentable {
+        let store = Store(initialState: Feature.State()) {
+          Feature()
+        }
+        func makeUIView(context: Context) -> UILabel {
+          let label = UILabel()
+          let cancellable = store.publisher.sink { [weak label] state in
+            label?.text = "\(state.count)"
+          }
+          objc_setAssociatedObject(label, cancellableKey, cancellable, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+          return label
+        }
+        func updateUIView(_ view: UILabel, context: Context) {}
+      }
+      render(ViewRepresentable())
+    #endif
+  }
+
+  @MainActor
   private func render(_ view: some View) {
     let image = ImageRenderer(content: view).cgImage
     _ = image
   }
 }
+
+@MainActor private let cancellableKey = malloc(1)!
 
 @Reducer
 private struct Feature {


### PR DESCRIPTION
Here's another case of failing perception checks for where TCA, SwiftUI, UIKit, and Combine meet.

Because the store is first accessed inside `makeUIView(_:context:)`, the `isSwiftUI()` check inside Perception considers it as valid.

But publishers seem to mix very unwell with `ObservableState` here… Not only should accessing `state.count` inside the `sink { ... }` call be free of perception checks: because `state` is just a `struct` (mostly!) and as such a snapshot of whatever state the store was in at the time of the publisher emitting a value, accessing its value members shouldn't even touch the observation/perception machinery, I think. Or why should it?

In any case, this is an example of the runtime warnings we started getting when attempting to upgrade to the latest Point-Free library versions.