### PR TITLE
Fix errors in stack navigation documentation examples

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
@@ -266,7 +266,7 @@ methods, such as ``StackState/popLast()``, ``StackState/pop(from:)`` and more:
 
 ```swift
 case .closeButtonTapped:
-  state.popLast()
+  state.path.popLast()
   return .none
 ```
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/StackBasedNavigation.md
@@ -430,7 +430,7 @@ func dismissal() {
       ])
     )
   ) {
-    CounterFeature()
+    Feature()
   }
 }
 ```
@@ -553,7 +553,7 @@ func dismissal() {
       ])
     )
   ) {
-    CounterFeature()
+    Feature()
   }
   store.exhaustivity = .off
 


### PR DESCRIPTION
## Summary

Fix two errors in the stack-based navigation documentation examples.

Changes include:

- Use `state.path.popLast()` instead of `state.popLast()` in the dismissal example.
- Use `Feature` instead of `CounterFeature` as the reducer in testing examples initialized with `Feature.State`.

## Testing

- Documentation changes only.