### PR TITLE
fix: replace obsolete numbersapi.com with number-trivia.com

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-Basics.swift
@@ -136,8 +136,8 @@ struct EffectsBasicsView: View {
       }
 
       Section {
-        Button("Number facts provided by numbersapi.com") {
-          openURL(URL(string: "http://numbersapi.com")!)
+        Button("Number facts provided by number-trivia.com") {
+          openURL(URL(string: "http://number-trivia.com")!)
         }
         .foregroundStyle(.secondary)
         .frame(maxWidth: .infinity)

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-Cancellation.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-Cancellation.swift
@@ -99,8 +99,8 @@ struct EffectsCancellationView: View {
       }
 
       Section {
-        Button("Number facts provided by numbersapi.com") {
-          self.openURL(URL(string: "http://numbersapi.com")!)
+        Button("Number facts provided by number-trivia.com") {
+          self.openURL(URL(string: "http://number-trivia.com")!)
         }
         .foregroundStyle(.secondary)
         .frame(maxWidth: .infinity)

--- a/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/FactClient.swift
@@ -21,7 +21,7 @@ extension FactClient: DependencyKey {
     fetch: { number in
       try await Task.sleep(for: .seconds(1))
       let (data, _) = try await URLSession.shared
-        .data(from: URL(string: "http://numbersapi.com/\(number)/trivia")!)
+        .data(from: URL(string: "http://number-trivia.com/\(number)/trivia")!)
       return String(decoding: data, as: UTF8.self)
     }
   )

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ struct Feature {
       case .numberFactButtonTapped:
         return .run { [count = state.count] send in
           let (data, _) = try await URLSession.shared.data(
-            from: URL(string: "http://numbersapi.com/\(count)/trivia")!
+            from: URL(string: "http://number-trivia.com/\(count)/trivia")!
           )
           await send(
             .numberFactResponse(String(decoding: data, as: UTF8.self))
@@ -395,7 +395,7 @@ struct MyApp: App {
           Feature(
             numberFact: { number in
               let (data, _) = try await URLSession.shared.data(
-                from: URL(string: "http://numbersapi.com/\(number)")!
+                from: URL(string: "http://number-trivia.com/\(number)")!
               )
               return String(decoding: data, as: UTF8.self)
             }
@@ -457,7 +457,7 @@ extension NumberFactClient: DependencyKey {
   static let liveValue = Self(
     fetch: { number in
       let (data, _) = try await URLSession.shared
-        .data(from: URL(string: "http://numbersapi.com/\(number)")!
+        .data(from: URL(string: "http://number-trivia.com/\(number)")!
       )
       return String(decoding: data, as: UTF8.self)
     }

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
@@ -130,7 +130,7 @@ struct Feature {
       case .numberFactButtonTapped:
         return .run { [count = state.count] send in
           let (data, _) = try await URLSession.shared.data(
-            from: URL(string: "http://numbersapi.com/\(count)/trivia")!
+            from: URL(string: "http://number-trivia.com/\(count)/trivia")!
           )
           await send(
             .numberFactResponse(String(decoding: data, as: UTF8.self))
@@ -335,7 +335,7 @@ struct MyApp: App {
           Feature(
             numberFact: { number in
               let (data, _) = try await URLSession.shared.data(
-                from: URL(string: "http://numbersapi.com/\(number)")!
+                from: URL(string: "http://number-trivia.com/\(number)")!
               )
               return String(decoding: data, as: UTF8.self)
             }
@@ -396,7 +396,7 @@ extension NumberFactClient: DependencyKey {
   static let liveValue = Self(
     fetch: { number in
       let (data, _) = try await URLSession.shared
-        .data(from: URL(string: "http://numbersapi.com/\(number)")!
+        .data(from: URL(string: "http://number-trivia.com/\(number)")!
       )
       return String(decoding: data, as: UTF8.self)
     }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-01-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-01-code-0005.swift
@@ -28,7 +28,7 @@ struct CounterFeature {
         state.isLoading = true
         
         let (data, _) = try await URLSession.shared
-          .data(from: URL(string: "http://numbersapi.com/\(state.count)")!)
+          .data(from: URL(string: "http://number-trivia.com/\(state.count)")!)
         // 🛑 'async' call in a function that does not support concurrency
         // 🛑 Errors thrown from here are not handled
         

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0002.swift
@@ -28,7 +28,7 @@ struct CounterFeature {
         state.isLoading = true
         return .run { [count = state.count] send in
           let (data, _) = try await URLSession.shared
-            .data(from: URL(string: "http://numbersapi.com/\(count)")!)
+            .data(from: URL(string: "http://number-trivia.com/\(count)")!)
           let fact = String(decoding: data, as: UTF8.self)
         }
         

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0003.swift
@@ -28,7 +28,7 @@ struct CounterFeature {
         state.isLoading = true
         return .run { [count = state.count] send in
           let (data, _) = try await URLSession.shared
-            .data(from: URL(string: "http://numbersapi.com/\(count)")!)
+            .data(from: URL(string: "http://number-trivia.com/\(count)")!)
           let fact = String(decoding: data, as: UTF8.self)
           state.fact = fact
           // 🛑 Mutable capture of 'inout' parameter 'state' is not allowed in

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0004.swift
@@ -29,7 +29,7 @@ struct CounterFeature {
         state.isLoading = true
         return .run { [count = state.count] send in
           let (data, _) = try await URLSession.shared
-            .data(from: URL(string: "http://numbersapi.com/\(count)")!)
+            .data(from: URL(string: "http://number-trivia.com/\(count)")!)
           let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-02-code-0005.swift
@@ -29,7 +29,7 @@ struct CounterFeature {
         state.isLoading = true
         return .run { [count = state.count] send in
           let (data, _) = try await URLSession.shared
-            .data(from: URL(string: "http://numbersapi.com/\(count)")!)
+            .data(from: URL(string: "http://number-trivia.com/\(count)")!)
           let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0002.swift
@@ -31,7 +31,7 @@ struct CounterFeature {
         state.isLoading = true
         return .run { [count = state.count] send in
           let (data, _) = try await URLSession.shared
-            .data(from: URL(string: "http://numbersapi.com/\(count)")!)
+            .data(from: URL(string: "http://number-trivia.com/\(count)")!)
           let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0003.swift
@@ -31,7 +31,7 @@ struct CounterFeature {
         state.isLoading = true
         return .run { [count = state.count] send in
           let (data, _) = try await URLSession.shared
-            .data(from: URL(string: "http://numbersapi.com/\(count)")!)
+            .data(from: URL(string: "http://number-trivia.com/\(count)")!)
           let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0004.swift
@@ -32,7 +32,7 @@ struct CounterFeature {
         state.isLoading = true
         return .run { [count = state.count] send in
           let (data, _) = try await URLSession.shared
-            .data(from: URL(string: "http://numbersapi.com/\(count)")!)
+            .data(from: URL(string: "http://number-trivia.com/\(count)")!)
           let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0005.swift
@@ -34,7 +34,7 @@ struct CounterFeature {
         state.isLoading = true
         return .run { [count = state.count] send in
           let (data, _) = try await URLSession.shared
-            .data(from: URL(string: "http://numbersapi.com/\(count)")!)
+            .data(from: URL(string: "http://number-trivia.com/\(count)")!)
           let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-03-code-0006.swift
@@ -34,7 +34,7 @@ struct CounterFeature {
         state.isLoading = true
         return .run { [count = state.count] send in
           let (data, _) = try await URLSession.shared
-            .data(from: URL(string: "http://numbersapi.com/\(count)")!)
+            .data(from: URL(string: "http://number-trivia.com/\(count)")!)
           let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-AddingSideEffects.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/02-AddingSideEffects/01-02-AddingSideEffects.tutorial
@@ -71,11 +71,11 @@
       
       @Step {
         Now the question is: how can we perform a side-effect? We will be using 
-        [numbersapi.com][numbersapi.com] to fetch a fact for the state's current count. We might
+        [number-trivia.com][number-trivia.com] to fetch a fact for the state's current count. We might
         hope we can just use `URLSession` directly in the reducer to perform some async work, but
         unfortunately that is not allowed. 
         
-        [numbersapi.com]: http://www.numbersapi.com
+        [number-trivia.com]: http://www.number-trivia.com
         
         @Code(name: "CounterFeature.swift", file: 01-02-01-code-0005.swift)
       }
@@ -116,13 +116,13 @@
       
       @Step {
         The trailing closure of `.run` is the perfect place to perform our network request to fetch
-        data from [numbersapi.com][numbersapi.com] and turn it into a string.
+        data from [number-trivia.com][number-trivia.com] and turn it into a string.
         
-        > Tip: Unfortunately [numbersapi.com][numbersapi.com] does not offer HTTPS, so you will need 
+        > Tip: Unfortunately [number-trivia.com][number-trivia.com] does not offer HTTPS, so you will need 
         > to add an entry to your application's Info.plist in order to allow HTTP requests. See 
         > [this][always-allow] article for information on how to do that.
         
-        [numbersapi.com]: http://www.numbersapi.com
+        [number-trivia.com]: http://www.number-trivia.com
         [always-allow]: https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity
                 
         @Code(name: "CounterFeature.swift", file: 01-02-02-code-0002.swift)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-01-code-0003-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-01-code-0003-previous.swift
@@ -34,7 +34,7 @@ struct CounterFeature {
         state.isLoading = true
         return .run { [count = state.count] send in
           let (data, _) = try await URLSession.shared
-            .data(from: URL(string: "http://numbersapi.com/\(count)")!)
+            .data(from: URL(string: "http://number-trivia.com/\(count)")!)
           let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-01-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-01-code-0003.swift
@@ -34,7 +34,7 @@ struct CounterFeature {
         state.isLoading = true
         return .run { [count = state.count] send in
           let (data, _) = try await URLSession.shared
-            .data(from: URL(string: "http://numbersapi.com/\(count)")!)
+            .data(from: URL(string: "http://number-trivia.com/\(count)")!)
           let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-02-code-0008.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-02-code-0008.swift
@@ -36,7 +36,7 @@ struct CounterFeature {
         state.isLoading = true
         return .run { [count = state.count] send in
           let (data, _) = try await URLSession.shared
-            .data(from: URL(string: "http://numbersapi.com/\(count)")!)
+            .data(from: URL(string: "http://number-trivia.com/\(count)")!)
           let fact = String(decoding: data, as: UTF8.self)
           await send(.factResponse(fact))
         }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-04-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-04-code-0003.swift
@@ -9,7 +9,7 @@ extension NumberFactClient: DependencyKey {
   static let liveValue = Self(
     fetch: { number in
       let (data, _) = try await URLSession.shared
-        .data(from: URL(string: "http://numbersapi.com/\(number)")!)
+        .data(from: URL(string: "http://number-trivia.com/\(number)")!)
       return String(decoding: data, as: UTF8.self)
     }
   )

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-04-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/03-TestingYourFeatures/01-03-04-code-0004.swift
@@ -9,7 +9,7 @@ extension NumberFactClient: DependencyKey {
   static let liveValue = Self(
     fetch: { number in
       let (data, _) = try await URLSession.shared
-        .data(from: URL(string: "http://numbersapi.com/\(number)")!)
+        .data(from: URL(string: "http://number-trivia.com/\(number)")!)
       return String(decoding: data, as: UTF8.self)
     }
   )


### PR DESCRIPTION
## Description

The `numbersapi.com` API endpoint is no longer working and causes network requests in the example applications and tutorials to time out or fail.

This PR replaces all usages of `numbersapi.com` with the new working endpoint `number-trivia.com` across the codebase.

## Changes Made
- Updated the base URL in `FactClient` and all related SwiftUI CaseStudies.
- Updated all API occurrences within `Meet The Composable Architecture` tutorials and documentation snippets.
- Reflected the new URL in the repository's README.md

## Expected Behavior
By merging this fix, the Fact fetching side-effects will resume functioning normally without network request failures. Users running example apps or following the tutorials will get the correct behavior from the trivia API.
