### PR TITLE
Fix regression: `SyncUpDetailNavigation` tutorial step 03-code-0004 drops the `Array(...)` wrapper from step 03-code-0003

### DIFF
--- a/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0004.swift
+++ b/Sources/ComposableArchitecture/Documentation.docc/Tutorials/BuildingSyncUps/07-SyncUpDetailNavigation/SyncUpDetailNavigation-03-code-0004.swift
@@ -11,7 +11,7 @@ struct SyncUpsListView: View {
 
   var body: some View {
     List {
-      ForEach(store.$syncUps) { $syncUp in
+      ForEach(Array(store.$syncUps)) { $syncUp in
         NavigationLink(
           state: AppFeature.Path.State.detail(SyncUpDetail.State(syncUp: $syncUp))
         ) {


### PR DESCRIPTION
### What's wrong

In the "Meet the Composable Architecture" → "Building SyncUps" → **SyncUpDetailNavigation** tutorial (section 3, `SyncUpsList.swift`), step `03-code-0003` correctly introduces:

```swift
ForEach(Array(store.$syncUps)) { $syncUp in
```

with an explicit callout explaining why the `Array` initializer is needed to pass the shared collection along to `ForEach`.

The very next step, `03-code-0004`, is documented as only replacing the `<#Shared<SyncUp>#>` placeholder with `$syncUp` inside `SyncUpDetail.State(syncUp: ...)`. However, the code file for that step also silently reverts the `ForEach` line back to:

```swift
ForEach(store.$syncUps) { $syncUp in
```

i.e. it drops the `Array(...)` wrapper that was just introduced and explained one step earlier — with no mention of this change in the step's instructions.

### Why this is a regression, not intentional

- The step 03-code-0004 instructions ("Pass the projected value `$syncUp` to `SyncUpDetail.State`") say nothing about touching the `ForEach` call.
- The reference implementation in `Examples/SyncUps/SyncUps/SyncUpsList.swift` uses `ForEach(Array(store.$syncUps))`, confirming this is the intended final form.
- Following the tutorial in order, a reader hits the exact same problem step 03-code-0003 had just fixed, right after fixing it — attached screenshots show the steps leading up to this.

### Fix

Restore `Array(...)` in `SyncUpDetailNavigation-03-code-0004.swift` so it matches step 03-code-0003 plus the placeholder replacement, consistent with the reference app.

### Screenshots

**1. Step 03-code-0002 — baseline, before the `Array` fix**
<img width="1311" height="406" alt="01 SyncUpDetailNavigation-03-code-0002 swift" src="https://github.com/user-attachments/assets/39415d31-0c38-4e1c-95a3-0444b4a0243d" />

**2. Step 03-code-0003 — the fix: `Array(...)` is introduced**
<img width="1271" height="506" alt="02 SyncUpDetailNavigation-03-code-0003 swift" src="https://github.com/user-attachments/assets/18778e81-60bf-4934-87ef-15372ec51b8d" />

**3. Step 03-code-0004 — the regression: `Array(...)` is dropped again**
<img width="1323" height="447" alt="03 SyncUpDetailNavigation-03-code-0004 swift" src="https://github.com/user-attachments/assets/6a429cdc-db53-4644-be31-074f2eb16a90" />
