### PR TITLE
Mark deprecated popover overload unavailable on tvOS/watchOS

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -2485,6 +2485,8 @@ extension View {
     }
   }
 
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
   @available(
     *,
     deprecated,


### PR DESCRIPTION
## Summary

This PR fixes a watchOS/tvOS availability regression introduced in `1.24.0` when deprecated SwiftUI APIs were moved into `Internal/Deprecations.swift`.

On watchOS, users can hit:

> `Deprecations.swift:2508:12: error: 'popover(item:attachmentAnchor:arrowEdge:content:)' is unavailable in watchOS`

## Cause

The deprecated overload:

`popover(store:state:action:attachmentAnchor:arrowEdge:content:)`

was moved in commit [`808a0be1022`](https://github.com/pointfreeco/swift-composable-architecture/commit/808a0be1022) ([PR #3851](https://github.com/pointfreeco/swift-composable-architecture/pull/3851)), but during that move it lost the platform guard that previously existed in `SwiftUI/Popover.swift`:

- `@available(tvOS, unavailable)`
- `@available(watchOS, unavailable)`

Reference to prior guarded implementation:
[`SwiftUI/Popover.swift` at `965656af19b4149ae2f2d939db907542775095dc`](https://github.com/pointfreeco/swift-composable-architecture/blob/965656af19b4149ae2f2d939db907542775095dc/Sources/ComposableArchitecture/SwiftUI/Popover.swift)

## Fix

I just added back the platform `@available` guards to mark `tvOS` and `watchOS` as unavailable.

## Impact

This should have no impact on anything but tvOS and watchOS, which will now compile against this.