### PR TITLE
Bump swift-navigation for Xcode 26

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.4.0"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "1.1.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
-    .package(url: "https://github.com/pointfreeco/swift-navigation", from: "2.3.0"),
+    .package(url: "https://github.com/pointfreeco/swift-navigation", from: "2.3.2"),
     .package(url: "https://github.com/pointfreeco/swift-perception", "1.3.4"..<"3.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-sharing", "0.1.2"..<"3.0.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.3.0"),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -26,7 +26,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.4.0"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "1.1.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
-    .package(url: "https://github.com/pointfreeco/swift-navigation", from: "2.3.0"),
+    .package(url: "https://github.com/pointfreeco/swift-navigation", from: "2.3.2"),
     .package(url: "https://github.com/pointfreeco/swift-perception", "1.3.4"..<"3.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-sharing", "0.1.2"..<"3.0.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.3.0"),


### PR DESCRIPTION
Xcode 26 has now been officially released.
To make sure the project compiles correctly with Xcode 26, I updated the swift-navigation dependency to version [2.3.2](https://github.com/pointfreeco/swift-navigation/releases/tag/2.3.2), which includes the necessary fixes.