### PR TITLE
Trait-deprecate `Effect.concatenate`, `Effect.map`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,11 +23,7 @@ let package = Package(
       description: """
         Prepare for the next major release by enabling some of the more viral deprecations.
         """
-<<<<<<< deprecate-merge-concat
-    ),
-=======
     )
->>>>>>> main
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-collections", from: "1.1.0"),


### PR DESCRIPTION
Since Swift concurrency landed, with `async`-`await` and task groups, we have pushed folks towards using these tools in a `.run` effect instead of `.merge` and `.concatenate`. While many still reach for `.merge` and `.concatenate` today, Composable Architecture 2.0 is making some fundamental changes to effects that make them more efficient and powerful but less transformable. To prepare folks, we should deprecate `.concatenate` and `.map` behind our 2.0 trait. As of now we'll retain `.merge`.