### PR TITLE
fix: avoid SyncUpForm preview crash on interaction

### DIFF
--- a/Examples/SyncUps/SyncUps/SyncUpForm.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpForm.swift
@@ -65,6 +65,25 @@ struct SyncUpFormView: View {
   @FocusState var focus: SyncUpForm.State.Field?
 
   var body: some View {
+    SyncUpFormContents(store: store, focus: $focus)
+    .bind($store.focus, to: $focus)
+  }
+}
+
+private struct SyncUpFormPreviewView: View {
+  @Bindable var store: StoreOf<SyncUpForm>
+  @FocusState var focus: SyncUpForm.State.Field?
+
+  var body: some View {
+    SyncUpFormContents(store: store, focus: $focus)
+  }
+}
+
+private struct SyncUpFormContents: View {
+  @Bindable var store: StoreOf<SyncUpForm>
+  @FocusState.Binding var focus: SyncUpForm.State.Field?
+
+  var body: some View {
     Form {
       Section {
         TextField("Title", text: $store.syncUp.title)
@@ -96,7 +115,6 @@ struct SyncUpFormView: View {
         Text("Attendees")
       }
     }
-    .bind($store.focus, to: $focus)
   }
 }
 
@@ -129,7 +147,7 @@ extension Duration {
 
 #Preview {
   NavigationStack {
-    SyncUpFormView(
+    SyncUpFormPreviewView(
       store: Store(initialState: SyncUpForm.State(syncUp: .mock)) {
         SyncUpForm()
       }


### PR DESCRIPTION
Fixes #3823.

## Summary
- keep `SyncUpFormView` unchanged for production usage
- extract shared form content into `SyncUpFormContents`
- make `#Preview` use `SyncUpFormPreviewView`, which intentionally omits `.bind($store.focus, to: $focus)`

This is a preview-only mitigation for the crash reported in #3823. The issue report notes that interacting with the `SyncUpForm` preview crashes, and that removing `.bind(...)` prevents the crash. This change keeps the production code path intact while making the preview use the same form content without the crashing focus-binding path.

## Validation
- `lsp_diagnostics Examples/SyncUps/SyncUps/SyncUpForm.swift` → no diagnostics
- `xcodebuild -workspace ComposableArchitecture.xcworkspace -scheme ComposableArchitecture -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` → succeeds
- `xcodebuild -workspace ComposableArchitecture.xcworkspace -scheme SyncUps -showdestinations`
  - this machine does not have the required iOS 26.4 platform/runtime installed, so the SyncUps scheme itself could not be built here