### PR TITLE
Un-trait deprecate `Effect`

### DIFF
--- a/Sources/ComposableArchitecture/Core.swift
+++ b/Sources/ComposableArchitecture/Core.swift
@@ -160,7 +160,7 @@ final class RootCore<Root: Reducer>: Core {
             let isCompleted = LockIsolated(false)
             defer { isCompleted.setValue(true) }
             await operation(
-              _Send { effectAction in
+              Send { effectAction in
                 if isCompleted.value {
                   reportIssue(
                     """

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.25.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.25.md
@@ -127,16 +127,8 @@ store _via_ `store.send(_:)` or `Effect.send`.
 The following APIs are deprecated only when the `ComposableArchitecture2Deprecations` package trait
 is enabled, allowing you to prepare for 2.0 on your own timeline.
 
-### `Effect` → `EffectOf`
-
-The `Effect<Action>` type should be replaced with `EffectOf<Feature>`, where `Feature` is your
-reducer type. Similarly, `Send<Action>` should be replaced with `SendOf<Feature>`. In Composable
-Architecture 2.0, `Effect` will change shape, so using the type alias now will ease the transition:
-
-```diff
--func sharedHelper(state: inout State) -> Effect<Action> {
-+func sharedHelper(state: inout State) -> EffectOf<Self> {
-```
+> 1.25.0 temporarily deprecated the `Effect` type for `EffectOf`. This change is no longer
+> necessary in the Composable 2.0 migration story.
 
 ### `Effect.concatenate`, `Effect.map`
 

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -2,33 +2,7 @@
 import Foundation
 import SwiftUI
 
-#if ComposableArchitecture2Deprecations
-  @available(*, deprecated, message: "Use 'EffectOf<Feature>' instead")
-#else
-  @available(
-    iOS,
-    deprecated: 9999,
-    message: "Use 'EffectOf<Feature>' instead"
-  )
-  @available(
-    macOS,
-    deprecated: 9999,
-    message: "Use 'EffectOf<Feature>' instead"
-  )
-  @available(
-    tvOS,
-    deprecated: 9999,
-    message: "Use 'EffectOf<Feature>' instead"
-  )
-  @available(
-    watchOS,
-    deprecated: 9999,
-    message: "Use 'EffectOf<Feature>' instead"
-  )
-#endif
-public typealias Effect = _Effect
-
-public struct _Effect<Action>: Sendable {
+public struct Effect<Action>: Sendable {
   @usableFromInline
   enum Operation: Sendable {
     case none
@@ -36,7 +10,7 @@ public struct _Effect<Action>: Sendable {
     case run(
       name: String? = nil,
       priority: TaskPriority? = nil,
-      operation: @Sendable (_ send: _Send<Action>) async -> Void
+      operation: @Sendable (_ send: Send<Action>) async -> Void
     )
   }
 
@@ -62,11 +36,11 @@ public struct _Effect<Action>: Sendable {
 /// ```swift
 /// let effect: EffectOf<Feature>
 /// ```
-public typealias EffectOf<R: Reducer> = _Effect<R.Action>
+public typealias EffectOf<R: Reducer> = Effect<R.Action>
 
 // MARK: - Creating Effects
 
-extension _Effect {
+extension Effect {
   /// An effect that does nothing and completes immediately. Useful for situations where you must
   /// return an effect, but you don't need to do anything.
   @inlinable
@@ -118,8 +92,8 @@ extension _Effect {
   public static func run(
     priority: TaskPriority? = nil,
     name: String? = nil,
-    operation: @escaping @Sendable (_ send: _Send<Action>) async throws -> Void,
-    catch handler: (@Sendable (_ error: any Error, _ send: _Send<Action>) async -> Void)? = nil,
+    operation: @escaping @Sendable (_ send: Send<Action>) async throws -> Void,
+    catch handler: (@Sendable (_ error: any Error, _ send: Send<Action>) async -> Void)? = nil,
     fileID: StaticString = #fileID,
     filePath: StaticString = #filePath,
     line: UInt = #line,
@@ -175,32 +149,6 @@ extension _Effect {
   }
 }
 
-#if ComposableArchitecture2Deprecations
-  @available(*, deprecated, message: "Use 'SendOf<Feature>' instead")
-#else
-  @available(
-    iOS,
-    deprecated: 9999,
-    message: "Use 'SendOf<Feature>' instead"
-  )
-  @available(
-    macOS,
-    deprecated: 9999,
-    message: "Use 'SendOf<Feature>' instead"
-  )
-  @available(
-    tvOS,
-    deprecated: 9999,
-    message: "Use 'SendOf<Feature>' instead"
-  )
-  @available(
-    watchOS,
-    deprecated: 9999,
-    message: "Use 'SendOf<Feature>' instead"
-  )
-#endif
-public typealias Send = _Send
-
 /// A type that can send actions back into the system when used from
 /// ``Effect/run(priority:operation:catch:fileID:filePath:line:column:)``.
 ///
@@ -230,7 +178,7 @@ public typealias Send = _Send
 ///
 /// [callAsFunction]: https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#ID622
 @MainActor
-public struct _Send<Action>: Sendable {
+public struct Send<Action>: Sendable {
   let send: @MainActor @Sendable (Action) -> Void
 
   public init(send: @escaping @MainActor @Sendable (Action) -> Void) {
@@ -267,11 +215,11 @@ public struct _Send<Action>: Sendable {
   }
 }
 
-public typealias SendOf<R: Reducer> = _Send<R.Action>
+public typealias SendOf<R: Reducer> = Send<R.Action>
 
 // MARK: - Composing Effects
 
-extension _Effect {
+extension Effect {
   /// Merges a variadic list of effects together into a single effect, which runs the effects at the
   /// same time.
   ///
@@ -505,7 +453,7 @@ extension _Effect {
     )
   #endif
   @inlinable
-  public func map<T>(_ transform: @escaping @Sendable (Action) -> T) -> _Effect<T> {
+  public func map<T>(_ transform: @escaping @Sendable (Action) -> T) -> Effect<T> {
     switch self.operation {
     case .none:
       return .none
@@ -531,7 +479,7 @@ extension _Effect {
           operation: .run(name: name, priority: priority) { send in
             await escaped.yield {
               await operation(
-                _Send { action in
+                Send { action in
                   send(transform(action))
                 }
               )

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -1,7 +1,7 @@
 @preconcurrency import Combine
 import Foundation
 
-extension _Effect {
+extension Effect {
   /// Turns an effect into one that is capable of being canceled.
   ///
   /// To turn an effect into a cancellable one you must provide an identifier, which is used in

--- a/Sources/ComposableArchitecture/Effects/Publisher.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher.swift
@@ -1,6 +1,6 @@
 import Combine
 
-extension _Effect {
+extension Effect {
   /// Creates an effect from a Combine publisher.
   ///
   /// - Parameter createPublisher: The closure to execute when the effect is performed.
@@ -14,9 +14,9 @@ public struct _EffectPublisher<Action>: Publisher {
   public typealias Output = Action
   public typealias Failure = Never
 
-  let effect: _Effect<Action>
+  let effect: Effect<Action>
 
-  public init(_ effect: _Effect<Action>) {
+  public init(_ effect: Effect<Action>) {
     self.effect = effect
   }
 
@@ -34,7 +34,7 @@ public struct _EffectPublisher<Action>: Publisher {
       return .create { subscriber in
         let task = Task(name: name, priority: priority) { @MainActor in
           defer { subscriber.send(completion: .finished) }
-          await operation(_Send { subscriber.send($0) })
+          await operation(Send { subscriber.send($0) })
         }
         return AnyCancellable { @Sendable in
           task.cancel()

--- a/Sources/ComposableArchitecture/Internal/Create.swift
+++ b/Sources/ComposableArchitecture/Internal/Create.swift
@@ -104,13 +104,13 @@ final class DemandBuffer<S: Subscriber>: @unchecked Sendable {
 
 extension AnyPublisher where Failure == Never {
   private init(
-    _ callback: @escaping @Sendable (_Effect<Output>.Subscriber) -> any Cancellable
+    _ callback: @escaping @Sendable (Effect<Output>.Subscriber) -> any Cancellable
   ) {
     self = Publishers.Create(callback: callback).eraseToAnyPublisher()
   }
 
   static func create(
-    _ factory: @escaping @Sendable (_Effect<Output>.Subscriber) -> any Cancellable
+    _ factory: @escaping @Sendable (Effect<Output>.Subscriber) -> any Cancellable
   ) -> AnyPublisher<Output, Failure> {
     AnyPublisher(factory)
   }
@@ -120,9 +120,9 @@ extension Publishers {
   fileprivate final class Create<Output>: Publisher, Sendable {
     typealias Failure = Never
 
-    private let callback: @Sendable (_Effect<Output>.Subscriber) -> any Cancellable
+    private let callback: @Sendable (Effect<Output>.Subscriber) -> any Cancellable
 
-    init(callback: @escaping @Sendable (_Effect<Output>.Subscriber) -> any Cancellable) {
+    init(callback: @escaping @Sendable (Effect<Output>.Subscriber) -> any Cancellable) {
       self.callback = callback
     }
 
@@ -139,7 +139,7 @@ extension Publishers.Create {
     private let cancellable = LockIsolated<(any Cancellable)?>(nil)
 
     init(
-      callback: @escaping @Sendable (_Effect<Output>.Subscriber) -> any Cancellable,
+      callback: @escaping @Sendable (Effect<Output>.Subscriber) -> any Cancellable,
       downstream: Downstream
     ) {
       self.buffer = DemandBuffer(subscriber: downstream)
@@ -170,7 +170,7 @@ extension Publishers.Create.Subscription: CustomStringConvertible {
   }
 }
 
-extension _Effect {
+extension Effect {
   struct Subscriber: Sendable {
     private let _send: @Sendable (Action) -> Void
     private let _complete: @Sendable (Subscribers.Completion<Never>) -> Void

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -235,7 +235,7 @@ public struct BindingViewStore<State> {
   }
 #endif
 
-extension _Effect {
+extension Effect {
   @available(
     *,
     deprecated,
@@ -270,7 +270,7 @@ extension Store {
   }
 }
 
-extension _Effect {
+extension Effect {
   @available(
     *,
     deprecated,
@@ -364,7 +364,7 @@ private struct TransactionPublisher<Upstream: Publisher>: Publisher {
   }
 }
 
-extension _Effect {
+extension Effect {
   @available(
     *,
     deprecated,
@@ -401,7 +401,7 @@ extension _Effect {
   }
 }
 
-extension _Effect where Action: Sendable {
+extension Effect where Action: Sendable {
   @available(
     *,
     deprecated,

--- a/Sources/ComposableArchitecture/Internal/EffectActions.swift
+++ b/Sources/ComposableArchitecture/Internal/EffectActions.swift
@@ -1,6 +1,6 @@
 @preconcurrency import Combine
 
-extension _Effect where Action: Sendable {
+extension Effect where Action: Sendable {
   @_spi(Internals) public var actions: AsyncStream<Action> {
     switch self.operation {
     case .none:
@@ -18,7 +18,7 @@ extension _Effect where Action: Sendable {
     case .run(let name, let priority, let operation):
       return AsyncStream { continuation in
         let task = Task(name: name, priority: priority) {
-          await operation(_Send { action in continuation.yield(action) })
+          await operation(Send { action in continuation.yield(action) })
           continuation.finish()
         }
         continuation.onTermination = { _ in task.cancel() }

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -31,9 +31,9 @@ public protocol Reducer<State, Action> {
       invoked by either reducer.
       """
   )
-  func reduce(into state: inout State, action: Action) -> _Effect<Action>
+  func reduce(into state: inout State, action: Action) -> Effect<Action>
 
-  func _reduce(into state: inout State, action: Action) -> _Effect<Action>
+  func _reduce(into state: inout State, action: Action) -> Effect<Action>
 
   /// The content and behavior of a reducer that is composed from other reducers.
   ///
@@ -67,7 +67,7 @@ public protocol Reducer<State, Action> {
 }
 
 extension Reducer {
-  public func _reduce(into state: inout State, action: Action) -> _Effect<Action> {
+  public func _reduce(into state: inout State, action: Action) -> Effect<Action> {
     reduce(into: &state, action: action)
   }
 
@@ -106,7 +106,7 @@ extension Reducer where Body: Reducer<State, Action> {
   @_optimize(none)
   public func _reduce(
     into state: inout Body.State, action: Body.Action
-  ) -> _Effect<Body.Action> {
+  ) -> Effect<Body.Action> {
     self.body._reduce(into: &state, action: action)
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
+++ b/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
@@ -85,7 +85,7 @@ public enum ReducerBuilder<State, Action> {
     case second(Second)
 
     @inlinable
-    public func _reduce(into state: inout First.State, action: First.Action) -> _Effect<
+    public func _reduce(into state: inout First.State, action: First.Action) -> Effect<
       First.Action
     > {
       switch self {
@@ -112,7 +112,7 @@ public enum ReducerBuilder<State, Action> {
     }
 
     @inlinable
-    public func _reduce(into state: inout R0.State, action: R0.Action) -> _Effect<R0.Action> {
+    public func _reduce(into state: inout R0.State, action: R0.Action) -> Effect<R0.Action> {
       self.r0._reduce(into: &state, action: action)
         .merge(with: self.r1._reduce(into: &state, action: action))
     }
@@ -130,7 +130,7 @@ public enum ReducerBuilder<State, Action> {
     @inlinable
     public func _reduce(
       into state: inout Element.State, action: Element.Action
-    ) -> _Effect<Element.Action> {
+    ) -> Effect<Element.Action> {
       self.reducers.reduce(.none) { $0.merge(with: $1._reduce(into: &state, action: action)) }
     }
   }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
@@ -64,7 +64,7 @@ where State == ViewAction.State {
   }
 
   @inlinable
-  public func _reduce(into state: inout State, action: Action) -> _Effect<Action> {
+  public func _reduce(into state: inout State, action: Action) -> Effect<Action> {
     // NB: Using a closure and not a `\.binding` key path literal to avoid a bug with archives:
     //     https://github.com/pointfreeco/swift-composable-architecture/pull/2641
     guard let bindingAction = self.toViewAction(action).flatMap({ $0.binding })

--- a/Sources/ComposableArchitecture/Reducer/Reducers/CombineReducers.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/CombineReducers.swift
@@ -38,7 +38,7 @@ where State == Reducers.State, Action == Reducers.Action {
   @inlinable
   public func _reduce(
     into state: inout Reducers.State, action: Reducers.Action
-  ) -> _Effect<Reducers.Action> {
+  ) -> Effect<Reducers.Action> {
     self.reducers._reduce(into: &state, action: action)
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
@@ -85,7 +85,7 @@ public struct _PrintChangesReducer<Base: Reducer>: Reducer {
   #if DEBUG
     public func _reduce(
       into state: inout Base.State, action: Base.Action
-    ) -> _Effect<Base.Action> {
+    ) -> Effect<Base.Action> {
       if let printer = self.printer {
         let changeTracker = SharedChangeTracker(reportUnassertedChanges: false)
         return changeTracker.track {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
@@ -168,7 +168,7 @@ public struct _DependencyKeyWritingReducer<Base: Reducer>: Reducer {
   @inlinable
   public func _reduce(
     into state: inout Base.State, action: Base.Action
-  ) -> _Effect<Base.Action> {
+  ) -> Effect<Base.Action> {
     withDependencies {
       self.update(&$0)
     } operation: {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/EmptyReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/EmptyReducer.swift
@@ -13,7 +13,7 @@ public struct EmptyReducer<State, Action>: Reducer {
   init(internal: Void) {}
 
   @inlinable
-  public func _reduce(into _: inout State, action _: Action) -> _Effect<Action> {
+  public func _reduce(into _: inout State, action _: Action) -> Effect<Action> {
     .none
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -193,14 +193,14 @@ public struct _ForEachReducer<
 
   public func _reduce(
     into state: inout Parent.State, action: Parent.Action
-  ) -> _Effect<Parent.Action> {
+  ) -> Effect<Parent.Action> {
     let elementEffects = self.reduceForEach(into: &state, action: action)
 
     let idsBefore = state[keyPath: self.toElementsState].ids
     let parentEffects = self.parent._reduce(into: &state, action: action)
     let idsAfter = state[keyPath: self.toElementsState].ids
 
-    let elementCancelEffects: _Effect<Parent.Action> =
+    let elementCancelEffects: Effect<Parent.Action> =
       areOrderedSetsDuplicates(idsBefore, idsAfter)
       ? .none
       : .merge(
@@ -221,7 +221,7 @@ public struct _ForEachReducer<
 
   func reduceForEach(
     into state: inout Parent.State, action: Parent.Action
-  ) -> _Effect<Parent.Action> {
+  ) -> Effect<Parent.Action> {
     guard let (id, elementAction) = self.toElementAction.extract(from: action) else { return .none }
     if state[keyPath: self.toElementsState][id: id] == nil {
       reportIssue(

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
@@ -134,7 +134,7 @@ public struct _IfCaseLetReducer<Parent: Reducer, Child: Reducer>: Reducer {
 
   public func _reduce(
     into state: inout Parent.State, action: Parent.Action
-  ) -> _Effect<Parent.Action> {
+  ) -> Effect<Parent.Action> {
     let childEffects = self.reduceChild(into: &state, action: action)
 
     let childIDBefore = self.toChildState.extract(from: state).map {
@@ -145,7 +145,7 @@ public struct _IfCaseLetReducer<Parent: Reducer, Child: Reducer>: Reducer {
       NavigationID(root: state, value: $0, casePath: self.toChildState)
     }
 
-    let childCancelEffects: _Effect<Parent.Action>
+    let childCancelEffects: Effect<Parent.Action>
     if let childElement = childIDBefore, childElement != childIDAfter {
       childCancelEffects = .cancel(id: childElement)
     } else {
@@ -161,7 +161,7 @@ public struct _IfCaseLetReducer<Parent: Reducer, Child: Reducer>: Reducer {
 
   func reduceChild(
     into state: inout Parent.State, action: Parent.Action
-  ) -> _Effect<Parent.Action> {
+  ) -> Effect<Parent.Action> {
     guard let childAction = self.toChildAction.extract(from: action)
     else { return .none }
     guard var childState = self.toChildState.extract(from: state) else {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
@@ -152,7 +152,7 @@ public struct _IfLetReducer<Parent: Reducer, Child: Reducer>: Reducer {
 
   public func _reduce(
     into state: inout Parent.State, action: Parent.Action
-  ) -> _Effect<Parent.Action> {
+  ) -> Effect<Parent.Action> {
     let childEffects = self.reduceChild(into: &state, action: action)
 
     let childIDBefore = state[keyPath: self.toChildState].map {
@@ -171,7 +171,7 @@ public struct _IfLetReducer<Parent: Reducer, Child: Reducer>: Reducer {
       state[keyPath: toChildState] = nil
     }
 
-    let childCancelEffects: _Effect<Parent.Action>
+    let childCancelEffects: Effect<Parent.Action>
     if let childID = childIDBefore, childID != childIDAfter {
       childCancelEffects = ._cancel(id: childID, navigationID: self.navigationIDPath)
     } else {
@@ -187,7 +187,7 @@ public struct _IfLetReducer<Parent: Reducer, Child: Reducer>: Reducer {
 
   func reduceChild(
     into state: inout Parent.State, action: Parent.Action
-  ) -> _Effect<Parent.Action> {
+  ) -> Effect<Parent.Action> {
     guard let childAction = self.toChildAction.extract(from: action)
     else { return .none }
     guard state[keyPath: self.toChildState] != nil else {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/OnChange.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/OnChange.swift
@@ -124,7 +124,7 @@ where Base.State == Body.State, Base.Action == Body.Action {
   }
 
   @inlinable
-  public func _reduce(into state: inout Base.State, action: Base.Action) -> _Effect<Base.Action> {
+  public func _reduce(into state: inout Base.State, action: Base.Action) -> Effect<Base.Action> {
     let oldValue = toValue(state)
     let baseEffects = self.base._reduce(into: &state, action: action)
     let newValue = toValue(state)

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Optional.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Optional.swift
@@ -2,7 +2,7 @@ extension Optional: Reducer where Wrapped: Reducer {
   @inlinable
   public func _reduce(
     into state: inout Wrapped.State, action: Wrapped.Action
-  ) -> _Effect<Wrapped.Action> {
+  ) -> Effect<Wrapped.Action> {
     switch self {
     case .some(let wrapped):
       return wrapped._reduce(into: &state, action: action)

--- a/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/PresentationReducer.swift
@@ -465,12 +465,12 @@ public struct _PresentationReducer<Base: Reducer, Destination: Reducer>: Reducer
     self.column = column
   }
 
-  public func _reduce(into state: inout Base.State, action: Base.Action) -> _Effect<Base.Action> {
+  public func _reduce(into state: inout Base.State, action: Base.Action) -> Effect<Base.Action> {
     let initialPresentationState = state[keyPath: self.toPresentationState]
     let presentationAction = self.toPresentationAction.extract(from: action)
 
-    let destinationEffects: _Effect<Base.Action>
-    let baseEffects: _Effect<Base.Action>
+    let destinationEffects: Effect<Base.Action>
+    let baseEffects: Effect<Base.Action>
 
     switch (initialPresentationState.wrappedValue, presentationAction) {
     case (.some(let destinationState), .some(.dismiss)):
@@ -543,7 +543,7 @@ public struct _PresentationReducer<Base: Reducer, Destination: Reducer>: Reducer
       initialPresentationState.presentedID
       != state[keyPath: self.toPresentationState].wrappedValue.map(self.navigationIDPath(for:))
 
-    let dismissEffects: _Effect<Base.Action>
+    let dismissEffects: Effect<Base.Action>
     if presentationIdentityChanged,
       let presentedPath = initialPresentationState.presentedID,
       initialPresentationState.wrappedValue.map({
@@ -560,7 +560,7 @@ public struct _PresentationReducer<Base: Reducer, Destination: Reducer>: Reducer
       state[keyPath: self.toPresentationState].presentedID = nil
     }
 
-    let presentEffects: _Effect<Base.Action>
+    let presentEffects: Effect<Base.Action>
     if presentationIdentityChanged || state[keyPath: self.toPresentationState].presentedID == nil,
       let presentationState = state[keyPath: self.toPresentationState].wrappedValue,
       !isEphemeral(presentationState)
@@ -628,7 +628,7 @@ extension Task<Never, Never> {
   }
 }
 
-extension _Effect {
+extension Effect {
   internal func _cancellable(
     id: some Hashable & Sendable = _PresentedID(),
     navigationIDPath: NavigationIDPath,

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Reduce.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Reduce.swift
@@ -4,11 +4,11 @@
 /// a new type that conforms to ``Reducer``.
 public struct Reduce<State, Action>: Reducer {
   @usableFromInline
-  let reduce: (inout State, Action) -> _Effect<Action>
+  let reduce: (inout State, Action) -> Effect<Action>
 
   @usableFromInline
   init(
-    internal reduce: @escaping (inout State, Action) -> _Effect<Action>
+    internal reduce: @escaping (inout State, Action) -> Effect<Action>
   ) {
     self.reduce = reduce
   }
@@ -17,7 +17,7 @@ public struct Reduce<State, Action>: Reducer {
   ///
   /// - Parameter reduce: A function that is called when ``reduce(into:action:)`` is invoked.
   @inlinable
-  public init(_ reduce: @escaping (_ state: inout State, _ action: Action) -> _Effect<Action>) {
+  public init(_ reduce: @escaping (_ state: inout State, _ action: Action) -> Effect<Action>) {
     self.init(internal: reduce)
   }
 
@@ -30,7 +30,7 @@ public struct Reduce<State, Action>: Reducer {
   }
 
   @inlinable
-  public func _reduce(into state: inout State, action: Action) -> _Effect<Action> {
+  public func _reduce(into state: inout State, action: Action) -> Effect<Action> {
     self.reduce(&state, action)
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
@@ -168,7 +168,7 @@ public struct Scope<ParentState, ParentAction, Child: Reducer>: Reducer {
   @inlinable
   public func _reduce(
     into state: inout ParentState, action: ParentAction
-  ) -> _Effect<ParentAction> {
+  ) -> Effect<ParentAction> {
     guard let childAction = self.toChildAction.extract(from: action)
     else { return .none }
     switch self.toChildState {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/SignpostReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/SignpostReducer.swift
@@ -59,7 +59,7 @@ public struct _SignpostReducer<Base: Reducer>: Reducer {
   @inlinable
   public func _reduce(
     into state: inout Base.State, action: Base.Action
-  ) -> _Effect<Base.Action> {
+  ) -> Effect<Base.Action> {
     var actionOutput: String!
     if self.log.signpostsEnabled {
       actionOutput = debugCaseOutput(action)
@@ -76,7 +76,7 @@ public struct _SignpostReducer<Base: Reducer>: Reducer {
   }
 }
 
-extension _Effect {
+extension Effect {
   @usableFromInline
   func effectSignpost(
     _ prefix: String,
@@ -122,7 +122,7 @@ extension _Effect {
             actionOutput
           )
           await operation(
-            _Send { action in
+            Send { action in
               os_signpost(
                 .event, log: log, name: "Effect Output", "%sOutput from %s", prefix, actionOutput
               )

--- a/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/StackReducer.swift
@@ -424,10 +424,10 @@ public struct _StackReducer<Base: Reducer, Destination: Reducer>: Reducer {
     self.column = column
   }
 
-  public func _reduce(into state: inout Base.State, action: Base.Action) -> _Effect<Base.Action> {
+  public func _reduce(into state: inout Base.State, action: Base.Action) -> Effect<Base.Action> {
     let idsBefore = state[keyPath: self.toStackState]._mounted
-    let destinationEffects: _Effect<Base.Action>
-    let baseEffects: _Effect<Base.Action>
+    let destinationEffects: Effect<Base.Action>
+    let baseEffects: Effect<Base.Action>
 
     switch self.toStackAction.extract(from: action) {
     case .element(let elementID, let destinationAction):
@@ -559,7 +559,7 @@ public struct _StackReducer<Base: Reducer, Destination: Reducer>: Reducer {
 
     let idsAfter = state[keyPath: self.toStackState].ids
 
-    let cancelEffects: _Effect<Base.Action> =
+    let cancelEffects: Effect<Base.Action> =
       areOrderedSetsDuplicates(idsBefore, idsAfter)
       ? .none
       : .merge(
@@ -567,7 +567,7 @@ public struct _StackReducer<Base: Reducer, Destination: Reducer>: Reducer {
           ._cancel(navigationID: self.navigationIDPath(for: $0))
         }
       )
-    let presentEffects: _Effect<Base.Action> =
+    let presentEffects: Effect<Base.Action> =
       areOrderedSetsDuplicates(idsBefore, idsAfter)
       ? .none
       : .merge(

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -2364,7 +2364,7 @@ class TestReducer<State: Equatable, Action>: Reducer {
     self.state = initialState
   }
 
-  func _reduce(into state: inout State, action: TestAction) -> _Effect<TestAction> {
+  func _reduce(into state: inout State, action: TestAction) -> Effect<TestAction> {
     var dependencies = self.dependencies
     let dismiss = dependencies.dismiss.dismiss
     dependencies.dismiss = DismissEffect { [weak store] in
@@ -2376,7 +2376,7 @@ class TestReducer<State: Equatable, Action>: Reducer {
     }
     let reducer = self.base.dependency(\.self, dependencies)
 
-    let effects: _Effect<Action>
+    let effects: Effect<Action>
     switch action.origin {
     case .send(let action):
       effects = reducer._reduce(into: &state, action: action)

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -21,7 +21,7 @@ final class EffectCancellationTests: BaseTCATestCase {
     let values = LockIsolated<[Int]>([])
 
     let subject = PassthroughSubject<Int, Never>()
-    let effect = _Effect.publisher { subject }
+    let effect = Effect.publisher { subject }
       .cancellable(id: CancelID())
 
     let task = Task {
@@ -52,7 +52,7 @@ final class EffectCancellationTests: BaseTCATestCase {
     let values = LockIsolated<[Int]>([])
 
     let subject = PassthroughSubject<Int, Never>()
-    let effect1 = _Effect.publisher { subject }
+    let effect1 = Effect.publisher { subject }
       .cancellable(id: CancelID(), cancelInFlight: true)
 
     let task1 = Task {
@@ -72,7 +72,7 @@ final class EffectCancellationTests: BaseTCATestCase {
 
     defer { Task.cancel(id: CancelID()) }
 
-    let effect2 = _Effect.publisher { subject }
+    let effect2 = Effect.publisher { subject }
       .cancellable(id: CancelID(), cancelInFlight: true)
 
     let task2 = Task {
@@ -97,7 +97,7 @@ final class EffectCancellationTests: BaseTCATestCase {
   func testCancellationAfterDelay() async {
     let result = LockIsolated<Int?>(nil)
 
-    let effect = _Effect.publisher {
+    let effect = Effect.publisher {
       Just(1)
         .delay(for: 0.15, scheduler: DispatchQueue.main)
     }
@@ -123,7 +123,7 @@ final class EffectCancellationTests: BaseTCATestCase {
     let mainQueue = DispatchQueue.test
     let result = LockIsolated<Int?>(nil)
 
-    let effect = _Effect.publisher {
+    let effect = Effect.publisher {
       Just(1)
         .delay(for: 2, scheduler: mainQueue)
     }
@@ -153,7 +153,7 @@ final class EffectCancellationTests: BaseTCATestCase {
     let values = LockIsolated<[Int]>([])
 
     let subject = PassthroughSubject<Int, Never>()
-    let effect = _Effect.publisher { subject }
+    let effect = Effect.publisher { subject }
       .cancellable(id: CancelID())
       .cancellable(id: CancelID())
 
@@ -185,7 +185,7 @@ final class EffectCancellationTests: BaseTCATestCase {
     let values = LockIsolated<[Int]>([])
 
     let subject = PassthroughSubject<Int, Never>()
-    let effect = _Effect.publisher { subject }
+    let effect = Effect.publisher { subject }
       .cancellable(id: CancelID())
 
     let task = Task {
@@ -212,13 +212,13 @@ final class EffectCancellationTests: BaseTCATestCase {
   func testSharedId() async {
     let mainQueue = DispatchQueue.test
 
-    let effect1 = _Effect.publisher {
+    let effect1 = Effect.publisher {
       Just(1)
         .delay(for: 1, scheduler: mainQueue)
     }
     .cancellable(id: "id")
 
-    let effect2 = _Effect.publisher {
+    let effect2 = Effect.publisher {
       Just(2)
         .delay(for: 2, scheduler: mainQueue)
     }
@@ -251,7 +251,7 @@ final class EffectCancellationTests: BaseTCATestCase {
     let mainQueue = DispatchQueue.test
 
     let expectedOutput = LockIsolated<[Int]>([])
-    let effect = _Effect.run { send in
+    let effect = Effect.run { send in
       try await mainQueue.sleep(for: .seconds(1))
       await send(1)
     }
@@ -273,7 +273,7 @@ final class EffectCancellationTests: BaseTCATestCase {
   }
 
   func testNestedMergeCancellation() async {
-    let effect = _Effect<Int>.merge(
+    let effect = Effect<Int>.merge(
       .publisher { (1...2).publisher }
         .cancellable(id: 1)
     )
@@ -287,7 +287,7 @@ final class EffectCancellationTests: BaseTCATestCase {
   }
 
   func testCancellationWithoutThrowingCancellationError() async throws {
-    let effect = _Effect<Void>.run { send in
+    let effect = Effect<Void>.run { send in
       let session = URLSession(configuration: .ephemeral)
       let request = URLRequest(url: URL(string: "http://ipv4.download.thinkbroadband.com/1GB.zip")!)
       let (data, response) = try await session.data(for: request, delegate: nil)
@@ -311,7 +311,7 @@ final class EffectCancellationTests: BaseTCATestCase {
     func testCancellablesCleanUp_OnComplete() async {
       let id = UUID()
 
-      for await _ in _Effect.send(1).cancellable(id: id).actions {}
+      for await _ in Effect.send(1).cancellable(id: id).actions {}
 
       XCTAssertEqual(
         _cancellationCancellables.withValue { $0.exists(at: id, path: NavigationIDPath()) },
@@ -323,7 +323,7 @@ final class EffectCancellationTests: BaseTCATestCase {
       let id = UUID()
 
       let mainQueue = DispatchQueue.test
-      let effect = _Effect.publisher {
+      let effect = Effect.publisher {
         Just(1)
           .delay(for: 1, scheduler: mainQueue)
       }
@@ -357,8 +357,8 @@ final class EffectCancellationTests: BaseTCATestCase {
       ]
       let ids = (1...10).map { _ in UUID() }
 
-      let effect = _Effect.merge(
-        (1...1_000).map { idx -> _Effect<Int> in
+      let effect = Effect.merge(
+        (1...1_000).map { idx -> Effect<Int> in
           let id = ids[idx % 10]
 
           return .merge(
@@ -455,7 +455,7 @@ final class EffectCancellationTests: BaseTCATestCase {
       let effect = withDependencies {
         $0.navigationIDPath = navigationIDPath
       } operation: {
-        _Effect
+        Effect
           .publisher {
             Just(()).delay(for: .seconds(1), scheduler: DispatchQueue(label: #function))
           }

--- a/Tests/ComposableArchitectureTests/EffectDebounceTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectDebounceTests.swift
@@ -14,7 +14,7 @@ final class EffectDebounceTests: BaseTCATestCase {
       Task {
         struct CancelToken: Hashable {}
 
-        let effect = _Effect.send(value)
+        let effect = Effect.send(value)
           .debounce(id: CancelToken(), for: 1, scheduler: mainQueue)
 
         for await action in effect.actions {

--- a/Tests/ComposableArchitectureTests/EffectFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectFailureTests.swift
@@ -22,7 +22,7 @@
       }
 
       line = #line
-      let effect = _Effect<Void>.run { _ in
+      let effect = Effect<Void>.run { _ in
         struct Unexpected: Error {}
         throw Unexpected()
       }

--- a/Tests/ComposableArchitectureTests/EffectOperationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectOperationTests.swift
@@ -5,7 +5,7 @@
 
   class EffectOperationTests: BaseTCATestCase {
     func testMergeDiscardsNones() async {
-      var effect = _Effect<Int>.none
+      var effect = Effect<Int>.none
         .merge(with: .none)
       switch effect.operation {
       case .none:
@@ -14,7 +14,7 @@
         XCTFail()
       }
 
-      effect = _Effect<Int>.run { send in await send(42) }
+      effect = Effect<Int>.run { send in await send(42) }
         .merge(with: .none)
       switch effect.operation {
       case .run(_, _, let send):
@@ -23,7 +23,7 @@
         XCTFail()
       }
 
-      effect = _Effect<Int>.none
+      effect = Effect<Int>.none
         .merge(with: .run { send in await send(42) })
       switch effect.operation {
       case .run(_, _, let send):
@@ -32,7 +32,7 @@
         XCTFail()
       }
 
-      effect = _Effect<Int>.run { await $0(42) }
+      effect = Effect<Int>.run { await $0(42) }
         .merge(with: .none)
       switch effect.operation {
       case .run(_, _, let send):
@@ -41,7 +41,7 @@
         XCTFail()
       }
 
-      effect = _Effect<Int>.none
+      effect = Effect<Int>.none
         .merge(with: .run { await $0(42) })
       switch effect.operation {
       case .run(_, _, let send):
@@ -52,7 +52,7 @@
     }
 
     func testConcatenateDiscardsNones() async {
-      var effect = _Effect<Int>.none
+      var effect = Effect<Int>.none
         .concatenate(with: .none)
       switch effect.operation {
       case .none:
@@ -61,7 +61,7 @@
         XCTFail()
       }
 
-      effect = _Effect<Int>.run { send in await send(42) }
+      effect = Effect<Int>.run { send in await send(42) }
         .concatenate(with: .none)
       switch effect.operation {
       case .run(_, _, let send):
@@ -70,7 +70,7 @@
         XCTFail()
       }
 
-      effect = _Effect<Int>.none
+      effect = Effect<Int>.none
         .concatenate(with: .run { send in await send(42) })
       switch effect.operation {
       case .run(_, _, let send):
@@ -79,7 +79,7 @@
         XCTFail()
       }
 
-      effect = _Effect<Int>.run { send in await send(42) }
+      effect = Effect<Int>.run { send in await send(42) }
         .concatenate(with: .none)
       switch effect.operation {
       case .run(_, _, let send):
@@ -88,7 +88,7 @@
         XCTFail()
       }
 
-      effect = _Effect<Int>.none
+      effect = Effect<Int>.none
         .concatenate(with: .run { send in await send(42) })
       switch effect.operation {
       case .run(_, _, let send):
@@ -102,7 +102,7 @@
     func testMergeFuses() async {
       var values = [Int]()
 
-      let effect = _Effect<Int>.run { send in
+      let effect = Effect<Int>.run { send in
         try await Task.sleep(nanoseconds: NSEC_PER_SEC / 10)
         await send(42)
       }
@@ -126,7 +126,7 @@
     func testConcatenateFuses() async {
       var values = [Int]()
 
-      let effect = _Effect<Int>.run { send in await send(42) }
+      let effect = Effect<Int>.run { send in await send(42) }
         .concatenate(with: .run { send in await send(1729) })
       switch effect.operation {
       case .run(_, _, let send):
@@ -139,7 +139,7 @@
     }
 
     func testMap() async {
-      let effect = _Effect<Int>.run { send in await send(42) }
+      let effect = Effect<Int>.run { send in await send(42) }
         .map { "\($0)" }
 
       switch effect.operation {

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -11,7 +11,7 @@ final class EffectTests: BaseTCATestCase {
       let clock = TestClock()
       let values = LockIsolated<[Int]>([])
 
-      let effect = _Effect<Int>.concatenate(
+      let effect = Effect<Int>.concatenate(
         (1...3).map { count in
           .run { send in
             try await clock.sleep(for: .seconds(count))
@@ -48,7 +48,7 @@ final class EffectTests: BaseTCATestCase {
     await withMainSerialExecutor { [mainQueue] in
       let values = LockIsolated<[Int]>([])
 
-      let effect = _Effect<Int>.concatenate(
+      let effect = Effect<Int>.concatenate(
         .publisher { Just(1).delay(for: 1, scheduler: mainQueue) }
       )
 
@@ -74,7 +74,7 @@ final class EffectTests: BaseTCATestCase {
     await withMainSerialExecutor {
       let clock = TestClock()
 
-      let effect = _Effect<Int>.merge(
+      let effect = Effect<Int>.merge(
         (1...3).map { count in
           .run { send in
             try await clock.sleep(for: .seconds(count))
@@ -109,7 +109,7 @@ final class EffectTests: BaseTCATestCase {
   func testDoubleCancelInFlight() async {
     var result: Int?
 
-    let effect = _Effect.send(42)
+    let effect = Effect.send(42)
       .cancellable(id: "id", cancelInFlight: true)
       .cancellable(id: "id", cancelInFlight: true)
 
@@ -193,7 +193,7 @@ final class EffectTests: BaseTCATestCase {
     let effect = withDependencies {
       $0.date.now = Date(timeIntervalSince1970: 1_234_567_890)
     } operation: {
-      _Effect.send(()).map { date() }
+      Effect.send(()).map { date() }
     }
     var output: Date?
     for await date in effect.actions {
@@ -206,7 +206,7 @@ final class EffectTests: BaseTCATestCase {
       let effect = withDependencies {
         $0.date.now = Date(timeIntervalSince1970: 1_234_567_890)
       } operation: {
-        _Effect<Void>.run { send in await send(()) }.map { date() }
+        Effect<Void>.run { send in await send(()) }.map { date() }
       }
       output = nil
       for await date in effect.actions {


### PR DESCRIPTION
We've found a migration path that can preserve `Effect` as it exists today, so let's make the pre-migration less annoying.

`EffectOf` will work fine for folks who have already migrated in preparation.