### PR TITLE
Fix `Timers` in CaseStudies 

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-Timers.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-Timers.swift
@@ -30,6 +30,7 @@ struct Timers {
     Reduce { state, action in
       switch action {
       case .onDisappear:
+        state.isTimerActive = false
         return .cancel(id: CancelID.timer)
 
       case .timerTicked:

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/03-Effects-TimersTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/03-Effects-TimersTests.swift
@@ -41,5 +41,15 @@ struct TimersTests {
     await store.send(.toggleTimerButtonTapped) {
       $0.isTimerActive = false
     }
+    await store.send(.toggleTimerButtonTapped) {
+      $0.isTimerActive = true
+    }
+    await clock.advance(by: .seconds(1))
+    await store.receive(\.timerTicked) {
+      $0.secondsElapsed = 7
+    }
+    await store.send(.onDisappear) {
+      $0.isTimerActive = false
+    }
   }
 }


### PR DESCRIPTION
In the timer example in 03-Effects-Timers.swift, the timer is canceled when the view disappears, but its activation state (`isTimerActive`) is not updated.
As a result, when the view is dismissed and then reopened, the UI may still indicate the timer is active instead of reflecting its actual state.


| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/77cdbdd4-818b-4430-86ee-0929f407b33d" width="300" ></video> | <video src="https://github.com/user-attachments/assets/cd25660d-1e1c-4130-9659-c867e8bd596b" width="300" ></video> |

