### PR TITLE
Fix use #filePath default for filePath in scoping APIs

### DIFF
--- a/Sources/ComposableArchitecture/Observation/Store+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Store+Observation.swift
@@ -175,7 +175,7 @@ extension Binding {
     state: KeyPath<State, ChildState?>,
     action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
     fileID: StaticString = #fileID,
-    filePath: StaticString = #fileID,
+    filePath: StaticString = #filePath,
     line: UInt = #line,
     column: UInt = #column
   ) -> Binding<Store<ChildState, ChildAction>?>
@@ -203,7 +203,7 @@ extension ObservedObject.Wrapper {
     state: KeyPath<State, ChildState?>,
     action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
     fileID: StaticString = #fileID,
-    filePath: StaticString = #fileID,
+    filePath: StaticString = #filePath,
     line: UInt = #line,
     column: UInt = #column
   ) -> Binding<Store<ChildState, ChildAction>?>
@@ -293,7 +293,7 @@ extension SwiftUI.Bindable {
     state: KeyPath<State, ChildState?>,
     action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
     fileID: StaticString = #fileID,
-    filePath: StaticString = #fileID,
+    filePath: StaticString = #filePath,
     line: UInt = #line,
     column: UInt = #column
   ) -> Binding<Store<ChildState, ChildAction>?>


### PR DESCRIPTION
Incorrect default parameter uses #fileID for filePath in three scoping helpers, causing diagnostics to report the wrong file path.

Replace filePath: StaticString = #fileID with filePath: StaticString =  #filePath 
in:
- Binding.scope(...)
- ObservedObject.Wrapper.scope(...)
- SwiftUI.Bindable.scope(...)