### PR TITLE
Fix "Extraneous argument label 'with:' in call" build error.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.4.0"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "1.1.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
-    .package(url: "https://github.com/pointfreeco/swift-navigation", from: "2.3.0"),
+    .package(url: "https://github.com/pointfreeco/swift-navigation", from: "2.3.2"),
     .package(url: "https://github.com/pointfreeco/swift-perception", "1.3.4"..<"3.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-sharing", "0.1.2"..<"3.0.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.3.0"),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -26,7 +26,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.4.0"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "1.1.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
-    .package(url: "https://github.com/pointfreeco/swift-navigation", from: "2.3.0"),
+    .package(url: "https://github.com/pointfreeco/swift-navigation", from: "2.3.2"),
     .package(url: "https://github.com/pointfreeco/swift-perception", "1.3.4"..<"3.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-sharing", "0.1.2"..<"3.0.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.3.0"),


### PR DESCRIPTION
# Bug
Build error:
<img width="727" height="723" alt="スクリーンショット 2025-10-20 13 19 14" src="https://github.com/user-attachments/assets/33c3a0d8-8ab6-4fa8-884e-91544e2f4578" />

# Related
The problem was issued. (the followings is essentially the same issues):
- https://github.com/pointfreeco/swift-navigation/issues/299
- https://github.com/pointfreeco/swift-navigation/issues/294
- https://github.com/pointfreeco/swift-navigation/issues/290

The issue was solved in swift-navigation v2.3.2:
- https://github.com/pointfreeco/swift-navigation/releases/tag/2.3.2
