### PR TITLE
Fix documentation link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     url: https://github.com/pointfreeco/swift-composable-architecture/discussions
     about: Composable Architecture Q&A, ideas, and more
   - name: Documentation
-    url: https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/
+    url: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture
     about: Read the Composable Architecture's documentation
   - name: Videos
     url: https://www.pointfree.co/collections/composable-architecture


### PR DESCRIPTION
Updates the issue template Documentation contact link to the Swift Package Index DocC URL.