### PR TITLE
Fix Xcode 26 xcodebuild archive failures: add `import Combine` to Logger.swift and `@unknown default` to non-frozen enum switches

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -2079,6 +2079,8 @@ extension View {
                 if let action {
                   store.send(.presented(fromDestinationAction(action)), animation: animation)
                 }
+              @unknown default:
+                break
               }
             } label: {
               Text(button.label)
@@ -2132,6 +2134,8 @@ extension View {
                 if let action {
                   store.send(.presented(fromDestinationAction(action)), animation: animation)
                 }
+              @unknown default:
+                break
               }
             } label: {
               Text(button.label)

--- a/Sources/ComposableArchitecture/Internal/Logger.swift
+++ b/Sources/ComposableArchitecture/Internal/Logger.swift
@@ -1,4 +1,5 @@
 import OSLog
+import Combine
 
 @_spi(Logging)
 @preconcurrency @MainActor

--- a/Sources/ComposableArchitecture/Observation/Alert+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Alert+Observation.swift
@@ -22,6 +22,8 @@ extension View {
               if let action {
                 store?.send(action, animation: animation)
               }
+            @unknown default:
+              break
             }
           } label: {
             Text(button.label)
@@ -59,6 +61,8 @@ extension View {
               if let action {
                 store?.send(action, animation: animation)
               }
+            @unknown default:
+              break
             }
           } label: {
             Text(button.label)


### PR DESCRIPTION
## Problem

When archiving with `xcodebuild archive` on Xcode 26, the `ComposableArchitecture` target is compiled in **Swift 6 mode** despite the package-level workaround that adds `.swiftLanguageMode(.v5)` to every target via a loop in `Package.swift`.

The root cause is a behaviour difference between xcodebuild archive and the Xcode GUI in Xcode 26: The former reads the package-level `swiftLanguageModes: [.v6]` declaration and **ignores the per-target `.swiftLanguageMode(.v5)` overrides** that are appended dynamically in the `for target in package.targets` loop. The latter does not exhibit this behaviour and archives successfully.

Once `xcodebuild` forces Swift 6 mode on TCA's targets, two classes of code that are valid in Swift 5 become compile errors:

### 1. `Logger.swift` — missing `import Combine`

```
Sources/ComposableArchitecture/Internal/Logger.swift:12:4: error: 'Published' aliases 'Combine.Published' and cannot be used as property wrapper here because 'Combine' was not imported by this file
```

`@Published` is a Combine type. In Swift 5, it could be used without an explicit `import Combine` because Combine was re-exported transitively. In Swift 6, **MemberImportVisibility** is a language requirement: every file must import the module that defines the symbol it uses. `Logger.swift` only imports `OSLog`.

**Fix:** add `import Combine` to `Logger.swift`.

### 2. `Alert+Observation.swift`, `Alert.swift`, `ConfirmationDialog.swift` — non-exhaustive switches on non-frozen enums
```
Sources/ComposableArchitecture/Observation/Alert+Observation.swift:21:13: error: switch covers known cases, but 'ButtonStateAction._ActionType' may have additional unknown values
```

`switch` statements over non-`@frozen` enums without an `@unknown default` case produce a **warning** in Swift 5 but an **error** in Swift 6. Three files contain such switches over `ButtonStateAction._ActionType`.

**Fix:** add `@unknown default: break` to the affected switch statements.

## Repro

1. Xcode 26 (any 26.x build)
2. A project that depends on TCA 1.25.5 as an SPM package inside an Xcode
   workspace, where the native target (`xcodeproj`) uses
   `BUILD_LIBRARY_FOR_DISTRIBUTION=YES`
3. Run:
   ```bash
   xcodebuild archive \
     -workspace MyApp.xcworkspace \
     -scheme MyFramework \
     -destination 'generic/platform=iOS Simulator' \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES

Reproducible Repo: https://github.com/joaomvfsantos/TCACompileIssue

Aims to fix #3918 