### PR TITLE
Hard-deprecate `@Reducer(state: .equatable)`

### DIFF
--- a/Sources/ComposableArchitecture/Macros.swift
+++ b/Sources/ComposableArchitecture/Macros.swift
@@ -39,11 +39,7 @@ public macro Reducer() =
 @attached(memberAttribute)
 @attached(extension, conformances: Reducer, CaseReducer)
 #if compiler(>=6)
-  @available(iOS, deprecated: 9999, message: "Define your conformance via extension, instead.")@available(
-    macOS, deprecated: 9999, message: "Define your conformance via extension, instead."
-  )@available(tvOS, deprecated: 9999, message: "Define your conformance via extension, instead.")@available(
-    watchOS, deprecated: 9999, message: "Define your conformance via extension, instead."
-  )
+  @available(*, deprecated, message: "Define your conformance using an extension, instead")
 #endif
 public macro Reducer(state: _SynthesizedConformance..., action: _SynthesizedConformance...) =
   #externalMacro(
@@ -56,11 +52,7 @@ public macro Reducer(state: _SynthesizedConformance..., action: _SynthesizedConf
 /// See <doc:Reducers#Synthesizing-protocol-conformances-on-State-and-Action> for more information.
 @_documentation(visibility: public)
 #if compiler(>=6)
-  @available(iOS, deprecated: 9999, message: "Define your conformance via extension, instead.")@available(
-    macOS, deprecated: 9999, message: "Define your conformance via extension, instead."
-  )@available(tvOS, deprecated: 9999, message: "Define your conformance via extension, instead.")@available(
-    watchOS, deprecated: 9999, message: "Define your conformance via extension, instead."
-  )
+  @available(*, deprecated, message: "Define your conformance using an extension, instead")
 #endif
 public struct _SynthesizedConformance: Sendable {}
 


### PR DESCRIPTION
These have been soft-deprecated for a long time in favor of folks using explicit extensions, but people seem to still be reaching for these APIs.

Let's finally hard-deprecate them.