### PR TITLE
Deprecate `Reducer.reduce`

### DIFF
--- a/Sources/ComposableArchitecture/Core.swift
+++ b/Sources/ComposableArchitecture/Core.swift
@@ -95,7 +95,7 @@ final class RootCore<Root: Reducer>: Core {
     while index < self.bufferedActions.endIndex {
       defer { index += 1 }
       let action = self.bufferedActions[index]
-      let effect = reducer.reduce(into: &currentState, action: action)
+      let effect = reducer._reduce(into: &currentState, action: action)
       let uuid = UUID()
 
       switch effect.operation {

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -19,10 +19,10 @@ This is an inefficient way to share logic. Sending actions is not as lightweight
 as, say, calling a method on a class. Actions travel through multiple layers of an application, and 
 at each layer a reducer can intercept and reinterpret the action.
 
-It is far better to share logic via simple methods on your ``Reducer`` conformance.
+It is far better to share logic via simple methods, for example on your ``Reducer`` conformance.
 The helper methods can take `inout State` as an argument if it needs to make mutations, and it
-can return an `Effect<Action>`. This allows you to share logic without incurring the cost
-of sending needless actions.
+can return an `Effect<Action>`. This allows you to share logic across a reducer without incurring
+the cost of sending needless actions.
 
 For example, suppose that there are 3 UI components in your feature such that when any is changed
 you want to update the corresponding field of state, but then you also want to make some mutations
@@ -184,9 +184,8 @@ store.send(.textFieldChanged("Hello") {
 ##### Sharing logic in child features
 
 There is another common scenario for sharing logic in features where the parent feature wants to
-invoke logic in a child feature. One can technically do this by sending actions from the parent 
-to the child, but we do not recommend it (see above in <doc:Performance#Sharing-logic-with-actions>
-to learn why):
+invoke logic in a child feature. You can accomplish this by sending actions from the parent to the
+child:
 
 ```swift
 // Handling action from parent feature:
@@ -195,12 +194,9 @@ case .buttonTapped:
   return .send(.child(.refresh))
 ```
 
-Instead, we recommend invoking the child reducer directly:
-
-```swift
-case .buttonTapped:
-  return reduce(into: &state, action: .child(.refresh))
-```
+With the same caveat that this is not the most efficient way to communicate to a child. If
+performance is a concern, consider extracting the shared logic to helpers that can be invoked from
+either domain.
 
 ### CPU intensive calculations
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/TestingTCA.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/TestingTCA.md
@@ -14,53 +14,9 @@ also how effects are executed and feed data back into the system.
 
 ## Testing state changes
 
-State changes are by far the simplest thing to test in features built with the library. A
-``Reducer``'s first responsibility is to mutate the current state based on the action received into
-the system. To test this we can technically run a piece of mutable state through the reducer and
-then assert on how it changed after, like this:
-
-```swift
-@Reducer
-struct Feature {
-  @ObservableState
-  struct State: Equatable {
-    var count = 0
-  }
-  enum Action {
-    case incrementButtonTapped
-    case decrementButtonTapped
-  }
-  var body: some Reduce<State, Action> {
-    Reduce { state, action in
-      switch action {
-      case .incrementButtonTapped:
-        state.count += 1
-        return .none
-      case .decrementButtonTapped:
-        state.count -= 1
-        return .none
-      }
-    }
-  }
-}
-
-@Test
-func basics() {
-  let feature = Feature()
-  var currentState = Feature.State(count: 0)
-  _ = feature.reduce(into: &currentState, action: .incrementButtonTapped)
-  #expect(currentState == State(count: 1))
-
-  _ = feature.reduce(into: &currentState, action: .decrementButtonTapped)
-  #expect(currentState == State(count: 0))
-}
-```
-
-This will technically work, but it's a lot boilerplate for something that should be quite simple.
-
-The library comes with a tool specifically designed to make testing like this much simpler and more
-concise. It's called ``TestStore``, and it is constructed similarly to ``Store`` by providing the
-initial state of the feature and the ``Reducer`` that runs the feature's logic:
+The library comes with a tool specifically designed to test features simply and concisely. It's
+called ``TestStore``, and it is constructed similarly to ``Store`` by providing the initial state of
+the feature and the ``Reducer`` that runs the feature's logic:
 
 ```swift
 import Testing
@@ -80,10 +36,10 @@ struct CounterTests {
 > ``TestStore`` can suspend. And while tests do not _require_ the main actor, ``TestStore`` _is_
 > main actor-isolated, and so we recommend annotating your tests and suites with `@MainActor`.
 
-Test stores have a ``TestStore/send(_:assert:fileID:file:line:column:)-8f2pl`` method, but it behaves differently from
-stores and view stores. You provide an action to send into the system, but then you must also
-provide a trailing closure to describe how the state of the feature changed after sending the
-action:
+Test stores have a ``TestStore/send(_:assert:fileID:file:line:column:)-8f2pl`` method, but it
+behaves differently from stores and view stores. You provide an action to send into the system, but
+then you must also provide a trailing closure to describe how the state of the feature changed after
+sending the action:
 
 ```swift
 await store.send(.incrementButtonTapped) {

--- a/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
+++ b/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
@@ -85,15 +85,15 @@ public enum ReducerBuilder<State, Action> {
     case second(Second)
 
     @inlinable
-    public func reduce(into state: inout First.State, action: First.Action) -> Effect<
+    public func _reduce(into state: inout First.State, action: First.Action) -> Effect<
       First.Action
     > {
       switch self {
       case .first(let first):
-        return first.reduce(into: &state, action: action)
+        return first._reduce(into: &state, action: action)
 
       case .second(let second):
-        return second.reduce(into: &state, action: action)
+        return second._reduce(into: &state, action: action)
       }
     }
   }
@@ -112,9 +112,9 @@ public enum ReducerBuilder<State, Action> {
     }
 
     @inlinable
-    public func reduce(into state: inout R0.State, action: R0.Action) -> Effect<R0.Action> {
-      self.r0.reduce(into: &state, action: action)
-        .merge(with: self.r1.reduce(into: &state, action: action))
+    public func _reduce(into state: inout R0.State, action: R0.Action) -> Effect<R0.Action> {
+      self.r0._reduce(into: &state, action: action)
+        .merge(with: self.r1._reduce(into: &state, action: action))
     }
   }
 
@@ -128,10 +128,10 @@ public enum ReducerBuilder<State, Action> {
     }
 
     @inlinable
-    public func reduce(
+    public func _reduce(
       into state: inout Element.State, action: Element.Action
     ) -> Effect<Element.Action> {
-      self.reducers.reduce(.none) { $0.merge(with: $1.reduce(into: &state, action: action)) }
+      self.reducers.reduce(.none) { $0.merge(with: $1._reduce(into: &state, action: action)) }
     }
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
@@ -69,7 +69,7 @@ where State == ViewAction.State {
   }
 
   @inlinable
-  public func reduce(into state: inout State, action: Action) -> Effect<Action> {
+  public func _reduce(into state: inout State, action: Action) -> Effect<Action> {
     // NB: Using a closure and not a `\.binding` key path literal to avoid a bug with archives:
     //     https://github.com/pointfreeco/swift-composable-architecture/pull/2641
     guard let bindingAction = self.toViewAction(action).flatMap({ $0.binding })

--- a/Sources/ComposableArchitecture/Reducer/Reducers/CombineReducers.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/CombineReducers.swift
@@ -36,9 +36,9 @@ where State == Reducers.State, Action == Reducers.Action {
   }
 
   @inlinable
-  public func reduce(
+  public func _reduce(
     into state: inout Reducers.State, action: Reducers.Action
   ) -> Effect<Reducers.Action> {
-    self.reducers.reduce(into: &state, action: action)
+    self.reducers._reduce(into: &state, action: action)
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
@@ -83,14 +83,14 @@ public struct _PrintChangesReducer<Base: Reducer>: Reducer {
   }
 
   #if DEBUG
-    public func reduce(
+    public func _reduce(
       into state: inout Base.State, action: Base.Action
     ) -> Effect<Base.Action> {
       if let printer = self.printer {
         let changeTracker = SharedChangeTracker(reportUnassertedChanges: false)
         return changeTracker.track {
           let oldState = UncheckedSendable(state)
-          let effects = self.base.reduce(into: &state, action: action)
+          let effects = self.base._reduce(into: &state, action: action)
           return withEscapedDependencies { continuation in
             effects.merge(
               with: .publisher {
@@ -118,14 +118,14 @@ public struct _PrintChangesReducer<Base: Reducer>: Reducer {
           }
         }
       }
-      return self.base.reduce(into: &state, action: action)
+      return self.base._reduce(into: &state, action: action)
     }
   #else
     @inlinable
-    public func reduce(
+    public func _reduce(
       into state: inout Base.State, action: Base.Action
     ) -> Effect<Base.Action> {
-      return self.base.reduce(into: &state, action: action)
+      return self.base._reduce(into: &state, action: action)
     }
   #endif
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
@@ -166,13 +166,13 @@ public struct _DependencyKeyWritingReducer<Base: Reducer>: Reducer {
   }
 
   @inlinable
-  public func reduce(
+  public func _reduce(
     into state: inout Base.State, action: Base.Action
   ) -> Effect<Base.Action> {
     withDependencies {
       self.update(&$0)
     } operation: {
-      self.base.reduce(into: &state, action: action)
+      self.base._reduce(into: &state, action: action)
     }
   }
 

--- a/Sources/ComposableArchitecture/Reducer/Reducers/EmptyReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/EmptyReducer.swift
@@ -13,7 +13,7 @@ public struct EmptyReducer<State, Action>: Reducer {
   init(internal: Void) {}
 
   @inlinable
-  public func reduce(into _: inout State, action _: Action) -> Effect<Action> {
+  public func _reduce(into _: inout State, action _: Action) -> Effect<Action> {
     .none
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -191,13 +191,13 @@ public struct _ForEachReducer<
     self.column = column
   }
 
-  public func reduce(
+  public func _reduce(
     into state: inout Parent.State, action: Parent.Action
   ) -> Effect<Parent.Action> {
     let elementEffects = self.reduceForEach(into: &state, action: action)
 
     let idsBefore = state[keyPath: self.toElementsState].ids
-    let parentEffects = self.parent.reduce(into: &state, action: action)
+    let parentEffects = self.parent._reduce(into: &state, action: action)
     let idsAfter = state[keyPath: self.toElementsState].ids
 
     let elementCancelEffects: Effect<Parent.Action> =
@@ -256,7 +256,7 @@ public struct _ForEachReducer<
     let elementNavigationID = self.navigationIDPath.appending(navigationID)
     return self.element
       .dependency(\.navigationIDPath, elementNavigationID)
-      .reduce(into: &state[keyPath: self.toElementsState][id: id]!, action: elementAction)
+      ._reduce(into: &state[keyPath: self.toElementsState][id: id]!, action: elementAction)
       .map { [toElementAction] in toElementAction.embed((id, $0)) }
       ._cancellable(id: navigationID, navigationIDPath: self.navigationIDPath)
   }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
@@ -132,7 +132,7 @@ public struct _IfCaseLetReducer<Parent: Reducer, Child: Reducer>: Reducer {
     self.column = column
   }
 
-  public func reduce(
+  public func _reduce(
     into state: inout Parent.State, action: Parent.Action
   ) -> Effect<Parent.Action> {
     let childEffects = self.reduceChild(into: &state, action: action)
@@ -140,7 +140,7 @@ public struct _IfCaseLetReducer<Parent: Reducer, Child: Reducer>: Reducer {
     let childIDBefore = self.toChildState.extract(from: state).map {
       NavigationID(root: state, value: $0, casePath: self.toChildState)
     }
-    let parentEffects = self.parent.reduce(into: &state, action: action)
+    let parentEffects = self.parent._reduce(into: &state, action: action)
     let childIDAfter = self.toChildState.extract(from: state).map {
       NavigationID(root: state, value: $0, casePath: self.toChildState)
     }
@@ -202,7 +202,7 @@ public struct _IfCaseLetReducer<Parent: Reducer, Child: Reducer>: Reducer {
     let newNavigationID = self.navigationIDPath.appending(childID)
     return self.child
       .dependency(\.navigationIDPath, newNavigationID)
-      .reduce(into: &childState, action: childAction)
+      ._reduce(into: &childState, action: childAction)
       .map { [toChildAction] in toChildAction.embed($0) }
       .cancellable(id: childID)
   }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
@@ -150,7 +150,7 @@ public struct _IfLetReducer<Parent: Reducer, Child: Reducer>: Reducer {
     self.column = column
   }
 
-  public func reduce(
+  public func _reduce(
     into state: inout Parent.State, action: Parent.Action
   ) -> Effect<Parent.Action> {
     let childEffects = self.reduceChild(into: &state, action: action)
@@ -158,7 +158,7 @@ public struct _IfLetReducer<Parent: Reducer, Child: Reducer>: Reducer {
     let childIDBefore = state[keyPath: self.toChildState].map {
       NavigationID(base: $0, keyPath: self.toChildState)
     }
-    let parentEffects = self.parent.reduce(into: &state, action: action)
+    let parentEffects = self.parent._reduce(into: &state, action: action)
     let childIDAfter = state[keyPath: self.toChildState].map {
       NavigationID(base: $0, keyPath: self.toChildState)
     }
@@ -224,7 +224,7 @@ public struct _IfLetReducer<Parent: Reducer, Child: Reducer>: Reducer {
       base: state[keyPath: self.toChildState]!, keyPath: self.toChildState)
     return self.child
       .dependency(\.navigationIDPath, self.navigationIDPath.appending(navigationID))
-      .reduce(into: &state[keyPath: self.toChildState]!, action: childAction)
+      ._reduce(into: &state[keyPath: self.toChildState]!, action: childAction)
       .map { [toChildAction] in toChildAction.embed($0) }
       ._cancellable(id: navigationID, navigationIDPath: self.navigationIDPath)
   }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/OnChange.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/OnChange.swift
@@ -86,12 +86,12 @@ where Base.State == Body.State, Base.Action == Body.Action {
   }
 
   @inlinable
-  public func reduce(into state: inout Base.State, action: Base.Action) -> Effect<Base.Action> {
+  public func _reduce(into state: inout Base.State, action: Base.Action) -> Effect<Base.Action> {
     let oldValue = toValue(state)
-    let baseEffects = self.base.reduce(into: &state, action: action)
+    let baseEffects = self.base._reduce(into: &state, action: action)
     let newValue = toValue(state)
     return isDuplicate(oldValue, newValue)
       ? baseEffects
-      : .merge(baseEffects, self.reducer(oldValue, newValue).reduce(into: &state, action: action))
+      : .merge(baseEffects, self.reducer(oldValue, newValue)._reduce(into: &state, action: action))
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Optional.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Optional.swift
@@ -1,11 +1,11 @@
 extension Optional: Reducer where Wrapped: Reducer {
   @inlinable
-  public func reduce(
+  public func _reduce(
     into state: inout Wrapped.State, action: Wrapped.Action
   ) -> Effect<Wrapped.Action> {
     switch self {
     case .some(let wrapped):
-      return wrapped.reduce(into: &state, action: action)
+      return wrapped._reduce(into: &state, action: action)
     case .none:
       return .none
     }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -465,7 +465,7 @@ public struct _PresentationReducer<Base: Reducer, Destination: Reducer>: Reducer
     self.column = column
   }
 
-  public func reduce(into state: inout Base.State, action: Base.Action) -> Effect<Base.Action> {
+  public func _reduce(into state: inout Base.State, action: Base.Action) -> Effect<Base.Action> {
     let initialPresentationState = state[keyPath: self.toPresentationState]
     let presentationAction = self.toPresentationAction.extract(from: action)
 
@@ -475,7 +475,7 @@ public struct _PresentationReducer<Base: Reducer, Destination: Reducer>: Reducer
     switch (initialPresentationState.wrappedValue, presentationAction) {
     case (.some(let destinationState), .some(.dismiss)):
       destinationEffects = .none
-      baseEffects = self.base.reduce(into: &state, action: action)
+      baseEffects = self.base._reduce(into: &state, action: action)
       if self.navigationIDPath(for: destinationState)
         == state[keyPath: self.toPresentationState].wrappedValue.map(self.navigationIDPath(for:))
       {
@@ -492,12 +492,12 @@ public struct _PresentationReducer<Base: Reducer, Destination: Reducer>: Reducer
           }
         )
         .dependency(\.navigationIDPath, destinationNavigationIDPath)
-        .reduce(
+        ._reduce(
           into: &state[keyPath: self.toPresentationState].wrappedValue!, action: destinationAction
         )
         .map { [toPresentationAction] in toPresentationAction.embed(.presented($0)) }
         ._cancellable(navigationIDPath: destinationNavigationIDPath)
-      baseEffects = self.base.reduce(into: &state, action: action)
+      baseEffects = self.base._reduce(into: &state, action: action)
       if let ephemeralType = ephemeralType(of: destinationState),
         destinationNavigationIDPath
           == state[keyPath: self.toPresentationState].wrappedValue.map(self.navigationIDPath(for:)),
@@ -508,7 +508,7 @@ public struct _PresentationReducer<Base: Reducer, Destination: Reducer>: Reducer
 
     case (.none, .none), (.some, .none):
       destinationEffects = .none
-      baseEffects = self.base.reduce(into: &state, action: action)
+      baseEffects = self.base._reduce(into: &state, action: action)
 
     case (.none, .some):
       reportIssue(
@@ -536,7 +536,7 @@ public struct _PresentationReducer<Base: Reducer, Destination: Reducer>: Reducer
         column: column
       )
       destinationEffects = .none
-      baseEffects = self.base.reduce(into: &state, action: action)
+      baseEffects = self.base._reduce(into: &state, action: action)
     }
 
     let presentationIdentityChanged =

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Reduce.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Reduce.swift
@@ -26,11 +26,11 @@ public struct Reduce<State, Action>: Reducer {
   /// - Parameter reducer: A reducer that is called when ``reduce(into:action:)`` is invoked.
   @inlinable
   public init(_ reducer: some Reducer<State, Action>) {
-    self.init(internal: reducer.reduce)
+    self.init(internal: reducer._reduce)
   }
 
   @inlinable
-  public func reduce(into state: inout State, action: Action) -> Effect<Action> {
+  public func _reduce(into state: inout State, action: Action) -> Effect<Action> {
     self.reduce(&state, action)
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
@@ -252,7 +252,7 @@ public struct Scope<ParentState, ParentAction, Child: Reducer>: Reducer {
   }
 
   @inlinable
-  public func reduce(
+  public func _reduce(
     into state: inout ParentState, action: ParentAction
   ) -> Effect<ParentAction> {
     guard let childAction = self.toChildAction.extract(from: action)
@@ -298,12 +298,12 @@ public struct Scope<ParentState, ParentAction, Child: Reducer>: Reducer {
       defer { state = toChildState.embed(childState) }
 
       return self.child
-        .reduce(into: &childState, action: childAction)
+        ._reduce(into: &childState, action: childAction)
         .map { [toChildAction] in toChildAction.embed($0) }
 
     case .keyPath(let toChildState):
       return self.child
-        .reduce(into: &state[keyPath: toChildState], action: childAction)
+        ._reduce(into: &state[keyPath: toChildState], action: childAction)
         .map { [toChildAction] in toChildAction.embed($0) }
     }
   }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/SignpostReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/SignpostReducer.swift
@@ -57,7 +57,7 @@ public struct _SignpostReducer<Base: Reducer>: Reducer {
   }
 
   @inlinable
-  public func reduce(
+  public func _reduce(
     into state: inout Base.State, action: Base.Action
   ) -> Effect<Base.Action> {
     var actionOutput: String!
@@ -65,7 +65,7 @@ public struct _SignpostReducer<Base: Reducer>: Reducer {
       actionOutput = debugCaseOutput(action)
       os_signpost(.begin, log: log, name: "Action", "%s%s", self.prefix, actionOutput)
     }
-    let effects = self.base.reduce(into: &state, action: action)
+    let effects = self.base._reduce(into: &state, action: action)
     if self.log.signpostsEnabled {
       os_signpost(.end, log: self.log, name: "Action")
       return

--- a/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
@@ -424,7 +424,7 @@ public struct _StackReducer<Base: Reducer, Destination: Reducer>: Reducer {
     self.column = column
   }
 
-  public func reduce(into state: inout Base.State, action: Base.Action) -> Effect<Base.Action> {
+  public func _reduce(into state: inout Base.State, action: Base.Action) -> Effect<Base.Action> {
     let idsBefore = state[keyPath: self.toStackState]._mounted
     let destinationEffects: Effect<Base.Action>
     let baseEffects: Effect<Base.Action>
@@ -444,7 +444,7 @@ public struct _StackReducer<Base: Reducer, Destination: Reducer>: Reducer {
             }
           )
           .dependency(\.navigationIDPath, elementNavigationIDPath)
-          .reduce(
+          ._reduce(
             into: &state[keyPath: self.toStackState][id: elementID]!,
             action: destinationAction
           )
@@ -481,12 +481,12 @@ public struct _StackReducer<Base: Reducer, Destination: Reducer>: Reducer {
         destinationEffects = .none
       }
 
-      baseEffects = self.base.reduce(into: &state, action: action)
+      baseEffects = self.base._reduce(into: &state, action: action)
 
     case .popFrom(let id):
       destinationEffects = .none
       let canPop = state[keyPath: self.toStackState].ids.contains(id)
-      baseEffects = self.base.reduce(into: &state, action: action)
+      baseEffects = self.base._reduce(into: &state, action: action)
       if canPop {
         state[keyPath: self.toStackState].pop(from: id)
       } else {
@@ -525,7 +525,7 @@ public struct _StackReducer<Base: Reducer, Destination: Reducer>: Reducer {
           line: line,
           column: column
         )
-        baseEffects = self.base.reduce(into: &state, action: action)
+        baseEffects = self.base._reduce(into: &state, action: action)
         break
       } else if DependencyValues._current.context == .test {
         let nextID = DependencyValues._current.stackElementID.peek()
@@ -550,11 +550,11 @@ public struct _StackReducer<Base: Reducer, Destination: Reducer>: Reducer {
         }
       }
       state[keyPath: self.toStackState]._dictionary[id] = element
-      baseEffects = self.base.reduce(into: &state, action: action)
+      baseEffects = self.base._reduce(into: &state, action: action)
 
     case .none:
       destinationEffects = .none
-      baseEffects = self.base.reduce(into: &state, action: action)
+      baseEffects = self.base._reduce(into: &state, action: action)
     }
 
     let idsAfter = state[keyPath: self.toStackState].ids

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -2440,7 +2440,7 @@ class TestReducer<State: Equatable, Action>: Reducer {
     self.state = initialState
   }
 
-  func reduce(into state: inout State, action: TestAction) -> Effect<TestAction> {
+  func _reduce(into state: inout State, action: TestAction) -> Effect<TestAction> {
     var dependencies = self.dependencies
     let dismiss = dependencies.dismiss.dismiss
     dependencies.dismiss = DismissEffect { [weak store] in
@@ -2455,11 +2455,11 @@ class TestReducer<State: Equatable, Action>: Reducer {
     let effects: Effect<Action>
     switch action.origin {
     case .send(let action):
-      effects = reducer.reduce(into: &state, action: action)
+      effects = reducer._reduce(into: &state, action: action)
       self.state = state
 
     case .receive(let action):
-      effects = reducer.reduce(into: &state, action: action)
+      effects = reducer._reduce(into: &state, action: action)
       self.receivedActions.append((action, state))
     }
 

--- a/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
@@ -174,14 +174,6 @@
           func reduce(into state: inout State, action: Action) -> EffectOf<Self> {
             .none
           }
-          var body: some ReducerOf<Self> {
-            Reduce(reduce)
-            Reduce(reduce(into:action:))
-            Reduce(self.reduce)
-            Reduce(self.reduce(into:action:))
-            Reduce(AnotherReducer().reduce)
-            Reduce(AnotherReducer().reduce(into:action:))
-          }
         }
         """
       } diagnostics: {
@@ -194,17 +186,44 @@
           }
           func reduce(into state: inout State, action: Action) -> EffectOf<Self> {
                ┬─────
-               ╰─ 🛑 A 'reduce' method should not be defined in a reducer with a 'body'; it takes precedence and 'body' will never be invoked
+               ╰─ ⚠️ 'reduce(into:action:)' is deprecated: Reducers should be defined using the 'body' property and a 'Reduce'.
+                  ✏️ Use 'body' instead
             .none
           }
-          var body: some ReducerOf<Self> {
-            Reduce(reduce)
-            Reduce(reduce(into:action:))
-            Reduce(self.reduce)
-            Reduce(self.reduce(into:action:))
-            Reduce(AnotherReducer().reduce)
-            Reduce(AnotherReducer().reduce(into:action:))
+        }
+        """
+      } fixes: {
+        """
+        @Reducer
+        struct Feature {
+          struct State {
           }
+          enum Action {
+          }
+          var body: some Reducer<State, Action> {
+        Reduce { state, action in
+        .none
+        }
+        }
+        }
+        """
+      } expansion: {
+        """
+        struct Feature {
+          struct State {
+          }
+          @CasePathable
+          enum Action {
+          }
+          @ComposableArchitecture.ReducerBuilder<State, Action>
+          var body: some Reducer<State, Action> {
+        Reduce { state, action in
+        .none
+        }
+        }
+        }
+
+        extension Feature: ComposableArchitecture.Reducer {
         }
         """
       }
@@ -1040,30 +1059,6 @@
         struct Feature {
           @ComposableArchitecture.ReducerBuilder<Base.State, Base.Action>
           var body: some ReducerOf<Base> { EmptyReducer() }
-        }
-
-        extension Feature: ComposableArchitecture.Reducer {
-        }
-        """
-      }
-    }
-
-    func testFilledRequirements_ReduceMethod() {
-      assertMacro {
-        """
-        @Reducer
-        struct Feature {
-          func reduce(into state: inout Base.State, action: Base.Action) -> EffectOf<Base> {
-            .none
-          }
-        }
-        """
-      } expansion: {
-        """
-        struct Feature {
-          func reduce(into state: inout Base.State, action: Base.Action) -> EffectOf<Base> {
-            .none
-          }
         }
 
         extension Feature: ComposableArchitecture.Reducer {


### PR DESCRIPTION
We've documented always using `Reducer.body` for awhile now.

While one exception has been documented for invoking a child's reducer directly from a parent to avoid a full `store.send` cycle, in practice we find that this is not a great pattern, so let's start pushing people away from the practice.

TCA 2.0 will not even offer the ability to invoke `reduce`, so this should also help prepare folks for the future.