### PR TITLE
Adds disfavoredOverload annotation to `~=` implementation in Binding.swift

### DIFF
--- a/Sources/ComposableArchitecture/SwiftUI/Binding.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Binding.swift
@@ -62,6 +62,7 @@ extension BindingAction {
   /// case .binding(\.enableNotifications):
   ///   // Return an authorization request effect
   /// ```
+  @_disfavoredOverload
   public static func ~= <Value>(
     keyPath: _SendableWritableKeyPath<Root, Value>,
     bindingAction: Self


### PR DESCRIPTION
When running versions of TCA >= 1.24.0 on Xcode 26.4, our team's project fails to compile with several instances of the following compiler error: `Ambiguous use of operator '~='`

It looks like the compiler is having trouble disambiguating between this function and the more constrained implementation declared in `Binding+Observation.swift`, where the only difference is the additional `where Root: ObservableState` constraint.

I've confirmed that adding the `@_disfavoredOverload` annotation to the less constrained operator gets us building again.