### PR TITLE
Fix missing access modifier on CaseScope.AllCasePaths properties

### DIFF
--- a/Sources/ComposableArchitectureMacros/ReducerMacro.swift
+++ b/Sources/ComposableArchitectureMacros/ReducerMacro.swift
@@ -268,7 +268,7 @@ extension ReducerMacro: MemberMacro {
         }
         storeCases.append(enumCaseElement.storeCase)
         storeScopes.append(enumCaseElement.storeScope)
-        storeCasePathProperties.append(enumCaseElement.storeCasePathProperty)
+        storeCasePathProperties.append(enumCaseElement.storeCasePathProperty(access: access))
       }
       if !hasState {
         var conformances: [String] = []
@@ -526,7 +526,8 @@ private enum ReducerCase {
     }
   }
 
-  var storeCasePathProperty: String {
+  func storeCasePathProperty(access: DeclModifierSyntax?) -> String {
+    let accessPrefix = access?.name.text.appending(" ") ?? ""
     switch self {
     case .element(let element, let attribute):
       let name = element.name.text
@@ -538,7 +539,7 @@ private enum ReducerCase {
       {
         let type = parameter.type
         return """
-          var \(name): CasePaths.AnyCasePath<CaseScope, ComposableArchitecture.StoreOf<\(type.trimmed)>> {
+          \(accessPrefix)var \(name): CasePaths.AnyCasePath<CaseScope, ComposableArchitecture.StoreOf<\(type.trimmed)>> {
           CasePaths.AnyCasePath(
           embed: CaseScope.\(name),
           extract: { guard case let .\(name)(v0) = $0 else { return nil }; return v0 }
@@ -550,7 +551,7 @@ private enum ReducerCase {
         let parameter = parameterClause.parameters.first
       {
         return """
-          var \(name): CasePaths.AnyCasePath<CaseScope, \(parameter.type.trimmed)> {
+          \(accessPrefix)var \(name): CasePaths.AnyCasePath<CaseScope, \(parameter.type.trimmed)> {
           CasePaths.AnyCasePath(
           embed: CaseScope.\(name),
           extract: { guard case let .\(name)(v0) = $0 else { return nil }; return v0 }
@@ -561,7 +562,7 @@ private enum ReducerCase {
         return ""
       } else {
         return """
-          var \(name): CasePaths.AnyCasePath<CaseScope, Void> {
+          \(accessPrefix)var \(name): CasePaths.AnyCasePath<CaseScope, Void> {
           CasePaths.AnyCasePath(
           embed: { CaseScope.\(name) },
           extract: { guard case .\(name) = $0 else { return nil }; return () }
@@ -570,7 +571,7 @@ private enum ReducerCase {
           """
       }
     case .ifConfig(let configs):
-      return Self.renderedIfConfig(configs) { $0.storeCasePathProperty } ?? ""
+      return Self.renderedIfConfig(configs) { $0.storeCasePathProperty(access: access) } ?? ""
     }
   }
 

--- a/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
@@ -855,6 +855,107 @@
       }
     }
 
+    func testEnum_TwoCases_AccessControl_Public() {
+      assertMacro {
+        """
+        @Reducer
+        public enum Destination {
+          case activity(Activity)
+          case timeline(Timeline)
+        }
+        """
+      } expansion: {
+        #"""
+        public enum Destination {
+          case activity(Activity)
+          case timeline(Timeline)
+
+          @CasePathable
+          @dynamicMemberLookup
+          @ObservableState
+
+          public enum State: ComposableArchitecture.CaseReducerState {
+
+            public typealias StateReducer = Destination
+            case activity(Activity.State)
+            case timeline(Timeline.State)
+          }
+
+          @CasePathable
+
+          public enum Action {
+            case activity(Activity.Action)
+            case timeline(Timeline.Action)
+          }
+
+          @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
+
+          public static var body: Reduce<Self.State, Self.Action> {
+            ComposableArchitecture.Reduce(
+              ComposableArchitecture.EmptyReducer<Self.State, Self.Action>()
+              .ifCaseLet(\Self.State.Cases.activity, action: \Self.Action.Cases.activity) {
+                Activity()
+              }
+              .ifCaseLet(\Self.State.Cases.timeline, action: \Self.Action.Cases.timeline) {
+                Timeline()
+              }
+            )
+          }
+
+          @dynamicMemberLookup
+
+          public enum CaseScope: ComposableArchitecture._CaseScopeProtocol, CasePaths.CasePathable {
+            case activity(ComposableArchitecture.StoreOf<Activity>)
+            case timeline(ComposableArchitecture.StoreOf<Timeline>)
+
+            public struct AllCasePaths {
+              public var activity: CasePaths.AnyCasePath<CaseScope, ComposableArchitecture.StoreOf<Activity>> {
+                CasePaths.AnyCasePath(
+                  embed: CaseScope.activity,
+                  extract: {
+                    guard case let .activity(v0) = $0 else {
+                      return nil
+                    };
+                    return v0
+                  }
+                )
+              }
+              public var timeline: CasePaths.AnyCasePath<CaseScope, ComposableArchitecture.StoreOf<Timeline>> {
+                CasePaths.AnyCasePath(
+                  embed: CaseScope.timeline,
+                  extract: {
+                    guard case let .timeline(v0) = $0 else {
+                      return nil
+                    };
+                    return v0
+                  }
+                )
+              }
+            }
+
+            public static var allCasePaths: AllCasePaths {
+              AllCasePaths()
+            }
+          }
+
+          @preconcurrency @MainActor
+
+          public static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
+            switch store.state {
+            case .activity:
+              return .activity(store.scope(state: \.activity, action: \.activity)!)
+            case .timeline:
+              return .timeline(store.scope(state: \.timeline, action: \.timeline)!)
+            }
+          }
+        }
+
+        extension Destination: ComposableArchitecture.CaseReducer, ComposableArchitecture.Reducer {
+        }
+        """#
+      }
+    }
+
     func testEnum_CaseIgnored() {
       assertMacro {
         """


### PR DESCRIPTION
## Summary

- Fixes `@Reducer` macro generating `internal` access for computed properties inside `CaseScope.AllCasePaths` when the enum is `public` or `package`, making the enum scope API inaccessible across module boundaries.
- Adds the `access` modifier to all three branches of `storeCasePathProperty` (store-backed, non-store parameter, and void cases).
- Adds `testEnum_TwoCases_AccessControl_Public` test covering `public` enum with multiple cases.

Fixes #3893