### PR TITLE
docs: Add AlertState and ConfirmationDialogState to SwiftUI Integration topics

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwiftUIIntegration.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwiftUIIntegration.md
@@ -11,6 +11,8 @@ designed with SwiftUI in mind, and comes with many powerful tools to integrate i
 
 ### Alerts and dialogs
 
+- ``AlertState``
+- ``ConfirmationDialogState``
 - ``SwiftUI/View/alert(_:)``
 - ``SwiftUI/View/confirmationDialog(_:)``
 - ``_EphemeralState``


### PR DESCRIPTION
## Problem

The **Alerts and Dialogs** section in the [SwiftUI Integration documentation](https://pointfreeco.github.io/swift-composable-architecture/documentation/composablearchitecture/swiftuiintegration) was only listing the `_EphemeralState` protocol and the two SwiftUI view modifiers, but was missing `AlertState` and `ConfirmationDialogState` — the primary types developers reach for when implementing alerts and dialogs in TCA.

This makes it hard to discover these types directly from the SwiftUI Integration page, since someone new to TCA navigating to the Alerts and Dialogs section would only see the protocol and the view modifier overloads, not the state types they need to use.

## Solution

Add `AlertState` and `ConfirmationDialogState` to the Alerts and Dialogs topic group in `SwiftUIIntegration.md`. Both types are already re-exported from `SwiftUINavigation` via `@_exported import` and are used throughout TCA's own documentation and tutorials, so this is a documentation discoverability fix only.

Fixes #3719