### PR TITLE
Update 1.25 migration guide for enum alerts

### DIFF
--- a/Examples/SyncUps/SyncUps/SyncUpDetail.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpDetail.swift
@@ -9,6 +9,12 @@ struct SyncUpDetail {
     case edit(SyncUpForm)
 
     @CasePathable
+    enum Action {
+      case alert(Alert)
+      case edit(SyncUpForm.Action)
+    }
+
+    @CasePathable
     enum Alert {
       case confirmDeletion
       case continueWithoutRecording

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "88b27ee0a566e74b7aad8d4d178b4e6824113129b455d896eefddb7fd47c5eac",
+  "originHash" : "1259be8d2815c9a7a292b760933ff562898164ae8ba7f180242c39f1152ecbdd",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-sharing",
       "state" : {
-        "revision" : "3bfc408cc2d0bee2287c174da6b1c76768377818",
-        "version" : "2.7.4"
+        "revision" : "bc27f8322bc30f6ce7d864d137dc77a6de8b57eb",
+        "version" : "2.8.0"
       }
     },
     {

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.25.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.25.md
@@ -39,9 +39,6 @@ directly to a specific case of a destination enum, you now scope to the entire d
 chain into the individual case:
 
 ```diff
--.alert($store.scope(state: \.destination?.alert, action: \.destination.alert))
-+.alert($store.scope(state: \.$destination, action: \.destination).alert)
-
 -.sheet(item: $store.scope(state: \.destination?.edit, action: \.destination.edit)) {
 +.sheet(item: $store.scope(state: \.$destination, action: \.destination).edit) {
 ```
@@ -61,6 +58,28 @@ bindings to `Bool` bindings:
 +  isPresented: Binding($store.scope(state: \.$destination, action: \.destination).help)
 +) {
 ```
+
+Another important difference is that holding non-feature state in a destination enum with an
+associated action (such as the action of an `AlertState<Action>`) requires an explicit `Action` enum
+definition:
+
+```diff
+ @Reducer enum Destination {
+   case alert(AlertState<Alert>)
+   case settings(Settings)
+
++  @CasePathable enum Action {
++    case alert(Alert)
++    case settings(Settings.Action)
++  }
+
+   enum Alert {
+     case .deleteTapped
+   }
+ }
+```
+
+ComposableArchitecture 2.0 will have newer tools for handling prompts.
 
 ### Streamlined `onChange` operator
 


### PR DESCRIPTION
Alerts and confirmation dialogs held in `@Reducer enum`s will require a bit of extra ceremony to be 2.0-compatible, but 2.0 will come with more flexible tooling around handling prompts.