### PR TITLE
Prune empty `#if` cases in enum reducers

### DIFF
--- a/Sources/ComposableArchitectureMacros/ReducerMacro.swift
+++ b/Sources/ComposableArchitectureMacros/ReducerMacro.swift
@@ -435,6 +435,24 @@ private enum ReducerCase {
     let cases: [ReducerCase]
   }
 
+  private static func renderedIfConfig(
+    _ configs: [IfConfig],
+    transform: (ReducerCase) -> String?
+  ) -> String? {
+    let configs = configs.compactMap { config -> String? in
+      let cases = config.cases.compactMap(transform).filter {
+        !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      }
+      guard !cases.isEmpty else { return nil }
+      return """
+        \(config.poundKeyword.text) \(config.condition?.trimmedDescription ?? "")
+        \(cases.joined(separator: "\n"))
+        """
+    }
+    guard !configs.isEmpty else { return nil }
+    return configs.joined(separator: "\n") + "#endif\n"
+  }
+
   var stateCaseDecl: String {
     switch self {
     case .element(let element, let attribute):
@@ -451,15 +469,7 @@ private enum ReducerCase {
       }
 
     case .ifConfig(let configs):
-      return
-        configs
-        .map {
-          """
-          \($0.poundKeyword.text) \($0.condition?.trimmedDescription ?? "")
-          \($0.cases.map(\.stateCaseDecl).joined(separator: "\n"))
-          """
-        }
-        .joined(separator: "\n") + "#endif\n"
+      return Self.renderedIfConfig(configs) { $0.stateCaseDecl } ?? ""
     }
   }
 
@@ -487,16 +497,7 @@ private enum ReducerCase {
       }
 
     case .ifConfig(let configs):
-      return
-        configs
-        .map {
-          let actionCaseDecls = $0.cases.map(\.actionCaseDecl)
-          return """
-            \($0.poundKeyword.text) \($0.condition?.trimmedDescription ?? "")
-            \(actionCaseDecls.joined(separator: "\n"))
-            """
-        }
-        .joined(separator: "\n") + "#endif\n"
+      return Self.renderedIfConfig(configs) { $0.actionCaseDecl } ?? ""
     }
   }
 
@@ -521,17 +522,7 @@ private enum ReducerCase {
         return nil
       }
     case .ifConfig(let configs):
-      return
-        configs
-        .map {
-          let ifCaseLets = $0.cases.compactMap(\.reducerIfCaseLet)
-          return """
-            \($0.poundKeyword.text) \($0.condition?.trimmedDescription ?? "")
-            \(ifCaseLets.joined(separator: "\n"))
-
-            """
-        }
-        .joined() + "#endif\n"
+      return Self.renderedIfConfig(configs) { $0.reducerIfCaseLet }
     }
   }
 
@@ -579,15 +570,7 @@ private enum ReducerCase {
           """
       }
     case .ifConfig(let configs):
-      return
-        configs
-        .map {
-          """
-          \($0.poundKeyword.text) \($0.condition?.trimmedDescription ?? "")
-          \($0.cases.map(\.storeCasePathProperty).joined(separator: "\n"))
-          """
-        }
-        .joined(separator: "\n") + "#endif\n"
+      return Self.renderedIfConfig(configs) { $0.storeCasePathProperty } ?? ""
     }
   }
 
@@ -607,15 +590,7 @@ private enum ReducerCase {
         return "case \(element.trimmedDescription)"
       }
     case .ifConfig(let configs):
-      return
-        configs
-        .map {
-          """
-          \($0.poundKeyword.text) \($0.condition?.trimmedDescription ?? "")
-          \($0.cases.map(\.storeCase).joined(separator: "\n"))
-          """
-        }
-        .joined(separator: "\n") + "#endif\n"
+      return Self.renderedIfConfig(configs) { $0.storeCase } ?? ""
     }
   }
 
@@ -649,15 +624,7 @@ private enum ReducerCase {
           """
       }
     case .ifConfig(let configs):
