### PR TITLE
docs(store): clarify ifLet vs observe re-fire semantics

### DIFF
--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -2482,7 +2482,12 @@ private final class NavigationLinkCore<
 }
 
 extension Store {
-  @available(*, deprecated, message: "Use 'observe' and 'if let store.scope', instead.")
+  @available(
+    *,
+    deprecated,
+    message:
+      "Use 'observe { if let store = store.scope(...) }' and distinguish the optional presence from child state mutations. 'observe' re-fires on every child mutation while 'ifLet(then:else:)' only fires on nil/non-nil transitions; avoid recreating views/controllers inside the 'observe' body or gate on the optional's identity."
+  )
   public func ifLet<Wrapped>(
     then unwrap: @escaping (_ store: Store<Wrapped, Action>) -> Void,
     else: @escaping () -> Void = {}


### PR DESCRIPTION
## Summary

Enhances the deprecated `Store.ifLet(then:else:)` message to call out the core semantic difference from its suggested replacement `observe { if let store.scope } `:

- `ifLet(then:else:)` fires only on nil/non-nil transitions (via `removeDuplicates` by presence).
- `observe { if let store.scope }` re-fires on *any* child state mutation while non-nil.

Callers that recreate views/controllers inside the `observe` body see duplicates (the reported UIKit bug). The new message directs authors to distinguish the optional's presence from child mutations or to gate recreation on the optional's identity.

## Issue

Addresses #3871 — migration from `ifLet(then:else:)` to `observe` duplicates work on child mutations.

## Validation

- `git diff --check` passes
- Deprecation-message-only change; no behavioral code change