### PR TITLE
Fix ShareChangeTracker(reportUnassertedChanges:) build error.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
     .package(url: "https://github.com/pointfreeco/swift-navigation", from: "2.3.2"),
     .package(url: "https://github.com/pointfreeco/swift-perception", "1.3.4"..<"3.0.0"),
-    .package(url: "https://github.com/pointfreeco/swift-sharing", "0.1.2"..<"3.0.0"),
+    .package(url: "https://github.com/pointfreeco/swift-sharing", "1.0.4"..<"3.0.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.3.0"),
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"603.0.0"),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -28,7 +28,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
     .package(url: "https://github.com/pointfreeco/swift-navigation", from: "2.3.2"),
     .package(url: "https://github.com/pointfreeco/swift-perception", "1.3.4"..<"3.0.0"),
-    .package(url: "https://github.com/pointfreeco/swift-sharing", "0.1.2"..<"3.0.0"),
+    .package(url: "https://github.com/pointfreeco/swift-sharing", "1.0.4"..<"3.0.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.3.0"),
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"603.0.0"),


### PR DESCRIPTION
# Bug
build error:

<img width="698" height="413" alt="スクリーンショット 2025-10-27 13 37 57" src="https://github.com/user-attachments/assets/e40050fc-f0e1-46f3-b157-78ea9dfc5ccf" />

# Fix
`reportUnassertedChanges` exists from swift-sharing v1.0.4. So fix minimum version of it in Package.swift