### PR TITLE
Remove unused `DefaultIsolation` actor from `RootCore`

### DIFF
--- a/Sources/ComposableArchitecture/Core.swift
+++ b/Sources/ComposableArchitecture/Core.swift
@@ -197,7 +197,6 @@ final class RootCore<Root: Reducer>: Core {
       }
     }
   }
-  private actor DefaultIsolation {}
 }
 
 final class ScopedCore<Base: Core, State, Action>: Core {


### PR DESCRIPTION
## Summary
- Remove the unused `private actor DefaultIsolation {}` declared inside `RootCore` in `Core.swift`

## Context
While exploring actor type usage within TCA's internals, I noticed that `DefaultIsolation` is declared but never referenced anywhere in the codebase.

It was introduced in #3460 (Store internals refactor to `Core` protocol composition), but has had no usage since its introduction and no subsequent commits have referenced it. It appears to be dead code left over from the refactor.