### PR TITLE
Fix missing await and syntax errors in documentation examples

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
@@ -295,10 +295,10 @@ let store = TestStore(initialState: Settings.State()) {
   Settings()
 }
 
-store.send(\.binding.displayName, "Blob") {
+await store.send(\.binding.displayName, "Blob") {
   $0.displayName = "Blob"
 }
-store.send(\.binding.protectMyPosts, true) {
+await store.send(\.binding.protectMyPosts, true) {
   $0.protectMyPosts = true
 }
 ```

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/FAQ.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/FAQ.md
@@ -131,10 +131,10 @@ Modeling user actions with an enum rather than methods defined on some object is
 - Having a data type of all actions in your feature also makes it possible to write exhaustive tests on every aspect of your feature. Using something known as a [`TestStore`][test-store-docs] you can emulate user flows by sending it actions and asserting how state changes each step of the way. And further, you must also assert on how effects feed their data back into the system by asserting on actions received:
 
   ```swift
-  store.send(.refreshButtonTapped) {
+  await store.send(.refreshButtonTapped) {
     $0.isLoading = true
   }
-  store.receive(\.userResponse) {
+  await store.receive(\.userResponse) {
     $0.currentUser = User(id: 42, name: "Blob")
     $0.isLoading = false
   }

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.10.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.10.md
@@ -38,7 +38,7 @@ changes of `signUpData` to be automatically persisted to the file system you can
 ```swift
 @ObservableState
 struct State {
-  @Shared(.fileStorage(URL(/* ... */) var signUpData = SignUpData()
+  @Shared(.fileStorage(URL(/* ... */))) var signUpData = SignUpData()
   // ...
 }
 ```

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.11.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigrationGuides/MigratingTo1.11.md
@@ -98,7 +98,7 @@ Xcode previews. It works like SwiftUI's `Binding.constant`, but for shared refer
       Feature()
     }
   )
-)
+}
 ```
 
 ## Migrating to 1.11.2

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -81,22 +81,22 @@ let store = TestStore(initialState: Feature.State()) {
   Feature()
 }
 
-store.send(.buttonTapped) {
+await store.send(.buttonTapped) {
   $0.count = 1
 }
-store.receive(\.sharedComputation) {
+await store.receive(\.sharedComputation) {
   // Assert on shared logic
 }
-store.send(.toggleChanged) {
+await store.send(.toggleChanged) {
   $0.isEnabled = true
 }
-store.receive(\.sharedComputation) {
+await store.receive(\.sharedComputation) {
   // Assert on shared logic
 }
-store.send(.textFieldChanged("Hello")) {
+await store.send(.textFieldChanged("Hello")) {
   $0.description = "Hello"
 }
-store.receive(\.sharedComputation) {
+await store.receive(\.sharedComputation) {
   // Assert on shared logic
 }
 ```
@@ -167,15 +167,15 @@ let store = TestStore(initialState: Feature.State()) {
   Feature()
 }
 
-store.send(.buttonTapped) {
+await store.send(.buttonTapped) {
   $0.count = 1
   // Assert on shared logic
 }
-store.send(.toggleChanged) {
+await store.send(.toggleChanged) {
   $0.isEnabled = true
   // Assert on shared logic
 }
-store.send(.textFieldChanged("Hello")) {
+await store.send(.textFieldChanged("Hello")) {
   $0.description = "Hello"
   // Assert on shared logic
 }


### PR DESCRIPTION
Follow-ups to the same classes of documentation bug fixed in #3940, #3936 and #3939 — I found remaining instances in other articles.

### Missing `await` on `TestStore` (13 lines)

`TestStore.send` and `TestStore.receive` are both `async`, so these examples do not compile as written. `TestingTCA.md` was corrected in #3940; the same shape survives in three other articles, each inside a block that constructs a `TestStore`:

- `Articles/Performance.md` — 9 lines across the two "sharing logic" test examples
- `Articles/Bindings.md` — 2 lines in the binding-action test example
- `Articles/FAQ.md` — 2 lines, in the paragraph that explicitly introduces `TestStore`

### Unbalanced parentheses (2 lines)

- `Articles/MigrationGuides/MigratingTo1.10.md` — `@Shared(.fileStorage(URL(/* ... */) var signUpData` is missing two closing parens. This is the same typo #3936 fixed in `SharingState.md`; that file now reads `@Shared(.fileStorage(URL(/* ... */))) var users`, and this line now matches it.
- `Articles/MigrationGuides/MigratingTo1.11.md` — the `#Preview { … }` example closes with `)` instead of `}`.

### How I found them

I extracted all 362 ```swift blocks from the DocC sources and checked paren/bracket balance outside strings and comments, then cross-checked every `store.send`/`store.receive` against whether its block builds a `TestStore`. Braces were deliberately not balance-checked, since the docs legitimately show fragments.

Two things I deliberately left alone:

- `Articles/StackBasedNavigation.md:212` also calls `store.send(.detailButtonTapped)` without `await`, but that one is inside a SwiftUI `Button` and so is the synchronous `Store.send` — correct as written.
- `Articles/MigrationGuides/MigratingTo1.15.md:38` has an unbalanced `])` , but it reads as an intentional excerpt from the middle of a `.target(…)` call rather than a typo. Happy to adjust if you'd prefer it balanced.

I did not touch the `store.receive` calls in the 1.4 and 1.9 migration guides, since those are illustrating an older API era and it wasn't obvious whether you want them modernized.
