### PR TITLE
Fix skipped observations for Equatable class and Optional properties

### DIFF
--- a/Tests/ComposableArchitectureMacrosTests/ObservableStateMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ObservableStateMacroTests.swift
@@ -70,7 +70,35 @@
           }
 
           private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu2_: Equatable & AnyObject>(_ lhs: __macro_local_6MemberfMu2_, _ rhs: __macro_local_6MemberfMu2_) -> Bool {
+            lhs !== rhs || lhs != rhs
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu_>(_ lhs: __macro_local_6MemberfMu_?, _ rhs: __macro_local_6MemberfMu_?) -> Bool {
+            switch (lhs, rhs) {
+            case (.none, .none): return false
+            case (.some, .some): return true
+            default: return true
+            }
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu0_: Equatable>(_ lhs: __macro_local_6MemberfMu0_?, _ rhs: __macro_local_6MemberfMu0_?) -> Bool {
             lhs != rhs
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu1_: AnyObject>(_ lhs: __macro_local_6MemberfMu1_?, _ rhs: __macro_local_6MemberfMu1_?) -> Bool {
+            switch (lhs, rhs) {
+            case (.none, .none): return false
+            case let (.some(lhs), .some(rhs)): return lhs !== rhs
+            default: return true
+            }
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu2_: Equatable & AnyObject>(_ lhs: __macro_local_6MemberfMu2_?, _ rhs: __macro_local_6MemberfMu2_?) -> Bool {
+            switch (lhs, rhs) {
+            case (.none, .none): return false
+            case let (.some(lhs), .some(rhs)): return lhs !== rhs || lhs != rhs
+            default: return true
+            }
           }
         }
         """#
@@ -132,7 +160,35 @@
           }
 
           private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu2_: Equatable & AnyObject>(_ lhs: __macro_local_6MemberfMu2_, _ rhs: __macro_local_6MemberfMu2_) -> Bool {
+            lhs !== rhs || lhs != rhs
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu_>(_ lhs: __macro_local_6MemberfMu_?, _ rhs: __macro_local_6MemberfMu_?) -> Bool {
+            switch (lhs, rhs) {
+            case (.none, .none): return false
+            case (.some, .some): return true
+            default: return true
+            }
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu0_: Equatable>(_ lhs: __macro_local_6MemberfMu0_?, _ rhs: __macro_local_6MemberfMu0_?) -> Bool {
             lhs != rhs
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu1_: AnyObject>(_ lhs: __macro_local_6MemberfMu1_?, _ rhs: __macro_local_6MemberfMu1_?) -> Bool {
+            switch (lhs, rhs) {
+            case (.none, .none): return false
+            case let (.some(lhs), .some(rhs)): return lhs !== rhs
+            default: return true
+            }
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu2_: Equatable & AnyObject>(_ lhs: __macro_local_6MemberfMu2_?, _ rhs: __macro_local_6MemberfMu2_?) -> Bool {
+            switch (lhs, rhs) {
+            case (.none, .none): return false
+            case let (.some(lhs), .some(rhs)): return lhs !== rhs || lhs != rhs
+            default: return true
+            }
           }
         }
         """#
@@ -194,7 +250,35 @@
           }
 
           private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu2_: Equatable & AnyObject>(_ lhs: __macro_local_6MemberfMu2_, _ rhs: __macro_local_6MemberfMu2_) -> Bool {
+            lhs !== rhs || lhs != rhs
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu_>(_ lhs: __macro_local_6MemberfMu_?, _ rhs: __macro_local_6MemberfMu_?) -> Bool {
+            switch (lhs, rhs) {
+            case (.none, .none): return false
+            case (.some, .some): return true
+            default: return true
+            }
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu0_: Equatable>(_ lhs: __macro_local_6MemberfMu0_?, _ rhs: __macro_local_6MemberfMu0_?) -> Bool {
             lhs != rhs
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu1_: AnyObject>(_ lhs: __macro_local_6MemberfMu1_?, _ rhs: __macro_local_6MemberfMu1_?) -> Bool {
+            switch (lhs, rhs) {
+            case (.none, .none): return false
+            case let (.some(lhs), .some(rhs)): return lhs !== rhs
+            default: return true
+            }
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu2_: Equatable & AnyObject>(_ lhs: __macro_local_6MemberfMu2_?, _ rhs: __macro_local_6MemberfMu2_?) -> Bool {
+            switch (lhs, rhs) {
+            case (.none, .none): return false
+            case let (.some(lhs), .some(rhs)): return lhs !== rhs || lhs != rhs
+            default: return true
+            }
           }
         }
         """#
@@ -253,7 +337,35 @@
           }
 
           private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu2_: Equatable & AnyObject>(_ lhs: __macro_local_6MemberfMu2_, _ rhs: __macro_local_6MemberfMu2_) -> Bool {
+            lhs !== rhs || lhs != rhs
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu_>(_ lhs: __macro_local_6MemberfMu_?, _ rhs: __macro_local_6MemberfMu_?) -> Bool {
+            switch (lhs, rhs) {
+            case (.none, .none): return false
+            case (.some, .some): return true
+            default: return true
+            }
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu0_: Equatable>(_ lhs: __macro_local_6MemberfMu0_?, _ rhs: __macro_local_6MemberfMu0_?) -> Bool {
             lhs != rhs
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu1_: AnyObject>(_ lhs: __macro_local_6MemberfMu1_?, _ rhs: __macro_local_6MemberfMu1_?) -> Bool {
+            switch (lhs, rhs) {
+            case (.none, .none): return false
+            case let (.some(lhs), .some(rhs)): return lhs !== rhs
+            default: return true
+            }
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu2_: Equatable & AnyObject>(_ lhs: __macro_local_6MemberfMu2_?, _ rhs: __macro_local_6MemberfMu2_?) -> Bool {
+            switch (lhs, rhs) {
+            case (.none, .none): return false
+            case let (.some(lhs), .some(rhs)): return lhs !== rhs || lhs != rhs
+            default: return true
+            }
           }
         }
         """#
@@ -297,7 +409,35 @@
           }
 
           private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu2_: Equatable & AnyObject>(_ lhs: __macro_local_6MemberfMu2_, _ rhs: __macro_local_6MemberfMu2_) -> Bool {
+            lhs !== rhs || lhs != rhs
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu_>(_ lhs: __macro_local_6MemberfMu_?, _ rhs: __macro_local_6MemberfMu_?) -> Bool {
+            switch (lhs, rhs) {
+            case (.none, .none): return false
+            case (.some, .some): return true
+            default: return true
+            }
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu0_: Equatable>(_ lhs: __macro_local_6MemberfMu0_?, _ rhs: __macro_local_6MemberfMu0_?) -> Bool {
             lhs != rhs
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu1_: AnyObject>(_ lhs: __macro_local_6MemberfMu1_?, _ rhs: __macro_local_6MemberfMu1_?) -> Bool {
+            switch (lhs, rhs) {
+            case (.none, .none): return false
+            case let (.some(lhs), .some(rhs)): return lhs !== rhs
+            default: return true
+            }
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu2_: Equatable & AnyObject>(_ lhs: __macro_local_6MemberfMu2_?, _ rhs: __macro_local_6MemberfMu2_?) -> Bool {
+            switch (lhs, rhs) {
+            case (.none, .none): return false
+            case let (.some(lhs), .some(rhs)): return lhs !== rhs || lhs != rhs
+            default: return true
+            }
           }
         }
         """
@@ -768,7 +908,35 @@
           }
 
           private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu2_: Equatable & AnyObject>(_ lhs: __macro_local_6MemberfMu2_, _ rhs: __macro_local_6MemberfMu2_) -> Bool {
+            lhs !== rhs || lhs != rhs
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu_>(_ lhs: __macro_local_6MemberfMu_?, _ rhs: __macro_local_6MemberfMu_?) -> Bool {
+            switch (lhs, rhs) {
+            case (.none, .none): return false
+            case (.some, .some): return true
+            default: return true
+            }
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu0_: Equatable>(_ lhs: __macro_local_6MemberfMu0_?, _ rhs: __macro_local_6MemberfMu0_?) -> Bool {
             lhs != rhs
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu1_: AnyObject>(_ lhs: __macro_local_6MemberfMu1_?, _ rhs: __macro_local_6MemberfMu1_?) -> Bool {
+            switch (lhs, rhs) {
+            case (.none, .none): return false
+            case let (.some(lhs), .some(rhs)): return lhs !== rhs
+            default: return true
+            }
+          }
+
+          private nonisolated func shouldNotifyObservers<__macro_local_6MemberfMu2_: Equatable & AnyObject>(_ lhs: __macro_local_6MemberfMu2_?, _ rhs: __macro_local_6MemberfMu2_?) -> Bool {
+            switch (lhs, rhs) {
+            case (.none, .none): return false
+            case let (.some(lhs), .some(rhs)): return lhs !== rhs || lhs != rhs
+            default: return true
+            }
           }
         }
         """


### PR DESCRIPTION
### 🐛 Bug
ObservableState macro observation issues
- Fixes skipped observations for Equatable class properties and optional references 
- Updates shouldNotifyObservers to consider identity changes (===) so views update when references change even if == remains true

This ensures that SwiftUI views properly update when class instances are replaced with new instances that have the same value but different identity, which is crucial for proper observation behavior in TCA.

### 🔧 Changes
ObservableState macro updates
Equatable & AnyObject: 
- notify when identity or equality changes (lhs !== rhs || lhs != rhs)

Add optional overloads of shouldNotifyObservers:
- `<T>(_ lhs: T?, _ rhs: T?) -> Bool`
- `<T: Equatable>(_ lhs: T?, _ rhs: T?) -> Bool`
- `<T: AnyObject>(_ lhs: T?, _ rhs: T?) -> Bool`
- `<T: Equatable & AnyObject>(_ lhs: T?, _ rhs: T?) -> Bool`

### 📝 Related
#3771