### PR TITLE
Fix access control for explicit action case scopes

### DIFF
--- a/Sources/ComposableArchitectureMacros/ReducerMacro.swift
+++ b/Sources/ComposableArchitectureMacros/ReducerMacro.swift
@@ -575,7 +575,7 @@ private enum ReducerCase {
       {
         let stateType = parameter.type
         return """
-          var \(name): CasePaths.AnyCasePath<CaseScope, ComposableArchitecture.Store<\(stateType.trimmed), \(explicitActionType.trimmed)>> {
+          \(accessPrefix)var \(name): CasePaths.AnyCasePath<CaseScope, ComposableArchitecture.Store<\(stateType.trimmed), \(explicitActionType.trimmed)>> {
           CasePaths.AnyCasePath(
           embed: CaseScope.\(name),
           extract: { guard case let .\(name)(v0) = $0 else { return nil }; return v0 }

--- a/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
+++ b/Tests/ComposableArchitectureMacrosTests/ReducerMacroTests.swift
@@ -1143,6 +1143,109 @@
         """#
       }
     }
+    
+    func testEnum_CaseIgnoredExplicitActions_AccessControl_Public() {
+      assertMacro {
+        """
+        @Reducer
+        public enum Destination {
+          @ReducerCaseIgnored case alert(AlertState<Alert>)
+          case settings(Settings)
+
+          public enum Action {
+            case alert(Alert)
+            case settings(Settings.Action)
+          }
+        }
+        """
+      } expansion: {
+        #"""
+        public enum Destination {
+          @ReducerCaseIgnored
+          @ReducerCaseEphemeral case alert(AlertState<Alert>)
+          case settings(Settings)
+          @CasePathable
+
+          public enum Action {
+            case alert(Alert)
+            case settings(Settings.Action)
+          }
+
+          @CasePathable
+          @dynamicMemberLookup
+          @ObservableState
+
+          public enum State: ComposableArchitecture.CaseReducerState {
+
+            public typealias StateReducer = Destination
+            case alert(AlertState<Alert>)
+            case settings(Settings.State)
+          }
+
+          @ComposableArchitecture.ReducerBuilder<Self.State, Self.Action>
+
+          public static var body: Reduce<Self.State, Self.Action> {
+            ComposableArchitecture.Reduce(
+              ComposableArchitecture.EmptyReducer<Self.State, Self.Action>()
+              .ifCaseLet(\Self.State.Cases.settings, action: \Self.Action.Cases.settings) {
+                Settings()
+              }
+            )
+          }
+
+          @dynamicMemberLookup
+
+          public enum CaseScope: ComposableArchitecture._CaseScopeProtocol, CasePaths.CasePathable {
+            case alert(ComposableArchitecture.Store<AlertState<Alert>, Alert>)
+            case settings(ComposableArchitecture.StoreOf<Settings>)
+
+            public struct AllCasePaths {
+              public var alert: CasePaths.AnyCasePath<CaseScope, ComposableArchitecture.Store<AlertState<Alert>, Alert>> {
+                CasePaths.AnyCasePath(
+                  embed: CaseScope.alert,
+                  extract: {
+                    guard case let .alert(v0) = $0 else {
+                      return nil
+                    };
+                    return v0
+                  }
+                )
+              }
+              public var settings: CasePaths.AnyCasePath<CaseScope, ComposableArchitecture.StoreOf<Settings>> {
+                CasePaths.AnyCasePath(
+                  embed: CaseScope.settings,
+                  extract: {
+                    guard case let .settings(v0) = $0 else {
+                      return nil
+                    };
+                    return v0
+                  }
+                )
+              }
+            }
+
+            public static var allCasePaths: AllCasePaths {
+              AllCasePaths()
+            }
+          }
+
+          @preconcurrency @MainActor
+
+          public static func scope(_ store: ComposableArchitecture.Store<Self.State, Self.Action>) -> CaseScope {
+            switch store.state {
+            case .alert:
+              return .alert(store.scope(\.alert, action: \.alert)!)
+            case .settings:
+              return .settings(store.scope(\.settings, action: \.settings)!)
+            }
+          }
+        }
+
+        extension Destination: ComposableArchitecture.CaseReducer, ComposableArchitecture.Reducer {
+        }
+        """#
+      }
+    }
 
     func testEnum_Attributes() {
       assertMacro {


### PR DESCRIPTION
## Summary

- Apply the enclosing reducer enum's access modifier to case-scope properties for cases with an explicit `Action` enum definition.
- Add macro expansion coverage for a public destination reducer with an ignored alert case.
- Complete the explicit `Action` branch not covered by [#3898](https://github.com/pointfreeco/swift-composable-architecture/pull/3898).

## Reproduction

When a public reducer is consumed from another module, an ignored alert case with
an explicit `Action` enum cannot use the enum-scope API:

```swift
// AFeature module
import ComposableArchitecture

@Reducer
public struct AFeature {
  @Reducer
  public enum Destination {
    @ReducerCaseIgnored
    case alert(AlertState<Alert>)

    public enum Action {
      case alert(Alert)
    }

    public enum Alert {
      case confirmButtonTapped
    }
  }

  @ObservableState
  public struct State {
    @Presents public var destination: Destination.State?

    public init() {}
  }

  public enum Action {
    case destination(PresentationAction<Destination.Action>)
  }
}
```

```swift
// App module
import AFeature
import ComposableArchitecture
import SwiftUI

public struct AFeatureView: View {
  @Bindable public var store: StoreOf<AFeature>

  public var body: some View {
    Text("Hello")
      // ❌ Error: 'alert' is inaccessible due to 'internal' protection level
      .alert($store.scope(\.$destination, action: \.destination).alert)
  }
}
```

The macro generates `CaseScope.AllCasePaths.alert` without the enclosing
reducer's `public` access modifier.

The direct key-path API does not access the generated
`CaseScope.AllCasePaths.alert` property, so it is unaffected by this
access-control issue:

```swift
.alert(
  $store.scope(
    state: \.$destination.alert,
    action: \.destination.alert
  )
)
```

## Testing

- [x] `ReducerMacroTests.testEnum_CaseIgnoredExplicitActions_AccessControl_Public`