### PR TITLE
Soft-deprecate trait-based deprecations in `#else`

### DIFF
--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -4,6 +4,27 @@ import SwiftUI
 
 #if ComposableArchitecture2Deprecations
   @available(*, deprecated, message: "Use 'EffectOf<Feature>' instead")
+#else
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use 'EffectOf<Feature>' instead"
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use 'EffectOf<Feature>' instead"
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use 'EffectOf<Feature>' instead"
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use 'EffectOf<Feature>' instead"
+  )
 #endif
 public typealias Effect = _Effect
 
@@ -156,6 +177,27 @@ extension _Effect {
 
 #if ComposableArchitecture2Deprecations
   @available(*, deprecated, message: "Use 'SendOf<Feature>' instead")
+#else
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use 'SendOf<Feature>' instead"
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use 'SendOf<Feature>' instead"
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use 'SendOf<Feature>' instead"
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use 'SendOf<Feature>' instead"
+  )
 #endif
 public typealias Send = _Send
 
@@ -297,6 +339,27 @@ extension _Effect {
   /// - Returns: A new effect
   #if ComposableArchitecture2Deprecations
     @available(*, deprecated, message: "Sequence work directly in a '.run' instead")
+  #else
+    @available(
+      iOS,
+      deprecated: 9999,
+      message: "Sequence work directly in a '.run' instead"
+    )
+    @available(
+      macOS,
+      deprecated: 9999,
+      message: "Sequence work directly in a '.run' instead"
+    )
+    @available(
+      tvOS,
+      deprecated: 9999,
+      message: "Sequence work directly in a '.run' instead"
+    )
+    @available(
+      watchOS,
+      deprecated: 9999,
+      message: "Sequence work directly in a '.run' instead"
+    )
   #endif
   @inlinable
   public static func concatenate(_ effects: Self...) -> Self {
@@ -310,6 +373,27 @@ extension _Effect {
   /// - Returns: A new effect
   #if ComposableArchitecture2Deprecations
     @available(*, deprecated, message: "Sequence work directly in a '.run' instead")
+  #else
+    @available(
+      iOS,
+      deprecated: 9999,
+      message: "Sequence work directly in a '.run' instead"
+    )
+    @available(
+      macOS,
+      deprecated: 9999,
+      message: "Sequence work directly in a '.run' instead"
+    )
+    @available(
+      tvOS,
+      deprecated: 9999,
+      message: "Sequence work directly in a '.run' instead"
+    )
+    @available(
+      watchOS,
+      deprecated: 9999,
+      message: "Sequence work directly in a '.run' instead"
+    )
   #endif
   @inlinable
   public static func concatenate(_ effects: some Collection<Self>) -> Self {
@@ -324,6 +408,27 @@ extension _Effect {
   ///   other.
   #if ComposableArchitecture2Deprecations
     @available(*, deprecated, message: "Sequence work directly in a '.run' instead")
+  #else
+    @available(
+      iOS,
+      deprecated: 9999,
+      message: "Sequence work directly in a '.run' instead"
+    )
+    @available(
+      macOS,
+      deprecated: 9999,
+      message: "Sequence work directly in a '.run' instead"
+    )
+    @available(
+      tvOS,
+      deprecated: 9999,
+      message: "Sequence work directly in a '.run' instead"
+    )
+    @available(
+      watchOS,
+      deprecated: 9999,
+      message: "Sequence work directly in a '.run' instead"
+    )
   #endif
   @inlinable
   @_disfavoredOverload
@@ -375,6 +480,27 @@ extension _Effect {
     @available(
       *,
       deprecated,
+      message: "Avoid transforming effects; construct them directly in a feature instead"
+    )
+  #else
+    @available(
+      iOS,
+      deprecated: 9999,
+      message: "Avoid transforming effects; construct them directly in a feature instead"
+    )
+    @available(
+      macOS,
+      deprecated: 9999,
+      message: "Avoid transforming effects; construct them directly in a feature instead"
+    )
+    @available(
+      tvOS,
+      deprecated: 9999,
+      message: "Avoid transforming effects; construct them directly in a feature instead"
+    )
+    @available(
+      watchOS,
+      deprecated: 9999,
       message: "Avoid transforming effects; construct them directly in a feature instead"
     )
   #endif

--- a/Sources/ComposableArchitecture/Observation/Store+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Store+Observation.swift
@@ -172,6 +172,27 @@ extension Binding {
       deprecated,
       message: "Scope state using projected '\\.$destination' syntax instead"
     )
+  #else
+    @available(
+      iOS,
+      deprecated: 9999,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
+    @available(
+      macOS,
+      deprecated: 9999,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
+    @available(
+      tvOS,
+      deprecated: 9999,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
+    @available(
+      watchOS,
+      deprecated: 9999,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
   #endif
   @preconcurrency @MainActor
   public func scope<State: ObservableState, Action, ChildState, ChildAction>(
@@ -267,6 +288,27 @@ extension ObservedObject.Wrapper {
     @available(
       *,
       deprecated,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
+  #else
+    @available(
+      iOS,
+      deprecated: 9999,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
+    @available(
+      macOS,
+      deprecated: 9999,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
+    @available(
+      tvOS,
+      deprecated: 9999,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
+    @available(
+      watchOS,
+      deprecated: 9999,
       message: "Scope state using projected '\\.$destination' syntax instead"
     )
   #endif
@@ -386,6 +428,27 @@ extension SwiftUI.Bindable {
     @available(
       *,
       deprecated,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
+  #else
+    @available(
+      iOS,
+      deprecated: 9999,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
+    @available(
+      macOS,
+      deprecated: 9999,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
+    @available(
+      tvOS,
+      deprecated: 9999,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
+    @available(
+      watchOS,
+      deprecated: 9999,
       message: "Scope state using projected '\\.$destination' syntax instead"
     )
   #endif
@@ -539,6 +602,27 @@ extension Perception.Bindable {
       deprecated,
       message: "Scope state using projected '\\.$destination' syntax instead"
     )
+  #else
+    @available(
+      iOS,
+      deprecated: 9999,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
+    @available(
+      macOS,
+      deprecated: 9999,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
+    @available(
+      tvOS,
+      deprecated: 9999,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
+    @available(
+      watchOS,
+      deprecated: 9999,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
   #endif
   public func scope<State: ObservableState, Action, ChildState, ChildAction>(
     state: KeyPath<State, ChildState?>,
@@ -632,6 +716,27 @@ extension UIBindable {
     @available(
       *,
       deprecated,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
+  #else
+    @available(
+      iOS,
+      deprecated: 9999,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
+    @available(
+      macOS,
+      deprecated: 9999,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
+    @available(
+      tvOS,
+      deprecated: 9999,
+      message: "Scope state using projected '\\.$destination' syntax instead"
+    )
+    @available(
+      watchOS,
+      deprecated: 9999,
       message: "Scope state using projected '\\.$destination' syntax instead"
     )
   #endif
@@ -835,18 +940,28 @@ extension Store where State: ObservableState {
   where ChildState.StateReducer.Action == ChildAction {
     get {
       let store: Store<ChildState, ChildAction>? = self[
-        id: id, state: state, action: action,
-        isInViewBody: isInViewBody, fileID: fileID, filePath: filePath,
-        line: line, column: column
+        id: id,
+        state: state,
+        action: action,
+        isInViewBody: isInViewBody,
+        fileID: fileID,
+        filePath: filePath,
+        line: line,
+        column: column
       ]
       return store.map { $0.case }
     }
     set {
       guard newValue == nil else { return }
       self[
-        id: id, state: state, action: action,
-        isInViewBody: isInViewBody, fileID: fileID, filePath: filePath,
-        line: line, column: column
+        id: id,
+        state: state,
+        action: action,
+        isInViewBody: isInViewBody,
+        fileID: fileID,
+        filePath: filePath,
+        line: line,
+        column: column
       ] = nil
     }
   }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/OnChange.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/OnChange.swift
@@ -65,6 +65,27 @@ extension Reducer {
       deprecated,
       message: "Use 'onChange' that directly returns an 'EffectOf<Feature>' instead"
     )
+  #else
+    @available(
+      iOS,
+      deprecated: 9999,
+      message: "Use 'onChange' that directly returns an 'EffectOf<Feature>' instead"
+    )
+    @available(
+      macOS,
+      deprecated: 9999,
+      message: "Use 'onChange' that directly returns an 'EffectOf<Feature>' instead"
+    )
+    @available(
+      tvOS,
+      deprecated: 9999,
+      message: "Use 'onChange' that directly returns an 'EffectOf<Feature>' instead"
+    )
+    @available(
+      watchOS,
+      deprecated: 9999,
+      message: "Use 'onChange' that directly returns an 'EffectOf<Feature>' instead"
+    )
   #endif
   @inlinable
   public func onChange<V: Equatable, R: Reducer>(

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -339,6 +339,27 @@ public final class Store<State, Action>: _Store {
   /// ```
   #if ComposableArchitecture2Deprecations
     @available(*, deprecated, message: "Use observation ('Observations', 'observe') instead")
+  #else
+    @available(
+      iOS,
+      deprecated: 9999,
+      message: "Use observation ('Observations', 'observe') instead"
+    )
+    @available(
+      macOS,
+      deprecated: 9999,
+      message: "Use observation ('Observations', 'observe') instead"
+    )
+    @available(
+      tvOS,
+      deprecated: 9999,
+      message: "Use observation ('Observations', 'observe') instead"
+    )
+    @available(
+      watchOS,
+      deprecated: 9999,
+      message: "Use observation ('Observations', 'observe') instead"
+    )
   #endif
   public var publisher: StorePublisher<State> {
     StorePublisher(
@@ -386,6 +407,27 @@ public typealias StoreOf<R: Reducer> = Store<R.State, R.Action>
 /// A publisher of store state.
 #if ComposableArchitecture2Deprecations
   @available(*, deprecated, message: "Use observation ('Observations', 'observe') instead")
+#else
+  @available(
+    iOS,
+    deprecated: 9999,
+    message: "Use observation ('Observations', 'observe') instead"
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use observation ('Observations', 'observe') instead"
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use observation ('Observations', 'observe') instead"
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
+    message: "Use observation ('Observations', 'observe') instead"
+  )
 #endif
 @dynamicMemberLookup
 public struct StorePublisher<State>: Publisher {


### PR DESCRIPTION
That way these APIs still surface as deprecated more visibly.