### PR TITLE
fix: SyncUpForm preview crash when interacting with UI

### DIFF
--- a/Examples/SyncUps/SyncUps/SyncUpForm.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpForm.swift
@@ -100,6 +100,45 @@ struct SyncUpFormView: View {
   }
 }
 
+private struct SyncUpFormPreviewView: View {
+  @Bindable var store: StoreOf<SyncUpForm>
+  @FocusState var focus: SyncUpForm.State.Field?
+
+  var body: some View {
+    Form {
+      Section {
+        TextField("Title", text: $store.syncUp.title)
+          .focused($focus, equals: .title)
+        HStack {
+          Slider(value: $store.syncUp.duration.minutes, in: 5...30, step: 1) {
+            Text("Length")
+          }
+          Spacer()
+          Text(store.syncUp.duration.formatted(.units()))
+        }
+        ThemePicker(selection: $store.syncUp.theme)
+      } header: {
+        Text("Sync-up Info")
+      }
+      Section {
+        ForEach($store.syncUp.attendees) { $attendee in
+          TextField("Name", text: $attendee.name)
+            .focused($focus, equals: .attendee(attendee.id))
+        }
+        .onDelete { indices in
+          store.send(.deleteAttendees(atOffsets: indices))
+        }
+
+        Button("New attendee") {
+          store.send(.addAttendeeButtonTapped)
+        }
+      } header: {
+        Text("Attendees")
+      }
+    }
+  }
+}
+
 struct ThemePicker: View {
   @Binding var selection: Theme
 
@@ -129,7 +168,7 @@ extension Duration {
 
 #Preview {
   NavigationStack {
-    SyncUpFormView(
+    SyncUpFormPreviewView(
       store: Store(initialState: SyncUpForm.State(syncUp: .mock)) {
         SyncUpForm()
       }


### PR DESCRIPTION
## Bug Report

Fixes #3823

The SyncUpForm preview was crashing when interacting with any UI element. This was caused by the `.bind()` modifier from SwiftUINavigation not working properly in SwiftUI previews.

## Changes

Created a separate `SyncUpFormPreviewView` for previews that doesn't use the `.bind()` modifier. This allows developers to use the preview for development and testing without crashes.

The actual `SyncUpFormView` used in the app remains unchanged and continues to use `.bind()` for proper focus management in production builds.

## Testing

1. Open SyncUpForm.swift in Xcode
2. Run the preview
3. Interact with any UI element (text fields, slider, buttons)
4. Preview should no longer crash

## Alternative Considered

An alternative would be to remove `.bind()` entirely and manage focus differently, but that would lose the two-way binding functionality that's needed in the actual app. The preview-specific view approach preserves all functionality while fixing the preview issue.