### PR TITLE
Better cancellation detection

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -102,6 +102,8 @@ extension Effect {
             } catch is CancellationError {
               return
             } catch {
+              guard !Task.isCancelled
+              else { return }
               guard let handler else {
                 reportIssue(
                   """


### PR DESCRIPTION
Turns out some async functions will detect cancellation and throw their own cancellation errors rather than just throwing `_Concurrency.CancellationError`. So we need to guard against those situations.