-      return
-        configs
-        .map {
-          """
-          \($0.poundKeyword.text) \($0.condition?.trimmedDescription ?? "")
-          \($0.cases.map(\.storeScope).joined(separator: "\n"))
-          """
-        }
-        .joined(separator: "\n") + "#endif\n"
+      return Self.renderedIfConfig(configs) { $0.storeScope } ?? ""
     }
   }
 }

--- a/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
@@ -1526,7 +1526,6 @@
                 InnerFeature()
               }
               #endif
-
               #endif
 
             )
@@ -1686,6 +1685,104 @@
             case let .innerDialog(v0):
               return .innerDialog(v0)
             #endif
+            #endif
+
+            }
+          }
+        }
+
+        extension Feature: ComposableArchitecture.CaseReducer, ComposableArchitecture.Reducer {
+        }
+        """#
+      }
+    }
+
+    func testEnum_IfConfigPrunesEmptyBranches() {
+      assertMacro {
+        """
+        @Reducer
+        enum Feature {
+          case child(ChildFeature)
+
+          #if DEBUG
+            case value(Int, String)
+          #endif
+        }
+        """
+      } expansion: {
+        #"""
+        enum Feature {
+          case child(ChildFeature)
+
+          #if DEBUG
+            case value(Int, String)
+          #endif
+
+          @CasePathable
+          @dynamicMemberLookup
+          @ObservableState
+          enum State: ComposableArchitecture.CaseReducerState {
+            typealias StateReducer = Feature
+            case child(ChildFeature.State)
+            #if DEBUG
+            case value(Int, String)
+            #endif
+
+          }
+
+          @CasePathable
+          enum Action {
+            case child(ChildFeature.Action)
+            #if DEBUG
+            case value(Swift.Never)
+            #endif
+
+          }
+
+          @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
+          static var body: Reduce<Self.State, Self.Action> {
+            ComposableArchitecture.Reduce(
+              ComposableArchitecture.EmptyReducer<Self.State, Self.Action>()
+              .ifCaseLet(\Self.State.Cases.child, action: \Self.Action.Cases.child) {
+                ChildFeature()
+              }
+            )
+          }
+
+          @dynamicMemberLookup
+          enum CaseScope: ComposableArchitecture._CaseScopeProtocol, CasePaths.CasePathable {
+            case child(ComposableArchitecture.StoreOf<ChildFeature>)
+            #if DEBUG
+            case value(Int, String)
+            #endif
+
+            struct AllCasePaths {
+              var child: CasePaths.AnyCasePath<CaseScope, ComposableArchitecture.StoreOf<ChildFeature>> {
+                CasePaths.AnyCasePath(
+                  embed: CaseScope.child,
+                  extract: {
+                    guard case let .child(v0) = $0 else {
+                      return nil
+                    };
+                    return v0
+                  }
+                )
+              }
+
+            }
+            static var allCasePaths: AllCasePaths {
+              AllCasePaths()
+            }
+          }
+
+          @preconcurrency @MainActor
+          static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
+            switch store.state {
+            case .child:
+              return .child(store.scope(state: \.child, action: \.child)!)
+            #if DEBUG
+            case let .value(v0, v1):
+              return .value(v0, v1)
             #endif
 
             }

--- a/Tests/ComposableArchitectureTests/CompileTimeTests.swift
+++ b/Tests/ComposableArchitectureTests/CompileTimeTests.swift
@@ -1,0 +1,11 @@
+import ComposableArchitecture
+
+@Reducer struct OtherFeature {}
+
+@Reducer enum Destination {
+  case other(OtherFeature)
+
+  #if !PRODUCTION_BUILD
+    @ReducerCaseIgnored case debug
+  #endif
+}


### PR DESCRIPTION
While this compiles in Swift 6.3, it fails in Swift 6.2. This regression was introduced in #3858.