### PR TITLE
Use DiscardingTaskGroup in Effect.merge(with:)

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -280,12 +280,23 @@ extension Effect {
     ):
       return Self(
         operation: .run { send in
-          await withTaskGroup(of: Void.self) { group in
-            group.addTask(name: lhsName, priority: lhsPriority) {
-              await lhsOperation(send)
+          if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+            await withDiscardingTaskGroup { group in
+              group.addTask(name: lhsName, priority: lhsPriority) {
+                await lhsOperation(send)
+              }
+              group.addTask(name: rhsName, priority: rhsPriority) {
+                await rhsOperation(send)
+              }
             }
-            group.addTask(name: rhsName, priority: rhsPriority) {
-              await rhsOperation(send)
+          } else {
+            await withTaskGroup(of: Void.self) { group in
+              group.addTask(name: lhsName, priority: lhsPriority) {
+                await lhsOperation(send)
+              }
+              group.addTask(name: rhsName, priority: rhsPriority) {
+                await rhsOperation(send)
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary

- Replace `withTaskGroup(of: Void.self)` with `withDiscardingTaskGroup` in `Effect.merge(with:)` on iOS 17+ / macOS 14+
- Fall back to `withTaskGroup` on older OS versions via `#available`

## Motivation

`Effect.merge(with:)` uses `withTaskGroup(of: Void.self)` to run two effects concurrently, but never calls `next()` to consume results. In this case, `TaskGroup` retains completed child tasks until the group scope ends.

`DiscardingTaskGroup` eagerly discards and releases child tasks as soon as they complete. When multiple effects are merged via `reduce`, the resulting nested group structure runs all effects concurrently — so effects that finish earlier have their resources reclaimed immediately, rather than waiting for the slowest sibling.

Reference: [DiscardingTaskGroup | Apple Developer Documentation](https://developer.apple.com/documentation/swift/discardingtaskgroup)

## Test plan

- [x] `EffectOperationTests` — 5 tests passed (includes `testMergeDiscardsNones`, `testMergeFuses`)
- [x] `EffectTests` — 9 tests passed (includes `testMerge`)
- [x] Project builds successfully