### PR TITLE
Updates the docs for Explicit shared state.

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/SharingState.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/SharingState.md
@@ -87,7 +87,7 @@ the feature's state:
 struct ParentFeature {
   @ObservableState
   struct State {
-    @Shared var count: Int
+    @Shared(value: 0) var count: Int
     // Other properties
   }
   // ...


### PR DESCRIPTION
The docs don't currently showcase how to assign the default value for the parent.