### PR TITLE
Fix SharingState documentation example syntax

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/SharingState.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/SharingState.md
@@ -187,7 +187,7 @@ It works similarly to the in-memory sharing discussed above, but it requires a U
 on disk, as well as a default value that will be used when there is no data in the file system:
 
 ```swift
-@Shared(.fileStorage(URL(/* ... */)) var users: [User] = []
+@Shared(.fileStorage(URL(/* ... */))) var users: [User] = []
 ```
 
 This strategy works by serializing your value to JSON to save to disk, and then deserializing JSON

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/SharingState.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/SharingState.md
@@ -868,7 +868,7 @@ like this:
 
 ```swift
 extension URL {
-  static let users = URL(/* ... */))
+  static let users = URL(/* ... */)
 }
 
 @Shared(.fileStorage(.users)) var users: [User] = []

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/SharingState.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/SharingState.md
@@ -1101,7 +1101,7 @@ await store.send(.tap)
 
 // ❌ Expected state to change, but no change occurred.
 await store.receive(.response) {
-  $0.$shared.withLock { $0 = true }
+  $0.$bool.withLock { $0 = true }
 }
 ```
 
@@ -1111,7 +1111,7 @@ must always assert against shared state mutations in the first action:
 
 ```swift
 await store.send(.tap) {  // ✅
-  $0.$shared.withLock { $0 = true }
+  $0.$bool.withLock { $0 = true }
 }
 
 // ❌ Expected state to change, but no change occurred.

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/SharingState.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/SharingState.md
@@ -653,7 +653,7 @@ section above to use app storage:
 struct State: Equatable {
   @Shared(.appStorage("count")) var count: Int
 }
-````
+```
 
 …then the test for this feature can be written in the same way as before and will still pass.
 


### PR DESCRIPTION
## Summary

Fix several syntax issues in the `SharingState.md` documentation examples:

- Add a missing closing delimiter to a `@Shared(.fileStorage(...))` example.
- Normalize a mismatched Swift code fence delimiter.
- Remove an extra closing delimiter from a `URL(/* ... */)` example.
- Update shared state test assertions to use the correct projected value.

## Details

| Change | Reason |
|---|---|
| `@Shared(.fileStorage(URL(/* ... */))) var users` | The example opens `@Shared(`, `.fileStorage(`, and `URL(`, so it needs three closing parentheses before `var users`. |
| Four backticks -> three backticks | The code block opens with three backticks, so closing it with the same delimiter keeps the DocC Markdown example consistent. |
| `static let users = URL(/* ... */)` | The previous example had one extra closing parenthesis, which made the Swift snippet invalid. |
| `$0.$shared` -> `$0.$bool` | The example declares `@Shared(value: false) var bool`, so the projected value is `$bool`. The `_shared` text shown in the failure output is backing storage, not an accessible state property. |