### PR TITLE
Add onChange overload with action that caused the change

### DIFF
--- a/Sources/ComposableArchitecture/Reducer/Reducers/OnChange.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/OnChange.swift
@@ -58,6 +58,18 @@ extension Reducer {
       })
     }
   }
+  
+  @inlinable
+  public func onChange<V: Equatable>(
+    of toValue: @escaping (State) -> V,
+    _ perform: @escaping (_ oldValue: V, _ state: inout State, _ action: Action) -> EffectOf<Self>
+  ) -> some Reducer<State, Action> {
+    _OnChangeReducer(base: self, toValue: toValue, isDuplicate: ==) { oldValue, _ in
+      Reduce(internal: { state, action in
+        perform(oldValue, &state, action)
+      })
+    }
+  }
 
   #if ComposableArchitecture2Deprecations
     @available(


### PR DESCRIPTION
## Prototype: Expose `Action` in change observation overload

### Motivation

Recent changes no longer expose the `Action` that caused a state update to callers observing state changes. In most cases this is desirable: callers should generally react to state, not to implementation details of how that state changed.

However, there are still cases where callers need to distinguish *why* a change occurred. For example, a feature may update the same piece of state from several different actions, but an external observer may only want to react when the change was triggered by a specific action.

Today, it is possible to achieve that by exposing the action to the caller. However, it is unclear whether that approach remains compatible with the direction of TCA 2.0.

The question here is whether action-aware observation is still appropriate, or whether callers should model this need differently

### Change

This PR adds an overload that exposes the `Action` associated with a state change.

Conceptually, this allows callers to write observation logic that can inspect both:

```swift
oldValue
newState
action
```

instead of only:

```swift
oldValue
newState
```

This makes it possible to filter out state changes that were caused by unrelated actions.

### Example use case

A feature may update the same state value from multiple actions:

```swift
enum Action {
  case userTappedRefresh
  case backgroundSyncCompleted
  case cacheRestored
}
```

All of these actions may update the same state field, but an external observer may only want to react to one of them:

```swift
.onChange(
  state: \.items
) { oldValue, state, action in
  // React only to user-initiated refreshes.
  guard action == .userTappedRefresh else { return .none }
}
```
