### PR TITLE
Fixed: Reading @Shared state from a BindableAction Store raises deprecation warning

### DIFF
--- a/Sources/ComposableArchitecture/Observation/Binding+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Binding+Observation.swift
@@ -168,6 +168,7 @@ extension BindableAction where State: ObservableState {
 }
 
 extension Store where State: ObservableState, Action: BindableAction, Action.State == State {
+  @_disfavoredOverload
   public subscript<Value: Equatable & Sendable>(
     dynamicMember keyPath: WritableKeyPath<State, Value>
   ) -> Value {
@@ -212,6 +213,7 @@ where
   Action.ViewAction: BindableAction,
   Action.ViewAction.State == State
 {
+  @_disfavoredOverload
   public subscript<Value: Equatable & Sendable>(
     dynamicMember keyPath: WritableKeyPath<State, Value>
   ) -> Value {


### PR DESCRIPTION
In a `View` context, reading a `@Shared` value from the store's state will raise a deprecation warning when the store's `Action` conforms to `BindableAction`.

```swift
@Reducer
struct Feature {
  @ObservableState
  struct State: Equatable {
    @Shared(.inMemory("value")) var value: Int = 0
  }
  enum Action: BindableAction {
    case binding(BindingAction<State>)
  }
}

struct FeatureView: View {
  let store: StoreOf<Feature>

  var body: some View {
    let _ = store.value
    // 🛑 Setter for 'value' is deprecated: Use '$shared.withLock' to modify a shared value with exclusive access; when constructing a SwiftUI binding, use 'Binding($shared)'
  }
}
```

This is because the dynamicMemberLookup selects an overload that requires a `WritableKeyPath` which is enough to trigger Swift to require a setter for the property which is invalid for a `@Shared` value. Applying `@_disfavoredOverload` will drive the lookup toward an overload requiring a `KeyPath` instead.