### PR TITLE
Warn against reentrant actions

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -551,7 +551,9 @@ private final class _IfLetCore<Base: Core<Wrapped?, Action>, Wrapped, Action>: C
     self.base = base
   }
   var state: Base.State { base.state }
-  func send(_ action: Action) -> Task<Void, Never>? { base.send(action) }
+  func send(_ action: Action, origin: Origin) -> Task<Void, Never>? {
+    base.send(action, origin: origin)
+  }
   var canStoreCacheChildren: Bool { base.canStoreCacheChildren }
   var didSet: CurrentValueRelay<Void> { base.didSet }
   var isInvalid: Bool { state == nil || base.isInvalid }
@@ -1499,8 +1501,8 @@ final class PresentationCore<
   var state: Base.State {
     base.state
   }
-  func send(_ action: Base.Action) -> Task<Void, Never>? {
-    base.send(action)
+  func send(_ action: Base.Action, origin: Origin) -> Task<Void, Never>? {
+    base.send(action, origin: origin)
   }
   var canStoreCacheChildren: Bool { base.canStoreCacheChildren }
   var didSet: CurrentValueRelay<Void> { base.didSet }
@@ -1966,8 +1968,8 @@ private final class NavigationLinkCore<
   var state: Base.State {
     base.state
   }
-  func send(_ action: Base.Action) -> Task<Void, Never>? {
-    base.send(action)
+  func send(_ action: Base.Action, origin: Origin) -> Task<Void, Never>? {
+    base.send(action, origin: origin)
   }
   var canStoreCacheChildren: Bool { base.canStoreCacheChildren }
   var didSet: CurrentValueRelay<Void> { base.didSet }

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -307,7 +307,7 @@ public final class Store<State, Action>: _Store {
   @_spi(Internals)
   @_disfavoredOverload
   public func send(_ action: Action) -> Task<Void, Never>? {
-    core.send(action)
+    core.send(action, origin: .store)
   }
 
   private init(core: some Core<State, Action>, scopeID: AnyHashable?, parent: (any _Store)?) {

--- a/Tests/ComposableArchitectureTests/CompatibilityTests.swift
+++ b/Tests/ComposableArchitectureTests/CompatibilityTests.swift
@@ -96,7 +96,11 @@ final class CompatibilityTests: BaseTCATestCase {
     viewStore.publisher
       .sink { value in
         if value == 1 {
-          viewStore.send(0)
+          XCTExpectFailure {
+            viewStore.send(0)
+          } issueMatcher: {
+            $0.compactDescription.contains("Reentrant actions are undefined")
+          }
         }
       }
       .store(in: &cancellables)

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -518,7 +518,11 @@ final class StoreTests: BaseTCATestCase {
 
     XCTAssertEqual(handledActions, [])
 
-    _ = ViewStore(parentStore, observe: { $0 }).send(.button)
+    XCTExpectFailure {
+      _ = ViewStore(parentStore, observe: { $0 }).send(.button)
+    } issueMatcher: {
+      $0.compactDescription.contains("Reentrant actions are undefined")
+    }
     XCTAssertEqual(
       handledActions,
       [


### PR DESCRIPTION
TCA 1.0 did its best to gracefully handle reentrant actions, but over time it became clear that there is no clear expectation for how they should behave. Other frameworks like ReSwift ban reentrancy, and we agree that is a good default behavior.

This PR begins to emit runtime warnings when it detects action reentrancy, which will allow users to address things in their code base when/should we break from support in a 2.0.