### PR TITLE
Fix reducer in tree-based navigation test examples

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/TreeBasedNavigation.md
@@ -586,7 +586,7 @@ func dismissal() {
       counter: CounterFeature.State(count: 3)
     )
   ) {
-    CounterFeature()
+    Feature()
   }
 }
 ```
@@ -642,7 +642,7 @@ func dismissal() {
       counter: CounterFeature.State(count: 3)
     )
   ) {
-    CounterFeature()
+    Feature()
   }
   store.exhaustivity = .off
 


### PR DESCRIPTION
## Summary

Fix the reducer used in the tree-based navigation testing examples.

Both examples initialize `TestStore` with `Feature.State`, but incorrectly use `CounterFeature` as the reducer. This updates them to use `Feature` so that the reducer matches the initial state.

## Testing

- Documentation changes only.