### PR TITLE
Fix missing await in TestingTCA send examples

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/TestingTCA.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/TestingTCA.md
@@ -119,7 +119,7 @@ on computed properties you might have defined on your state. For example, if `St
 computed property for checking if `count` was prime, we could test it like so:
 
 ```swift
-store.send(.incrementButtonTapped) {
+await store.send(.incrementButtonTapped) {
   $0.count = 3
 }
 XCTAssertTrue(store.state.isPrime)
@@ -131,7 +131,7 @@ prevents you from being able to use an escape hatch to get around needing to act
 state mutation, like so:
 
 ```swift
-store.send(.incrementButtonTapped) {
+await store.send(.incrementButtonTapped) {
   $0 = store.state  // ❌ store.state is the previous, not current, state.
 }
 ```

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/TestingTCA.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/TestingTCA.md
@@ -535,7 +535,7 @@ let store = TestStore(/* ... */)
 // ℹ️ "on" is the default so technically this is not needed
 store.exhaustivity = .on
 
-store.send(.buttonTapped) {
+await store.send(.buttonTapped) {
   $0  // Represents the state *before* the action was sent
 }
 ```
@@ -550,7 +550,7 @@ trailing closure of `send` represents the state _after_ the action was sent:
 let store = TestStore(/* ... */)
 store.exhaustivity = .off
 
-store.send(.buttonTapped) {
+await store.send(.buttonTapped) {
   $0  // Represents the state *after* the action was sent
 }
 ```


### PR DESCRIPTION
## Summary

Fix a few `TestingTCA.md` documentation examples that call `TestStore.send` without `await`:

- Add `await` to examples that explain how `TestStore.state` behaves inside `send` assertions.
- Add `await` to examples that compare exhaustive and non-exhaustive `TestStore` behavior.
- Align the snippets with the rest of the article, where `TestStore.send` is already awaited.

## Details

| Change | Reason |
|---|---|
| `await store.send(.incrementButtonTapped) { ... }` | `TestStore.send` is async and returns `TestStoreTask`, so copied test code needs `await`. |
| `await store.send(.buttonTapped) { ... }` | The surrounding examples use `await` for the same API, and these snippets were the remaining inconsistent calls. |
