### PR TITLE
Issue 3950 - Backport Xcode 27 support to TCA 1.23

### DIFF
--- a/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
+++ b/Sources/ComposableArchitecture/Observation/NavigationStack+Observation.swift
@@ -149,6 +149,7 @@ extension NavigationStack {
   /// See the dedicated article on <doc:Navigation> for more information on the library's
   /// navigation tools, and in particular see <doc:StackBasedNavigation> for information on using
   /// this view.
+  @MainActor
   public init<State, Action, Destination: View, R>(
     path: Binding<Store<StackState<State>, StackAction<State, Action>>>,
     @ViewBuilder root: () -> R,


### PR DESCRIPTION
## Summary

- Backport the Xcode 27 actor-isolation fix to the 1.23 compatibility source by marking the store-backed `NavigationStack` initializer `@MainActor`.

Fixes #3950

## Validation

- `swift package dump-package`
- `swift test --filter StackReducerTests` — 24 tests passed.
- `git diff --check`
- `swift test` completed the build and ran the test suites, but the process exited with signal 5 in the existing runtime-warning test path after earlier suites passed. No failure was reported for this change.

The change mirrors the one-line actor-isolation fix already used by the related Xcode 27 fix in #3931.
