### PR TITLE
Add delay to child dismissal

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -343,7 +343,9 @@ public final class Store<State, Action>: _Store {
           .sink { [weak self, weak parent] _ in
             guard let scopeID = self?.scopeID
             else { return }
-            parent?.removeChild(scopeID: scopeID)
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300)) {
+              parent?.removeChild(scopeID: scopeID)
+            }
           } receiveValue: { [weak self] _ in
             guard let self else { return }
             self._$observationRegistrar.withMutation(of: self, keyPath: \.currentState) {}


### PR DESCRIPTION
By immediately `nil`-ing out the child store, SwiftUI can misbehave in a number of ways, as the following issues report.

This PR attempts to fix #3789, #3783, #3779, but will also preserve the original fix of cleaning up child reducer state.