### PR TITLE
Fix syntax errors in bindings documentation examples

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
@@ -255,7 +255,7 @@ var body: some Reducer<State, Action> {
   BindingReducer()
 
   Reduce { state, action in
-    switch action
+    switch action {
     case .binding(\.displayName):
       // Validate display name
   

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
@@ -300,5 +300,5 @@ store.send(\.binding.displayName, "Blob") {
 }
 store.send(\.binding.protectMyPosts, true) {
   $0.protectMyPosts = true
-)
+}
 ```

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
@@ -243,7 +243,7 @@ Then bindings can be derived from the store using familiar `$` syntax:
 
 ```swift
 TextField("Display name", text: $store.displayName)
-Toggle("Notifications", text: $store.enableNotifications)
+Toggle("Notifications", isOn: $store.enableNotifications)
 // ...
 ```
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
@@ -162,27 +162,27 @@ struct Settings {
   var body: some Reducer<State, Action> {
     Reduce { state, action in
       switch action {
-      case let digestChanged(digest):
+      case let .digestChanged(digest):
         state.digest = digest
         return .none
 
-      case let displayNameChanged(displayName):
+      case let .displayNameChanged(displayName):
         state.displayName = displayName
         return .none
 
-      case let enableNotificationsChanged(isOn):
+      case let .enableNotificationsChanged(isOn):
         state.enableNotifications = isOn
         return .none
 
-      case let protectMyPostsChanged(isOn):
+      case let .protectMyPostsChanged(isOn):
         state.protectMyPosts = isOn
         return .none
 
-      case let sendEmailNotificationsChanged(isOn):
+      case let .sendEmailNotificationsChanged(isOn):
         state.sendEmailNotifications = isOn
         return .none
 
-      case let sendMobileNotificationsChanged(isOn):
+      case let .sendMobileNotificationsChanged(isOn):
         state.sendMobileNotifications = isOn
         return .none
       }


### PR DESCRIPTION
## Summary

Fix several syntax issues in the bindings documentation examples:

- Add missing leading dots to enum case patterns.
- Use `isOn:` instead of `text:` for a `Toggle` binding.
- Add a missing `{` after `switch action`.
- Fix a mismatched closing delimiter in a binding test example.

## Testing

- Documentation changes only.