### PR TITLE
Fully-deprecate `AnyCasePath` APIs

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -7,6 +7,368 @@
 
 // NB: Deprecated with 1.24.0:
 
+extension PresentationState {
+  @available(
+    *,
+    deprecated,
+    message:
+      "Use the version of this subscript with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
+  )
+  public subscript<Case>(
+    case path: AnyCasePath<State, Case>,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) -> Case? {
+    _read { yield self[_case: path] }
+    _modify { yield &self[_case: path] }
+  }
+}
+
+extension Reducer {
+  @available(
+    *,
+    deprecated,
+    message:
+      "Use a case key path to an 'IdentifiedAction', instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4"
+  )
+  @inlinable
+  @warn_unqualified_access
+  public func forEach<
+    ElementState,
+    ElementAction,
+    ID: Hashable & Sendable,
+    Element: Reducer<ElementState, ElementAction>
+  >(
+    _ toElementsState: WritableKeyPath<State, IdentifiedArray<ID, ElementState>>,
+    action toElementAction: AnyCasePath<Action, (ID, ElementAction)>,
+    @ReducerBuilder<ElementState, ElementAction> element: () -> Element,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) -> some Reducer<State, Action> {
+    _ForEachReducer(
+      parent: self,
+      toElementsState: toElementsState,
+      toElementAction: .init(
+        embed: { toElementAction.embed($0) },
+        extract: { toElementAction.extract(from: $0) }
+      ),
+      element: element(),
+      fileID: fileID,
+      filePath: filePath,
+      line: line,
+      column: column
+    )
+  }
+
+  @available(
+    *,
+    deprecated,
+    message:
+      "Use the version of this operator with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
+  )
+  @inlinable
+  @warn_unqualified_access
+  public func forEach<
+    DestinationState, DestinationAction, Destination: Reducer<DestinationState, DestinationAction>
+  >(
+    _ toStackState: WritableKeyPath<State, StackState<DestinationState>>,
+    action toStackAction: AnyCasePath<Action, StackAction<DestinationState, DestinationAction>>,
+    @ReducerBuilder<DestinationState, DestinationAction> destination: () -> Destination,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) -> some Reducer<State, Action> {
+    _StackReducer(
+      base: self,
+      toStackState: toStackState,
+      toStackAction: toStackAction,
+      destination: destination(),
+      fileID: fileID,
+      filePath: filePath,
+      line: line,
+      column: column
+    )
+  }
+
+  @available(
+    *,
+    deprecated,
+    message:
+      "Use the version of this operator with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
+  )
+  @inlinable
+  @warn_unqualified_access
+  public func ifCaseLet<CaseState, CaseAction, Case: Reducer<CaseState, CaseAction>>(
+    _ toCaseState: AnyCasePath<State, CaseState>,
+    action toCaseAction: AnyCasePath<Action, CaseAction>,
+    @ReducerBuilder<CaseState, CaseAction> then case: () -> Case,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) -> some Reducer<State, Action> {
+    _IfCaseLetReducer(
+      parent: self,
+      child: `case`(),
+      toChildState: toCaseState,
+      toChildAction: toCaseAction,
+      fileID: fileID,
+      filePath: filePath,
+      line: line,
+      column: column
+    )
+  }
+
+  @available(
+    *,
+    deprecated,
+    message:
+      "Use the version of this operator with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
+  )
+  @inlinable
+  @warn_unqualified_access
+  public func ifLet<WrappedState, WrappedAction, Wrapped: Reducer<WrappedState, WrappedAction>>(
+    _ toWrappedState: WritableKeyPath<State, WrappedState?>,
+    action toWrappedAction: AnyCasePath<Action, WrappedAction>,
+    @ReducerBuilder<WrappedState, WrappedAction> then wrapped: () -> Wrapped,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) -> some Reducer<State, Action> {
+    _IfLetReducer(
+      parent: self,
+      child: wrapped(),
+      toChildState: toWrappedState,
+      toChildAction: toWrappedAction,
+      fileID: fileID,
+      filePath: filePath,
+      line: line,
+      column: column
+    )
+  }
+
+  @available(
+    *,
+    deprecated,
+    message:
+      "Use the version of this operator with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
+  )
+  @inlinable
+  @warn_unqualified_access
+  public func ifLet<WrappedState: _EphemeralState, WrappedAction>(
+    _ toWrappedState: WritableKeyPath<State, WrappedState?>,
+    action toWrappedAction: AnyCasePath<Action, WrappedAction>,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) -> _IfLetReducer<Self, EmptyReducer<WrappedState, WrappedAction>> {
+    .init(
+      parent: self,
+      child: EmptyReducer(),
+      toChildState: toWrappedState,
+      toChildAction: toWrappedAction,
+      fileID: fileID,
+      filePath: filePath,
+      line: line,
+      column: column
+    )
+  }
+
+  @available(
+    *,
+    deprecated,
+    message:
+      "Use the version of this operator with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
+  )
+  @warn_unqualified_access
+  @inlinable
+  public func ifLet<
+    DestinationState, DestinationAction, Destination: Reducer<DestinationState, DestinationAction>
+  >(
+    _ toPresentationState: WritableKeyPath<State, PresentationState<DestinationState>>,
+    action toPresentationAction: AnyCasePath<Action, PresentationAction<DestinationAction>>,
+    @ReducerBuilder<DestinationState, DestinationAction> destination: () -> Destination,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) -> some Reducer<State, Action> {
+    _PresentationReducer(
+      base: self,
+      toPresentationState: toPresentationState,
+      toPresentationAction: toPresentationAction,
+      destination: destination(),
+      fileID: fileID,
+      filePath: filePath,
+      line: line,
+      column: column
+    )
+  }
+
+  @available(
+    *,
+    deprecated,
+    message:
+      "Use the version of this operator with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
+  )
+  @warn_unqualified_access
+  @inlinable
+  public func ifLet<DestinationState: _EphemeralState, DestinationAction>(
+    _ toPresentationState: WritableKeyPath<State, PresentationState<DestinationState>>,
+    action toPresentationAction: AnyCasePath<Action, PresentationAction<DestinationAction>>,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) -> some Reducer<State, Action> {
+    self.ifLet(
+      toPresentationState,
+      action: toPresentationAction,
+      destination: {},
+      fileID: fileID,
+      filePath: filePath,
+      line: line,
+      column: column
+    )
+  }
+}
+
+extension Scope {
+  @available(
+    *,
+    deprecated,
+    message:
+      "Use the version of this operator with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
+  )
+  @inlinable
+  public init<ChildState, ChildAction>(
+    state toChildState: WritableKeyPath<ParentState, ChildState>,
+    action toChildAction: AnyCasePath<ParentAction, ChildAction>,
+    @ReducerBuilder<ChildState, ChildAction> child: () -> Child
+  ) where ChildState == Child.State, ChildAction == Child.Action {
+    self.init(
+      toChildState: .keyPath(toChildState),
+      toChildAction: toChildAction,
+      child: child()
+    )
+  }
+
+  @available(
+    *,
+    deprecated,
+    message:
+      "Use the version of this operator with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
+  )
+  @inlinable
+  public init<ChildState, ChildAction>(
+    state toChildState: AnyCasePath<ParentState, ChildState>,
+    action toChildAction: AnyCasePath<ParentAction, ChildAction>,
+    @ReducerBuilder<ChildState, ChildAction> child: () -> Child,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) where ChildState == Child.State, ChildAction == Child.Action {
+    self.init(
+      toChildState: .casePath(
+        toChildState,
+        fileID: fileID,
+        filePath: filePath,
+        line: line,
+        column: column
+      ),
+      toChildAction: toChildAction,
+      child: child()
+    )
+  }
+}
+
+extension StackState {
+  @available(
+    *,
+    deprecated,
+    message:
+      "Use the version of this subscript with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
+  )
+  public subscript<Case>(
+    id id: StackElementID,
+    case path: AnyCasePath<Element, Case>,
+    fileID fileID: _HashableStaticString = #fileID,
+    filePath filePath: _HashableStaticString = #filePath,
+    line line: UInt = #line,
+    column column: UInt = #column
+  ) -> Case? {
+    _read {
+      yield self[
+        id: id,
+        _case: path,
+        fileID: fileID,
+        filePath: filePath,
+        line: line,
+        column: column
+      ]
+    }
+    _modify {
+      yield &self[
+        id: id,
+        _case: path,
+        fileID: fileID,
+        filePath: filePath,
+        line: line,
+        column: column
+      ]
+    }
+  }
+}
+
+extension TestStore {
+  @_disfavoredOverload
+  @available(
+    *,
+    deprecated,
+    message:
+      "Use the version of this operator with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
+  )
+  public func receive<Value>(
+    _ actionCase: AnyCasePath<Action, Value>,
+    timeout duration: Duration? = nil,
+    assert updateStateToExpectedResult: ((_ state: inout State) throws -> Void)? = nil,
+    fileID: StaticString = #fileID,
+    file filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) async {
+    await self._receive(
+      actionCase,
+      timeout: duration,
+      assert: updateStateToExpectedResult,
+      fileID: fileID,
+      file: filePath,
+      line: line,
+      column: column
+    )
+  }
+
+  @available(
+    *,
+    deprecated,
+    message:
+      "Use the version of this operator with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
+  )
+  public func bindings<ViewAction: BindableAction>(
+    action toViewAction: AnyCasePath<Action, ViewAction>
+  ) -> BindingViewStore<State> where State == ViewAction.State {
+    self._bindings(action: toViewAction)
+  }
+}
+
 @available(
   *,
   message:

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -117,36 +117,12 @@ public struct PresentationState<State> {
   /// > Important: Accessing the wrong case will result in a runtime warning and test failure.
   public subscript<Case>(case path: CaseKeyPath<State, Case>) -> Case?
   where State: CasePathable {
-    _read { yield self[case: AnyCasePath(path)] }
-    _modify { yield &self[case: AnyCasePath(path)] }
+    _read { yield self[_case: AnyCasePath(path)] }
+    _modify { yield &self[_case: AnyCasePath(path)] }
   }
 
-  @available(
-    iOS,
-    deprecated: 9999,
-    message:
-      "Use the version of this subscript with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
-  )
-  @available(
-    macOS,
-    deprecated: 9999,
-    message:
-      "Use the version of this subscript with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
-  )
-  @available(
-    tvOS,
-    deprecated: 9999,
-    message:
-      "Use the version of this subscript with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
-  )
-  @available(
-    watchOS,
-    deprecated: 9999,
-    message:
-      "Use the version of this subscript with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
-  )
-  public subscript<Case>(
-    case path: AnyCasePath<State, Case>,
+  subscript<Case>(
+    _case path: AnyCasePath<State, Case>,
     fileID: StaticString = #fileID,
     filePath: StaticString = #filePath,
     line: UInt = #line,

--- a/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
@@ -89,37 +89,13 @@ public struct StackState<Element> {
   /// > Important: Accessing the wrong case will result in a runtime warning and test failure.
   public subscript<Case>(id id: StackElementID, case path: CaseKeyPath<Element, Case>) -> Case?
   where Element: CasePathable {
-    _read { yield self[id: id, case: AnyCasePath(path)] }
-    _modify { yield &self[id: id, case: AnyCasePath(path)] }
+    _read { yield self[id: id, _case: AnyCasePath(path)] }
+    _modify { yield &self[id: id, _case: AnyCasePath(path)] }
   }
 
-  @available(
-    iOS,
-    deprecated: 9999,
-    message:
-      "Use the version of this subscript with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
-  )
-  @available(
-    macOS,
-    deprecated: 9999,
-    message:
-      "Use the version of this subscript with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
-  )
-  @available(
-    tvOS,
-    deprecated: 9999,
-    message:
-      "Use the version of this subscript with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
-  )
-  @available(
-    watchOS,
-    deprecated: 9999,
-    message:
-      "Use the version of this subscript with case key paths, instead. See the following migration guide for more information: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4#Using-case-key-paths"
-  )
-  public subscript<Case>(
+  subscript<Case>(
     id id: StackElementID,
-    case path: AnyCasePath<Element, Case>,
+    _case path: AnyCasePath<Element, Case>,
     fileID fileID: _HashableStaticString = #fileID,
     filePath filePath: _HashableStaticString = #filePath,
     line line: UInt = #line,


### PR DESCRIPTION
Soft-deprecated in 1.4.0.