### PR TITLE
Fix(Todos): resolve actor isolation issue with CancelID in TCA reducer

### DIFF
--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -36,7 +36,9 @@ struct Todos {
 
   @Dependency(\.continuousClock) var clock
   @Dependency(\.uuid) var uuid
-  private enum CancelID { case todoCompletion }
+  private nonisolated enum CancelID: Hashable, Sendable {
+    case todoCompletion
+  }
 
   var body: some Reducer<State, Action> {
     BindingReducer()


### PR DESCRIPTION
## 💡 Pull Request Description
### Summary

This PR fixes a Swift 6 concurrency issue in the Todos reducer, where
CancelID inherited the `@MainActor` isolation from the `@Reducer` type,
causing a compiler error when used as a Sendable Hashable ID in .cancellable.

### Changes
* Declared CancelID as `nonisolated` to remove actor isolation.
* Added explicit Sendable conformance to CancelID.

### Result

✅ Eliminates the compiler error:

> "Main actor-isolated conformance of 'Todos.CancelID' to 'Hashable' cannot satisfy conformance requirement for a 'Sendable' type parameter."

✅ Keeps Todos reducer stable and compatible with Swift 6’s stricter actor isolation rules.