### PR TITLE
Fix missing @ObservableState annotations in bindings examples

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
@@ -18,6 +18,7 @@ state:
 ```swift
 @Reducer
 struct Settings {
+  @ObservableState
   struct State: Equatable {
     var isHapticsEnabled = true
     // ...
@@ -33,6 +34,7 @@ define a corresponding action that can be sent updates:
 ```swift
 @Reducer
 struct Settings {
+  @ObservableState
   struct State: Equatable { /* ... */ }
 
   enum Action { 
@@ -49,6 +51,7 @@ When the reducer handles this action, it can update state accordingly:
 ```swift
 @Reducer
 struct Settings {
+  @ObservableState
   struct State: Equatable { /* ... */ }
   enum Action { /* ... */ }
 


### PR DESCRIPTION
## Summary

Fix the ad hoc binding examples by adding the missing `@ObservableState` annotations.

The examples use `@Bindable` and access state through `$store`, which requires
`Settings.State` to conform to `ObservableState`. This makes the examples consistent
with the binding action examples below.

## Testing

- Documentation changes only.