### PR TITLE
Fix syntax error and typo in documentation examples

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -175,7 +175,7 @@ store.send(.toggleChanged) {
   $0.isEnabled = true
   // Assert on shared logic
 }
-store.send(.textFieldChanged("Hello") {
+store.send(.textFieldChanged("Hello")) {
   $0.description = "Hello"
   // Assert on shared logic
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
@@ -238,7 +238,7 @@ struct InventoryFeature {
 }
 ```
 
-> Note: It's not necessary to specify `Destination` in a trialing closure of `ifLet` because it can
+> Note: It's not necessary to specify `Destination` in a trailing closure of `ifLet` because it can
 > automatically be inferred due to how the `Destination` enum was defined with the ``Reducer()``
 > macro.
 


### PR DESCRIPTION
## Summary

Fix two small issues in the documentation examples:

- **Performance.md**: Add a missing closing parenthesis to a `store.send(.textFieldChanged("Hello"))` example. The two preceding `store.send` examples in the same code block correctly close the parenthesis before the trailing closure.
- **TreeBasedNavigation.md**: Fix a "trialing" → "trailing" typo.

## Testing

- `git diff --check` passes.