### PR TITLE
Add `scope(_:action:)` and `Scope(_:action:)`

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -115,8 +115,8 @@ struct AlertAndConfirmationDialogView: View {
       Button("Confirmation Dialog") { store.send(.confirmationDialogButtonTapped) }
     }
     .navigationTitle("Alerts & Dialogs")
-    .alert($store.scope(state: \.alert, action: \.alert))
-    .confirmationDialog($store.scope(state: \.confirmationDialog, action: \.confirmationDialog))
+    .alert($store.scope(\.alert, action: \.alert))
+    .confirmationDialog($store.scope(\.confirmationDialog, action: \.confirmationDialog))
   }
 }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -142,7 +142,7 @@ struct AnimationsView: View {
       Button("Reset") { store.send(.resetButtonTapped) }
         .padding([.horizontal, .bottom])
     }
-    .alert($store.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(\.alert, action: \.alert))
     .navigationBarTitleDisplayMode(.inline)
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -22,10 +22,10 @@ struct TwoCounters {
   }
 
   var body: some Reducer<State, Action> {
-    Scope(state: \.counter1, action: \.counter1) {
+    Scope(\.counter1, action: \.counter1) {
       Counter()
     }
-    Scope(state: \.counter2, action: \.counter2) {
+    Scope(\.counter2, action: \.counter2) {
       Counter()
     }
   }
@@ -43,13 +43,13 @@ struct TwoCountersView: View {
       HStack {
         Text("Counter 1")
         Spacer()
-        CounterView(store: store.scope(state: \.counter1, action: \.counter1))
+        CounterView(store: store.scope(\.counter1, action: \.counter1))
       }
 
       HStack {
         Text("Counter 2")
         Spacer()
-        CounterView(store: store.scope(state: \.counter2, action: \.counter2))
+        CounterView(store: store.scope(\.counter2, action: \.counter2))
       }
     }
     .buttonStyle(.borderless)

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -56,7 +56,7 @@ struct OptionalBasicsView: View {
         store.send(.toggleCounterButtonTapped)
       }
 
-      if let store = store.scope(state: \.optionalCounter, action: \.optionalCounter) {
+      if let store = store.scope(\.optionalCounter, action: \.optionalCounter) {
         Text(template: "`Counter.State` is non-`nil`")
         CounterView(store: store)
           .buttonStyle(.borderless)

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-SharedState-FileStorage.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-SharedState-FileStorage.swift
@@ -33,11 +33,11 @@ struct SharedStateFileStorage {
   }
 
   var body: some Reducer<State, Action> {
-    Scope(state: \.counter, action: \.counter) {
+    Scope(\.counter, action: \.counter) {
       CounterTab()
     }
 
-    Scope(state: \.profile, action: \.profile) {
+    Scope(\.profile, action: \.profile) {
       ProfileTab()
     }
 
@@ -59,13 +59,13 @@ struct SharedStateFileStorageView: View {
   var body: some View {
     TabView(selection: $store.currentTab.sending(\.selectTab)) {
       CounterTabView(
-        store: store.scope(state: \.counter, action: \.counter)
+        store: store.scope(\.counter, action: \.counter)
       )
       .tag(SharedStateFileStorage.Tab.counter)
       .tabItem { Text("Counter") }
 
       ProfileTabView(
-        store: store.scope(state: \.profile, action: \.profile)
+        store: store.scope(\.profile, action: \.profile)
       )
       .tag(SharedStateFileStorage.Tab.profile)
       .tabItem { Text("Profile") }
@@ -173,7 +173,7 @@ private struct CounterTabView: View {
       }
     }
     .buttonStyle(.borderless)
-    .alert($store.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(\.alert, action: \.alert))
   }
 }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-SharedState-InMemory.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-SharedState-InMemory.swift
@@ -32,11 +32,11 @@ struct SharedStateInMemory {
   }
 
   var body: some Reducer<State, Action> {
-    Scope(state: \.counter, action: \.counter) {
+    Scope(\.counter, action: \.counter) {
       CounterTab()
     }
 
-    Scope(state: \.profile, action: \.profile) {
+    Scope(\.profile, action: \.profile) {
       ProfileTab()
     }
 
@@ -58,13 +58,13 @@ struct SharedStateInMemoryView: View {
   var body: some View {
     TabView(selection: $store.currentTab.sending(\.selectTab)) {
       CounterTabView(
-        store: store.scope(state: \.counter, action: \.counter)
+        store: store.scope(\.counter, action: \.counter)
       )
       .tag(SharedStateInMemory.Tab.counter)
       .tabItem { Text("Counter") }
 
       ProfileTabView(
-        store: store.scope(state: \.profile, action: \.profile)
+        store: store.scope(\.profile, action: \.profile)
       )
       .tag(SharedStateInMemory.Tab.profile)
       .tabItem { Text("Profile") }
@@ -172,7 +172,7 @@ private struct CounterTabView: View {
       }
     }
     .buttonStyle(.borderless)
-    .alert($store.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(\.alert, action: \.alert))
   }
 }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-SharedState-Onboarding.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-SharedState-Onboarding.swift
@@ -69,7 +69,7 @@ struct SignUpFlow: View {
   }
 
   var body: some View {
-    NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
+    NavigationStack(path: $store.scope(\.path, action: \.path)) {
       Form {
         Section {
           Text(readMe)
@@ -270,7 +270,7 @@ private struct TopicsStep: View {
       }
     }
     .navigationTitle("Topics")
-    .alert($store.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(\.alert, action: \.alert))
     .toolbar {
       ToolbarItem {
         if store.isEditingFromSummary {
@@ -409,14 +409,14 @@ private struct SummaryStep: View {
       }
     }
     .navigationTitle("Summary")
-    .sheet(item: $store.scope(state: \.$destination, action: \.destination).basics) { basicsStore in
+    .sheet(item: $store.scope(\.$destination, action: \.destination).basics) { basicsStore in
       NavigationStack {
         BasicsStep(store: basicsStore)
       }
       .presentationDetents([.medium])
     }
     .sheet(
-      item: $store.scope(state: \.$destination, action: \.destination).personalInfo
+      item: $store.scope(\.$destination, action: \.destination).personalInfo
     ) { personalStore in
       NavigationStack {
         PersonalInfoStep(store: personalStore)
@@ -424,14 +424,14 @@ private struct SummaryStep: View {
       .presentationDetents([.medium])
     }
     .sheet(
-      item: $store.scope(state: \.$destination, action: \.destination).topics
+      item: $store.scope(\.$destination, action: \.destination).topics
     ) { topicsStore in
       NavigationStack {
         TopicsStep(store: topicsStore)
       }
       .presentationDetents([.medium])
     }
-    .alert($store.scope(state: \.$destination, action: \.destination).alert)
+    .alert($store.scope(\.$destination, action: \.destination).alert)
   }
 }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-SharedState-UserDefaults.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-SharedState-UserDefaults.swift
@@ -29,11 +29,11 @@ struct SharedStateUserDefaults {
   }
 
   var body: some Reducer<State, Action> {
-    Scope(state: \.counter, action: \.counter) {
+    Scope(\.counter, action: \.counter) {
       CounterTab()
     }
 
-    Scope(state: \.profile, action: \.profile) {
+    Scope(\.profile, action: \.profile) {
       ProfileTab()
     }
 
@@ -55,13 +55,13 @@ struct SharedStateUserDefaultsView: View {
   var body: some View {
     TabView(selection: $store.currentTab.sending(\.selectTab)) {
       CounterTabView(
-        store: store.scope(state: \.counter, action: \.counter)
+        store: store.scope(\.counter, action: \.counter)
       )
       .tag(SharedStateUserDefaults.Tab.counter)
       .tabItem { Text("Counter") }
 
       ProfileTabView(
-        store: store.scope(state: \.profile, action: \.profile)
+        store: store.scope(\.profile, action: \.profile)
       )
       .tag(SharedStateUserDefaults.Tab.profile)
       .tabItem { Text("Profile") }
@@ -169,7 +169,7 @@ private struct CounterTabView: View {
       }
     }
     .buttonStyle(.borderless)
-    .alert($store.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(\.alert, action: \.alert))
   }
 }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-WebSocket.swift
@@ -182,7 +182,7 @@ struct WebSocketView: View {
         Text("Received messages")
       }
     }
-    .alert($store.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(\.alert, action: \.alert))
     .navigationTitle("Web Socket")
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-Navigation-Lists-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-Navigation-Lists-NavigateAndLoad.swift
@@ -88,7 +88,7 @@ struct NavigateAndLoadListView: View {
             set: { id in store.send(.setNavigation(selection: id)) }
           )
         ) {
-          if let store = store.scope(state: \.selection?.value, action: \.counter) {
+          if let store = store.scope(\.selection?.value, action: \.counter) {
             CounterView(store: store)
           } else {
             ProgressView()

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-Navigation-Multiple-Destinations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-Navigation-Multiple-Destinations.swift
@@ -67,17 +67,17 @@ struct MultipleDestinationsView: View {
       }
     }
     .navigationDestination(
-      item: $store.scope(state: \.$destination, action: \.destination).drillDown
+      item: $store.scope(\.$destination, action: \.destination).drillDown
     ) { store in
       CounterView(store: store)
     }
     .popover(
-      item: $store.scope(state: \.$destination, action: \.destination).popover
+      item: $store.scope(\.$destination, action: \.destination).popover
     ) { store in
       CounterView(store: store)
     }
     .sheet(
-      item: $store.scope(state: \.$destination, action: \.destination).sheet
+      item: $store.scope(\.$destination, action: \.destination).sheet
     ) { store in
       CounterView(store: store)
     }

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-Navigation-NavigateAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-Navigation-NavigateAndLoad.swift
@@ -67,7 +67,7 @@ struct NavigateAndLoadView: View {
         "Load optional counter",
         isActive: $store.isNavigationActive.sending(\.setNavigation)
       ) {
-        if let store = store.scope(state: \.optionalCounter, action: \.optionalCounter) {
+        if let store = store.scope(\.optionalCounter, action: \.optionalCounter) {
           CounterView(store: store)
         } else {
           ProgressView()

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-Navigation-Sheet-LoadThenPresent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-Navigation-Sheet-LoadThenPresent.swift
@@ -71,7 +71,7 @@ struct LoadThenPresentView: View {
         }
       }
     }
-    .sheet(item: $store.scope(state: \.counter, action: \.counter)) { store in
+    .sheet(item: $store.scope(\.counter, action: \.counter)) { store in
       CounterView(store: store)
     }
     .navigationTitle("Load and present")

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-Navigation-Sheet-PresentAndLoad.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-Navigation-Sheet-PresentAndLoad.swift
@@ -68,7 +68,7 @@ struct PresentAndLoadView: View {
       }
     }
     .sheet(isPresented: $store.isSheetPresented.sending(\.setSheet)) {
-      if let store = store.scope(state: \.optionalCounter, action: \.optionalCounter) {
+      if let store = store.scope(\.optionalCounter, action: \.optionalCounter) {
         CounterView(store: store)
       } else {
         ProgressView()

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-NavigationStack.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-NavigationStack.swift
@@ -71,7 +71,7 @@ struct NavigationDemoView: View {
   @Bindable var store: StoreOf<NavigationDemo>
 
   var body: some View {
-    NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
+    NavigationStack(path: $store.scope(\.path, action: \.path)) {
       Form {
         Section { Text(template: readMe) }
 

--- a/Examples/CaseStudies/SwiftUICaseStudies/05-HigherOrderReducers-Recursion.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/05-HigherOrderReducers-Recursion.swift
@@ -67,7 +67,7 @@ struct NestedView: View {
         AboutView(readMe: readMe)
       }
 
-      ForEach(store.scope(state: \.rows, action: \.rows)) { rowStore in
+      ForEach(store.scope(\.rows, action: \.rows)) { rowStore in
         @Bindable var rowStore = rowStore
         NavigationLink {
           NestedView(store: rowStore)

--- a/Examples/CaseStudies/SwiftUICaseStudies/05-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/05-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
@@ -142,7 +142,7 @@ struct DownloadComponentView: View {
     VStack {
       if isVisible {
         button
-          .alert($store.scope(state: \.alert, action: \.alert))
+          .alert($store.scope(\.alert, action: \.alert))
       } else {
         button
       }

--- a/Examples/CaseStudies/SwiftUICaseStudies/05-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/05-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -44,7 +44,7 @@ struct CityMap {
   }
 
   var body: some Reducer<State, Action> {
-    Scope(state: \.downloadComponent, action: \.downloadComponent) {
+    Scope(\.downloadComponent, action: \.downloadComponent) {
       DownloadComponent()
     }
 
@@ -77,7 +77,7 @@ struct CityMapRowView: View {
         Text(store.download.title)
         Spacer()
         DownloadComponentView(
-          store: store.scope(state: \.downloadComponent, action: \.downloadComponent)
+          store: store.scope(\.downloadComponent, action: \.downloadComponent)
         )
       }
     }
@@ -106,7 +106,7 @@ struct CityMapDetailView: View {
         Spacer()
 
         DownloadComponentView(
-          store: store.scope(state: \.downloadComponent, action: \.downloadComponent)
+          store: store.scope(\.downloadComponent, action: \.downloadComponent)
         )
       }
     }
@@ -140,7 +140,7 @@ struct CitiesView: View {
       Section {
         AboutView(readMe: readMe)
       }
-      ForEach(store.scope(state: \.cityMaps, action: \.cityMaps)) { cityMapStore in
+      ForEach(store.scope(\.cityMaps, action: \.cityMaps)) { cityMapStore in
         CityMapRowView(store: cityMapStore)
       }
     }

--- a/Examples/CaseStudies/SwiftUICaseStudies/05-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/05-HigherOrderReducers-ReusableFavoriting.swift
@@ -79,7 +79,7 @@ struct FavoriteButton<ID: Hashable & Sendable>: View {
       Image(systemName: "heart")
         .symbolVariant(store.isFavorite ? .fill : .none)
     }
-    .alert($store.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(\.alert, action: \.alert))
   }
 }
 
@@ -105,7 +105,7 @@ struct Episode {
   let favorite: @Sendable (UUID, Bool) async throws -> Bool
 
   var body: some Reducer<State, Action> {
-    Scope(state: \.favorite, action: \.favorite) {
+    Scope(\.favorite, action: \.favorite) {
       Favoriting(favorite: self.favorite)
     }
   }
@@ -120,7 +120,7 @@ struct EpisodeView: View {
 
       Spacer()
 
-      FavoriteButton(store: store.scope(state: \.favorite, action: \.favorite))
+      FavoriteButton(store: store.scope(\.favorite, action: \.favorite))
     }
   }
 }
@@ -157,7 +157,7 @@ struct EpisodesView: View {
         AboutView(readMe: readMe)
       }
 
-      ForEach(store.scope(state: \.episodes, action: \.episodes)) { rowStore in
+      ForEach(store.scope(\.episodes, action: \.episodes)) { rowStore in
         EpisodeView(store: rowStore)
       }
       .buttonStyle(.borderless)

--- a/Examples/CaseStudies/UIKitCaseStudies/ListsOfState.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/ListsOfState.swift
@@ -63,7 +63,7 @@ final class CountersTableViewController: UITableViewController {
 
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     let id = store.counters[indexPath.row].id
-    if let store = store.scope(state: \.counters[id: id], action: \.counters[id: id]) {
+    if let store = store.scope(\.counters[id: id], action: \.counters[id: id]) {
       navigationController?.pushViewController(CounterViewController(store: store), animated: true)
     }
   }

--- a/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
@@ -94,7 +94,7 @@ final class LazyNavigationViewController: UIViewController {
       guard let self else { return }
       activityIndicator.isHidden = store.isActivityIndicatorHidden
 
-      if let store = store.scope(state: \.optionalCounter, action: \.optionalCounter) {
+      if let store = store.scope(\.optionalCounter, action: \.optionalCounter) {
         navigationController?.pushViewController(
           CounterViewController(store: store), animated: true
         )

--- a/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
@@ -83,7 +83,7 @@ final class EagerNavigationViewController: UIViewController {
       if store.isNavigationActive {
         navigationController?.pushViewController(
           IfLetStoreController(
-            store.scope(state: \.optionalCounter, action: \.optionalCounter)
+            store.scope(\.optionalCounter, action: \.optionalCounter)
           ) {
             CounterViewController(store: $0)
           } else: {

--- a/Examples/CaseStudies/tvOSCaseStudies/Core.swift
+++ b/Examples/CaseStudies/tvOSCaseStudies/Core.swift
@@ -11,7 +11,7 @@ struct Root {
   }
 
   var body: some Reducer<State, Action> {
-    Scope(state: \.focus, action: \.focus) {
+    Scope(\.focus, action: \.focus) {
       Focus()
     }
   }

--- a/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
+++ b/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
@@ -9,7 +9,7 @@ struct RootView: View {
       Form {
         Section {
           FocusView(
-            store: store.scope(state: \.focus, action: \.focus)
+            store: store.scope(\.focus, action: \.focus)
           )
         }
       }

--- a/Examples/Integration/Integration/Legacy/BindingLocalTestCase.swift
+++ b/Examples/Integration/Integration/Legacy/BindingLocalTestCase.swift
@@ -87,7 +87,7 @@ struct BindingLocalTestCaseView: View {
   }
 
   var body: some View {
-    NavigationStackStore(self.store.scope(state: \.path, action: \.path)) {
+    NavigationStackStore(self.store.scope(\.path, action: \.path)) {
       VStack {
         Button("Full-screen-cover") {
           self.store.send(.fullScreenCoverButtonTapped)
@@ -104,21 +104,21 @@ struct BindingLocalTestCaseView: View {
         }
       }
       .fullScreenCover(
-        store: self.store.scope(state: \.$fullScreenCover, action: \.fullScreenCover)
+        store: self.store.scope(\.$fullScreenCover, action: \.fullScreenCover)
       ) { store in
         ChildView(store: store)
       }
       .navigationDestination(
         store: self.store.scope(
-          state: \.$navigationDestination, action: \.navigationDestination
+          \.$navigationDestination, action: \.navigationDestination
         )
       ) { store in
         ChildView(store: store)
       }
-      .popover(store: self.store.scope(state: \.$popover, action: \.popover)) { store in
+      .popover(store: self.store.scope(\.$popover, action: \.popover)) { store in
         ChildView(store: store)
       }
-      .sheet(store: self.store.scope(state: \.$sheet, action: \.sheet)) { store in
+      .sheet(store: self.store.scope(\.$sheet, action: \.sheet)) { store in
         ChildView(store: store)
       }
     } destination: { store in

--- a/Examples/Integration/Integration/Legacy/IfLetStoreTestCase.swift
+++ b/Examples/Integration/Integration/Legacy/IfLetStoreTestCase.swift
@@ -9,7 +9,7 @@ struct IfLetStoreTestCase: View {
   var body: some View {
     Form {
       IfLetStore(
-        store.scope(state: \.$child, action: \.child),
+        store.scope(\.$child, action: \.child),
         then: ChildView.init(store:),
         else: {
           Button(action: { store.send(.show) }) {

--- a/Examples/Integration/Integration/Legacy/LegacyPresentationTestCase.swift
+++ b/Examples/Integration/Integration/Legacy/LegacyPresentationTestCase.swift
@@ -341,7 +341,7 @@ struct PresentationTestCaseView: View {
       Button("Open alert") {
         self.viewStore.send(.alertButtonTapped)
       }
-      .alert(store: self.store.scope(state: \.$destination.alert, action: \.destination.alert))
+      .alert(store: self.store.scope(\.$destination.alert, action: \.destination.alert))
 
       Button("Open custom alert") {
         self.viewStore.send(.customAlertButtonTapped)
@@ -364,7 +364,7 @@ struct PresentationTestCaseView: View {
         self.viewStore.send(.dialogButtonTapped)
       }
       .confirmationDialog(
-        store: self.store.scope(state: \.$destination.dialog, action: \.destination.dialog)
+        store: self.store.scope(\.$destination.dialog, action: \.destination.dialog)
       )
 
       Button("Open full screen cover") {
@@ -372,7 +372,7 @@ struct PresentationTestCaseView: View {
       }
       .fullScreenCover(
         store: self.store.scope(
-          state: \.$destination.fullScreenCover,
+          \.$destination.fullScreenCover,
           action: \.destination.fullScreenCover
         )
       ) { store in
@@ -388,7 +388,7 @@ struct PresentationTestCaseView: View {
       }
       .sheet(
         store: self.store.scope(
-          state: \.$destination.navigationLinkDemo, action: \.destination.navigationLinkDemo
+          \.$destination.navigationLinkDemo, action: \.destination.navigationLinkDemo
         )
       ) { store in
         NavigationLinkDemoView(store: store)
@@ -399,7 +399,7 @@ struct PresentationTestCaseView: View {
       }
       .navigationDestination(
         store: self.store.scope(
-          state: \.$destination.navigationDestination, action: \.destination.navigationDestination
+          \.$destination.navigationDestination, action: \.destination.navigationDestination
         )
       ) { store in
         ChildView(store: store)
@@ -409,7 +409,7 @@ struct PresentationTestCaseView: View {
         self.viewStore.send(.popoverButtonTapped)
       }
       .popover(
-        store: self.store.scope(state: \.$destination.popover, action: \.destination.popover)
+        store: self.store.scope(\.$destination.popover, action: \.destination.popover)
       ) { store in
         ChildView(store: store)
       }
@@ -418,7 +418,7 @@ struct PresentationTestCaseView: View {
         self.viewStore.send(.sheetButtonTapped)
       }
       .sheet(
-        store: self.store.scope(state: \.$destination.sheet, action: \.destination.sheet)
+        store: self.store.scope(\.$destination.sheet, action: \.destination.sheet)
       ) { store in
         ChildView(store: store)
       }
@@ -471,7 +471,7 @@ private struct NavigationLinkDemoView: View {
           Text(viewStore.state)
 
           NavigationLinkStore(
-            self.store.scope(state: \.$child, action: \.child)
+            self.store.scope(\.$child, action: \.child)
           ) {
             viewStore.send(.navigationLinkButtonTapped)
           } destination: { store in
@@ -481,7 +481,7 @@ private struct NavigationLinkDemoView: View {
           }
 
           NavigationLinkStore(
-            self.store.scope(state: \.$identifiedChild, action: \.identifiedChild),
+            self.store.scope(\.$identifiedChild, action: \.identifiedChild),
             id: UUID(uuidString: "deadbeef-dead-beef-dead-beefdeadbeef")!
           ) {
             viewStore.send(.identifiedNavigationLinkButtonTapped)

--- a/Examples/Integration/Integration/Legacy/NavigationStackTestCase.swift
+++ b/Examples/Integration/Integration/Legacy/NavigationStackTestCase.swift
@@ -125,9 +125,9 @@ private struct ChildView: View {
         print("onAppear")
         viewStore.send(.onAppear)
       }
-      .alert(store: self.store.scope(state: \.$alert, action: \.alert))
+      .alert(store: self.store.scope(\.$alert, action: \.alert))
       .navigationDestination(
-        store: self.store.scope(state: \.$navigationDestination, action: \.navigationDestination)
+        store: self.store.scope(\.$navigationDestination, action: \.navigationDestination)
       ) {
         DestinationView(store: $0)
       }
@@ -183,7 +183,7 @@ struct NavigationStackTestCaseView: View {
   }
 
   var body: some View {
-    NavigationStackStore(self.store.scope(state: \.children, action: \.child)) {
+    NavigationStackStore(self.store.scope(\.children, action: \.child)) {
       WithViewStore(self.store, observe: \.childResponse) { viewStore in
         Form {
           if let childResponse = viewStore.state {

--- a/Examples/Integration/Integration/Legacy/PresentationItemTestCase.swift
+++ b/Examples/Integration/Integration/Legacy/PresentationItemTestCase.swift
@@ -91,7 +91,7 @@ struct PresentationItemTestCaseView: View {
         self.behavior = .sheetStores
       }
       self.core.sheet(
-        store: self.store.scope(state: \.$destination, action: \.destination)
+        store: self.store.scope(\.$destination, action: \.destination)
       ) { store in
         SwitchStore(store) {
           switch $0 {
@@ -124,7 +124,7 @@ struct PresentationItemTestCaseView: View {
       }
       self.core
         .sheet(
-          store: self.store.scope(state: \.$destination.childA, action: \.destination.childA)
+          store: self.store.scope(\.$destination.childA, action: \.destination.childA)
         ) { store in
           Text("Child A")
           Button("Swap") {
@@ -132,7 +132,7 @@ struct PresentationItemTestCaseView: View {
           }
         }
         .sheet(
-          store: self.store.scope(state: \.$destination.childB, action: \.destination.childB)
+          store: self.store.scope(\.$destination.childB, action: \.destination.childB)
         ) { store in
           Text("Child B")
           Button("Swap") {

--- a/Examples/Integration/Integration/Test Cases/MultipleAlertsTestCase.swift
+++ b/Examples/Integration/Integration/Test Cases/MultipleAlertsTestCase.swift
@@ -68,7 +68,7 @@ struct MultipleAlertsTestCaseView: View {
           store.send(.showAlertButtonTapped)
         }
       }
-      .alert($store.scope(state: \.alert, action: \.alert))
+      .alert($store.scope(\.alert, action: \.alert))
     }
   }
 }

--- a/Examples/Integration/Integration/iOS 16+17/NewContainsOldTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16+17/NewContainsOldTestCase.swift
@@ -25,7 +25,7 @@ struct NewContainsOldTestCase: View {
           }
         }
         Section {
-          BasicsView(store: self.store.scope(state: \.child, action: \.child))
+          BasicsView(store: self.store.scope(\.child, action: \.child))
         } header: {
           Text("iOS 16")
         }
@@ -47,7 +47,7 @@ struct NewContainsOldTestCase: View {
       case toggleIsObservingChildCount
     }
     var body: some ReducerOf<Self> {
-      Scope(state: \.child, action: \.child) {
+      Scope(\.child, action: \.child) {
         BasicsView.Feature()
       }
       Reduce { state, action in

--- a/Examples/Integration/Integration/iOS 16+17/NewOldSiblingsTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16+17/NewOldSiblingsTestCase.swift
@@ -11,7 +11,7 @@ struct NewOldSiblingsView: View {
     Form {
       Section {
         BasicsView(
-          store: self.store.scope(state: \.child1, action: \.child1)
+          store: self.store.scope(\.child1, action: \.child1)
         )
       } header: {
         Text("iOS 16")
@@ -19,7 +19,7 @@ struct NewOldSiblingsView: View {
 
       Section {
         ObservableBasicsView(
-          store: self.store.scope(state: \.child2, action: \.child2)
+          store: self.store.scope(\.child2, action: \.child2)
         )
       } header: {
         Text("iOS 17")
@@ -49,10 +49,10 @@ struct NewOldSiblingsView: View {
       case resetSelfButtonTapped
     }
     var body: some ReducerOf<Self> {
-      Scope(state: \.child1, action: \.child1) {
+      Scope(\.child1, action: \.child1) {
         BasicsView.Feature()
       }
-      Scope(state: \.child2, action: \.child2) {
+      Scope(\.child2, action: \.child2) {
         ObservableBasicsView.Feature()
       }
       Reduce { state, action in

--- a/Examples/Integration/Integration/iOS 16+17/NewPresentsOldTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16+17/NewPresentsOldTestCase.swift
@@ -28,7 +28,7 @@ struct NewPresentsOldTestCase: View {
           Button("Present child") { self.store.send(.presentChildButtonTapped) }
         }
       }
-      .sheet(store: self.store.scope(state: \.$child, action: \.child)) { store in
+      .sheet(store: self.store.scope(\.$child, action: \.child)) { store in
         Form {
           BasicsView(store: store)
         }

--- a/Examples/Integration/Integration/iOS 16+17/OldContainsNewTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16+17/OldContainsNewTestCase.swift
@@ -36,7 +36,7 @@ struct OldContainsNewTestCase: View {
           }
         }
         Section {
-          ObservableBasicsView(store: self.store.scope(state: \.child, action: \.child))
+          ObservableBasicsView(store: self.store.scope(\.child, action: \.child))
         } header: {
           Text("iOS 17")
         }
@@ -57,7 +57,7 @@ struct OldContainsNewTestCase: View {
       case toggleIsObservingChildCount
     }
     var body: some ReducerOf<Self> {
-      Scope(state: \.child, action: \.child) {
+      Scope(\.child, action: \.child) {
         ObservableBasicsView.Feature()
       }
       Reduce { state, action in

--- a/Examples/Integration/Integration/iOS 16+17/OldPresentsNewTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16+17/OldPresentsNewTestCase.swift
@@ -38,7 +38,7 @@ struct OldPresentsNewTestCase: View {
         }
       }
     }
-    .sheet(store: self.store.scope(state: \.$child, action: \.child)) { store in
+    .sheet(store: self.store.scope(\.$child, action: \.child)) { store in
       Form {
         ObservableBasicsView(store: store)
       }

--- a/Examples/Integration/Integration/iOS 16/EnumTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16/EnumTestCase.swift
@@ -51,7 +51,7 @@ struct EnumView: View {
           }
         }
       }
-      IfLetStore(self.store.scope(state: \.$destination, action: \.destination)) { store in
+      IfLetStore(self.store.scope(\.$destination, action: \.destination)) { store in
         SwitchStore(store) {
           switch $0 {
           case .feature1:
@@ -101,10 +101,10 @@ struct EnumView: View {
         case feature2(BasicsView.Feature.Action)
       }
       var body: some ReducerOf<Self> {
-        Scope(state: \.feature1, action: \.feature1) {
+        Scope(\.feature1, action: \.feature1) {
           BasicsView.Feature()
         }
-        Scope(state: \.feature2, action: \.feature2) {
+        Scope(\.feature2, action: \.feature2) {
           BasicsView.Feature()
         }
       }

--- a/Examples/Integration/Integration/iOS 16/IdentifiedListTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16/IdentifiedListTestCase.swift
@@ -28,9 +28,9 @@ struct IdentifiedListView: View {
             }
           }
         }
-        ForEachStore(self.store.scope(state: \.rows, action: \.rows)) { store in
+        ForEachStore(self.store.scope(\.rows, action: \.rows)) { store in
           let _ = Logger.shared.log("\(Self.self).body.ForEachStore")
-          let idStore = store.scope(state: \.id, action: \.self)
+          let idStore = store.scope(\.id, action: \.self)
           WithViewStore(idStore, observe: { $0 }) { viewStore in
             let _ = Logger.shared.log("\(type(of: idStore))")
             Section {

--- a/Examples/Integration/Integration/iOS 16/NavigationTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16/NavigationTestCase.swift
@@ -7,7 +7,7 @@ struct NavigationTestCaseView: View {
   }
 
   var body: some View {
-    NavigationStackStore(self.store.scope(state: \.path, action: \.path)) {
+    NavigationStackStore(self.store.scope(\.path, action: \.path)) {
       NavigationLink(state: BasicsView.Feature.State()) {
         Text("Push feature")
       }

--- a/Examples/Integration/Integration/iOS 16/OptionalTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16/OptionalTestCase.swift
@@ -38,7 +38,7 @@ struct OptionalView: View {
         }
       }
     }
-    IfLetStore(self.store.scope(state: \.$child, action: \.child)) { store in
+    IfLetStore(self.store.scope(\.$child, action: \.child)) { store in
       Form {
         BasicsView(store: store)
       }

--- a/Examples/Integration/Integration/iOS 16/PresentationTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16/PresentationTestCase.swift
@@ -41,7 +41,7 @@ struct PresentationView: View {
     }
     .fullScreenCover(
       store: self.store.scope(
-        state: \.$destination.fullScreenCover, action: \.destination.fullScreenCover
+        \.$destination.fullScreenCover, action: \.destination.fullScreenCover
       )
     ) { store in
       NavigationStack {
@@ -59,7 +59,7 @@ struct PresentationView: View {
       }
     }
     .popover(
-      store: self.store.scope(state: \.$destination.popover, action: \.destination.popover)
+      store: self.store.scope(\.$destination.popover, action: \.destination.popover)
     ) { store in
       NavigationStack {
         Form {
@@ -75,7 +75,7 @@ struct PresentationView: View {
         }
       }
     }
-    .sheet(store: self.store.scope(state: \.$sheet, action: \.sheet)) { store in
+    .sheet(store: self.store.scope(\.$sheet, action: \.sheet)) { store in
       NavigationStack {
         Form {
           BasicsView(store: store)

--- a/Examples/Integration/Integration/iOS 16/SiblingTestCase.swift
+++ b/Examples/Integration/Integration/iOS 16/SiblingTestCase.swift
@@ -11,14 +11,14 @@ struct SiblingFeaturesView: View {
       Form {
         Section {
           BasicsView(
-            store: self.store.scope(state: \.child1, action: \.child1)
+            store: self.store.scope(\.child1, action: \.child1)
           )
         } header: {
           Text("Child 1")
         }
         Section {
           BasicsView(
-            store: self.store.scope(state: \.child2, action: \.child2)
+            store: self.store.scope(\.child2, action: \.child2)
           )
         } header: {
           Text("Child 2")
@@ -52,10 +52,10 @@ struct SiblingFeaturesView: View {
       case swapButtonTapped
     }
     var body: some ReducerOf<Self> {
-      Scope(state: \.child1, action: \.child1) {
+      Scope(\.child1, action: \.child1) {
         BasicsView.Feature()
       }
-      Scope(state: \.child2, action: \.child2) {
+      Scope(\.child2, action: \.child2) {
         BasicsView.Feature()
       }
       Reduce { state, action in

--- a/Examples/Integration/Integration/iOS 17/ObservableBindingLocalTest.swift
+++ b/Examples/Integration/Integration/iOS 17/ObservableBindingLocalTest.swift
@@ -90,7 +90,7 @@ struct ObservableBindingLocalTestCaseView: View {
 
   var body: some View {
     WithPerceptionTracking {
-      NavigationStack(path: self.$store.scope(state: \.path, action: \.path)) {
+      NavigationStack(path: self.$store.scope(\.path, action: \.path)) {
         VStack {
           Button("Full-screen-cover") {
             self.store.send(.fullScreenCoverButtonTapped)
@@ -107,19 +107,19 @@ struct ObservableBindingLocalTestCaseView: View {
           }
         }
         .fullScreenCover(
-          item: self.$store.scope(state: \.fullScreenCover, action: \.fullScreenCover)
+          item: self.$store.scope(\.fullScreenCover, action: \.fullScreenCover)
         ) { store in
           ChildView(store: store)
         }
         .navigationDestination(
-          store: self.store.scope(state: \.$navigationDestination, action: \.navigationDestination)
+          store: self.store.scope(\.$navigationDestination, action: \.navigationDestination)
         ) { store in
           ChildView(store: store)
         }
-        .popover(item: self.$store.scope(state: \.popover, action: \.popover)) { store in
+        .popover(item: self.$store.scope(\.popover, action: \.popover)) { store in
           ChildView(store: store)
         }
-        .sheet(item: self.$store.scope(state: \.sheet, action: \.sheet)) { store in
+        .sheet(item: self.$store.scope(\.sheet, action: \.sheet)) { store in
           ChildView(store: store)
         }
       } destination: { store in

--- a/Examples/Integration/Integration/iOS 17/ObservableEnumTestCase.swift
+++ b/Examples/Integration/Integration/iOS 17/ObservableEnumTestCase.swift
@@ -35,10 +35,10 @@ struct ObservableEnumView: View {
             }
           }
         }
-        if let store = self.store.scope(state: \.destination, action: \.destination.presented) {
+        if let store = self.store.scope(\.destination, action: \.destination.presented) {
           switch store.state {
           case .feature1:
-            if let store = store.scope(state: \.feature1, action: \.feature1) {
+            if let store = store.scope(\.feature1, action: \.feature1) {
               Section {
                 ObservableBasicsView(store: store)
               } header: {
@@ -46,7 +46,7 @@ struct ObservableEnumView: View {
               }
             }
           case .feature2:
-            if let store = store.scope(state: \.feature2, action: \.feature2) {
+            if let store = store.scope(\.feature2, action: \.feature2) {
               Section {
                 ObservableBasicsView(store: store)
               } header: {

--- a/Examples/Integration/Integration/iOS 17/ObservableIdentifiedListTestCase.swift
+++ b/Examples/Integration/Integration/iOS 17/ObservableIdentifiedListTestCase.swift
@@ -21,7 +21,7 @@ struct ObservableIdentifiedListView: View {
             }
           }
         }
-        ForEach(self.store.scope(state: \.rows, action: \.rows)) { store in
+        ForEach(self.store.scope(\.rows, action: \.rows)) { store in
           let _ = Logger.shared.log("\(Self.self).body.ForEach")
           Section {
             HStack {

--- a/Examples/Integration/Integration/iOS 17/ObservableNavigationTestCase.swift
+++ b/Examples/Integration/Integration/iOS 17/ObservableNavigationTestCase.swift
@@ -8,7 +8,7 @@ struct ObservableNavigationTestCaseView: View {
 
   var body: some View {
     WithPerceptionTracking {
-      NavigationStack(path: self.$store.scope(state: \.path, action: \.path)) {
+      NavigationStack(path: self.$store.scope(\.path, action: \.path)) {
         NavigationLink(state: ObservableBasicsView.Feature.State()) {
           Text("Push feature")
         }

--- a/Examples/Integration/Integration/iOS 17/ObservableOptionalTestCase.swift
+++ b/Examples/Integration/Integration/iOS 17/ObservableOptionalTestCase.swift
@@ -26,7 +26,7 @@ struct ObservableOptionalView: View {
           }
         }
       }
-      if let store = self.store.scope(state: \.child, action: \.child.presented) {
+      if let store = self.store.scope(\.child, action: \.child.presented) {
         Form {
           ObservableBasicsView(store: store)
         }

--- a/Examples/Integration/Integration/iOS 17/ObservablePresentationTestCase.swift
+++ b/Examples/Integration/Integration/iOS 17/ObservablePresentationTestCase.swift
@@ -33,7 +33,7 @@ struct ObservablePresentationView: View {
       }
       .fullScreenCover(
         item: self.$store.scope(
-          state: \.destination?.fullScreenCover,
+          \.destination?.fullScreenCover,
           action: \.destination.fullScreenCover
         )
       ) { store in
@@ -52,7 +52,7 @@ struct ObservablePresentationView: View {
         }
       }
       .popover(
-        item: self.$store.scope(state: \.destination?.popover, action: \.destination.popover)
+        item: self.$store.scope(\.destination?.popover, action: \.destination.popover)
       ) { store in
         NavigationStack {
           Form {
@@ -68,7 +68,7 @@ struct ObservablePresentationView: View {
           }
         }
       }
-      .sheet(item: self.$store.scope(state: \.sheet, action: \.sheet)) { store in
+      .sheet(item: self.$store.scope(\.sheet, action: \.sheet)) { store in
         NavigationStack {
           Form {
             ObservableBasicsView(store: store)

--- a/Examples/Integration/Integration/iOS 17/ObservableSiblingTestCase.swift
+++ b/Examples/Integration/Integration/iOS 17/ObservableSiblingTestCase.swift
@@ -13,14 +13,14 @@ struct ObservableSiblingFeaturesView: View {
         Form {
           Section {
             ObservableBasicsView(
-              store: self.store.scope(state: \.child1, action: \.child1)
+              store: self.store.scope(\.child1, action: \.child1)
             )
           } header: {
             Text("Child 1")
           }
           Section {
             ObservableBasicsView(
-              store: self.store.scope(state: \.child2, action: \.child2)
+              store: self.store.scope(\.child2, action: \.child2)
             )
           } header: {
             Text("Child 2")
@@ -61,10 +61,10 @@ struct ObservableSiblingFeaturesView: View {
       case swapButtonTapped
     }
     var body: some ReducerOf<Self> {
-      Scope(state: \.child1, action: \.child1) {
+      Scope(\.child1, action: \.child1) {
         ObservableBasicsView.Feature()
       }
-      Scope(state: \.child2, action: \.child2) {
+      Scope(\.child2, action: \.child2) {
         ObservableBasicsView.Feature()
       }
       Reduce { state, action in

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
@@ -148,7 +148,7 @@ struct SpeechRecognitionView: View {
       }
     }
     .padding()
-    .alert($store.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(\.alert, action: \.alert))
   }
 }
 

--- a/Examples/SyncUps/SyncUps/AppFeature.swift
+++ b/Examples/SyncUps/SyncUps/AppFeature.swift
@@ -25,7 +25,7 @@ struct AppFeature {
   @Dependency(\.uuid) var uuid
 
   var body: some ReducerOf<Self> {
-    Scope(state: \.syncUpsList, action: \.syncUpsList) {
+    Scope(\.syncUpsList, action: \.syncUpsList) {
       SyncUpsList()
     }
     Reduce { state, action in
@@ -53,8 +53,8 @@ struct AppView: View {
   @Bindable var store: StoreOf<AppFeature>
 
   var body: some View {
-    NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
-      SyncUpsListView(store: store.scope(state: \.syncUpsList, action: \.syncUpsList))
+    NavigationStack(path: $store.scope(\.path, action: \.path)) {
+      SyncUpsListView(store: store.scope(\.syncUpsList, action: \.syncUpsList))
     } destination: { store in
       switch store.case {
       case .detail(let store):

--- a/Examples/SyncUps/SyncUps/RecordMeeting.swift
+++ b/Examples/SyncUps/SyncUps/RecordMeeting.swift
@@ -189,7 +189,7 @@ struct RecordMeetingView: View {
       }
     }
     .navigationBarBackButtonHidden(true)
-    .alert($store.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(\.alert, action: \.alert))
     .task { await store.send(.onTask).finish() }
   }
 }

--- a/Examples/SyncUps/SyncUps/SyncUpDetail.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpDetail.swift
@@ -192,9 +192,9 @@ struct SyncUpDetailView: View {
       }
     }
     .navigationTitle(store.syncUp.title)
-    .alert($store.scope(state: \.$destination, action: \.destination).alert)
+    .alert($store.scope(\.$destination, action: \.destination).alert)
     .sheet(
-      item: $store.scope(state: \.$destination, action: \.destination).edit
+      item: $store.scope(\.$destination, action: \.destination).edit
     ) { editSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: editSyncUpStore)

--- a/Examples/SyncUps/SyncUps/SyncUpsList.swift
+++ b/Examples/SyncUps/SyncUps/SyncUpsList.swift
@@ -99,7 +99,7 @@ struct SyncUpsListView: View {
     }
     .navigationTitle("Daily Sync-ups")
     .sheet(
-      item: $store.scope(state: \.destination?.add, action: \.destination.add)
+      item: $store.scope(\.destination?.add, action: \.destination.add)
     ) { addSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: addSyncUpStore)

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -53,8 +53,8 @@ public struct LoginView: View {
       .disabled(store.isLoginButtonDisabled)
     }
     .disabled(store.isFormDisabled)
-    .alert($store.scope(state: \.alert, action: \.alert))
-    .navigationDestination(item: $store.scope(state: \.twoFactor, action: \.twoFactor)) { store in
+    .alert($store.scope(\.alert, action: \.alert))
+    .navigationDestination(item: $store.scope(\.twoFactor, action: \.twoFactor)) { store in
       TwoFactorView(store: store)
     }
     .navigationTitle("Login")

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginUIKit/LoginViewController.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginUIKit/LoginViewController.swift
@@ -91,11 +91,11 @@ public class LoginViewController: UIViewController {
       activityIndicator.isHidden = store.isActivityIndicatorHidden
     }
 
-    present(item: $store.scope(state: \.alert, action: \.alert)) { store in
+    present(item: $store.scope(\.alert, action: \.alert)) { store in
       UIAlertController(store: store)
     }
 
-    navigationDestination(item: $store.scope(state: \.twoFactor, action: \.twoFactor)) { store in
+    navigationDestination(item: $store.scope(\.twoFactor, action: \.twoFactor)) { store in
       TwoFactorViewController(store: store)
     }
   }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
@@ -38,7 +38,7 @@ public struct NewGameView: View {
     }
     .navigationTitle("New Game")
     .navigationBarItems(trailing: Button("Logout") { store.send(.logoutButtonTapped) })
-    .navigationDestination(item: $store.scope(state: \.game, action: \.game)) { store in
+    .navigationDestination(item: $store.scope(\.game, action: \.game)) { store in
       GameView(store: store)
     }
   }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/NewGameUIKit/NewGameViewController.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/NewGameUIKit/NewGameViewController.swift
@@ -85,7 +85,7 @@ public class NewGameViewController: UIViewController {
       letsPlayButton.isEnabled = store.isLetsPlayButtonEnabled
     }
 
-    navigationDestination(item: $store.scope(state: \.game, action: \.game)) { store in
+    navigationDestination(item: $store.scope(\.game, action: \.game)) { store in
       GameViewController(store: store)
     }
   }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
@@ -39,7 +39,7 @@ public struct TwoFactorView: View {
         }
       }
     }
-    .alert($store.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(\.alert, action: \.alert))
     .disabled(store.isFormDisabled)
     .navigationTitle("Confirmation Code")
   }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorUIKit/TwoFactorViewController.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorUIKit/TwoFactorViewController.swift
@@ -64,7 +64,7 @@ public final class TwoFactorViewController: UIViewController {
       loginButton.isEnabled = store.isLoginButtonEnabled
     }
 
-    present(item: $store.scope(state: \.alert, action: \.alert)) { store in
+    present(item: $store.scope(\.alert, action: \.alert)) { store in
       UIAlertController(store: store)
     }
   }

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -117,7 +117,7 @@ struct AppView: View {
         .padding(.horizontal)
 
         List {
-          ForEach(store.scope(state: \.filteredTodos, action: \.todos)) { store in
+          ForEach(store.scope(\.filteredTodos, action: \.todos)) { store in
             TodoView(store: store)
           }
           .onDelete { store.send(.delete($0)) }

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -139,7 +139,7 @@ struct VoiceMemosView: View {
     NavigationStack {
       VStack {
         List {
-          ForEach(store.scope(state: \.voiceMemos, action: \.voiceMemos)) { store in
+          ForEach(store.scope(\.voiceMemos, action: \.voiceMemos)) { store in
             VoiceMemoView(store: store)
           }
           .onDelete { store.send(.onDelete($0)) }
@@ -147,7 +147,7 @@ struct VoiceMemosView: View {
 
         Group {
           if let store = store.scope(
-            state: \.recordingMemo, action: \.recordingMemo.presented
+            \.recordingMemo, action: \.recordingMemo.presented
           ) {
             RecordingMemoView(store: store)
           } else {
@@ -162,7 +162,7 @@ struct VoiceMemosView: View {
         .frame(maxWidth: .infinity)
         .background(Color.init(white: 0.95))
       }
-      .alert($store.scope(state: \.alert, action: \.alert))
+      .alert($store.scope(\.alert, action: \.alert))
       .navigationTitle("Voice memos")
     }
   }

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/ObservationBackport.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/ObservationBackport.md
@@ -94,7 +94,7 @@ This means that even if you wrap the body of the view in `WithPerceptionTracking
 
 ```swift
 WithPerceptionTracking {
-  ForEach(store.scope(state: \.rows, action: \.rows), id: \.state.id) { store in
+  ForEach(store.scope(\.rows, action: \.rows), id: \.state.id) { store in
     Text(store.title)
   }
 }
@@ -107,7 +107,7 @@ The fix for this is to wrap the content of the trailing closure in another `With
 
 ```swift
 WithPerceptionTracking {
-  ForEach(store.scope(state: \.rows, action: \.rows), id: \.state.id) { store in
+  ForEach(store.scope(\.rows, action: \.rows), id: \.state.id) { store in
     WithPerceptionTracking {
       Text(store.title)
     }

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -326,8 +326,8 @@ This way an action is only sent once the user stops moving the slider.
 
 ### Store scoping
 
-In the 1.5.6 release of the library a change was made to ``Store/scope(state:action:)-90255`` that
-made it more sensitive to performance considerations.
+In the 1.5.6 release of the library a change was made to ``Store/scope(_:action:)`` that made it
+more sensitive to performance considerations.
 
 The most common form of scoping, that of scoping directly along boundaries of child features, is
 the most performant form of scoping and is the intended use of scoping. The library is slowly 
@@ -338,7 +338,7 @@ child view:
 
 ```swift
 ChildView(
-  store: store.scope(state: \.child, action: \.child)
+  store: store.scope(\.child, action: \.child)
 )
 ```
 
@@ -347,7 +347,7 @@ such as ``SwiftUI/View/sheet(store:onDismiss:content:)``, also falls under the i
 use of scope:
 
 ```swift
-.sheet(store: store.scope(state: \.child, action: \.child)) { store in
+.sheet(store: store.scope(\.child, action: \.child)) { store in
   ChildView(store: store)
 }
 ```
@@ -373,7 +373,7 @@ And then in the view, say you scoped along that computed property:
 
 ```swift
 ChildView(
-  store: store.scope(state: \.computedChild, action: \.child)
+  store: store.scope(\.computedChild, action: \.child)
 )
 ```
 
@@ -391,9 +391,8 @@ using computed properties in scopes. You can even put a `print` statement in the
 so that you can see first hand just how many times it is being invoked while running your 
 application.
 
-To fix the problem we recommend using ``Store/scope(state:action:)-90255`` only along stored 
-properties of child features. Such key paths are simple getters, and so not have a problem with
-performance. If you are using a computed property in a scope, then reconsider if that could instead
-be done along a plain, stored property and moving the computed logic into the child view. The 
-further you push the computation towards the leaf nodes of your application, the less performance
-problems you will see.
+To fix the problem we recommend using ``Store/scope(_:action:)`` only along stored properties of
+child features. Such key paths are simple getters, and so not have a problem with performance. If
+you are using a computed property in a scope, then reconsider if that could instead be done along a
+plain, stored property and moving the computed logic into the child view. The further you push the
+computation towards the leaf nodes of your application, the less performance problems you will see.

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
@@ -120,7 +120,7 @@ struct RootView: View {
 
   var body: some View {
     NavigationStack(
-      path: $store.scope(state: \.path, action: \.path)
+      path: $store.scope(\.path, action: \.path)
     ) {
       // Root view of the navigation stack
     } destination: { store in
@@ -407,7 +407,7 @@ struct Feature {
     enum State: Equatable { case counter(CounterFeature.State) }
     enum Action { case counter(CounterFeature.Action) }
     var body: some ReducerOf<Self> {
-      Scope(state: \.counter, action: \.counter) { CounterFeature() }
+      Scope(\.counter, action: \.counter) { CounterFeature() }
     }
   }
 
@@ -670,7 +670,7 @@ class AppController: NavigationStackController {
   convenience init(store: StoreOf<AppFeature>) {
     @UIBindable var store = store
 
-    self.init(path: $store.scope(state: \.path, action: \.path)) {
+    self.init(path: $store.scope(\.path, action: \.path)) {
       RootViewController(store: store)
     } destination: { store in 
       switch store.case {

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
@@ -106,7 +106,7 @@ struct InventoryView: View {
       // ...
     }
     .sheet(
-      item: $store.scope(state: \.addItem, action: \.addItem)
+      item: $store.scope(\.addItem, action: \.addItem)
     ) { store in
       ItemFormView(store: store)
     }
@@ -115,7 +115,7 @@ struct InventoryView: View {
 ```
 
 > Note: We use SwiftUI's `@Bindable` property wrapper to produce a binding to a store, which can be
-> further scoped using ``SwiftUI/Binding/scope(state:action:fileID:filePath:line:column:)``.
+> further scoped using ``SwiftUI/Binding/scope(_:action:fileID:filePath:line:column:)``.
 
 With those few steps completed the domains and views of the parent and child features are now
 integrated together, and when the `addItem` state flips to a non-`nil` value the sheet will be
@@ -276,7 +276,8 @@ struct InventoryView: View {
 ```
 
 And then in the `body` of the view you can use the
-``SwiftUI/Binding/scope(state:action:fileID:filePath:line:column:)`` operator to derive bindings from `$store`:
+``SwiftUI/Binding/scope(_:action:fileID:filePath:line:column:)`` operator to derive bindings from
+`$store`:
 
 ```swift
 var body: some View {
@@ -284,17 +285,17 @@ var body: some View {
     // ...
   }
   .sheet(
-    item: $store.scope(state: \.destination, action: \.destination).addItem
+    item: $store.scope(\.destination, action: \.destination).addItem
   ) { store in 
     AddFeatureView(store: store)
   }
   .popover(
-    item: $store.scope(state: \.destination, action: \.destination).editItem
+    item: $store.scope(\.destination, action: \.destination).editItem
   ) { store in 
     EditFeatureView(store: store)
   }
   .navigationDestination(
-    item: $store.scope(state: \.destination, action: \.destination).detailItem
+    item: $store.scope(\.destination, action: \.destination).detailItem
   ) { store in 
     DetailFeatureView(store: store)
   }
@@ -311,8 +312,8 @@ drill-down will occur immediately.
 One of the best features of tree-based navigation is that it unifies all forms of navigation with a
 single style of API. First of all, regardless of the type of navigation you plan on performing,
 integrating the parent and child features together can be done with the single
-``Reducer/ifLet(_:action:destination:fileID:filePath:line:column:)-4ub6q`` operator. This one single API services
-all forms of optional-driven navigation.
+``Reducer/ifLet(_:action:destination:fileID:filePath:line:column:)-4ub6q`` operator. This one single
+API services all forms of optional-driven navigation.
 
 And then in the view, whether you are wanting to perform a drill-down, show a sheet, display
 an alert, or even show a custom navigation component, all you need to do is invoke an API that
@@ -326,25 +327,25 @@ forms of navigation could be as simple as this:
 
 ```swift
 .sheet(
-  item: $store.scope(state: \.addItem, action: \.addItem)
+  item: $store.scope(\.addItem, action: \.addItem)
 ) { store in 
   AddFeatureView(store: store)
 }
 .popover(
-  item: $store.scope(state: \.editItem, action: \.editItem)
+  item: $store.scope(\.editItem, action: \.editItem)
 ) { store in 
   EditFeatureView(store: store)
 }
 .navigationDestination(
-  item: $store.scope(state: \.detailItem, action: \.detailItem)
+  item: $store.scope(\.detailItem, action: \.detailItem)
 ) { store in 
   DetailFeatureView(store: store)
 }
 .alert(
-  $store.scope(state: \.alert, action: \.alert)
+  $store.scope(\.alert, action: \.alert)
 )
 .confirmationDialog(
-  $store.scope(state: \.confirmationDialog, action: \.confirmationDialog)
+  $store.scope(\.confirmationDialog, action: \.confirmationDialog)
 )
 ```
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Reducer.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Reducer.md
@@ -214,13 +214,13 @@ enum of options:
 
 ```swift
 .sheet(
-  item: $store.scope(state: \.destination?.editForm, action: \.destination.editForm)
+  item: $store.scope(\.destination?.editForm, action: \.destination.editForm)
 ) { store in
   FormView(store: store)
 }
 ```
 
-The syntax `state: \.destination?.editForm` is only possible due to both `@dynamicMemberLookup` and
+The syntax `\.destination?.editForm` is only possible due to both `@dynamicMemberLookup` and
 `@CasePathable` being applied to the `State` enum.
 
 ### Automatic fulfillment of reducer requirements
@@ -268,13 +268,13 @@ struct Destination {
     case edit(EditFeature.Action)
   }
   var body: some ReducerOf<Self> {
-    Scope(state: \.add, action: \.add) {
+    Scope(\.add, action: \.add) {
       FormFeature()
     }
-    Scope(state: \.detail, action: \.detail) {
+    Scope(\.detail, action: \.detail) {
       DetailFeature()
     }
-    Scope(state: \.edit, action: \.edit) {
+    Scope(\.edit, action: \.edit) {
       EditFeature()
     }
   }
@@ -333,7 +333,7 @@ In the last trailing closure you can use the ``Store/case`` computed property to
 `Path.State` enum and extract out a store for each case:
 
 ```swift
-NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
+NavigationStack(path: $store.scope(\.path, action: \.path)) {
   // Root view
 } destination: { store in
   switch store.case {
@@ -377,7 +377,7 @@ reason we have to ignore it from some of `@Reducer`'s macro expansion.
 Then, to present a view from this case one can do:
 
 ```swift
-.sheet(item: $store.scope(state: \.destination?.item, action: \.destination.item)) { store in
+.sheet(item: $store.scope(\.destination?.item, action: \.destination.item)) { store in
   ItemView(item: store.withState { $0 })
 }
 ```

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Store.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Store.md
@@ -22,9 +22,8 @@
 
 ### Scoping stores
 
-- ``scope(state:action:)-90255``
-- ``scope(state:action:fileID:filePath:line:column:)-3yvuf``
-- ``scope(state:action:fileID:filePath:line:column:)-2ym6k``
+- ``scope(_:action:)``
+- ``scope(_:action:fileID:filePath:line:column:)``
 - ``case``
 
 ### Scoping store bindings

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwiftUIBinding.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwiftUIBinding.md
@@ -15,5 +15,5 @@ controls and drive navigation.
 
 ### Navigation bindings
 
-- ``SwiftUI/Binding/scope(state:action:fileID:filePath:line:column:)``
-- ``SwiftUI/Binding/scope(state:action:)-35r82``
+- ``SwiftUI/Binding/scope(_:action:fileID:filePath:line:column:)``
+- ``SwiftUI/Binding/scope(_:action:)``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwiftUIBindingScopeForEach.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwiftUIBindingScopeForEach.md
@@ -1,8 +1,8 @@
-# ``SwiftUI/Binding/scope(state:action:)-35r82``
+# ``SwiftUI/Binding/scope(_:action:)``
 
 ## Topics
 
 ### Bindable
 
-- ``SwiftUI/Bindable/scope(state:action:)``
-- ``Perception/Bindable/scope(state:action:)``
+- ``SwiftUI/Bindable/scope(_:action:)``
+- ``Perception/Bindable/scope(_:action:)``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwiftUIBindingScopeIfLet.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwiftUIBindingScopeIfLet.md
@@ -1,8 +1,8 @@
-# ``SwiftUI/Binding/scope(state:action:fileID:filePath:line:column:)``
+# ``SwiftUI/Binding/scope(_:action:fileID:filePath:line:column:)``
 
 ## Topics
 
 ### Bindable
 
-- ``SwiftUI/Bindable/scope(state:action:fileID:line:)``
-- ``Perception/Bindable/scope(state:action:fileID:line:)``
+- ``SwiftUI/Bindable/scope(_:action:fileID:line:)``
+- ``Perception/Bindable/scope(_:action:fileID:line:)``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwiftUIIntegration.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/SwiftUIIntegration.md
@@ -19,11 +19,11 @@ designed with SwiftUI in mind, and comes with many powerful tools to integrate i
 
 ### Presentation
 
-- ``SwiftUI/Binding/scope(state:action:fileID:filePath:line:column:)``
+- ``SwiftUI/Binding/scope(_:action:fileID:filePath:line:column:)``
 
 ### Navigation stacks and links
 
-- ``SwiftUI/Binding/scope(state:action:)-35r82``
+- ``SwiftUI/Binding/scope(_:action:)-35r82``
 - ``SwiftUI/NavigationStack/init(path:root:destination:fileID:filePath:line:column:)``
 - ``SwiftUI/NavigationLink/init(state:label:fileID:filePath:line:column:)``
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-02-code-0003.swift
@@ -20,7 +20,7 @@ struct SyncUpsListView: View {
         .listRowBackground(syncUp.theme.mainColor)
       }
     }
-    .sheet(item: $store.scope(state: \.addSyncUp, action: \.addSyncUp)) { addSyncUpStore in
+    .sheet(item: $store.scope(\.addSyncUp, action: \.addSyncUp)) { addSyncUpStore in
       SyncUpFormView(store: addSyncUpStore)
     }
     .toolbar {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-03-code-0001-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-03-code-0001-previous.swift
@@ -20,7 +20,7 @@ struct SyncUpsListView: View {
         .listRowBackground(syncUp.theme.mainColor)
       }
     }
-    .sheet(item: $store.scope(state: \.addSyncUp, action: \.addSyncUp)) { addSyncUpStore in
+    .sheet(item: $store.scope(\.addSyncUp, action: \.addSyncUp)) { addSyncUpStore in
       SyncUpFormView(store: addSyncUpStore)
     }
     .toolbar {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-03-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-03-code-0001.swift
@@ -20,7 +20,7 @@ struct SyncUpsListView: View {
         .listRowBackground(syncUp.theme.mainColor)
       }
     }
-    .sheet(item: $store.scope(state: \.addSyncUp, action: \.addSyncUp)) { addSyncUpStore in
+    .sheet(item: $store.scope(\.addSyncUp, action: \.addSyncUp)) { addSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: addSyncUpStore)
           .navigationTitle("New sync-up")

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-03-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm-03-code-0002.swift
@@ -20,7 +20,7 @@ struct SyncUpsListView: View {
         .listRowBackground(syncUp.theme.mainColor)
       }
     }
-    .sheet(item: $store.scope(state: \.addSyncUp, action: \.addSyncUp)) { addSyncUpStore in
+    .sheet(item: $store.scope(\.addSyncUp, action: \.addSyncUp)) { addSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: addSyncUpStore)
           .navigationTitle("New sync-up")

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/04-PresentingSyncUpForm/PresentingSyncUpForm.tutorial
@@ -112,7 +112,7 @@
       
       Luckily the library comes with the tools necessary. Just as there is a scoping operation on
       stores for focusing on sub-domains of a parent domain, there is also a scope on _bindings_ of
-      stores for doing the same: ``SwiftUI/Binding/scope(state:action:fileID:filePath:line:column:)``. This tool can
+      stores for doing the same: ``SwiftUI/Binding/scope(_:action:fileID:filePath:line:column:)``. This tool can
       be used to derive a binding that is appropriate to pass to `sheet(item:)`.
       
       @Step {
@@ -127,7 +127,7 @@
       }
       
       @Step {
-        Use the ``SwiftUI/Binding/scope(state:action:fileID:filePath:line:column:)`` operator on `$store` to focus
+        Use the ``SwiftUI/Binding/scope(_:action:fileID:filePath:line:column:)`` operator on `$store` to focus
         the binding to the presentation domain of the `SyncUpForm`. The `sheet(item:)` modifier will
         hand the trailing closure a `StoreOf<SyncUpForm>`, and that is exactly what can be handed to
         the `SyncUpFormView`.

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-01-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-01-code-0006.swift
@@ -75,7 +75,7 @@ struct SyncUpDetailView: View {
         store.send(.editButtonTapped)
       }
     }
-    .sheet(item: $store.scope(state: \.editSyncUp, action: \.editSyncUp)) { editSyncUpStore in
+    .sheet(item: $store.scope(\.editSyncUp, action: \.editSyncUp)) { editSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: editSyncUpStore)
       }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-01-code-0007.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-01-code-0007.swift
@@ -75,7 +75,7 @@ struct SyncUpDetailView: View {
         store.send(.editButtonTapped)
       }
     }
-    .sheet(item: $store.scope(state: \.editSyncUp, action: \.editSyncUp)) { editSyncUpStore in
+    .sheet(item: $store.scope(\.editSyncUp, action: \.editSyncUp)) { editSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: editSyncUpStore)
           .navigationTitle(store.syncUp.title)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-01-code-0008.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-01-code-0008.swift
@@ -75,7 +75,7 @@ struct SyncUpDetailView: View {
         store.send(.editButtonTapped)
       }
     }
-    .sheet(item: $store.scope(state: \.editSyncUp, action: \.editSyncUp)) { editSyncUpStore in
+    .sheet(item: $store.scope(\.editSyncUp, action: \.editSyncUp)) { editSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: editSyncUpStore)
           .navigationTitle(store.syncUp.title)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-02-code-0014-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-02-code-0014-previous.swift
@@ -76,7 +76,7 @@ struct SyncUpDetailView: View {
         store.send(.editButtonTapped)
       }
     }
-    .sheet(item: $store.scope(state: \.editSyncUp, action: \.editSyncUp)) { editSyncUpStore in
+    .sheet(item: $store.scope(\.editSyncUp, action: \.editSyncUp)) { editSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: editSyncUpStore)
           .navigationTitle(store.syncUp.title)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-02-code-0014.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-02-code-0014.swift
@@ -76,8 +76,8 @@ struct SyncUpDetailView: View {
         store.send(.editButtonTapped)
       }
     }
-    .alert($store.scope(state: \.alert, action: \.alert))
-    .sheet(item: $store.scope(state: \.editSyncUp, action: \.editSyncUp)) { editSyncUpStore in
+    .alert($store.scope(\.alert, action: \.alert))
+    .sheet(item: $store.scope(\.editSyncUp, action: \.editSyncUp)) { editSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: editSyncUpStore)
           .navigationTitle(store.syncUp.title)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-03-code-0013-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-03-code-0013-previous.swift
@@ -76,8 +76,8 @@ struct SyncUpDetailView: View {
         store.send(.editButtonTapped)
       }
     }
-    .alert($store.scope(state: \.alert, action: \.alert))
-    .sheet(item: $store.scope(state: \.editSyncUp, action: \.editSyncUp)) { editSyncUpStore in
+    .alert($store.scope(\.alert, action: \.alert))
+    .sheet(item: $store.scope(\.editSyncUp, action: \.editSyncUp)) { editSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: editSyncUpStore)
           .navigationTitle(store.syncUp.title)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-03-code-0013.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp-03-code-0013.swift
@@ -76,9 +76,9 @@ struct SyncUpDetailView: View {
       }
     }
     .navigationTitle(Text(store.syncUp.title))
-    .alert($store.scope(state: \.$destination, action: \.destination).alert)
+    .alert($store.scope(\.$destination, action: \.destination).alert)
     .sheet(
-      item: $store.scope(state: \.$destination, action: \.destination).edit
+      item: $store.scope(\.$destination, action: \.destination).edit
     ) { editSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: editSyncUpStore)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/06-SyncUpDetail/EditingAndDeletingSyncUp.tutorial
@@ -71,7 +71,7 @@
       
       @Step {
         At the very bottom of the view use the `sheet(item:)` modifier by deriving a binding to the 
-        `SyncUpForm` domain using ``SwiftUI/Binding/scope(state:action:fileID:filePath:line:column:)``.
+        `SyncUpForm` domain using ``SwiftUI/Binding/scope(_:action:fileID:filePath:line:column:)``.
         
         @Code(name: "SyncUpDetail.swift", file: EditingAndDeletingSyncUp-01-code-0006.swift)
       }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/MeetingNavigation-02-code-0003-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/MeetingNavigation-02-code-0003-previous.swift
@@ -11,10 +11,10 @@ struct AppView: View {
 
   var body: some View {
     NavigationStack(
-      path: $store.scope(state: \.path, action: \.path)
+      path: $store.scope(\.path, action: \.path)
     ) {
       SyncUpsListView(
-        store: store.scope(state: \.syncUpsList, action: \.syncUpsList)
+        store: store.scope(\.syncUpsList, action: \.syncUpsList)
       )
     } destination: { store in
       switch store.case {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/MeetingNavigation-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/MeetingNavigation-02-code-0003.swift
@@ -11,10 +11,10 @@ struct AppView: View {
 
   var body: some View {
     NavigationStack(
-      path: $store.scope(state: \.path, action: \.path)
+      path: $store.scope(\.path, action: \.path)
     ) {
       SyncUpsListView(
-        store: store.scope(state: \.syncUpsList, action: \.syncUpsList)
+        store: store.scope(\.syncUpsList, action: \.syncUpsList)
       )
     } destination: { store in
       switch store.case {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/MeetingNavigation-02-code-0004-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/MeetingNavigation-02-code-0004-previous.swift
@@ -76,9 +76,9 @@ struct SyncUpDetailView: View {
         store.send(.editButtonTapped)
       }
     }
-    .alert($store.scope(state: \.$destination, action: \.destination).alert)
+    .alert($store.scope(\.$destination, action: \.destination).alert)
     .sheet(
-      item: $store.scope(state: \.$destination, action: \.destination).edit
+      item: $store.scope(\.$destination, action: \.destination).edit
     ) { editSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: editSyncUpStore)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/MeetingNavigation-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/MeetingNavigation-02-code-0004.swift
@@ -77,9 +77,9 @@ struct SyncUpDetailView: View {
         store.send(.editButtonTapped)
       }
     }
-    .alert($store.scope(state: \.$destination, action: \.destination).alert)
+    .alert($store.scope(\.$destination, action: \.destination).alert)
     .sheet(
-      item: $store.scope(state: \.$destination, action: \.destination).edit
+      item: $store.scope(\.$destination, action: \.destination).edit
     ) { editSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: editSyncUpStore)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-01-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-01-code-0002.swift
@@ -11,7 +11,7 @@ struct AppFeature {
     case syncUpsList(SyncUpsList.Action)
   }
   var body: some ReducerOf<Self> {
-    Scope(state: \.syncUpsList, action: \.syncUpsList) {
+    Scope(\.syncUpsList, action: \.syncUpsList) {
       SyncUpsList()
     }
     Reduce { state, action in

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-01-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-01-code-0003.swift
@@ -12,7 +12,7 @@ struct AppFeature {
     case syncUpsList(SyncUpsList.Action)
   }
   var body: some ReducerOf<Self> {
-    Scope(state: \.syncUpsList, action: \.syncUpsList) {
+    Scope(\.syncUpsList, action: \.syncUpsList) {
       SyncUpsList()
     }
     Reduce { state, action in

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-01-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-01-code-0004.swift
@@ -15,7 +15,7 @@ struct AppFeature {
     case syncUpsList(SyncUpsList.Action)
   }
   var body: some ReducerOf<Self> {
-    Scope(state: \.syncUpsList, action: \.syncUpsList) {
+    Scope(\.syncUpsList, action: \.syncUpsList) {
       SyncUpsList()
     }
     Reduce { state, action in

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-01-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-01-code-0005.swift
@@ -16,7 +16,7 @@ struct AppFeature {
     case syncUpsList(SyncUpsList.Action)
   }
   var body: some ReducerOf<Self> {
-    Scope(state: \.syncUpsList, action: \.syncUpsList) {
+    Scope(\.syncUpsList, action: \.syncUpsList) {
       SyncUpsList()
     }
     Reduce { state, action in

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-01-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-01-code-0006.swift
@@ -16,7 +16,7 @@ struct AppFeature {
     case syncUpsList(SyncUpsList.Action)
   }
   var body: some ReducerOf<Self> {
-    Scope(state: \.syncUpsList, action: \.syncUpsList) {
+    Scope(\.syncUpsList, action: \.syncUpsList) {
       SyncUpsList()
     }
     Reduce { state, action in

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-01-code-0007.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-01-code-0007.swift
@@ -17,7 +17,7 @@ struct AppFeature {
     case syncUpsList(SyncUpsList.Action)
   }
   var body: some ReducerOf<Self> {
-    Scope(state: \.syncUpsList, action: \.syncUpsList) {
+    Scope(\.syncUpsList, action: \.syncUpsList) {
       SyncUpsList()
     }
     Reduce { state, action in

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-01-code-0008.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-01-code-0008.swift
@@ -17,7 +17,7 @@ struct AppFeature {
     case syncUpsList(SyncUpsList.Action)
   }
   var body: some ReducerOf<Self> {
-    Scope(state: \.syncUpsList, action: \.syncUpsList) {
+    Scope(\.syncUpsList, action: \.syncUpsList) {
       SyncUpsList()
     }
     Reduce { state, action in

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-02-code-0003.swift
@@ -11,7 +11,7 @@ struct AppView: View {
 
   var body: some View {
     NavigationStack(
-      path: $store.scope(state: \.path, action: \.path)
+      path: $store.scope(\.path, action: \.path)
     ) {
 
     } destination: { store in

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-02-code-0004.swift
@@ -11,10 +11,10 @@ struct AppView: View {
 
   var body: some View {
     NavigationStack(
-      path: $store.scope(state: \.path, action: \.path)
+      path: $store.scope(\.path, action: \.path)
     ) {
       SyncUpsListView(
-        store: store.scope(state: \.syncUpsList, action: \.syncUpsList)
+        store: store.scope(\.syncUpsList, action: \.syncUpsList)
       )
     } destination: { store in
       

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-02-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-02-code-0005.swift
@@ -11,10 +11,10 @@ struct AppView: View {
 
   var body: some View {
     NavigationStack(
-      path: $store.scope(state: \.path, action: \.path)
+      path: $store.scope(\.path, action: \.path)
     ) {
       SyncUpsListView(
-        store: store.scope(state: \.syncUpsList, action: \.syncUpsList)
+        store: store.scope(\.syncUpsList, action: \.syncUpsList)
       )
     } destination: { store in
       switch store.case {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-02-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-02-code-0006.swift
@@ -11,10 +11,10 @@ struct AppView: View {
 
   var body: some View {
     NavigationStack(
-      path: $store.scope(state: \.path, action: \.path)
+      path: $store.scope(\.path, action: \.path)
     ) {
       SyncUpsListView(
-        store: store.scope(state: \.syncUpsList, action: \.syncUpsList)
+        store: store.scope(\.syncUpsList, action: \.syncUpsList)
       )
     } destination: { store in
       switch store.case {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-02-code-0007.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-02-code-0007.swift
@@ -11,10 +11,10 @@ struct AppView: View {
 
   var body: some View {
     NavigationStack(
-      path: $store.scope(state: \.path, action: \.path)
+      path: $store.scope(\.path, action: \.path)
     ) {
       SyncUpsListView(
-        store: store.scope(state: \.syncUpsList, action: \.syncUpsList)
+        store: store.scope(\.syncUpsList, action: \.syncUpsList)
       )
     } destination: { store in
       switch store.case {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0001-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0001-previous.swift
@@ -20,7 +20,7 @@ struct SyncUpsListView: View {
         .listRowBackground(syncUp.theme.mainColor)
       }
     }
-    .sheet(item: $store.scope(state: \.addSyncUp, action: \.addSyncUp)) { addSyncUpStore in
+    .sheet(item: $store.scope(\.addSyncUp, action: \.addSyncUp)) { addSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: addSyncUpStore)
           .navigationTitle("New sync-up")

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0001.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0001.swift
@@ -20,7 +20,7 @@ struct SyncUpsListView: View {
         .listRowBackground(syncUp.theme.mainColor)
       }
     }
-    .sheet(item: $store.scope(state: \.addSyncUp, action: \.addSyncUp)) { addSyncUpStore in
+    .sheet(item: $store.scope(\.addSyncUp, action: \.addSyncUp)) { addSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: addSyncUpStore)
           .navigationTitle("New sync-up")

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0002.swift
@@ -20,7 +20,7 @@ struct SyncUpsListView: View {
         .listRowBackground(syncUp.theme.mainColor)
       }
     }
-    .sheet(item: $store.scope(state: \.addSyncUp, action: \.addSyncUp)) { addSyncUpStore in
+    .sheet(item: $store.scope(\.addSyncUp, action: \.addSyncUp)) { addSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: addSyncUpStore)
           .navigationTitle("New sync-up")

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0003.swift
@@ -20,7 +20,7 @@ struct SyncUpsListView: View {
         .listRowBackground(syncUp.theme.mainColor)
       }
     }
-    .sheet(item: $store.scope(state: \.addSyncUp, action: \.addSyncUp)) { addSyncUpStore in
+    .sheet(item: $store.scope(\.addSyncUp, action: \.addSyncUp)) { addSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: addSyncUpStore)
           .navigationTitle("New sync-up")

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0004.swift
@@ -20,7 +20,7 @@ struct SyncUpsListView: View {
         .listRowBackground(syncUp.theme.mainColor)
       }
     }
-    .sheet(item: $store.scope(state: \.addSyncUp, action: \.addSyncUp)) { addSyncUpStore in
+    .sheet(item: $store.scope(\.addSyncUp, action: \.addSyncUp)) { addSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: addSyncUpStore)
           .navigationTitle("New sync-up")

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation.tutorial
@@ -165,8 +165,8 @@
       
       @Step {
         For the root view we can construct the `SyncUpsListView` by using 
-        ``ComposableArchitecture/Store/scope(state:action:)-90255`` on the `store` to isolate
-        the `SyncUpsList` domain.
+        ``ComposableArchitecture/Store/scope(_:action:)`` on the `store` to isolate the
+        `SyncUpsList` domain.
         
         @Code(name: "App.swift", file: SyncUpDetailNavigation-02-code-0004.swift)
       }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0005.swift
@@ -118,7 +118,7 @@ struct RecordMeetingView: View {
     }
     .navigationBarBackButtonHidden(true)
     .onAppear { store.send(.onAppear) }
-    .alert($store.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(\.alert, action: \.alert))
   }
 }
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0006.swift
@@ -138,7 +138,7 @@ struct RecordMeetingView: View {
     }
     .navigationBarBackButtonHidden(true)
     .onAppear { store.send(.onAppear) }
-    .alert($store.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(\.alert, action: \.alert))
   }
 }
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0007.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0007.swift
@@ -153,7 +153,7 @@ struct RecordMeetingView: View {
     }
     .navigationBarBackButtonHidden(true)
     .onAppear { store.send(.onAppear) }
-    .alert($store.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(\.alert, action: \.alert))
   }
 }
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0008.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/ImplementingTimer-03-code-0008.swift
@@ -156,7 +156,7 @@ struct RecordMeetingView: View {
     }
     .navigationBarBackButtonHidden(true)
     .onAppear { store.send(.onAppear) }
-    .alert($store.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(\.alert, action: \.alert))
   }
 }
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-02-code-0002-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-02-code-0002-previous.swift
@@ -11,10 +11,10 @@ struct AppView: View {
 
   var body: some View {
     NavigationStack(
-      path: $store.scope(state: \.path, action: \.path)
+      path: $store.scope(\.path, action: \.path)
     ) {
       SyncUpsListView(
-        store: store.scope(state: \.syncUpsList, action: \.syncUpsList)
+        store: store.scope(\.syncUpsList, action: \.syncUpsList)
       )
     } destination: { store in
       switch store.case {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-02-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-02-code-0002.swift
@@ -11,10 +11,10 @@ struct AppView: View {
 
   var body: some View {
     NavigationStack(
-      path: $store.scope(state: \.path, action: \.path)
+      path: $store.scope(\.path, action: \.path)
     ) {
       SyncUpsListView(
-        store: store.scope(state: \.syncUpsList, action: \.syncUpsList)
+        store: store.scope(\.syncUpsList, action: \.syncUpsList)
       )
     } destination: { store in
       switch store.case {

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-02-code-0003-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-02-code-0003-previous.swift
@@ -76,9 +76,9 @@ struct SyncUpDetailView: View {
         store.send(.editButtonTapped)
       }
     }
-    .alert($store.scope(state: \.$destination, action: \.destination).alert)
+    .alert($store.scope(\.$destination, action: \.destination).alert)
     .sheet(
-      item: $store.scope(state: \.$destination, action: \.destination).edit
+      item: $store.scope(\.$destination, action: \.destination).edit
     ) { editSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: editSyncUpStore)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/08-RecordMeeting/RecordMeetingFeature-02-code-0003.swift
@@ -77,9 +77,9 @@ struct SyncUpDetailView: View {
         store.send(.editButtonTapped)
       }
     }
-    .alert($store.scope(state: \.$destination, action: \.destination).alert)
+    .alert($store.scope(\.$destination, action: \.destination).alert)
     .sheet(
-      item: $store.scope(state: \.$destination, action: \.destination).edit
+      item: $store.scope(\.$destination, action: \.destination).edit
     ) { editSyncUpStore in
       NavigationStack {
         SyncUpFormView(store: editSyncUpStore)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-02-code-0004.swift
@@ -11,10 +11,10 @@ struct AppFeature {
     case tab2(CounterFeature.Action)
   }
   var body: some ReducerOf<Self> {
-    Scope(state: \.tab1, action: \.tab1) {
+    Scope(\.tab1, action: \.tab1) {
       CounterFeature()
     }
-    Scope(state: \.tab2, action: \.tab2) {
+    Scope(\.tab2, action: \.tab2) {
       CounterFeature()
     }
     Reduce { state, action in

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-03-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-03-code-0002.swift
@@ -6,7 +6,7 @@ struct AppView: View {
   
   var body: some View {
     TabView {
-      CounterView(store: store.scope(state: \.tab1, action: \.tab1))
+      CounterView(store: store.scope(\.tab1, action: \.tab1))
         .tabItem {
           Text("Counter 1")
         }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-03-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-03-code-0003.swift
@@ -6,12 +6,12 @@ struct AppView: View {
   
   var body: some View {
     TabView {
-      CounterView(store: store.scope(state: \.tab1, action: \.tab1))
+      CounterView(store: store.scope(\.tab1, action: \.tab1))
         .tabItem {
           Text("Counter 1")
         }
       
-      CounterView(store: store.scope(state: \.tab2, action: \.tab2))
+      CounterView(store: store.scope(\.tab2, action: \.tab2))
         .tabItem {
           Text("Counter 2")
         }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-03-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-03-code-0004.swift
@@ -6,12 +6,12 @@ struct AppView: View {
   
   var body: some View {
     TabView {
-      CounterView(store: store.scope(state: \.tab1, action: \.tab1))
+      CounterView(store: store.scope(\.tab1, action: \.tab1))
         .tabItem {
           Text("Counter 1")
         }
       
-      CounterView(store: store.scope(state: \.tab2, action: \.tab2))
+      CounterView(store: store.scope(\.tab2, action: \.tab2))
         .tabItem {
           Text("Counter 2")
         }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-ComposingFeatures.tutorial
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/01-Essentials/04-ComposingFeatures/01-04-ComposingFeatures.tutorial
@@ -195,7 +195,7 @@
       }
       
       @Step {
-        Use the ``ComposableArchitecture/Store/scope(state:action:)-90255`` method on 
+        Use the ``ComposableArchitecture/Store/scope(_:action:)`` method on 
         ``ComposableArchitecture/Store`` to derive a child store focused in on just the `tab1`
         domain. This is done by using key path syntax to single out the field of the state and
         the case of the action enum.
@@ -232,8 +232,8 @@
       simplest form it starts by composing the reducers together in the `body` of a parent reducer
       and using the ``ComposableArchitecture/Scope`` reducer to focus in on a sub-domain of 
       the parent to run a child reducer. Then in the view you derive child stores from the parent
-      using the ``ComposableArchitecture/Store/scope(state:action:)-90255`` and hand those child
-      stores to the child views.
+      using the ``ComposableArchitecture/Store/scope(_:action:)`` and hand those child stores to
+      the child views.
       
       There are more advanced ways of composing features, especially when it comes to navigation. 
       See the article <doc:Navigation> for more information on the navigation tools in the library,

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-02-code-0009.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/01-YourFirstPresentation/02-01-02-code-0009.swift
@@ -20,7 +20,7 @@ struct ContactsView: View {
       }
     }
     .sheet(
-      item: $store.scope(state: \.addContact, action: \.addContact)
+      item: $store.scope(\.addContact, action: \.addContact)
     ) { addContactStore in
       NavigationStack {
         AddContactView(store: addContactStore)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-01-code-0006-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-01-code-0006-previous.swift
@@ -20,7 +20,7 @@ struct ContactsView: View {
       }
     }
     .sheet(
-      item: $store.scope(state: \.addContact, action: \.addContact)
+      item: $store.scope(\.addContact, action: \.addContact)
     ) { addContactStore in
       NavigationStack {
         AddContactView(store: addContactStore)

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-01-code-0006.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-01-code-0006.swift
@@ -20,12 +20,12 @@ struct ContactsView: View {
       }
     }
     .sheet(
-      item: $store.scope(state: \.addContact, action: \.addContact)
+      item: $store.scope(\.addContact, action: \.addContact)
     ) { addContactStore in
       NavigationStack {
         AddContactView(store: addContactStore)
       }
     }
-    .alert($store.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(\.alert, action: \.alert))
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-01-code-0007.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-01-code-0007.swift
@@ -29,12 +29,12 @@ struct ContactsView: View {
       }
     }
     .sheet(
-      item: $store.scope(state: \.addContact, action: \.addContact)
+      item: $store.scope(\.addContact, action: \.addContact)
     ) { addContactStore in
       NavigationStack {
         AddContactView(store: addContactStore)
       }
     }
-    .alert($store.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(\.alert, action: \.alert))
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0013-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0013-previous.swift
@@ -29,12 +29,12 @@ struct ContactsView: View {
       }
     }
     .sheet(
-      item: $store.scope(state: \.addContact, action: \.addContact)
+      item: $store.scope(\.addContact, action: \.addContact)
     ) { addContactStore in
       NavigationStack {
         AddContactView(store: addContactStore)
       }
     }
-    .alert($store.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(\.alert, action: \.alert))
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0013.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0013.swift
@@ -29,12 +29,12 @@ struct ContactsView: View {
       }
     }
     .sheet(
-      item: $store.scope(state: \.$destination, action: \.destination).addContact
+      item: $store.scope(\.$destination, action: \.destination).addContact
     ) { addContactStore in
       NavigationStack {
         AddContactView(store: addContactStore)
       }
     }
-    .alert($store.scope(state: \.$alert, action: \.alert))
+    .alert($store.scope(\.$alert, action: \.alert))
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0014.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0014.swift
@@ -29,12 +29,12 @@ struct ContactsView: View {
       }
     }
     .sheet(
-      item: $store.scope(state: \.$destination, action: \.destination).addContact
+      item: $store.scope(\.$destination, action: \.destination).addContact
     ) { addContactStore in
       NavigationStack {
         AddContactView(store: addContactStore)
       }
     }
-    .alert($store.scope(state: \.$destination, action: \.destination).alert)
+    .alert($store.scope(\.$destination, action: \.destination).alert)
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003-previous.swift
@@ -32,12 +32,12 @@ struct ContactsView: View {
       }
     }
     .sheet(
-      item: $store.scope(state: \.$destination, action: \.destination).addContact
+      item: $store.scope(\.$destination, action: \.destination).addContact
     ) { addContactStore in
       NavigationStack {
         AddContactView(store: addContactStore)
       }
     }
-    .alert($store.scope(state: \.$destination, action: \.destination).alert)
+    .alert($store.scope(\.$destination, action: \.destination).alert)
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003.swift
@@ -5,7 +5,7 @@ struct ContactsView: View {
   @Bindable var store: StoreOf<ContactsFeature>
   
   var body: some View {
-    NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
+    NavigationStack(path: $store.scope(\.path, action: \.path)) {
       List {
         ForEach(store.contacts) { contact in
           HStack {
@@ -32,12 +32,12 @@ struct ContactsView: View {
       }
     }
     .sheet(
-      item: $store.scope(state: \.$destination, action: \.destination).addContact
+      item: $store.scope(\.$destination, action: \.destination).addContact
     ) { addContactStore in
       NavigationStack {
         AddContactView(store: addContactStore)
       }
     }
-    .alert($store.scope(state: \.$destination, action: \.destination).alert)
+    .alert($store.scope(\.$destination, action: \.destination).alert)
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0004.swift
@@ -5,7 +5,7 @@ struct ContactsView: View {
   @Bindable var store: StoreOf<ContactsFeature>
   
   var body: some View {
-    NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
+    NavigationStack(path: $store.scope(\.path, action: \.path)) {
       List {
         ForEach(store.contacts) { contact in
           HStack {
@@ -34,12 +34,12 @@ struct ContactsView: View {
       ContactDetailView(store: store)
     }
     .sheet(
-      item: $store.scope(state: \.$destination, action: \.destination).addContact
+      item: $store.scope(\.$destination, action: \.destination).addContact
     ) { addContactStore in
       NavigationStack {
         AddContactView(store: addContactStore)
       }
     }
-    .alert($store.scope(state: \.$destination, action: \.destination).alert)
+    .alert($store.scope(\.$destination, action: \.destination).alert)
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0005-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0005-previous.swift
@@ -5,7 +5,7 @@ struct ContactsView: View {
   @Bindable var store: StoreOf<ContactsFeature>
   
   var body: some View {
-    NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
+    NavigationStack(path: $store.scope(\.path, action: \.path)) {
       List {
         ForEach(store.contacts) { contact in
           HStack {
@@ -34,12 +34,12 @@ struct ContactsView: View {
       ContactDetailView(store: store)
     }
     .sheet(
-      item: $store.scope(state: \.$destination, action: \.destination).addContact
+      item: $store.scope(\.$destination, action: \.destination).addContact
     ) { addContactStore in
       NavigationStack {
         AddContactView(store: addContactStore)
       }
     }
-    .alert($store.scope(state: \.$destination, action: \.destination).alert)
+    .alert($store.scope(\.$destination, action: \.destination).alert)
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0005.swift
@@ -2,7 +2,7 @@ struct ContactsView: View {
   @Bindable var store: StoreOf<ContactsFeature>
   
   var body: some View {
-    NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
+    NavigationStack(path: $store.scope(\.path, action: \.path)) {
       List {
         ForEach(store.contacts) { contact in
           NavigationLink(state: ContactDetailFeature.State(contact: contact)) {
@@ -30,12 +30,12 @@ struct ContactsView: View {
       ContactDetailView(store: store)
     }
     .sheet(
-      item: $store.scope(state: \.$destination, action: \.destination).addContact
+      item: $store.scope(\.$destination, action: \.destination).addContact
     ) { addContactStore in
       NavigationStack {
         AddContactView(store: addContactStore)
       }
     }
-    .alert($store.scope(state: \.$destination, action: \.destination).alert)
+    .alert($store.scope(\.$destination, action: \.destination).alert)
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-03-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-03-code-0003.swift
@@ -11,7 +11,7 @@ struct ContactDetailView: View {
       }
     }
     .navigationTitle(Text(store.contact.name))
-    .alert($store.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(\.alert, action: \.alert))
   }
 }
 

--- a/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/IdentifiedArray+Observation.swift
@@ -37,7 +37,7 @@ extension Store where State: ObservableState {
   ///
   ///   var body: some View {
   ///     List {
-  ///       ForEach(store.scope(state: \.rows, action: \.rows), id: \.state.id) { store in
+  ///       ForEach(store.scope(\.rows, action: \.rows), id: \.state.id) { store in
   ///         ChildView(store: store)
   ///       }
   ///     }
@@ -51,9 +51,9 @@ extension Store where State: ObservableState {
   /// >
   /// > ```diff
   /// >  ForEach(
-  /// > -  store.scope(state: \.rows, action: \.rows),
+  /// > -  store.scope(\.rows, action: \.rows),
   /// > -  id: \.state.id,
-  /// > +  store.scope(state: \.rows, action: \.rows)
+  /// > +  store.scope(\.rows, action: \.rows)
   /// >  ) { childStore in
   /// >    ChildView(store: childStore)
   /// >  }
@@ -67,6 +67,35 @@ extension Store where State: ObservableState {
   ///   - filePath: The filePath.
   ///   - line: The line.
   /// - Returns: An collection of stores of child state.
+  @_disfavoredOverload
+  public func scope<ElementID, ElementState, ElementAction>(
+    _ state: KeyPath<State, IdentifiedArray<ElementID, ElementState>>,
+    action: CaseKeyPath<Action, IdentifiedAction<ElementID, ElementAction>>,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) -> some RandomAccessCollection<Store<ElementState, ElementAction>> {
+    if !core.canStoreCacheChildren {
+      reportIssue(
+        uncachedStoreWarning(self),
+        fileID: fileID,
+        filePath: filePath,
+        line: line,
+        column: column
+      )
+    }
+    return _StoreCollection(self.scope(state, action: action))
+  }
+
+  #if ComposableArchitecture2Deprecations
+    @available(*, deprecated, renamed: "scope(_:action:fileID:filePath:line:column:)")
+  #else
+    @available(iOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    @available(macOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    @available(tvOS, deprecated: 9999,renamed: "scope(_:action:fileID:filePath:line:column:)")
+    @available(watchOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+  #endif
   @_disfavoredOverload
   public func scope<ElementID, ElementState, ElementAction>(
     state: KeyPath<State, IdentifiedArray<ElementID, ElementState>>,
@@ -112,7 +141,7 @@ public struct _StoreCollection<ID: Hashable & Sendable, State, Action>: RandomAc
       When passing a scoped store to a 'ForEach' in a lazy view (for example, 'LazyVStack'), it \
       must be eagerly transformed into a collection to avoid access off the main actor:
 
-          Array(store.scope(state: \.elements, action: \.elements))
+          Array(store.scope(\.elements, action: \.elements))
       """#
     )
     return MainActor.assumeIsolated { [uncheckedSelf = UncheckedSendable(self)] in

--- a/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
@@ -48,7 +48,7 @@ extension Binding {
   ///   @Bindable var store: StoreOf<Feature>
   ///
   ///   var body: some View {
-  ///     NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
+  ///     NavigationStack(path: $store.scope(\.path, action: \.path)) {
   ///       // Root view
   ///     } destination: {
   ///       // Destinations
@@ -56,6 +56,23 @@ extension Binding {
   ///   }
   /// }
   /// ```
+  @preconcurrency @MainActor
+  public func scope<State: ObservableState, Action, ElementState, ElementAction>(
+    _ state: KeyPath<State, StackState<ElementState>>,
+    action: CaseKeyPath<Action, StackAction<ElementState, ElementAction>>
+  ) -> Binding<Store<StackState<ElementState>, StackAction<ElementState, ElementAction>>>
+  where Value == Store<State, Action> {
+    self[state: state, action: action]
+  }
+
+  #if ComposableArchitecture2Deprecations
+    @available(*, deprecated, renamed: "scope(_:action:)")
+  #else
+    @available(iOS, deprecated: 9999, renamed: "scope(_:action:)")
+    @available(macOS, deprecated: 9999, renamed: "scope(_:action:)")
+    @available(tvOS, deprecated: 9999,renamed: "scope(_:action:)")
+    @available(watchOS, deprecated: 9999, renamed: "scope(_:action:)")
+  #endif
   @preconcurrency @MainActor
   public func scope<State: ObservableState, Action, ElementState, ElementAction>(
     state: KeyPath<State, StackState<ElementState>>,
@@ -67,6 +84,23 @@ extension Binding {
 }
 
 extension ObservedObject.Wrapper {
+  @preconcurrency @MainActor
+  public func scope<State: ObservableState, Action, ElementState, ElementAction>(
+    _ state: KeyPath<State, StackState<ElementState>>,
+    action: CaseKeyPath<Action, StackAction<ElementState, ElementAction>>
+  ) -> Binding<Store<StackState<ElementState>, StackAction<ElementState, ElementAction>>>
+  where ObjectType == Store<State, Action> {
+    self[state: state, action: action]
+  }
+
+  #if ComposableArchitecture2Deprecations
+    @available(*, deprecated, renamed: "scope(_:action:)")
+  #else
+    @available(iOS, deprecated: 9999, renamed: "scope(_:action:)")
+    @available(macOS, deprecated: 9999, renamed: "scope(_:action:)")
+    @available(tvOS, deprecated: 9999,renamed: "scope(_:action:)")
+    @available(watchOS, deprecated: 9999, renamed: "scope(_:action:)")
+  #endif
   @preconcurrency @MainActor
   public func scope<State: ObservableState, Action, ElementState, ElementAction>(
     state: KeyPath<State, StackState<ElementState>>,
@@ -81,8 +115,25 @@ extension ObservedObject.Wrapper {
 extension SwiftUI.Bindable {
   /// Derives a binding to a store focused on ``StackState`` and ``StackAction``.
   ///
-  /// See ``SwiftUI/Binding/scope(state:action:fileID:filePath:line:column:)`` defined on `Binding` for more
-  /// information.
+  /// See ``SwiftUI/Binding/scope(_:action:fileID:filePath:line:column:)`` defined on `Binding` for
+  /// more information.
+  @preconcurrency @MainActor
+  public func scope<State: ObservableState, Action, ElementState, ElementAction>(
+    _ state: KeyPath<State, StackState<ElementState>>,
+    action: CaseKeyPath<Action, StackAction<ElementState, ElementAction>>
+  ) -> Binding<Store<StackState<ElementState>, StackAction<ElementState, ElementAction>>>
+  where Value == Store<State, Action> {
+    self[state: state, action: action]
+  }
+
+  #if ComposableArchitecture2Deprecations
+    @available(*, deprecated, renamed: "scope(_:action:)")
+  #else
+    @available(iOS, deprecated: 9999, renamed: "scope(_:action:)")
+    @available(macOS, deprecated: 9999, renamed: "scope(_:action:)")
+    @available(tvOS, deprecated: 9999,renamed: "scope(_:action:)")
+    @available(watchOS, deprecated: 9999, renamed: "scope(_:action:)")
+  #endif
   @preconcurrency @MainActor
   public func scope<State: ObservableState, Action, ElementState, ElementAction>(
     state: KeyPath<State, StackState<ElementState>>,
@@ -100,8 +151,24 @@ extension SwiftUI.Bindable {
 extension Perception.Bindable {
   /// Derives a binding to a store focused on ``StackState`` and ``StackAction``.
   ///
-  /// See ``SwiftUI/Binding/scope(state:action:fileID:filePath:line:column:)`` defined on `Binding` for more
-  /// information.
+  /// See ``SwiftUI/Binding/scope(_:action:fileID:filePath:line:column:)`` defined on `Binding` for
+  /// more information.
+  public func scope<State: ObservableState, Action, ElementState, ElementAction>(
+    _ state: KeyPath<State, StackState<ElementState>>,
+    action: CaseKeyPath<Action, StackAction<ElementState, ElementAction>>
+  ) -> Binding<Store<StackState<ElementState>, StackAction<ElementState, ElementAction>>>
+  where Value == Store<State, Action> {
+    self[state: state, action: action]
+  }
+
+  #if ComposableArchitecture2Deprecations
+    @available(*, deprecated, renamed: "scope(_:action:)")
+  #else
+    @available(iOS, deprecated: 9999, renamed: "scope(_:action:)")
+    @available(macOS, deprecated: 9999, renamed: "scope(_:action:)")
+    @available(tvOS, deprecated: 9999,renamed: "scope(_:action:)")
+    @available(watchOS, deprecated: 9999, renamed: "scope(_:action:)")
+  #endif
   public func scope<State: ObservableState, Action, ElementState, ElementAction>(
     state: KeyPath<State, StackState<ElementState>>,
     action: CaseKeyPath<Action, StackAction<ElementState, ElementAction>>
@@ -116,6 +183,23 @@ extension UIBindable {
   ///
   /// See ``SwiftUI/Binding/scope(state:action:fileID:filePath:line:column:)`` defined on `Binding` for more
   /// information.
+  @preconcurrency @MainActor
+  public func scope<State: ObservableState, Action, ElementState, ElementAction>(
+    _ state: KeyPath<State, StackState<ElementState>>,
+    action: CaseKeyPath<Action, StackAction<ElementState, ElementAction>>
+  ) -> UIBinding<Store<StackState<ElementState>, StackAction<ElementState, ElementAction>>>
+  where Value == Store<State, Action> {
+    self[state: state, action: action]
+  }
+
+  #if ComposableArchitecture2Deprecations
+    @available(*, deprecated, renamed: "scope(_:action:)")
+  #else
+    @available(iOS, deprecated: 9999, renamed: "scope(_:action:)")
+    @available(macOS, deprecated: 9999, renamed: "scope(_:action:)")
+    @available(tvOS, deprecated: 9999,renamed: "scope(_:action:)")
+    @available(watchOS, deprecated: 9999, renamed: "scope(_:action:)")
+  #endif
   @preconcurrency @MainActor
   public func scope<State: ObservableState, Action, ElementState, ElementAction>(
     state: KeyPath<State, StackState<ElementState>>,

--- a/Sources/ComposableArchitecture/Observation/Store+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/Store+Observation.swift
@@ -74,7 +74,7 @@ extension Store where State: ObservableState {
   /// a non-optional store of the child domain:
   ///
   /// ```swift
-  /// if let childStore = store.scope(state: \.child, action: \.child) {
+  /// if let childStore = store.scope(\.child, action: \.child) {
   ///   ChildView(store: childStore)
   /// }
   /// ```
@@ -92,7 +92,7 @@ extension Store where State: ObservableState {
   ///   - column: The source `#column` associated with the scoping.
   /// - Returns: An optional store of non-optional child state and actions.
   public func scope<ChildState, ChildAction>(
-    state stateKeyPath: KeyPath<State, ChildState?>,
+    _ stateKeyPath: KeyPath<State, ChildState?>,
     action actionKeyPath: CaseKeyPath<Action, ChildAction>,
     fileID: StaticString = #fileID,
     filePath: StaticString = #filePath,
@@ -123,6 +123,32 @@ extension Store where State: ObservableState {
       )
     }
     return scope(id: id, childCore: open(core))
+  }
+
+  #if ComposableArchitecture2Deprecations
+    @available(*, deprecated, renamed: "scope(_:action:fileID:filePath:line:column:)")
+  #else
+    @available(iOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    @available(macOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    @available(tvOS, deprecated: 9999,renamed: "scope(_:action:fileID:filePath:line:column:)")
+    @available(watchOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+  #endif
+  public func scope<ChildState, ChildAction>(
+    state stateKeyPath: KeyPath<State, ChildState?>,
+    action actionKeyPath: CaseKeyPath<Action, ChildAction>,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) -> Store<ChildState, ChildAction>? {
+    scope(
+      stateKeyPath,
+      action: actionKeyPath,
+      fileID: fileID,
+      filePath: filePath,
+      line: line,
+      column: column
+    )
   }
 }
 
@@ -162,7 +188,7 @@ extension Binding {
   ///
   ///   var body: some View {
   ///     // ...
-  ///     .sheet(item: $store.scope(state: \.child, action: \.child)) { store in
+  ///     .sheet(item: $store.scope(\.child, action: \.child)) { store in
   ///       ChildView(store: store)
   ///     }
   ///   }
@@ -177,6 +203,36 @@ extension Binding {
   ///   - line: The line.
   ///   - column: The column.
   /// - Returns: A binding of an optional child store.
+  @preconcurrency @MainActor
+  public func scope<State: ObservableState, Action, Container: _ScopableState, ChildAction>(
+    _ state: KeyPath<State, Container>,
+    action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) -> Binding<Store<Container.Unwrapped, ChildAction>?>
+  where Value == Store<State, Action> {
+    self[
+      id: wrappedValue.currentState[keyPath: state]._scopeID,
+      state: Container._scopeKeyPath(state),
+      action: action,
+      isInViewBody: _isInPerceptionTracking,
+      fileID: _HashableStaticString(rawValue: fileID),
+      filePath: _HashableStaticString(rawValue: filePath),
+      line: line,
+      column: column
+    ]
+  }
+
+  #if ComposableArchitecture2Deprecations
+    @available(*, deprecated, renamed: "scope(_:action:fileID:filePath:line:column:)")
+  #else
+    @available(iOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    @available(macOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    @available(tvOS, deprecated: 9999,renamed: "scope(_:action:fileID:filePath:line:column:)")
+    @available(watchOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+  #endif
   @preconcurrency @MainActor
   public func scope<State: ObservableState, Action, Container: _ScopableState, ChildAction>(
     state: KeyPath<State, Container>,
@@ -198,10 +254,44 @@ extension Binding {
       column: column
     ]
   }
-
 }
 
 extension ObservedObject.Wrapper {
+  @preconcurrency @MainActor
+  public func scope<State: ObservableState, Action, Container: _ScopableState, ChildAction>(
+    _ state: KeyPath<State, Container>,
+    action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) -> Binding<Store<Container.Unwrapped, ChildAction>?>
+  where ObjectType == Store<State, Action> {
+    let scopedState = Container._scopeKeyPath(state)
+    let id = self[dynamicMember: \._currentState].wrappedValue[keyPath: state]._scopeID
+    return self[
+      dynamicMember:
+        \.[
+          id: id,
+          state: scopedState,
+          action: action,
+          isInViewBody: _isInPerceptionTracking,
+          fileID: _HashableStaticString(rawValue: fileID),
+          filePath: _HashableStaticString(rawValue: filePath),
+          line: line,
+          column: column
+        ]
+    ]
+  }
+
+  #if ComposableArchitecture2Deprecations
+    @available(*, deprecated, renamed: "scope(_:action:fileID:filePath:line:column:)")
+  #else
+    @available(iOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    @available(macOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    @available(tvOS, deprecated: 9999,renamed: "scope(_:action:fileID:filePath:line:column:)")
+    @available(watchOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+  #endif
   @preconcurrency @MainActor
   public func scope<State: ObservableState, Action, Container: _ScopableState, ChildAction>(
     state: KeyPath<State, Container>,
@@ -242,6 +332,36 @@ extension SwiftUI.Bindable {
   #if ComposableArchitecture2DeprecationOverloads
     @preconcurrency @MainActor
     public func scope<State: ObservableState, Action, ChildState, ChildAction>(
+      _ state: WritableKeyPath<State, PresentationState<ChildState>>,
+      action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
+      fileID: StaticString = #fileID,
+      filePath: StaticString = #filePath,
+      line: UInt = #line,
+      column: UInt = #column
+    ) -> Binding<Store<ChildState, ChildAction>?>
+    where Value == Store<State, Action> {
+      return self[
+        id: wrappedValue.currentState[keyPath: state]._scopeID,
+        state: state.appending(path: \.wrappedValue),
+        action: action,
+        isInViewBody: _isInPerceptionTracking,
+        fileID: _HashableStaticString(rawValue: fileID),
+        filePath: _HashableStaticString(rawValue: filePath),
+        line: line,
+        column: column
+      ]
+    }
+
+    #if ComposableArchitecture2Deprecations
+      @available(*, deprecated, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    #else
+      @available(iOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+      @available(macOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+      @available(tvOS, deprecated: 9999,renamed: "scope(_:action:fileID:filePath:line:column:)")
+      @available(watchOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    #endif
+    @preconcurrency @MainActor
+    public func scope<State: ObservableState, Action, ChildState, ChildAction>(
       state: WritableKeyPath<State, PresentationState<ChildState>>,
       action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
       fileID: StaticString = #fileID,
@@ -266,7 +386,7 @@ extension SwiftUI.Bindable {
       *,
       deprecated,
       message: """
-        Use '$store.scope(state: \\.$destination, action: \\.destination)' (and optional trailing dot syntax '.sheet') instead. For alert or confirmation cases, additional work is needed. See the migration guide for more details: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/1.25.5/documentation/composablearchitecture/migratingto1.25#Enum-scopes
+        Use '$store.scope(\\.$destination, action: \\.destination)' (and optional trailing dot syntax '.sheet') instead. For alert or confirmation cases, additional work is needed. See the migration guide for more details: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/1.25.5/documentation/composablearchitecture/migratingto1.25#Enum-scopes
         """
     )
     @preconcurrency @MainActor
@@ -326,7 +446,7 @@ extension SwiftUI.Bindable {
     ///
     ///   var body: some View {
     ///     // ...
-    ///     .sheet(item: $store.scope(state: \.child, action: \.child)) { store in
+    ///     .sheet(item: $store.scope(\.child, action: \.child)) { store in
     ///       ChildView(store: store)
     ///     }
     ///   }
@@ -341,6 +461,36 @@ extension SwiftUI.Bindable {
     ///   - line: The line.
     ///   - column: The column.
     /// - Returns: A binding of an optional child store.
+    @preconcurrency @MainActor
+    public func scope<State: ObservableState, Action, Container: _ScopableState, ChildAction>(
+      _ state: KeyPath<State, Container>,
+      action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
+      fileID: StaticString = #fileID,
+      filePath: StaticString = #filePath,
+      line: UInt = #line,
+      column: UInt = #column
+    ) -> Binding<Store<Container.Unwrapped, ChildAction>?>
+    where Value == Store<State, Action> {
+      self[
+        id: wrappedValue.currentState[keyPath: state]._scopeID,
+        state: Container._scopeKeyPath(state),
+        action: action,
+        isInViewBody: _isInPerceptionTracking,
+        fileID: _HashableStaticString(rawValue: fileID),
+        filePath: _HashableStaticString(rawValue: filePath),
+        line: line,
+        column: column
+      ]
+    }
+
+    #if ComposableArchitecture2Deprecations
+      @available(*, deprecated, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    #else
+      @available(iOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+      @available(macOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+      @available(tvOS, deprecated: 9999,renamed: "scope(_:action:fileID:filePath:line:column:)")
+      @available(watchOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    #endif
     @preconcurrency @MainActor
     public func scope<State: ObservableState, Action, Container: _ScopableState, ChildAction>(
       state: KeyPath<State, Container>,
@@ -373,6 +523,36 @@ extension Perception.Bindable {
   #if ComposableArchitecture2DeprecationOverloads
     @preconcurrency @MainActor
     public func scope<State: ObservableState, Action, ChildState, ChildAction>(
+      _ state: WritableKeyPath<State, PresentationState<ChildState>>,
+      action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
+      fileID: StaticString = #fileID,
+      filePath: StaticString = #filePath,
+      line: UInt = #line,
+      column: UInt = #column
+    ) -> Binding<Store<ChildState, ChildAction>?>
+    where Value == Store<State, Action> {
+      self[
+        id: wrappedValue.currentState[keyPath: state]._scopeID,
+        state: state.appending(path: \.wrappedValue),
+        action: action,
+        isInViewBody: _isInPerceptionTracking,
+        fileID: _HashableStaticString(rawValue: fileID),
+        filePath: _HashableStaticString(rawValue: filePath),
+        line: line,
+        column: column
+      ]
+    }
+
+    #if ComposableArchitecture2Deprecations
+      @available(*, deprecated, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    #else
+      @available(iOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+      @available(macOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+      @available(tvOS, deprecated: 9999,renamed: "scope(_:action:fileID:filePath:line:column:)")
+      @available(watchOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    #endif
+    @preconcurrency @MainActor
+    public func scope<State: ObservableState, Action, ChildState, ChildAction>(
       state: WritableKeyPath<State, PresentationState<ChildState>>,
       action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
       fileID: StaticString = #fileID,
@@ -397,7 +577,7 @@ extension Perception.Bindable {
       *,
       deprecated,
       message: """
-        Use '$store.scope(state: \\.$destination, action: \\.destination)' (and optional trailing dot syntax '.sheet') instead. For alert or confirmation cases, additional work is needed. See the migration guide for more details: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/1.25.5/documentation/composablearchitecture/migratingto1.25#Enum-scopes
+        Use '$store.scope(\\.$destination, action: \\.destination)' (and optional trailing dot syntax '.sheet') instead. For alert or confirmation cases, additional work is needed. See the migration guide for more details: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/1.25.5/documentation/composablearchitecture/migratingto1.25#Enum-scopes
         """
     )
     @preconcurrency @MainActor
@@ -457,7 +637,7 @@ extension Perception.Bindable {
     ///
     ///   var body: some View {
     ///     // ...
-    ///     .sheet(item: $store.scope(state: \.child, action: \.child)) { store in
+    ///     .sheet(item: $store.scope(\.child, action: \.child)) { store in
     ///       ChildView(store: store)
     ///     }
     ///   }
@@ -472,6 +652,35 @@ extension Perception.Bindable {
     ///   - line: The line.
     ///   - column: The column.
     /// - Returns: A binding of an optional child store.
+    public func scope<State: ObservableState, Action, Container: _ScopableState, ChildAction>(
+      _ state: KeyPath<State, Container>,
+      action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
+      fileID: StaticString = #fileID,
+      filePath: StaticString = #filePath,
+      line: UInt = #line,
+      column: UInt = #column
+    ) -> Binding<Store<Container.Unwrapped, ChildAction>?>
+    where Value == Store<State, Action> {
+      self[
+        id: wrappedValue.currentState[keyPath: state]._scopeID,
+        state: Container._scopeKeyPath(state),
+        action: action,
+        isInViewBody: _isInPerceptionTracking,
+        fileID: _HashableStaticString(rawValue: fileID),
+        filePath: _HashableStaticString(rawValue: filePath),
+        line: line,
+        column: column
+      ]
+    }
+
+    #if ComposableArchitecture2Deprecations
+      @available(*, deprecated, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    #else
+      @available(iOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+      @available(macOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+      @available(tvOS, deprecated: 9999,renamed: "scope(_:action:fileID:filePath:line:column:)")
+      @available(watchOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    #endif
     public func scope<State: ObservableState, Action, Container: _ScopableState, ChildAction>(
       state: KeyPath<State, Container>,
       action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
@@ -497,6 +706,43 @@ extension Perception.Bindable {
 
 extension UIBindable {
   #if ComposableArchitecture2DeprecationOverloads
+    @preconcurrency @MainActor
+    public func scope<State: ObservableState, Action, ChildState, ChildAction>(
+      _ state: WritableKeyPath<State, PresentationState<ChildState>>,
+      action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
+      fileID: StaticString = #fileID,
+      filePath: StaticString = #filePath,
+      line: UInt = #line,
+      column: UInt = #column
+    ) -> UIBinding<Store<ChildState, ChildAction>?>
+    where Value == Store<State, Action> {
+      #if DEBUG && canImport(SwiftUI)
+        let id = _PerceptionLocals.$skipPerceptionChecking.withValue(true) {
+          wrappedValue.currentState[keyPath: state]._scopeID
+        }
+      #else
+        let id = wrappedValue.currentState[keyPath: state]._scopeID
+      #endif
+      return self[
+        id: id,
+        state: state.appending(path: \.wrappedValue),
+        action: action,
+        isInViewBody: true,
+        fileID: _HashableStaticString(rawValue: fileID),
+        filePath: _HashableStaticString(rawValue: filePath),
+        line: line,
+        column: column
+      ]
+    }
+
+    #if ComposableArchitecture2Deprecations
+      @available(*, deprecated, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    #else
+      @available(iOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+      @available(macOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+      @available(tvOS, deprecated: 9999,renamed: "scope(_:action:fileID:filePath:line:column:)")
+      @available(watchOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    #endif
     @preconcurrency @MainActor
     public func scope<State: ObservableState, Action, ChildState, ChildAction>(
       state: WritableKeyPath<State, PresentationState<ChildState>>,
@@ -530,7 +776,7 @@ extension UIBindable {
       *,
       deprecated,
       message: """
-        Use '$store.scope(state: \\.$destination, action: \\.destination)' (and optional trailing dot syntax '.sheet') instead. For alert or confirmation cases, additional work is needed. See the migration guide for more details: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/1.25.5/documentation/composablearchitecture/migratingto1.25#Enum-scopes
+        Use '$store.scope(\\.$destination, action: \\.destination)' (and optional trailing dot syntax '.sheet') instead. For alert or confirmation cases, additional work is needed. See the migration guide for more details: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/1.25.5/documentation/composablearchitecture/migratingto1.25#Enum-scopes
         """
     )
     @preconcurrency @MainActor
@@ -562,6 +808,43 @@ extension UIBindable {
       ]
     }
   #else
+    @preconcurrency @MainActor
+    public func scope<State: ObservableState, Action, Container: _ScopableState, ChildAction>(
+      _ state: KeyPath<State, Container>,
+      action: CaseKeyPath<Action, PresentationAction<ChildAction>>,
+      fileID: StaticString = #fileID,
+      filePath: StaticString = #filePath,
+      line: UInt = #line,
+      column: UInt = #column
+    ) -> UIBinding<Store<Container.Unwrapped, ChildAction>?>
+    where Value == Store<State, Action> {
+      #if DEBUG && canImport(SwiftUI)
+        let id = _PerceptionLocals.$skipPerceptionChecking.withValue(true) {
+          wrappedValue.currentState[keyPath: state]._scopeID
+        }
+      #else
+        let id = wrappedValue.currentState[keyPath: state]._scopeID
+      #endif
+      return self[
+        id: id,
+        state: Container._scopeKeyPath(state),
+        action: action,
+        isInViewBody: true,
+        fileID: _HashableStaticString(rawValue: fileID),
+        filePath: _HashableStaticString(rawValue: filePath),
+        line: line,
+        column: column
+      ]
+    }
+
+    #if ComposableArchitecture2Deprecations
+      @available(*, deprecated, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    #else
+      @available(iOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+      @available(macOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+      @available(tvOS, deprecated: 9999,renamed: "scope(_:action:fileID:filePath:line:column:)")
+      @available(watchOS, deprecated: 9999, renamed: "scope(_:action:fileID:filePath:line:column:)")
+    #endif
     @preconcurrency @MainActor
     public func scope<State: ObservableState, Action, Container: _ScopableState, ChildAction>(
       state: KeyPath<State, Container>,

--- a/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
@@ -23,7 +23,7 @@ extension Reducer {
   ///   }
   ///
   ///   var body: some Reducer<State, Action> {
-  ///     Scope(state: \.feature, action: \.feature) {
+  ///     Scope(\.feature, action: \.feature) {
   ///       Feature()
   ///     }
   ///
@@ -46,7 +46,7 @@ extension Reducer {
   ///
   /// ```swift
   /// var body: some Reducer<State, Action> {
-  ///   Scope(state: \.feature, action: \.feature) {
+  ///   Scope(\.feature, action: \.feature) {
   ///     Feature()
   ///       .dependency(\.apiClient, .mock)
   ///       .dependency(\.userDefaults, .mock)

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
@@ -47,7 +47,7 @@
 ///   }
 ///
 ///   var body: some Reducer<State, Action> {
-///     Scope(state: \.child, action: \.child) {
+///     Scope(\.child, action: \.child) {
 ///       Child()
 ///     }
 ///     Reduce { state, action in
@@ -80,7 +80,7 @@
 ///   }
 ///
 ///   var body: some Reducer<State, Action> {
-///     Scope(state: \.loaded, action: \.child) {
+///     Scope(\.loaded, action: \.child) {
 ///       Child()
 ///     }
 ///     Reduce { state, action in
@@ -138,10 +138,10 @@ public struct Scope<ParentState, ParentAction, Child: Reducer>: Reducer {
   ///
   /// ```swift
   /// var body: some Reducer<State, Action> {
-  ///   Scope(state: \.profile, action: \.profile) {
+  ///   Scope(\.profile, action: \.profile) {
   ///     Profile()
   ///   }
-  ///   Scope(state: \.settings, action: \.settings) {
+  ///   Scope(\.settings, action: \.settings) {
   ///     Settings()
   ///   }
   ///   // ...
@@ -152,6 +152,27 @@ public struct Scope<ParentState, ParentAction, Child: Reducer>: Reducer {
   ///   - toChildState: A writable key path from parent state to a property containing child state.
   ///   - toChildAction: A case path from parent action to a case containing child actions.
   ///   - child: A reducer that will be invoked with child actions against child state.
+  @inlinable
+  public init<ChildState, ChildAction>(
+    _ toChildState: WritableKeyPath<ParentState, ChildState>,
+    action toChildAction: CaseKeyPath<ParentAction, ChildAction>,
+    @ReducerBuilder<ChildState, ChildAction> _ child: () -> Child
+  ) where ChildState == Child.State, ChildAction == Child.Action {
+    self.init(
+      toChildState: .keyPath(toChildState),
+      toChildAction: AnyCasePath(toChildAction),
+      child: child()
+    )
+  }
+
+  #if ComposableArchitecture2Deprecations
+    @available(*, deprecated, renamed: "init(_:action:_:)")
+  #else
+    @available(iOS, deprecated: 9999, renamed: "init(_:action:_:)")
+    @available(macOS, deprecated: 9999, renamed: "init(_:action:_:)")
+    @available(tvOS, deprecated: 9999,renamed: "init(_:action:_:)")
+    @available(watchOS, deprecated: 9999, renamed: "init(_:action:_:)")
+  #endif
   @inlinable
   public init<ChildState, ChildAction>(
     state toChildState: WritableKeyPath<ParentState, ChildState>,

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -23,13 +23,13 @@ import SwiftUI
 /// }
 /// ```
 ///
-/// …and then use the ``scope(state:action:)-90255`` method to derive more focused stores that can be
-/// passed to subviews.
+/// …and then use the ``scope(_:action:)`` method to derive more focused stores that can be passed
+/// to subviews.
 ///
 /// ### Scoping
 ///
-/// The most important operation defined on ``Store`` is the ``scope(state:action:)-90255`` method,
-/// which allows you to transform a store into one that deals with child state and actions. This is
+/// The most important operation defined on ``Store`` is the ``scope(_:action:)`` method, which
+/// allows you to transform a store into one that deals with child state and actions. This is
 /// necessary for passing stores to subviews that only care about a small portion of the entire
 /// application's domain.
 ///
@@ -55,9 +55,8 @@ import SwiftUI
 /// }
 /// ```
 ///
-/// We can construct a view for each of these domains by applying ``scope(state:action:)-90255`` to
-/// a store that holds onto the full app domain in order to transform it into a store for each
-/// subdomain:
+/// We can construct a view for each of these domains by applying ``scope(_:action:)`` to a store
+/// that holds onto the full app domain in order to transform it into a store for each subdomain:
 ///
 /// ```swift
 /// struct AppView: View {
@@ -66,17 +65,17 @@ import SwiftUI
 ///   var body: some View {
 ///     TabView {
 ///       ActivityView(
-///         store: store.scope(state: \.activity, action: \.activity)
+///         store: store.scope(\.activity, action: \.activity)
 ///       )
 ///       .tabItem { Text("Activity") }
 ///
 ///       SearchView(
-///         store: store.scope(state: \.search, action: \.search)
+///         store: store.scope(\.search, action: \.search)
 ///       )
 ///       .tabItem { Text("Search") }
 ///
 ///       ProfileView(
-///         store: store.scope(state: \.profile, action: \.profile)
+///         store: store.scope(\.profile, action: \.profile)
 ///       )
 ///       .tabItem { Text("Profile") }
 ///     }
@@ -278,7 +277,7 @@ public final class Store<State, Action>: _Store {
   /// // Construct a login view by scoping the store
   /// // to one that works with only login domain.
   /// LoginView(
-  ///   store: store.scope(state: \.login, action: \.login)
+  ///   store: store.scope(\.login, action: \.login)
   /// )
   /// ```
   ///
@@ -290,6 +289,24 @@ public final class Store<State, Action>: _Store {
   ///   - state: A key path from `State` to `ChildState`.
   ///   - action: A case key path from `Action` to `ChildAction`.
   /// - Returns: A new store with its domain (state and action) transformed.
+  public func scope<ChildState, ChildAction>(
+    _ state: KeyPath<State, ChildState>,
+    action: CaseKeyPath<Action, ChildAction>
+  ) -> Store<ChildState, ChildAction> {
+    func open(_ core: some Core<State, Action>) -> any Core<ChildState, ChildAction> {
+      ScopedCore(base: core, stateKeyPath: state, actionKeyPath: action)
+    }
+    return scope(id: id(state: state, action: action), childCore: open(core))
+  }
+
+  #if ComposableArchitecture2Deprecations
+    @available(*, deprecated, renamed: "scope(_:action:)")
+  #else
+    @available(iOS, deprecated: 9999, renamed: "scope(_:action:)")
+    @available(macOS, deprecated: 9999, renamed: "scope(_:action:)")
+    @available(tvOS, deprecated: 9999,renamed: "scope(_:action:)")
+    @available(watchOS, deprecated: 9999, renamed: "scope(_:action:)")
+  #endif
   public func scope<ChildState, ChildAction>(
     state: KeyPath<State, ChildState>,
     action: CaseKeyPath<Action, ChildAction>

--- a/Sources/ComposableArchitecture/UIKit/AlertStateUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/AlertStateUIKit.swift
@@ -17,7 +17,7 @@
     ///   func viewDidLoad() {
     ///     // ...
     ///
-    ///     present(item: $store.scope(state: \.alert, action: \.alert)) { store in
+    ///     present(item: $store.scope(\.alert, action: \.alert)) { store in
     ///       UIAlertController(store: store)
     ///     }
     ///   }
@@ -41,7 +41,7 @@
     ///   func viewDidLoad() {
     ///     // ...
     ///
-    ///     present(item: $store.scope(state: \.dialog, action: \.dialog)) { store in
+    ///     present(item: $store.scope(\.dialog, action: \.dialog)) { store in
     ///       UIAlertController(store: store)
     ///     }
     ///   }

--- a/Sources/ComposableArchitectureMacros/ReducerMacro.swift
+++ b/Sources/ComposableArchitectureMacros/ReducerMacro.swift
@@ -652,12 +652,12 @@ private enum ReducerCase {
       {
         return """
           case .\(name):
-          return .\(name)(store.scope(state: \\.\(name), action: \\.\(name))!)
+          return .\(name)(store.scope(\\.\(name), action: \\.\(name))!)
           """
       } else if explicitActionType != nil {
         return """
           case .\(name):
-          return .\(name)(store.scope(state: \\.\(name), action: \\.\(name))!)
+          return .\(name)(store.scope(\\.\(name), action: \\.\(name))!)
           """
       } else if let parameters = element.parameterClause?.parameters {
         let bindingNames = (0..<parameters.count).map { "v\($0)" }.joined(separator: ", ")

--- a/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
@@ -406,11 +406,11 @@
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
             case .activity:
-              return .activity(store.scope(state: \.activity, action: \.activity)!)
+              return .activity(store.scope(\.activity, action: \.activity)!)
             case .timeline:
-              return .timeline(store.scope(state: \.timeline, action: \.timeline)!)
+              return .timeline(store.scope(\.timeline, action: \.timeline)!)
             case .tweet:
-              return .tweet(store.scope(state: \.tweet, action: \.tweet)!)
+              return .tweet(store.scope(\.tweet, action: \.tweet)!)
             case let .alert(v0):
               return .alert(v0)
             }
@@ -503,9 +503,9 @@
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
             case .timeline:
-              return .timeline(store.scope(state: \.timeline, action: \.timeline)!)
+              return .timeline(store.scope(\.timeline, action: \.timeline)!)
             case .meeting:
-              return .meeting(store.scope(state: \.meeting, action: \.meeting)!)
+              return .meeting(store.scope(\.meeting, action: \.meeting)!)
             }
           }
         }
@@ -842,9 +842,9 @@
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
             case .activity:
-              return .activity(store.scope(state: \.activity, action: \.activity)!)
+              return .activity(store.scope(\.activity, action: \.activity)!)
             case .timeline:
-              return .timeline(store.scope(state: \.timeline, action: \.timeline)!)
+              return .timeline(store.scope(\.timeline, action: \.timeline)!)
             }
           }
         }
@@ -943,9 +943,9 @@
           public static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
             case .activity:
-              return .activity(store.scope(state: \.activity, action: \.activity)!)
+              return .activity(store.scope(\.activity, action: \.activity)!)
             case .timeline:
-              return .timeline(store.scope(state: \.timeline, action: \.timeline)!)
+              return .timeline(store.scope(\.timeline, action: \.timeline)!)
             }
           }
         }
@@ -1035,7 +1035,7 @@
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
             case .timeline:
-              return .timeline(store.scope(state: \.timeline, action: \.timeline)!)
+              return .timeline(store.scope(\.timeline, action: \.timeline)!)
             case let .meeting(v0):
               return .meeting(v0)
             }
@@ -1131,9 +1131,9 @@
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
             case .alert:
-              return .alert(store.scope(state: \.alert, action: \.alert)!)
+              return .alert(store.scope(\.alert, action: \.alert)!)
             case .settings:
-              return .settings(store.scope(state: \.settings, action: \.settings)!)
+              return .settings(store.scope(\.settings, action: \.settings)!)
             }
           }
         }
@@ -1339,11 +1339,11 @@
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
             case .drillDown:
-              return .drillDown(store.scope(state: \.drillDown, action: \.drillDown)!)
+              return .drillDown(store.scope(\.drillDown, action: \.drillDown)!)
             case .popover:
-              return .popover(store.scope(state: \.popover, action: \.popover)!)
+              return .popover(store.scope(\.popover, action: \.popover)!)
             case .sheet:
-              return .sheet(store.scope(state: \.sheet, action: \.sheet)!)
+              return .sheet(store.scope(\.sheet, action: \.sheet)!)
             }
           }
         }
@@ -1415,7 +1415,7 @@
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
             case .feature:
-              return .feature(store.scope(state: \.feature, action: \.feature)!)
+              return .feature(store.scope(\.feature, action: \.feature)!)
             }
           }
         }
@@ -1859,18 +1859,18 @@
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
             case .child:
-              return .child(store.scope(state: \.child, action: \.child)!)
+              return .child(store.scope(\.child, action: \.child)!)
             #if os(macOS)
             case .mac:
-              return .mac(store.scope(state: \.mac, action: \.mac)!)
+              return .mac(store.scope(\.mac, action: \.mac)!)
             case let .macAlert(v0):
               return .macAlert(v0)
             #elseif os(iOS)
             case .phone:
-              return .phone(store.scope(state: \.phone, action: \.phone)!)
+              return .phone(store.scope(\.phone, action: \.phone)!)
             #else
             case .other:
-              return .other(store.scope(state: \.other, action: \.other)!)
+              return .other(store.scope(\.other, action: \.other)!)
             case .another:
               return .another
             #endif
@@ -1878,7 +1878,7 @@
             #if DEBUG
             #if INNER
             case .inner:
-              return .inner(store.scope(state: \.inner, action: \.inner)!)
+              return .inner(store.scope(\.inner, action: \.inner)!)
             case let .innerDialog(v0):
               return .innerDialog(v0)
             #endif
@@ -1976,7 +1976,7 @@
           static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
             switch store.state {
             case .child:
-              return .child(store.scope(state: \.child, action: \.child)!)
+              return .child(store.scope(\.child, action: \.child)!)
             #if DEBUG
             case let .value(v0, v1):
               return .value(v0, v1)

--- a/Tests/ComposableArchitectureTests/NestedEnumFeatureTests.swift
+++ b/Tests/ComposableArchitectureTests/NestedEnumFeatureTests.swift
@@ -28,8 +28,9 @@ import ComposableArchitecture
 }
 
 #if canImport(SwiftUI)
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   struct ParentView: View {
-    @Bindable fileprivate var store: StoreOf<Parent>
+    @SwiftUI.Bindable fileprivate var store: StoreOf<Parent>
 
     var body: some View {
       EmptyView()

--- a/Tests/ComposableArchitectureTests/NestedEnumFeatureTests.swift
+++ b/Tests/ComposableArchitectureTests/NestedEnumFeatureTests.swift
@@ -34,7 +34,7 @@ import ComposableArchitecture
     var body: some View {
       EmptyView()
         .sheet(
-          item: $store.scope(state: \.destination, action: \.destination).inner.leaf
+          item: $store.scope(\.destination, action: \.destination).inner.leaf
         ) { (store: StoreOf<Leaf>) in
           EmptyView()
         }

--- a/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
@@ -71,11 +71,11 @@ private struct Root {
 
   var body: some ReducerOf<Self> {
     CombineReducers {
-      Scope(state: \.feature, action: \.feature) {
+      Scope(\.feature, action: \.feature) {
         Feature()
         Feature()
       }
-      Scope(state: \.feature, action: \.feature) {
+      Scope(\.feature, action: \.feature) {
         Feature()
         Feature()
       }
@@ -217,7 +217,7 @@ private struct ScopeIfLetExample {
   enum Action {}
 
   var body: some ReducerOf<Self> {
-    Scope(state: \.self, action: \.self) {
+    Scope(\.self, action: \.self) {
       EmptyReducer()
         .ifLet(\.optionalSelf, action: \.self) {
           EmptyReducer()

--- a/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
+++ b/Tests/ComposableArchitectureTests/RuntimeWarningTests.swift
@@ -113,7 +113,7 @@
       }
 
       XCTExpectFailure {
-        store.scope(state: \.path, action: \.path)[
+        store.scope(\.path, action: \.path)[
           fileID: "file.swift",
           filePath: "/file.swift",
           line: 1,

--- a/Tests/ComposableArchitectureTests/ScopeCacheTests.swift
+++ b/Tests/ComposableArchitectureTests/ScopeCacheTests.swift
@@ -12,7 +12,7 @@ final class ScopeCacheTests: BaseTCATestCase {
       _ =
         store
         .scope(state: { $0 }, action: { $0 })
-        .scope(state: \.child, action: \.child.presented)?
+        .scope(\.child, action: \.child.presented)?
         .send(.show)
     } issueMatcher: {
       $0.compactDescription.hasSuffix(
@@ -40,8 +40,8 @@ final class ScopeCacheTests: BaseTCATestCase {
       let store = StoreOf<Feature>(initialState: Feature.State(child: Feature.State())) {
       }
       store
-        .scope(state: \.self, action: \.self)
-        .scope(state: \.child, action: \.child.presented)?
+        .scope(\.self, action: \.self)
+        .scope(\.child, action: \.child.presented)?
         .send(.show)
     #endif
   }
@@ -55,9 +55,9 @@ final class ScopeCacheTests: BaseTCATestCase {
       }
       let cancellable =
         store
-        .scope(state: \.child, action: \.child.presented)
+        .scope(\.child, action: \.child.presented)
         .ifLet { store in
-          store.scope(state: \.child, action: \.child.presented)?.send(.show)
+          store.scope(\.child, action: \.child.presented)?.send(.show)
         }
       _ = cancellable
     #endif
@@ -73,7 +73,7 @@ final class ScopeCacheTests: BaseTCATestCase {
         store
         .scope(state: { $0 }, action: { $0 })
         .ifLet { store in
-          store.scope(state: \.child, action: \.child.presented)?.send(.show)
+          store.scope(\.child, action: \.child.presented)?.send(.show)
         }
       _ = cancellable
     } issueMatcher: {
@@ -103,8 +103,8 @@ final class ScopeCacheTests: BaseTCATestCase {
 
       let rowsStore = Array(
         store
-          .scope(state: \.self, action: \.self)
-          .scope(state: \.rows, action: \.rows)
+          .scope(\.self, action: \.self)
+          .scope(\.rows, action: \.rows)
       )
       rowsStore[0].send(.show)
     #endif
@@ -120,7 +120,7 @@ final class ScopeCacheTests: BaseTCATestCase {
       _ = Array(
         store
           .scope(state: { $0 }, action: { $0 })
-          .scope(state: \.rows, action: \.rows)
+          .scope(\.rows, action: \.rows)
       )
     } issueMatcher: {
       $0.compactDescription.hasSuffix(

--- a/Tests/ComposableArchitectureTests/ScopeLoggerTests.swift
+++ b/Tests/ComposableArchitectureTests/ScopeLoggerTests.swift
@@ -18,8 +18,8 @@ class ScopeLoggerTests: XCTestCase {
         NavigationTestCaseView.Feature()
       }
       let viewStore = ViewStore(store, observe: { $0 })
-      let pathStore = store.scope(state: \.path, action: \.path)
-      let elementStore = pathStore.scope(state: \.[id: 0]!, action: \.[id: 0])
+      let pathStore = store.scope(\.path, action: \.path)
+      let elementStore = pathStore.scope(\.[id: 0]!, action: \.[id: 0])
       Logger.shared.clear()
       elementStore.send(.incrementButtonTapped)
       XCTAssertEqual(

--- a/Tests/ComposableArchitectureTests/ScopeTests.swift
+++ b/Tests/ComposableArchitectureTests/ScopeTests.swift
@@ -89,10 +89,10 @@ private struct Feature {
     case child2(Child2.Action)
   }
   var body: some ReducerOf<Self> {
-    Scope(state: \.child1, action: \.child1) {
+    Scope(\.child1, action: \.child1) {
       Child1()
     }
-    Scope(state: \.child2, action: \.child2) {
+    Scope(\.child2, action: \.child2) {
       Child2()
     }
   }

--- a/Tests/ComposableArchitectureTests/StoreLifetimeTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreLifetimeTests.swift
@@ -9,13 +9,13 @@ final class StoreLifetimeTests: BaseTCATestCase {
     let grandparentStore = Store(initialState: Grandparent.State()) {
       Grandparent()
     }
-    let parentStore = grandparentStore.scope(state: \.child, action: \.child)
-    XCTAssertTrue(parentStore === grandparentStore.scope(state: \.child, action: \.child))
+    let parentStore = grandparentStore.scope(\.child, action: \.child)
+    XCTAssertTrue(parentStore === grandparentStore.scope(\.child, action: \.child))
     XCTAssertFalse(
       parentStore === grandparentStore.scope(state: { $0.child }, action: { .child($0) })
     )
-    let childStore = parentStore.scope(state: \.child, action: \.child)
-    XCTAssertTrue(childStore === parentStore.scope(state: \.child, action: \.child))
+    let childStore = parentStore.scope(\.child, action: \.child)
+    XCTAssertTrue(childStore === parentStore.scope(\.child, action: \.child))
     XCTAssertFalse(
       childStore === parentStore.scope(state: { $0.child }, action: { .child($0) })
     )
@@ -28,7 +28,7 @@ final class StoreLifetimeTests: BaseTCATestCase {
       Grandparent()
     }
     var parentStore: Store! = grandparentStore.scope(state: { $0.child }, action: { .child($0) })
-    let childStore = parentStore.scope(state: \.child, action: \.child)
+    let childStore = parentStore.scope(\.child, action: \.child)
 
     childStore.send(.tap)
     XCTAssertEqual(1, grandparentStore.withState(\.child.child.count))
@@ -201,7 +201,7 @@ private struct Parent {
     case child(Child.Action)
   }
   var body: some ReducerOf<Self> {
-    Scope(state: \.child, action: \.child) {
+    Scope(\.child, action: \.child) {
       Child()
     }
   }
@@ -217,7 +217,7 @@ private struct Grandparent {
     case incrementGrandchild
   }
   var body: some ReducerOf<Self> {
-    Scope(state: \.child, action: \.child) {
+    Scope(\.child, action: \.child) {
       Parent()
     }
     Reduce { state, action in


### PR DESCRIPTION
To prepare for changes coming in 2.0, we are introducing new scoping overloads that omit the `state:` parameter label. This label is already omitted for some scoping operations (`ifLet`, `forEach`, etc.) and is just added noise for the dominant part of the operation.

The old API has been trait-deprecated so that folks can migrate at their own pace without too much noise.