### PR TITLE
Fix typo: ContactFeature → ContactsFeature in tutorial code

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0003.swift
@@ -6,4 +6,4 @@ extension ContactsFeature {
   }
 }
 
-extension ContactFeature.Destination.State: Equatable {}
+extension ContactsFeature.Destination.State: Equatable {}


### PR DESCRIPTION
## Description
Fixed a typo in the MeetTheComposableArchitecture tutorial documentation.

## Changes
- Changed `ContactFeature` to `ContactsFeature` in the extension declaration
- This ensures consistency with the actual type name defined in the same file

## Files Changed
- `Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0003.swift`
