### PR TITLE
Fix: alert action not routed to reducer in MultipleDestinations tutorial

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0014.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/02-MultipleDestinations/02-02-02-code-0014.swift
@@ -35,6 +35,10 @@ struct ContactsView: View {
         AddContactView(store: addContactStore)
       }
     }
-    .alert($store.scope(\.$destination, action: \.destination).alert)
+    .alert($store.scope(\.$destination, action: \.destination).alert) { action in
+      if let action {
+        store.send(.destination(.presented(.alert(action))))
+      }
+    }
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003-previous.swift
@@ -38,6 +38,10 @@ struct ContactsView: View {
         AddContactView(store: addContactStore)
       }
     }
-    .alert($store.scope(\.$destination, action: \.destination).alert)
+    .alert($store.scope(\.$destination, action: \.destination).alert) { action in
+      if let action {
+        store.send(.destination(.presented(.alert(action))))
+      }
+    }
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0003.swift
@@ -38,6 +38,10 @@ struct ContactsView: View {
         AddContactView(store: addContactStore)
       }
     }
-    .alert($store.scope(\.$destination, action: \.destination).alert)
+    .alert($store.scope(\.$destination, action: \.destination).alert) { action in
+      if let action {
+        store.send(.destination(.presented(.alert(action))))
+      }
+    }
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0004.swift
@@ -40,6 +40,10 @@ struct ContactsView: View {
         AddContactView(store: addContactStore)
       }
     }
-    .alert($store.scope(\.$destination, action: \.destination).alert)
+    .alert($store.scope(\.$destination, action: \.destination).alert) { action in
+      if let action {
+        store.send(.destination(.presented(.alert(action))))
+      }
+    }
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0005-previous.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0005-previous.swift
@@ -40,6 +40,10 @@ struct ContactsView: View {
         AddContactView(store: addContactStore)
       }
     }
-    .alert($store.scope(\.$destination, action: \.destination).alert)
+    .alert($store.scope(\.$destination, action: \.destination).alert) { action in
+      if let action {
+        store.send(.destination(.presented(.alert(action))))
+      }
+    }
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0005.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/MeetTheComposableArchitecture/02-Navigation/04-NavigationStacks/02-04-02-code-0005.swift
@@ -36,6 +36,10 @@ struct ContactsView: View {
         AddContactView(store: addContactStore)
       }
     }
-    .alert($store.scope(\.$destination, action: \.destination).alert)
+    .alert($store.scope(\.$destination, action: \.destination).alert) { action in
+      if let action {
+        store.send(.destination(.presented(.alert(action))))
+      }
+    }
   }
 }


### PR DESCRIPTION
## What

`02-02-02-code-0014.swift` in the "Multiple destinations" tutorial step presents the alert like this:

```swift
.alert($store.scope(\.$destination, action: \.destination).alert)
```

This single-argument call resolves to the `alert(_ state:)` overload in swift-navigation that's deprecated as of 2.7.0, since it discards the button action instead of forwarding it:

```swift
public func alert<Value>(_ state: Binding<AlertState<Value>?>) -> some View {
  alert(state) { _ in }
}
```

As a result, tapping a button in the alert never reaches the reducer — and building the tutorial's code as written produces this deprecation warning in Xcode:

<img width="1390" height="24" alt="alert deprecation warning" src="https://github.com/user-attachments/assets/93b8e8a4-e8d6-4c1a-9f90-4d9b0b458e9e" />
'alert' is deprecated: Binding to alert state must not ignore actions; provide an explicit trailing action handler`

## Why this happens

With the enum-scope API introduced in TCA 1.25, scoping into a non-reducer case of a destination enum (like `.alert`) now returns direct access to the state (a plain `Binding<AlertState<Value>?>`) rather than a `Store`-wrapped binding. That means the action handler is no longer wired automatically and must be supplied explicitly.

## Suggested fix

```swift
.alert($store.scope(state: \.$destination, action: \.destination).alert) { action in
  if let action {
    store.send(.destination(.presented(.alert(action))))
  }
}
```

I confirmed locally that the current tutorial code compiles with the deprecation warning above and drops the alert's action, while this change compiles cleanly and correctly routes the action to the reducer.

## Note

I'm learning TCA, so please let me know if there's a more idiomatic way to route the action here that I'm missing — happy to update the PR.
