### PR TITLE
Fix TestStore initialization in navigation tutorial

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-03-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-03-code-0002.swift
@@ -8,7 +8,8 @@ import Testing
 struct ContactsFeatureTests {
   @Test
   func deleteContact() async {
-    let store = TestStore(initialState: ContactsFeature.State(
+    let store = TestStore(
+      initialState: ContactsFeature.State(
         contacts: [
           Contact(id: UUID(0), name: "Blob"),
           Contact(id: UUID(1), name: "Blob Jr."),

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-03-code-0002.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-03-code-0002.swift
@@ -8,8 +8,7 @@ import Testing
 struct ContactsFeatureTests {
   @Test
   func deleteContact() async {
-    let store = TestStore(initialState: ContactsFeature.State()) {
-      initialState: ContactsFeature.State(
+    let store = TestStore(initialState: ContactsFeature.State(
         contacts: [
           Contact(id: UUID(0), name: "Blob"),
           Contact(id: UUID(1), name: "Blob Jr."),


### PR DESCRIPTION
## Summary

Fix the `TestStore` initialization in the navigation testing tutorial.

The example previously initialized the test store with an empty state and then placed a second `initialState:` expression inside the reducer closure, which made the tutorial snapshot invalid Swift.

This change:

- Initializes `ContactsFeature.State` with the contact fixtures directly in the existing `initialState` argument.
- Removes the duplicated `initialState:` expression from the reducer closure.
- Keeps the snapshot consistent with the following tutorial step.

## Testing

- `xcrun swiftc -frontend -parse Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/03-TestingPresentation/02-03-03-code-0002.swift`
- `git diff --check main...HEAD`