### PR TITLE
Fix outdated Path reducer examples in stack navigation docs

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
@@ -411,7 +411,7 @@ struct Feature {
     Reduce { state, action in
       // Logic and behavior for core feature.
     }
-    .forEach(\.path, action: \.path)
+    .forEach(\.path, action: \.path) { Path.body }
   }
 }
 ```

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
@@ -426,7 +426,7 @@ func dismissal() {
   let store = TestStore(
     initialState: Feature.State(
       path: StackState([
-        CounterFeature.State(count: 3)
+        .counter(CounterFeature.State(count: 3))
       ])
     )
   ) {
@@ -549,7 +549,7 @@ func dismissal() {
   let store = TestStore(
     initialState: Feature.State(
       path: StackState([
-        CounterFeature.State(count: 3)
+        .counter(CounterFeature.State(count: 3))
       ])
     )
   ) {

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
@@ -403,19 +403,15 @@ struct Feature {
   }
 
   @Reducer  
-  struct Path {
-    enum State: Equatable { case counter(CounterFeature.State) }
-    enum Action { case counter(CounterFeature.Action) }
-    var body: some ReducerOf<Self> {
-      Scope(\.counter, action: \.counter) { CounterFeature() }
-    }
+  enum Path {
+    case counter(CounterFeature)
   }
 
   var body: some ReducerOf<Self> {
     Reduce { state, action in
       // Logic and behavior for core feature.
     }
-    .forEach(\.path, action: \.path) { Path() }
+    .forEach(\.path, action: \.path)
   }
 }
 ```


### PR DESCRIPTION
## Summary

Update the testing examples in `StackBasedNavigation.md` to be consistent with earlier examples in the document.

Changes include:

- Replace the manual `Path` reducer definition with `@Reducer enum Path`
- Remove the explicit `Path()` argument from `.forEach`
- Wrap test states in the appropriate `Path.State` case

## Testing

- Documentation changes only.