### PR TITLE
Lifecycle action

### DIFF
--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -353,6 +353,10 @@ public final class Store<State, Action>: _Store {
       }
       self.parentCancellable = subscribeToDidSet(stateType)
     }
+    
+    if let lifecycleAction = (Action.self as? (any LifecycleAction.Type))?.lifecycle as? Action {
+      send(lifecycleAction)
+    }
   }
 
   convenience init<R: Reducer<State, Action>>(
@@ -599,4 +603,14 @@ let _isStorePerceptionCheckingEnabled: Bool = {
 @MainActor
 private protocol _Store: AnyObject {
   func removeChild(scopeID: AnyHashable)
+}
+
+/// Marks an `Action` as tied to the Store lifecycle.
+///
+/// When an `Action` conforms to `LifecycleAction`, the `lifecycle` action is
+/// executed immediately when the Store is created and is automatically
+/// cancelled when the Store is destroyed.
+public protocol LifecycleAction {
+  /// Action triggered on Store creation.
+  static var lifecycle: Self { get }
 }

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -1298,6 +1298,24 @@ final class StoreTests: BaseTCATestCase {
       }
     }
   }
+  
+  @MainActor
+  func testLifecycleAction() async {
+    enum Action: LifecycleAction {
+      case lifecycle
+    }
+    
+    let store = Store<Int, Action>(initialState: 0) {
+      Reduce<Int, Action> { state, action in
+        switch action {
+        case .lifecycle:
+          state += 1
+          return .none
+        }
+      }
+    }
+    XCTAssertEqual(store.currentState, 1)
+  }
 }
 
 #if canImport(Testing)


### PR DESCRIPTION
Inspired by https://github.com/pointfreeco/swift-composable-architecture/pull/3624

> It is common to send an action to a store when it is first created to kick off some long-living effects. While many utilize the onAppear view modifier for this work, we can simplify things by making the store's initializer a little more powerful.